### PR TITLE
Align internal version with pyproject

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -2,7 +2,7 @@
   "name": "TNFR — Teoria de la Naturaleza Fractal Resonante",
   "shortName": "TNFR",
   "language": "en",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "license": "MIT",
   "description": "TNFR is an operational framework that models reality as coherent reorganization rather than fixed substances. Forms that persist (cells, ideas, teams, emotional states) do so because they resonate — they share structure, rhythm and phase with their environment. TNFR provides a practical grammar (structural operators) and a nodal equation to design, stabilize, transform or collapse forms in a controlled way.",
   "summary": "Design-by-coherence: use structural frequency, phase and nodal gradients to activate and stabilize forms (EPI) across scales, from personal routines to teams, products and curricula.",

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -8,7 +8,7 @@ Ecuación nodal:
     ∂EPI/∂t = νf · ΔNFR(t)
 """
 
-__version__ = "4.5.1"
+__version__ = "4.5.2"
 
 # Re-exports de la API pública
 from .dynamics import step, run, set_delta_nfr_hook, validate_canon


### PR DESCRIPTION
## Summary
- update `__version__` to 4.5.2
- sync meta.json version with project configuration

## Testing
- `python -m pip install -e .` *(fails: Expected '=' after a key in a key/value pair in pyproject.toml)*
- `PYTHONPATH=src pytest` *(fails: Expected '=' after a key in a key/value pair in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68b4327c93a883218ad069bbce2f1266