### PR TITLE
Handle missing SHA counts in morph metrics

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -133,7 +133,7 @@ def _update_morph_metrics(G, hist, counts, t):
     cm_val = (counts.get("ZHIR", 0) + counts.get("NAV", 0)) / total
     ne_val = (counts.get("IL", 0) + counts.get("THOL", 0)) / total
     remesh = counts.get("REMESH", 0)
-    pp_val = 0.0 if remesh == 0 else counts["SHA"] / remesh
+    pp_val = 0.0 if remesh == 0 else counts.get("SHA", 0) / remesh
     hist.setdefault("morph", []).append({"t": t, "ID": id_val, "CM": cm_val, "NE": ne_val, "PP": pp_val})
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,6 +17,19 @@ def test_pp_val_zero_when_no_remesh(graph_canon):
     assert morph["PP"] == 0.0
 
 
+def test_pp_val_handles_missing_sha(graph_canon):
+    """PP metric handles absence of SHA counts gracefully."""
+    G = graph_canon()
+    # Nodo en estado REMESH pero sin nodos SHA
+    G.add_node(0, EPI_kind="REMESH")
+    attach_defaults(G)
+
+    _metrics_step(G)
+
+    morph = G.graph["history"]["morph"][0]
+    assert morph["PP"] == 0.0
+
+
 def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
     """Disabling per-node storage should not alter global metrics."""
     G_true = graph_canon()


### PR DESCRIPTION
## Summary
- Avoid KeyError in `_update_morph_metrics` by using `counts.get('SHA', 0)`
- Add regression test ensuring `_metrics_step` handles glyph counts without `SHA`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d1de07f483219d825b44d3280dd8