### PR TITLE
Add coherence matrix and nodal diagnosis metrics

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -120,6 +120,21 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.export_history_base:
         export_history(G, args.export_history_base, fmt=args.export_format)
 
+    # Resúmenes rápidos (si están activados)
+    if G.graph.get("COHERENCE", DEFAULTS["COHERENCE"]).get("enabled", True):
+        Wstats = G.graph.get("history", {}).get(
+            G.graph.get("COHERENCE", DEFAULTS["COHERENCE"]).get("stats_history_key", "W_stats"), []
+        )
+        if Wstats:
+            print("[COHERENCE] último paso:", Wstats[-1])
+    if G.graph.get("DIAGNOSIS", DEFAULTS["DIAGNOSIS"]).get("enabled", True):
+        last_diag = G.graph.get("history", {}).get(
+            G.graph.get("DIAGNOSIS", DEFAULTS["DIAGNOSIS"]).get("history_key", "nodal_diag"), []
+        )
+        if last_diag:
+            sample = list(last_diag[-1].values())[:3]
+            print("[DIAGNOSIS] ejemplo:", sample)
+
     if args.summary:
         tg = Tg_global(G, normalize=True)
         lat = latency_series(G)

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -182,6 +182,41 @@ DEFAULTS.setdefault("GRAMMAR_CANON", {
     "si_high": 0.66,                # umbral para elegir NU’L vs SH’A al cerrar
 })
 
+# --- Coherencia (W) ---
+DEFAULTS.setdefault("COHERENCE", {
+    "enabled": True,
+    "scope": "neighbors",      # "neighbors" | "all"
+    "weights": {
+        "phase": 0.34,
+        "epi": 0.33,
+        "vf": 0.20,
+        "si": 0.13,
+    },
+    "self_on_diag": True,      # W_ii = 1.0
+    "store_mode": "sparse",   # "sparse" | "dense"
+    "threshold": 0.0,
+    "history_key": "W_sparse",
+    "Wi_history_key": "W_i",
+    "stats_history_key": "W_stats",
+})
+
+# --- Diagnóstico nodal ---
+DEFAULTS.setdefault("DIAGNOSIS", {
+    "enabled": True,
+    "window": 16,
+    "history_key": "nodal_diag",
+    "stable":     {"Rloc_hi": 0.80, "dnfr_lo": 0.20, "persist": 3},
+    "dissonance": {"Rloc_lo": 0.40, "dnfr_hi": 0.50, "persist": 3},
+    "transition": {"persist": 2},
+    "compute_symmetry": True,
+    "include_typology": False,
+    "advice": {
+        "stable":     ["Coherencia", "Acoplamiento", "Resonancia"],
+        "transition": ["Transición", "Resonancia", "Autoorganización"],
+        "dissonant":  ["Silencio", "Contracción", "Mutación"],
+    },
+})
+
 
 # -------------------------
 # Utilidades


### PR DESCRIPTION
## Summary
- add default configuration for coherence matrix W and nodal diagnosis
- implement coherence_matrix and diagnosis callbacks with weighted phase sync
- show quick coherence and diagnosis summaries in CLI run command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3b989cd64832186c4ef388c4d9593