### PR TITLE
Document dependencies and improve edge-case robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@
 
 ## Testing
 
-Install the project in editable mode and run the test suite with `pytest`:
+Install the dependencies and project in editable mode before running the test suite with `pytest`:
 
 ```
+pip install networkx
 pip install -e .
 pytest
 ```

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Dict, Any, Iterable
 import math
 from collections import deque
+import networkx as nx
 
 from .observers import sincronía_fase, carga_glifica, orden_kuramoto, sigma_vector
 from .operators import aplicar_remesh_si_estabilizacion_global
@@ -121,8 +122,16 @@ def dnfr_epi_vf_mixed(G) -> None:
 # -------------------------
 
 def update_epi_via_nodal_equation(G, *, dt: float = None) -> None:
+    if not isinstance(G, (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)):
+        raise TypeError("G must be a networkx graph instance")
     if dt is None:
         dt = float(G.graph.get("DT", DEFAULTS["DT"]))
+    else:
+        if not isinstance(dt, (int, float)):
+            raise TypeError("dt must be a number")
+        if dt < 0:
+            raise ValueError("dt must be non-negative")
+        dt = float(dt)
     for n in G.nodes():
         nd = G.nodes[n]
         vf = _get_attr(nd, ALIAS_VF, 0.0)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,29 @@
+import pytest
+import networkx as nx
+
+from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
+
+
+def test_empty_graph_handling():
+    G = nx.Graph()
+    default_compute_delta_nfr(G)
+    update_epi_via_nodal_equation(G)  # should not raise
+
+
+def test_update_epi_invalid_dt():
+    G = nx.Graph()
+    G.add_node(1)
+    with pytest.raises(ValueError):
+        update_epi_via_nodal_equation(G, dt=-0.1)
+    with pytest.raises(TypeError):
+        update_epi_via_nodal_equation(G, dt="bad")
+
+
+def test_dnfr_weights_normalization():
+    G = nx.Graph()
+    G.graph["DNFR_WEIGHTS"] = {"phase": -1, "epi": -1, "vf": -1}
+    default_compute_delta_nfr(G)
+    weights = G.graph["_DNFR_META"]["weights_norm"]
+    assert pytest.approx(weights["phase"], rel=1e-6) == 1/3
+    assert pytest.approx(weights["epi"], rel=1e-6) == 1/3
+    assert pytest.approx(weights["vf"], rel=1e-6) == 1/3


### PR DESCRIPTION
## Summary
- Document networkx installation in testing instructions
- Add validation for graph type and timestep in `update_epi_via_nodal_equation`
- Cover empty graphs, invalid timesteps, and negative DNFR weights in tests

## Testing
- `pip install networkx -q`
- `pip install -e . -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6127a9e88321a8c4fb933c48f1f4