### PR TITLE
refactor: handle expected errors explicitly

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 try:  # pragma: no cover - opcional
     import yaml  # type: ignore
-except Exception:  # pragma: no cover - yaml es opcional
+except ImportError:  # pragma: no cover - yaml es opcional
     yaml = None
 
 import networkx as nx

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -10,7 +10,7 @@ import json
 
 try:  # pragma: no cover - dependencia opcional
     import yaml  # type: ignore
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     yaml = None
 
 from .constants import inject_defaults

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -282,7 +282,7 @@ def inject_defaults(G, defaults: Dict[str, Any] = DEFAULTS, override: bool = Fal
         from .operators import _ensure_node_offset_map
 
         _ensure_node_offset_map(G)
-    except Exception:
+    except ImportError:
         pass
 
 

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -863,8 +863,10 @@ def _update_history(G) -> None:
         _update_phase_sync(G, hist)
         _update_sigma(G, hist)
         if hist.get("C_steps") and hist.get("stable_frac"):
-            hist.setdefault("iota", []).append(hist["C_steps"][-1] * hist["stable_frac"][-1])
-    except Exception:
+            hist.setdefault("iota", []).append(
+                hist["C_steps"][-1] * hist["stable_frac"][-1]
+            )
+    except (KeyError, ValueError, TypeError):
         # observadores son opcionales; si fallan se ignoran
         pass
   
@@ -878,8 +880,12 @@ def _update_history(G) -> None:
             si_mean = list_mean(sis, 0.0)
             hist["Si_mean"].append(si_mean)
             # umbrales preferentes del selector paramétrico; fallback a los del selector simple
-            thr_sel = G.graph.get("SELECTOR_THRESHOLDS", DEFAULTS.get("SELECTOR_THRESHOLDS", {}))
-            thr_def = G.graph.get("GLYPH_THRESHOLDS", DEFAULTS.get("GLYPH_THRESHOLDS", {"hi":0.66,"lo":0.33}))
+            thr_sel = G.graph.get(
+                "SELECTOR_THRESHOLDS", DEFAULTS.get("SELECTOR_THRESHOLDS", {})
+            )
+            thr_def = G.graph.get(
+                "GLYPH_THRESHOLDS", DEFAULTS.get("GLYPH_THRESHOLDS", {"hi": 0.66, "lo": 0.33})
+            )
             si_hi = float(thr_sel.get("si_hi", thr_def.get("hi", 0.66)))
             si_lo = float(thr_sel.get("si_lo", thr_def.get("lo", 0.33)))
             n = len(sis)
@@ -889,6 +895,6 @@ def _update_history(G) -> None:
             hist["Si_mean"].append(0.0)
             hist["Si_hi_frac"].append(0.0)
             hist["Si_lo_frac"].append(0.0)
-    except Exception:
+    except (KeyError, ValueError, TypeError):
         # si aún no se calculó Si este paso, no interrumpimos
         pass

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -159,5 +159,5 @@ def eval_gamma(G, node, t) -> float:
         _ensure_kuramoto_cache(G, t)
     try:
         return float(fn(G, node, t, spec))
-    except Exception:
+    except (KeyError, TypeError, ValueError):
         return 0.0

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -12,7 +12,7 @@ from statistics import fmean, StatisticsError
 
 try:
     import networkx as nx  # solo para tipos
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     nx = None  # type: ignore
 
 from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_EPI_KIND
@@ -103,7 +103,7 @@ def alias_lookup(
             return d[k]
         try:
             return conv(d[k])
-        except Exception:
+        except (ValueError, TypeError):
             # Si la conversión falla, forzamos búsqueda normal
             pass
 
@@ -118,7 +118,7 @@ def alias_lookup(
                 return d[k]
             try:
                 return conv(d[k])
-            except Exception:
+            except (ValueError, TypeError):
                 continue
 
     if value is not _sentinel:
@@ -268,7 +268,7 @@ def last_glifo(nd: Dict[str, Any]) -> str | None:
         return None
     try:
         return hist[-1]
-    except Exception:
+    except IndexError:
         return None
 
 # -------------------------
@@ -328,7 +328,7 @@ def invoke_callbacks(G, event: str, ctx: dict | None = None):
             name, fn = getattr(cb, "__name__", None), cb
         try:
             fn(G, ctx)
-        except Exception as e:
+        except (KeyError, ValueError, TypeError) as e:
             if strict:
                 raise
             G.graph.setdefault("_callback_errors", []).append({

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -58,9 +58,9 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         try:
             from .observers import attach_standard_observer
             attach_standard_observer(G)
-        except Exception as e:
+        except ImportError as e:
             G.graph.setdefault("_callback_errors", []).append(
-                {"event":"attach_std_observer","error":repr(e)}
+                {"event": "attach_std_observer", "error": repr(e)}
             )
     # Hook explícito para ΔNFR (se puede sustituir luego con dynamics.set_delta_nfr_hook)
     G.graph.setdefault("compute_delta_nfr", default_compute_delta_nfr)

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -332,7 +332,7 @@ def aplicar_remesh_red(G) -> None:
         degs = sorted(d for _, d in G.degree())
         topo_str = f"n={n_nodes};m={n_edges};deg=" + ",".join(map(str, degs))
         topo_hash = hashlib.sha1(topo_str.encode()).hexdigest()[:12]
-    except Exception:
+    except (AttributeError, TypeError, nx.NetworkXError):
         topo_hash = None
 
     def _epi_items():

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -7,13 +7,13 @@ from .helpers import register_callback, ensure_history, last_glifo
 
 try:
     from .gamma import kuramoto_R_psi
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     def kuramoto_R_psi(G):
         return 0.0, 0.0
 
 try:
     from .sense import sigma_vector_global
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     def sigma_vector_global(G, *args, **kwargs):
         return {"x": 1.0, "y": 0.0, "mag": 1.0, "angle": 0.0, "n": 0}
 


### PR DESCRIPTION
## Summary
- avoid swallowing unexpected errors and catch only known cases
- improve optional imports to use ImportError
- narrow callback error handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4648cd8708321a2e24af359532444