### PR TITLE
refactor: simplify E'N neighbor average

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -71,7 +71,7 @@ def _op_EN(node: NodoProtocol) -> None:  # E’N — Recepción
     neigh = list(node.neighbors())
     if not neigh:
         return
-    epi_bar = list_mean(v.EPI for v in neigh) if neigh else epi
+    epi_bar = list_mean(v.EPI for v in neigh)
     node.EPI = (1 - mix) * epi + mix * epi_bar
 
     candidatos = [(abs(node.EPI), node.epi_kind)]


### PR DESCRIPTION
## Summary
- simplify neighbor averaging in EN operator by dropping redundant conditional

## Testing
- `PYTHONPATH=src pytest -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68b42e1cce948321a71276363e8def46