### PR TITLE
Add optional Γi(R) coupling to TNFR nodal equation

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -14,10 +14,12 @@ __version__ = "3.0.3"
 from .dynamics import step, run, set_delta_nfr_hook
 from .ontosim import preparar_red
 from .observers import attach_standard_observer, coherencia_global, orden_kuramoto
+from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
 
 __all__ = [
     "preparar_red",
     "step", "run", "set_delta_nfr_hook",
     "attach_standard_observer", "coherencia_global", "orden_kuramoto",
+    "GAMMA_REGISTRY", "eval_gamma", "kuramoto_R_psi",
     "__version__",
 ]

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -148,6 +148,11 @@ DEFAULTS: Dict[str, Any] = {
         "accel_hi": 0.50, "accel_lo": 0.10
     },
     # Callbacks Γ(R)
+    "GAMMA": {
+        "type": "none",  # 'none' | 'kuramoto_linear' | 'kuramoto_bandpass'
+        "beta": 0.0,
+        "R0": 0.0,
+    },
     "CALLBACKS_STRICT": False,  # si True, un error en callback detiene; si False, se loguea y continúa
 }
 

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -1,0 +1,83 @@
+"""gamma.py — TNFR canónica
+
+Γi(R): acoplamientos de red para la ecuación nodal extendida
+    ∂EPI/∂t = νf · ΔNFR(t) + Γi(R)
+
+Provee:
+- kuramoto_R_psi(G): (R, ψ) orden de Kuramoto en la red
+- GAMMA_REGISTRY: registro de acoplamientos canónicos
+- eval_gamma(G, node, t): evalúa Γ para cada nodo según G.graph['GAMMA']
+"""
+from __future__ import annotations
+from typing import Dict, Any, Tuple
+import math
+import cmath
+
+from .constants import ALIAS_THETA
+
+
+def _get_attr(nd: Dict[str, Any], aliases, default: float = 0.0) -> float:
+    """Obtiene el primer atributo presente en nd según aliases."""
+    for k in aliases:
+        if k in nd:
+            return nd[k]
+    return default
+
+
+def kuramoto_R_psi(G) -> Tuple[float, float]:
+    """Devuelve (R, ψ) del orden de Kuramoto usando θ de todos los nodos."""
+    acc = 0 + 0j
+    n = 0
+    for node in G.nodes():
+        nd = G.nodes[node]
+        th = _get_attr(nd, ALIAS_THETA, 0.0)
+        acc += cmath.exp(1j * th)
+        n += 1
+    if n == 0:
+        return 0.0, 0.0
+    z = acc / n
+    return abs(z), math.atan2(z.imag, z.real)
+
+
+# -----------------
+# Γi(R) canónicos
+# -----------------
+
+
+def gamma_none(G, node, t, cfg: Dict[str, Any]) -> float:
+    return 0.0
+
+
+def gamma_kuramoto_linear(G, node, t, cfg: Dict[str, Any]) -> float:
+    """Γ = β · (R - R0) · cos(θ_i - ψ)"""
+    beta = float(cfg.get("beta", 0.0))
+    R0 = float(cfg.get("R0", 0.0))
+    R, psi = kuramoto_R_psi(G)
+    th_i = _get_attr(G.nodes[node], ALIAS_THETA, 0.0)
+    return beta * (R - R0) * math.cos(th_i - psi)
+
+
+def gamma_kuramoto_bandpass(G, node, t, cfg: Dict[str, Any]) -> float:
+    """Γ = β · R(1-R) · sign(cos(θ_i - ψ))"""
+    beta = float(cfg.get("beta", 0.0))
+    R, psi = kuramoto_R_psi(G)
+    th_i = _get_attr(G.nodes[node], ALIAS_THETA, 0.0)
+    sgn = 1.0 if math.cos(th_i - psi) >= 0.0 else -1.0
+    return beta * R * (1.0 - R) * sgn
+
+
+GAMMA_REGISTRY = {
+    "none": gamma_none,
+    "kuramoto_linear": gamma_kuramoto_linear,
+    "kuramoto_bandpass": gamma_kuramoto_bandpass,
+}
+
+
+def eval_gamma(G, node, t) -> float:
+    """Evalúa Γi para `node` según la especificación en G.graph['GAMMA']."""
+    spec = G.graph.get("GAMMA", {"type": "none"})
+    fn = GAMMA_REGISTRY.get(spec.get("type", "none"), gamma_none)
+    try:
+        return float(fn(G, node, t, spec))
+    except Exception:
+        return 0.0

--- a/src/tnfr/main.py
+++ b/src/tnfr/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse, sys
 import networkx as nx
 from . import preparar_red, run, __version__
+from .constants import merge_overrides
 
 def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(
@@ -21,6 +22,8 @@ def main(argv: list[str] | None = None) -> None:
 
     G = nx.erdos_renyi_graph(args.n, args.p)
     preparar_red(G, ATTACH_STD_OBSERVER=bool(args.observer))
+    # Ejemplo: activar Γi(R) lineal con β=0.2 y R0=0.5
+    merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": 0.2, "R0": 0.5})
     run(G, args.steps)
 
     h = G.graph.get("history", {})

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,0 +1,20 @@
+import networkx as nx
+import pytest
+
+from tnfr.constants import attach_defaults, merge_overrides
+from tnfr.dynamics import update_epi_via_nodal_equation
+
+
+def test_gamma_linear_integration():
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    attach_defaults(G)
+    merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0})
+    for n in G.nodes():
+        G.nodes[n]["νf"] = 1.0
+        G.nodes[n]["ΔNFR"] = 0.0
+        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["EPI"] = 0.0
+    update_epi_via_nodal_equation(G, dt=1.0)
+    assert pytest.approx(G.nodes[0]["EPI"], rel=1e-6) == 1.0
+    assert pytest.approx(G.nodes[1]["EPI"], rel=1e-6) == 1.0


### PR DESCRIPTION
## Summary
- introduce `gamma` module with canonical Γi(R) functions (Kuramoto-based) and registry
- extend nodal integration to include optional Γi(R) term and expose defaults
- demo configuration via CLI and export gamma utilities in package API

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af75366f0483219b9e82b626d18129