### PR TITLE
Compute selector norms only for parametric glyph selector

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -613,11 +613,12 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
         compute_Si(G, inplace=True)
 
     # 2b) Normalizadores para selector paramétrico (por paso)
-    _norms_para_selector(G)  # no molesta si luego se usa el selector por defecto
+    selector = G.graph.get("glyph_selector", default_glyph_selector)
+    if selector is parametric_glyph_selector:
+        _norms_para_selector(G)
 
     # 3) Selección glífica + aplicación (con lags obligatorios A’L/E’N)
     if apply_glyphs:
-        selector = G.graph.get("glyph_selector", default_glyph_selector)
         from .operators import aplicar_glifo
         window = int(G.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS["GLYPH_HYSTERESIS_WINDOW"]))
         use_canon = bool(G.graph.get("GRAMMAR_CANON", DEFAULTS.get("GRAMMAR_CANON", {})).get("enabled", False))

--- a/tests/test_selector_norms.py
+++ b/tests/test_selector_norms.py
@@ -1,0 +1,28 @@
+import networkx as nx
+
+from tnfr.dynamics import step, default_glyph_selector, parametric_glyph_selector
+
+
+def _make_graph():
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    G.add_edge(0, 1)
+    G.graph["GRAMMAR_CANON"] = {"enabled": False}
+    G.graph.update(EPI_MIN=0.0, EPI_MAX=1.0, VF_MIN=0.0, VF_MAX=1.0)
+    return G
+
+
+def test_default_selector_does_not_compute_norms():
+    G = _make_graph()
+    G.graph["glyph_selector"] = default_glyph_selector
+    step(G, use_Si=False, apply_glyphs=True)
+    assert "_sel_norms" not in G.graph
+
+
+def test_parametric_selector_computes_norms():
+    G = _make_graph()
+    G.graph["glyph_selector"] = parametric_glyph_selector
+    step(G, use_Si=False, apply_glyphs=True)
+    assert "_sel_norms" in G.graph
+    assert "dnfr_max" in G.graph["_sel_norms"]
+    assert "accel_max" in G.graph["_sel_norms"]


### PR DESCRIPTION
## Summary
- Skip per-step norm calculations unless using the `parametric_glyph_selector`.
- Add regression tests to ensure selector norms appear only for the parametric mode.

## Testing
- `PYTHONPATH=src pytest -c /tmp/empty.ini --rootdir=. tests`


------
https://chatgpt.com/codex/tasks/task_e_68b4379863888321b33b443a3db49ed6