### PR TITLE
Cache glyph unit vectors

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -28,6 +28,10 @@ GLYPHS_CANONICAL: List[str] = [
 
 _SIGMA_ANGLES: Dict[str, float] = {g: (2.0*math.pi * i / len(GLYPHS_CANONICAL)) for i, g in enumerate(GLYPHS_CANONICAL)}
 
+GLYPH_UNITS: Dict[str, complex] = {
+    g: complex(math.cos(a), math.sin(a)) for g, a in _SIGMA_ANGLES.items()
+}
+
 # -------------------------
 # Utilidades básicas
 # -------------------------
@@ -37,8 +41,7 @@ def glyph_angle(g: str) -> float:
 
 
 def glyph_unit(g: str) -> complex:
-    a = glyph_angle(g)
-    return complex(math.cos(a), math.sin(a))
+    return GLYPH_UNITS.get(g, 1+0j)
 
 
 def _weight(G, n, mode: str) -> float:


### PR DESCRIPTION
## Summary
- Precompute complex unit vectors for glyphs
- Reuse cached vectors in glyph_unit to avoid repeated trig

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4961a1c3c8321bbf2aa3e407903c9