### PR TITLE
Refactor node iteration to use data dictionaries

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -109,8 +109,7 @@ def default_compute_delta_nfr(G) -> None:
 
     degs = dict(G.degree()) if w_topo != 0 else None
 
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         th_i = _get_attr(nd, ALIAS_THETA, 0.0)
         epi_i = _get_attr(nd, ALIAS_EPI, 0.0)
         vf_i = _get_attr(nd, ALIAS_VF, 0.0)
@@ -173,8 +172,7 @@ def set_delta_nfr_hook(G, func, *, name: str | None = None, note: str | None = N
 # --- Hooks de ejemplo (opcionales) ---
 def dnfr_phase_only(G) -> None:
     """Ejemplo: ΔNFR solo desde fase (tipo Kuramoto-like)."""
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         th_i = _get_attr(nd, ALIAS_THETA, 0.0)
         th_bar = fase_media(G, n)
         g_phase = -angle_diff(th_i, th_bar) / math.pi
@@ -183,8 +181,7 @@ def dnfr_phase_only(G) -> None:
 
 def dnfr_epi_vf_mixed(G) -> None:
     """Ejemplo: ΔNFR sin fase, mezclando EPI y νf."""
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         epi_i = _get_attr(nd, ALIAS_EPI, 0.0)
         epi_bar = media_vecinal(G, n, ALIAS_EPI, default=epi_i)
         g_epi = (epi_bar - epi_i)
@@ -199,8 +196,7 @@ def dnfr_laplacian(G) -> None:
     """Gradiente topológico explícito usando Laplaciano sobre EPI y νf."""
     wE = float(G.graph.get("DNFR_WEIGHTS", {}).get("epi", 0.33))
     wV = float(G.graph.get("DNFR_WEIGHTS", {}).get("vf", 0.33))
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         epi = _get_attr(nd, ALIAS_EPI, 0.0)
         vf = _get_attr(nd, ALIAS_VF, 0.0)
         neigh = list(G.neighbors(n))
@@ -272,8 +268,7 @@ def update_epi_via_nodal_equation(
 
     t_local = t
     for _ in range(steps):
-        for n in G.nodes():
-            nd = G.nodes[n]
+        for n, nd in G.nodes(data=True):
             vf = _get_attr(nd, ALIAS_VF, 0.0)
             dnfr = _get_attr(nd, ALIAS_DNFR, 0.0)
             dEPI_dt_prev = _get_attr(nd, ALIAS_dEPI, 0.0)
@@ -470,8 +465,7 @@ def coordinar_fase_global_vecinal(G, fuerza_global: float | None = None, fuerza_
         thG = 0.0
 
     # 7) Aplicar corrección global+vecinal
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         th = _get_attr(nd, ALIAS_THETA, 0.0)
         thL = fase_media(G, n)
         dG = angle_diff(thG, th)
@@ -494,8 +488,7 @@ def adaptar_vf_por_coherencia(G) -> None:
     vf_max = float(G.graph.get("VF_MAX", DEFAULTS["VF_MAX"]))
 
     updates = {}
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         Si = _get_attr(nd, ALIAS_SI, 0.0)
         dnfr = abs(_get_attr(nd, ALIAS_DNFR, 0.0))
         if Si >= si_hi and dnfr <= eps_dnfr:
@@ -543,8 +536,7 @@ def _norms_para_selector(G) -> dict:
     """Calcula y guarda en G.graph los máximos para normalizar |ΔNFR| y |d2EPI/dt2|."""
     dnfr_max = 0.0
     accel_max = 0.0
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         dnfr_max = max(dnfr_max, abs(_get_attr(nd, ALIAS_DNFR, 0.0)))
         accel_max = max(accel_max, abs(_get_attr(nd, ALIAS_D2EPI, 0.0)))
     if dnfr_max <= 0: dnfr_max = 1.0
@@ -841,8 +833,7 @@ def _update_history(G) -> None:
     dt = float(G.graph.get("DT", DEFAULTS.get("DT", 1.0))) or 1.0
     delta_si_acc = []
     B_acc = []
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         if abs(_get_attr(nd, ALIAS_DNFR, 0.0)) <= eps_dnfr and abs(_get_attr(nd, ALIAS_dEPI, 0.0)) <= eps_depi:
             stables += 1
 

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -382,8 +382,7 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
     dnfrmax = 1.0 if dnfrmax == 0 else dnfrmax
 
     out: Dict[Any, float] = {}
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         vf = _get_attr(nd, ALIAS_VF, 0.0)
         vf_norm = clamp01(abs(vf) / vfmax)
 

--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -77,8 +77,7 @@ def _metrics_step(G, *args, **kwargs):
     tg_total = hist.setdefault("Tg_total", defaultdict(float))  # tiempo total por glifo (global)
     tg_by_node = hist.setdefault("Tg_by_node", {})             # nodo → {glifo: [runs,...]}
 
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         g = last_glifo(nd)
         if not g:
             continue

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -79,8 +79,7 @@ def carga_glifica(G, window: int | None = None) -> dict:
     Retorna un dict con proporciones por glifo y agregados útiles.
     """
     total = Counter()
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         hist = nd.get("hist_glifos")
         if not hist:
             continue

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -356,8 +356,7 @@ def aplicar_remesh_red(G) -> None:
     ).hexdigest()[:12]
 
     # --- Mezcla (1-α)·now + α·old ---
-    for n in G.nodes():
-        nd = G.nodes[n]
+    for n, nd in G.nodes(data=True):
         epi_now = _get_attr(nd, ALIAS_EPI, 0.0)
         epi_old_l = float(past_l.get(n, epi_now))
         epi_old_g = float(past_g.get(n, epi_now))

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -138,8 +138,7 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
     # Trayectoria por nodo (opcional)
     if cfg.get("per_node", False):
         per = hist.setdefault("sigma_per_node", {})
-        for n in G.nodes():
-            nd = G.nodes[n]
+        for n, nd in G.nodes(data=True):
             g = last_glifo(nd)
             if not g:
                 continue


### PR DESCRIPTION
## Summary
- replace manual node lookups with `G.nodes(data=True)` iteration
- streamline node-based computations in dynamics, helpers, metrics, observers, operators and sense modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b474a10420832190d30cb213b79cbf