### PR TITLE
Fix NodoTNFR all_nodes lookup

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -143,7 +143,7 @@ class NodoTNFR:
         return 0
 
     def all_nodes(self) -> Iterable["NodoTNFR"]:
-        return list(getattr(self.graph, "_all_nodes", [self]))
+        return list(self.graph.get("_all_nodes", [self]))
 
     def aplicar_glifo(self, glifo: str, window: Optional[int] = None) -> None:
         from .operators import aplicar_glifo_obj

--- a/tests/test_node_all_nodes.py
+++ b/tests/test_node_all_nodes.py
@@ -1,0 +1,13 @@
+from tnfr.node import NodoTNFR
+
+
+def test_all_nodes_returns_full_list():
+    a = NodoTNFR()
+    b = NodoTNFR()
+    graph = {"_all_nodes": [a, b]}
+    a.graph = graph
+    b.graph = graph
+
+    assert set(a.all_nodes()) == {a, b}
+    assert set(b.all_nodes()) == {a, b}
+


### PR DESCRIPTION
## Summary
- Use mapping access for `_all_nodes` in `NodoTNFR.all_nodes`
- Add regression test ensuring the full node list is returned

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a34aca84832190287ca275055a64