### PR TITLE
Use helper for glyph hysteresis window

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -143,7 +143,7 @@ def apply_glyph_with_grammar(G, nodes: Optional[Iterable[Any]], glyph: Glyph | s
     from .operators import aplicar_glifo
 
     if window is None:
-        window = int(get_param(G, "GLYPH_HYSTERESIS_WINDOW"))
+        window = get_param(G, "GLYPH_HYSTERESIS_WINDOW")
 
     g_str = glyph.value if isinstance(glyph, Glyph) else str(glyph)
     for n in list(G.nodes() if nodes is None else nodes):


### PR DESCRIPTION
## Summary
- simplify apply_glyph_with_grammar by using `get_param` to fetch the default `GLYPH_HYSTERESIS_WINDOW`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6833a94832187ce74edb98ece48