### PR TITLE
refactor: replace alias cache with lru_cache

### DIFF
--- a/tests/test_alias_lookup_threadsafe.py
+++ b/tests/test_alias_lookup_threadsafe.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 
-from tnfr.helpers import alias_lookup, _alias_cache, _ALIAS_CACHE_MAX
+from tnfr.helpers import alias_lookup, _resolve_alias
 
 
 def _worker(i):
@@ -14,4 +14,4 @@ def test_alias_lookup_thread_safety():
     with ThreadPoolExecutor(max_workers=32) as ex:
         results = list(ex.map(_worker, range(32)))
     assert results == list(range(32))
-    assert len(_alias_cache) <= _ALIAS_CACHE_MAX
+    assert _resolve_alias.cache_info().currsize <= 16


### PR DESCRIPTION
## Summary
- simplify alias resolution by replacing manual OrderedDict cache with `functools.lru_cache`
- streamline `alias_lookup` to use new cached resolver
- adapt thread-safety test to inspect the new cache

## Testing
- `PYTHONPATH=src python -m pytest tests/test_alias_lookup_threadsafe.py`
- `PYTHONPATH=src python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48c40cbe083218c74d3ab6fc5cc24