### PR TITLE
Utilizar helper push_glifo en NodoTNFR

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -134,9 +134,9 @@ class NodoTNFR:
         other._neighbors[self] = weight
 
     def push_glifo(self, glifo: str, window: int) -> None:
-        if self._hist_glifos.maxlen != window:
-            self._hist_glifos = deque(self._hist_glifos, maxlen=window)
-        self._hist_glifos.append(glifo)
+        nd = {"hist_glifos": self._hist_glifos}
+        push_glifo(nd, glifo, window)
+        self._hist_glifos = nd["hist_glifos"]
         self.epi_kind = glifo
 
     def offset(self) -> int:


### PR DESCRIPTION
## Summary
- Reutiliza `helpers.push_glifo` en `NodoTNFR.push_glifo` para gestionar el historial y actualizar `epi_kind`

## Testing
- `PYTHONPATH=src pytest tests/test_export_history.py tests/test_metrics.py tests/test_grammar.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4a407f5a4832193ffa15598bc4559