### PR TITLE
Refactor sigma_vector to reuse shared angle constants

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -28,6 +28,30 @@ GLYPHS_CANONICAL: List[str] = [
 
 _SIGMA_ANGLES: Dict[str, float] = {g: (2.0*math.pi * i / len(GLYPHS_CANONICAL)) for i, g in enumerate(GLYPHS_CANONICAL)}
 
+# Glifos relevantes para el plano Σ de observadores de sentido
+SIGMA_ANGLE_KEYS: tuple[str, ...] = (
+    Glyph.IL.value,
+    Glyph.RA.value,
+    Glyph.UM.value,
+    Glyph.SHA.value,
+    Glyph.OZ.value,
+    Glyph.ZHIR.value,
+    Glyph.NAV.value,
+    Glyph.THOL.value,
+)
+
+# Ajustes específicos de ángulos para Σ
+_SIGMA_ANGLES.update({
+    Glyph.IL.value: 0.0,
+    Glyph.RA.value: math.pi/4,
+    Glyph.UM.value: math.pi/2,
+    Glyph.SHA.value: 3*math.pi/4,
+    Glyph.OZ.value: math.pi,
+    Glyph.ZHIR.value: 5*math.pi/4,
+    Glyph.NAV.value: 3*math.pi/2,
+    Glyph.THOL.value: 7*math.pi/4,
+})
+
 GLYPH_UNITS: Dict[str, complex] = {
     g: complex(math.cos(a), math.sin(a)) for g, a in _SIGMA_ANGLES.items()
 }


### PR DESCRIPTION
## Summary
- Define reusable `SIGMA_ANGLE_KEYS` and angle overrides in `sense` for observer plane
- Refactor `sigma_vector` to derive vectors via `glyph_unit` and shared constants
- Add regression test ensuring `sigma_vector` yields same result after refactor

## Testing
- `PYTHONPATH=src pytest tests/test_observers.py -q`
- `PYTHONPATH=src pytest tests/test_edge_cases.py::test_sigma_vector_global_empty_graph -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49c4b17588321bcc7f4b701e8b8ad