### PR TITLE
Return zero magnitude for empty sigma vectors

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -100,7 +100,7 @@ def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
         acc += complex(v["x"], v["y"])
         cnt += 1
     if cnt == 0:
-        return {"x": 1.0, "y": 0.0, "mag": 1.0, "angle": 0.0, "n": 0}
+        return {"x": 1.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
     x, y = acc.real / max(1, cnt), acc.imag / max(1, cnt)
     mag = math.hypot(x, y)
     ang = math.atan2(y, x)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -11,6 +11,15 @@ def test_empty_graph_handling():
     update_epi_via_nodal_equation(G)  # should not raise
 
 
+def test_sigma_vector_global_empty_graph():
+    G = nx.Graph()
+    from tnfr.sense import sigma_vector_global
+
+    sv = sigma_vector_global(G)
+    assert sv["mag"] == 0.0
+    assert sv["n"] == 0
+
+
 def test_update_epi_invalid_dt():
     G = nx.Graph()
     G.add_node(1)


### PR DESCRIPTION
## Summary
- Return `mag = 0.0` when `sigma_vector_global` is called on an empty graph
- Add regression test for empty graph case

## Testing
- `PYTHONPATH=src pytest -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68b4359145cc832193762fc142c58c5c