### PR TITLE
Eliminar print residual en ontosim

### DIFF
--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -144,4 +144,4 @@ if __name__ == "__main__":
     G = nx.erdos_renyi_graph(30, 0.15)
     preparar_red(G)
     run(G, 100)
-    print("C(t) muestras:", G.graph["history"]["C_steps"][-5:])
+    # print("C(t) muestras:", G.graph["history"]["C_steps"][-5:])  # usado solo para pruebas


### PR DESCRIPTION
## Summary
- Comenta la línea de depuración que mostraba muestras de C(t) en `ontosim.py`.
- Verificación de que no quedan declaraciones `print` fuera de los módulos CLI.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tnfr')*

------
https://chatgpt.com/codex/tasks/task_e_68b496b703788321b74bcb15c61a300d