### PR TITLE
Add advanced coupling, history metrics, and remesh gating

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -26,7 +26,7 @@ from .metrics import (
     register_metrics_callbacks,
     Tg_global, Tg_by_node,
     latency_series, glifogram_series,
-    glyph_top, glyph_dwell_stats,
+    glyph_top, glyph_dwell_stats, export_history,
 )
 from .trace import register_trace
 from .program import play, seq, block, target, wait, THOL, TARGET, WAIT, ejemplo_canonico_basico
@@ -52,6 +52,7 @@ __all__ = [
     "Tg_global", "Tg_by_node",
     "latency_series", "glifogram_series",
     "glyph_top", "glyph_dwell_stats",
+    "export_history",
     "play", "seq", "block", "target", "wait", "THOL", "TARGET", "WAIT",
     "cli_main", "build_graph", "get_preset", "NodeState",
     "ejemplo_canonico_basico",

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -80,10 +80,15 @@ DEFAULTS: Dict[str, Any] = {
     "REMESH_STABILITY_WINDOW": 25,     # tamaño de ventana para evaluar estabilidad
     "REMESH_MIN_PHASE_SYNC": 0.85,     # media mínima de sincronía de fase en ventana
     "REMESH_MAX_GLYPH_DISR": 0.35,     # media máxima de carga glífica disruptiva en ventana
+    "REMESH_MIN_SIGMA_MAG": 0.50,      # magnitud mínima de σ en ventana
+    "REMESH_MIN_KURAMOTO_R": 0.80,    # R de Kuramoto mínimo en ventana
+    "REMESH_MIN_SI_HI_FRAC": 0.50,    # fracción mínima de nodos con Si alto
     "REMESH_LOG_EVENTS": True,         # guarda eventos y metadatos del RE’MESH
 
-    # RE’MESH: memoria τ y mezcla α
-    "REMESH_TAU": 8,                  # pasos hacia atrás
+    # RE’MESH: memoria τ y mezcla α (global/local)
+    "REMESH_TAU": 8,                  # compatibilidad: tau global por defecto
+    "REMESH_TAU_GLOBAL": 8,           # pasos hacia atrás (escala global)
+    "REMESH_TAU_LOCAL": 4,            # pasos hacia atrás (escala local)
     "REMESH_ALPHA": 0.5,              # mezcla con pasado
     "REMESH_ALPHA_HARD": False,       # si True ignora GLYPH_FACTORS['REMESH_alpha']
 
@@ -214,3 +219,6 @@ ALIAS_EPI    = ("EPI", "psi", "PSI", "value")
 ALIAS_SI     = ("Si", "sense_index", "S_i", "sense", "meaning_index")
 ALIAS_dEPI   = ("dEPI_dt", "dpsi_dt", "dEPI", "velocity")
 ALIAS_D2EPI  = ("d2EPI_dt2", "d2psi_dt2", "d2EPI", "accel")
+ALIAS_dVF    = ("dνf_dt", "dvf_dt", "dnu_dt", "dvf")
+ALIAS_D2VF   = ("d2νf_dt2", "d2vf_dt2", "d2nu_dt2", "B")
+ALIAS_dSI    = ("δSi", "delta_Si", "dSi")

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -83,10 +83,27 @@ def gamma_kuramoto_bandpass(G, node, t, cfg: Dict[str, Any]) -> float:
     return beta * R * (1.0 - R) * sgn
 
 
+def gamma_kuramoto_tanh(G, node, t, cfg: Dict[str, Any]) -> float:
+    """Acoplamiento saturante tipo tanh para Γi(R).
+
+    Fórmula: Γ = β · tanh(k·(R - R0)) · cos(θ_i - ψ)
+      - β: ganancia del acoplamiento
+      - k: pendiente de la tanh (cuán rápido satura)
+      - R0: umbral de activación
+    """
+    beta = float(cfg.get("beta", 0.0))
+    k = float(cfg.get("k", 1.0))
+    R0 = float(cfg.get("R0", 0.0))
+    R, psi = kuramoto_R_psi(G)
+    th_i = _get_attr(G.nodes[node], ALIAS_THETA, 0.0)
+    return beta * math.tanh(k * (R - R0)) * math.cos(th_i - psi)
+
+
 GAMMA_REGISTRY = {
     "none": gamma_none,
     "kuramoto_linear": gamma_kuramoto_linear,
     "kuramoto_bandpass": gamma_kuramoto_bandpass,
+    "kuramoto_tanh": gamma_kuramoto_tanh,
 }
 
 

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -16,6 +16,9 @@ _PRESETS = {
         "SH’A",
     ),
     "ejemplo_canonico": ejemplo_canonico_basico(),
+    # Topologías fractales: expansión/contracción modular
+    "fractal_expand": seq(block("T’HOL", "VA’L", "U’M", repeat=2, close="NU’L"), "R’A"),
+    "fractal_contract": seq(block("T’HOL", "NU’L", "U’M", repeat=2, close="SH’A"), "R’A"),
 }
 
 

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -1,0 +1,27 @@
+import networkx as nx
+
+from tnfr.constants import attach_defaults
+from tnfr.dynamics import step
+from tnfr.gamma import GAMMA_REGISTRY
+
+
+def test_history_delta_si_and_B():
+    G = nx.Graph()
+    G.add_node(0, EPI=0.0, νf=0.5, θ=0.0)
+    attach_defaults(G)
+    step(G, apply_glyphs=False)
+    step(G, apply_glyphs=False)
+    hist = G.graph.get("history", {})
+    assert "delta_Si" in hist and len(hist["delta_Si"]) >= 2
+    assert "B" in hist and len(hist["B"]) >= 2
+
+
+def test_gamma_kuramoto_tanh_registry():
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    attach_defaults(G)
+    G.nodes[0]["θ"] = 0.0
+    G.nodes[1]["θ"] = 0.0
+    cfg = {"type": "kuramoto_tanh", "beta": 0.5, "k": 2.0, "R0": 0.0}
+    val = GAMMA_REGISTRY["kuramoto_tanh"](G, 0, 0.0, cfg)
+    assert abs(val) <= cfg["beta"]


### PR DESCRIPTION
## Summary
- implement saturating `kuramoto_tanh` coupling and register it
- track sense variation `δSi` and frequency bifurcation `B` in history with selector penalty for stagnation
- gate RE'MESH with multi-metric stability and multi-scale memory; add exportable history and fractal presets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9037a518832195e6be770ec0b3b3