### PR TITLE
Raise ValueError for unknown topology

### DIFF
--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -15,7 +15,8 @@ def build_graph(n: int = 24, topology: str = "ring", seed: int | None = 1):
     elif topology == "erdos":
         G = nx.gnp_random_graph(n, 3.0 / n, seed=seed)
     else:
-        G = nx.path_graph(n)
+        valid = ["ring", "complete", "erdos"]
+        raise ValueError(f"Invalid topology '{topology}'. Valid options are: {', '.join(valid)}")
 
     # Valores canónicos para inicialización
     inject_defaults(G, DEFAULTS)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,23 @@
+import pytest
+import networkx as nx
+
+from tnfr.scenarios import build_graph
+
+
+def test_build_graph_valid_topologies():
+    n = 6
+    seed = 1
+    references = {
+        "ring": nx.cycle_graph(n),
+        "complete": nx.complete_graph(n),
+        "erdos": nx.gnp_random_graph(n, 3.0 / n, seed=seed),
+    }
+    for topology, ref_graph in references.items():
+        G = build_graph(n=n, topology=topology, seed=seed)
+        assert nx.is_isomorphic(G, ref_graph)
+
+
+def test_build_graph_invalid_topology():
+    with pytest.raises(ValueError):
+        build_graph(n=5, topology="invalid", seed=1)
+


### PR DESCRIPTION
## Summary
- Raise `ValueError` when `build_graph` receives an unknown topology
- Add tests covering valid and invalid topologies

## Testing
- `PYTHONPATH=src pytest -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b44004dd74832191f7f6f9cad232b3