### PR TITLE
chore: remove unused deque import

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -6,7 +6,6 @@ from .constants import (
     ALIAS_SI, ALIAS_DNFR, ALIAS_EPI,
 )
 from .helpers import _get_attr, clamp01, reciente_glifo
-from collections import deque
 
 # Glifos nominales (para evitar typos)
 AL = "A’L"; EN = "E’N"; IL = "I’L"; OZ = "O’Z"; UM = "U’M"; RA = "R’A"; SHA = "SH’A"; VAL = "VA’L"; NUL = "NU’L"; THOL = "T’HOL"; ZHIR = "Z’HIR"; NAV = "NA’V"; REMESH = "RE’MESH"


### PR DESCRIPTION
## Summary
- remove unused deque import from grammar module

## Testing
- `python -m flake8 --select E303 src/tnfr/grammar.py`
- `python -m autopep8 --in-place --select E303 src/tnfr/grammar.py`
- `python -m pytest` *(fails: Expected '=' after a key in a key/value pair in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68b433104f608321b7332183ae6ac640