### PR TITLE
refactor: split constants into thematic defaults

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -10,7 +10,7 @@ import networkx as nx
 
 logger = logging.getLogger(__name__)
 
-from .constants import inject_defaults, DEFAULTS
+from .constants import inject_defaults, DEFAULTS, METRIC_DEFAULTS
 from .sense import register_sigma_callback, sigma_series, sigma_rose
 from .metrics import (
     register_metrics_callbacks,
@@ -142,7 +142,7 @@ def _build_graph_from_args(args: argparse.Namespace) -> nx.Graph:
     if args.remesh_mode:
         G.graph["REMESH_MODE"] = str(args.remesh_mode)
 
-    gcanon = dict(DEFAULTS["GRAMMAR_CANON"])
+    gcanon = dict(METRIC_DEFAULTS["GRAMMAR_CANON"])
     gcanon.update(_args_to_dict(args, prefix="grammar."))
     if hasattr(args, "grammar_canon") and args.grammar_canon is not None:
         gcanon["enabled"] = bool(args.grammar_canon)
@@ -203,15 +203,15 @@ def cmd_run(args: argparse.Namespace) -> int:
     _persist_history(G, args)
 
     # Resúmenes rápidos (si están activados)
-    if G.graph.get("COHERENCE", DEFAULTS["COHERENCE"]).get("enabled", True):
+    if G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get("enabled", True):
         Wstats = G.graph.get("history", {}).get(
-            G.graph.get("COHERENCE", DEFAULTS["COHERENCE"]).get("stats_history_key", "W_stats"), []
+            G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get("stats_history_key", "W_stats"), []
         )
         if Wstats:
             logger.info("[COHERENCE] último paso: %s", Wstats[-1])
-    if G.graph.get("DIAGNOSIS", DEFAULTS["DIAGNOSIS"]).get("enabled", True):
+    if G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get("enabled", True):
         last_diag = G.graph.get("history", {}).get(
-            G.graph.get("DIAGNOSIS", DEFAULTS["DIAGNOSIS"]).get("history_key", "nodal_diag"), []
+            G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get("history_key", "nodal_diag"), []
         )
         if last_diag:
             sample = list(last_diag[-1].values())[:3]

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -1,267 +1,272 @@
 """
 constants.py — TNFR canónica
 
-Centraliza parámetros por defecto y nombres que usan el resto de módulos.
-Provee utilidades para inyectarlos en G.graph.
+Centraliza parámetros por defecto organizados en sub-diccionarios temáticos.
+Provee utilidades para inyectarlos en ``G.graph``.
 """
 from __future__ import annotations
+from dataclasses import dataclass, asdict, field
 from typing import Dict, Any
 from types import MappingProxyType
 import math
 import warnings
 
 # -------------------------
-# Parámetros canónicos
+# Dataclasses de defaults
 # -------------------------
-DEFAULTS: Dict[str, Any] = {
-    # Discretización
-    "DT": 1.0,
-    "INTEGRATOR_METHOD": "euler",
-    "DT_MIN": 0.1,
-
-    # Rango de EPI (estructura primaria)
-    "EPI_MIN": -1.0,
-    "EPI_MAX": 1.0,
-    # Alias histórico usado por algunos proyectos
-    "EPI_MAX_GLOBAL": 1.0,
-
-    # Rango de frecuencia estructural νf
-    "VF_MIN": 0.0,
-    "VF_MAX": 1.0,
-
-    # Envolvente de fase
-    "THETA_WRAP": True,
-
-    # --- Inicialización (evitar simetrías) ---
-    "INIT_RANDOM_PHASE": True,        # si True, θ ~ U[-π, π]
-    "INIT_THETA_MIN": -math.pi,
-    "INIT_THETA_MAX":  math.pi,
-
-    "INIT_VF_MODE": "uniform",        # "uniform" | "normal"
-    # para uniform:
-    "INIT_VF_MIN": None,              # si None → usa VF_MIN
-    "INIT_VF_MAX": None,              # si None → usa VF_MAX
-    # para normal:
-    "INIT_VF_MEAN": 0.5,
-    "INIT_VF_STD":  0.15,
-    # clamp de νf a límites canónicos
-    "INIT_VF_CLAMP_TO_LIMITS": True,
 
 
-    # Mezcla para ΔNFR (campo nodal)
-    # phase: dispersión de fase local; epi: gradiente de EPI; vf: desajuste de νf;
-    # topo: término topológico (p. ej., centralidad). Pesos se normalizan.
-    "DNFR_WEIGHTS": {"phase": 0.34, "epi": 0.33, "vf": 0.33, "topo": 0.0},
-
-    # Índice de sentido Si = α·νf_norm + β·(1 - disp_fase) + γ·(1 - |ΔNFR|/max)
-    "SI_WEIGHTS": {"alpha": 0.34, "beta": 0.33, "gamma": 0.33},
-
-    # Coordinación de fase (UM) global/vecinal por paso
-    "PHASE_K_GLOBAL": 0.05,
-    "PHASE_K_LOCAL": 0.15,
-    "PHASE_HISTORY_MAXLEN": 50,   # longitud máx. para series de fase
-
-    # Coordinación de fase adaptativa (kG/kL dinámicos por estado)
-    "PHASE_ADAPT": {
-        "enabled": True,     # activar adaptación automática si no se pasan fuerzas explícitas a la función
-        "R_hi": 0.90,        # sincronía alta (Kuramoto R) => estado ESTABLE
-        "R_lo": 0.60,        # sincronía baja => estado DISONANTE
-        "disr_hi": 0.50,     # carga glífica disruptiva alta => DISONANTE
-        "disr_lo": 0.25,     # carga glífica disruptiva baja + R alta => ESTABLE
-        "kG_min": 0.01, "kG_max": 0.20,
-        "kL_min": 0.05, "kL_max": 0.25,
-        "up": 0.10,          # velocidad de subida hacia el objetivo
-        "down": 0.07         # velocidad de bajada hacia el objetivo
-    },
-
-    "STOP_EARLY": {"enabled": False, "window": 25, "fraction": 0.90},
-
-    # Criterios de estabilidad (para activar REMESH de red)
-    "EPS_DNFR_STABLE": 1e-3,
-    "EPS_DEPI_STABLE": 1e-3,
-    "FRACTION_STABLE_REMESH": 0.80,   # fracción de nodos estables requerida
-    "REMESH_COOLDOWN_VENTANA": 20,    # pasos mínimos entre REMESH
-    "REMESH_COOLDOWN_TS": 0.0,        # cooldown adicional por tiempo simulado
-    # Gating adicional basado en observadores (conmutador + ventana)
-    "REMESH_REQUIRE_STABILITY": True,  # si True, exige ventana de estabilidad multi-métrica
-    "REMESH_STABILITY_WINDOW": 25,     # tamaño de ventana para evaluar estabilidad
-    "REMESH_MIN_PHASE_SYNC": 0.85,     # media mínima de sincronía de fase en ventana
-    "REMESH_MAX_GLYPH_DISR": 0.35,     # media máxima de carga glífica disruptiva en ventana
-    "REMESH_MIN_SIGMA_MAG": 0.50,      # magnitud mínima de σ en ventana
-    "REMESH_MIN_KURAMOTO_R": 0.80,    # R de Kuramoto mínimo en ventana
-    "REMESH_MIN_SI_HI_FRAC": 0.50,    # fracción mínima de nodos con Si alto
-    "REMESH_LOG_EVENTS": True,         # guarda eventos y metadatos del REMESH
-    "REMESH_MODE": "knn",            # modo de remallado topológico
-    "REMESH_COMMUNITY_K": 2,          # conexiones por comunidad
-
-    # REMESH: memoria τ y mezcla α (global/local)
-    "REMESH_TAU_GLOBAL": 8,           # pasos hacia atrás (escala global)
-    "REMESH_TAU_LOCAL": 4,            # pasos hacia atrás (escala local)
-    "REMESH_ALPHA": 0.5,              # mezcla con pasado
-    "REMESH_ALPHA_HARD": False,       # si True ignora GLYPH_FACTORS['REMESH_alpha']
-
-    # Soporte y norma de la EPI
-    "EPI_SUPPORT_THR": 0.05,          # umbral para Supp(EPI)
-
-    # U'M — compatibilidad mínima para crear/reforzar enlaces funcionales
-    "UM_COMPAT_THRESHOLD": 0.75,
-
-    # Histéresis glífica
-    "GLYPH_HYSTERESIS_WINDOW": 7,
-
-    # Lags máximos sin emisión (AL) y recepción (EN)
-    "AL_MAX_LAG": 5,
-    "EN_MAX_LAG": 3,
-
-    # Margen de histéresis del selector (cuánto "aguanta" sin cambiar glifo si está cerca de un umbral)
-    "GLYPH_SELECTOR_MARGIN": 0.05,
-
-    # Ventana para estimar la carga glífica en history/plots
-    "GLYPH_LOAD_WINDOW": 50,
-
-    # Tamaño de ventana para coherencia promedio W̄
-    "WBAR_WINDOW": 25,
-
-    # Adaptación de frecuencia estructural por coherencia
-    "VF_ADAPT_TAU": 5,   # pasos estables antes de ajustar νf
-    "VF_ADAPT_MU": 0.1,  # velocidad de ajuste hacia la media vecinal
-
-    # Factores suaves por glifo (operadores)
-    "GLYPH_FACTORS": {
-        "AL_boost": 0.05,   # AL — pequeña emisión
-        "EN_mix": 0.25,     # EN — mezcla con vecindad
-        "IL_dnfr_factor": 0.7,  # IL — reduce ΔNFR
-        "OZ_dnfr_factor": 1.3,  # OZ — aumenta ΔNFR
-        "UM_theta_push": 0.25,  # UM — empuje adicional de fase local
-        "RA_epi_diff": 0.15,    # RA — difusión EPI
-        "SHA_vf_factor": 0.85,  # SHA — baja νf
-        "VAL_scale": 1.15,      # VAL — expande EPI
-        "NUL_scale": 0.85,      # NUL — contrae EPI
-        "THOL_accel": 0.10,     # THOL — acelera (seg. deriv.) si hay umbral
-        "ZHIR_theta_shift": 1.57079632679,  # ZHIR — desplazamiento ~π/2
-        "NAV_jitter": 0.05,     # NAV — pequeña inestabilidad creativa
-        "NAV_eta": 0.5,         # NAV — peso de convergencia hacia νf
-        "REMESH_alpha": 0.5,    # REMESH — mezcla si no se usa REMESH_ALPHA
-    },
-
-    # Umbrales para el selector glífico por defecto
-    "GLYPH_THRESHOLDS": {"hi": 0.66, "lo": 0.33, "dnfr": 1e-3},
-
-    # Comportamiento NAV
-    "NAV_RANDOM": True,   # si True, usa jitter aleatorio en [-j, j]; si False, jitter determinista por signo
-    "NAV_STRICT": False,  # si True, fuerza ΔNFR ← νf (sin mezcla)
-    "RANDOM_SEED": 0,     # semilla base para reproducibilidad del jitter
-
-    # Modo ruido para OZ
-    "OZ_NOISE_MODE": False,  # si True, añade ruido aditivo en ΔNFR
-    "OZ_SIGMA": 0.1,         # amplitud del ruido uniforme [-σ, σ]
-
-    # Gramática glífica (suave): evita repetir ciertos glifos salvo que el campo lo exija
-    "GRAMMAR": {
-        "window": 3,                       # cuántos pasos recientes miramos por nodo
-        "avoid_repeats": ["ZHIR", "OZ", "THOL"],
-        "force_dnfr": 0.60,                # si |ΔNFR|_norm ≥ este valor, se permite repetir
-        "force_accel": 0.60,               # o si |accel|_norm ≥ este valor
-        "fallbacks": {                     # a qué glifo caer si se bloquea el candidato
-            "ZHIR": "NAV",
-            "OZ":   "ZHIR",
-            "THOL": "NAV"
+@dataclass(frozen=True)
+class CoreDefaults:
+    DT: float = 1.0
+    INTEGRATOR_METHOD: str = "euler"
+    DT_MIN: float = 0.1
+    EPI_MIN: float = -1.0
+    EPI_MAX: float = 1.0
+    EPI_MAX_GLOBAL: float = 1.0
+    VF_MIN: float = 0.0
+    VF_MAX: float = 1.0
+    THETA_WRAP: bool = True
+    DNFR_WEIGHTS: Dict[str, float] = field(
+        default_factory=lambda: {"phase": 0.34, "epi": 0.33, "vf": 0.33, "topo": 0.0}
+    )
+    SI_WEIGHTS: Dict[str, float] = field(
+        default_factory=lambda: {"alpha": 0.34, "beta": 0.33, "gamma": 0.33}
+    )
+    PHASE_K_GLOBAL: float = 0.05
+    PHASE_K_LOCAL: float = 0.15
+    PHASE_ADAPT: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "R_hi": 0.90,
+            "R_lo": 0.60,
+            "disr_hi": 0.50,
+            "disr_lo": 0.25,
+            "kG_min": 0.01,
+            "kG_max": 0.20,
+            "kL_min": 0.05,
+            "kL_max": 0.25,
+            "up": 0.10,
+            "down": 0.07,
         }
-    },
+    )
+    UM_COMPAT_THRESHOLD: float = 0.75
+    GLYPH_HYSTERESIS_WINDOW: int = 7
+    AL_MAX_LAG: int = 5
+    EN_MAX_LAG: int = 3
+    GLYPH_SELECTOR_MARGIN: float = 0.05
+    VF_ADAPT_TAU: int = 5
+    VF_ADAPT_MU: float = 0.1
+    GLYPH_FACTORS: Dict[str, float] = field(
+        default_factory=lambda: {
+            "AL_boost": 0.05,
+            "EN_mix": 0.25,
+            "IL_dnfr_factor": 0.7,
+            "OZ_dnfr_factor": 1.3,
+            "UM_theta_push": 0.25,
+            "RA_epi_diff": 0.15,
+            "SHA_vf_factor": 0.85,
+            "VAL_scale": 1.15,
+            "NUL_scale": 0.85,
+            "THOL_accel": 0.10,
+            "ZHIR_theta_shift": 1.57079632679,
+            "NAV_jitter": 0.05,
+            "NAV_eta": 0.5,
+            "REMESH_alpha": 0.5,
+        }
+    )
+    GLYPH_THRESHOLDS: Dict[str, float] = field(
+        default_factory=lambda: {"hi": 0.66, "lo": 0.33, "dnfr": 1e-3}
+    )
+    NAV_RANDOM: bool = True
+    NAV_STRICT: bool = False
+    RANDOM_SEED: int = 0
+    OZ_NOISE_MODE: bool = False
+    OZ_SIGMA: float = 0.1
+    GRAMMAR: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "window": 3,
+            "avoid_repeats": ["ZHIR", "OZ", "THOL"],
+            "force_dnfr": 0.60,
+            "force_accel": 0.60,
+            "fallbacks": {"ZHIR": "NAV", "OZ": "ZHIR", "THOL": "NAV"},
+        }
+    )
+    SELECTOR_WEIGHTS: Dict[str, float] = field(
+        default_factory=lambda: {"w_si": 0.5, "w_dnfr": 0.3, "w_accel": 0.2}
+    )
+    SELECTOR_THRESHOLDS: Dict[str, float] = field(
+        default_factory=lambda: {
+            "si_hi": 0.66,
+            "si_lo": 0.33,
+            "dnfr_hi": 0.50,
+            "dnfr_lo": 0.10,
+            "accel_hi": 0.50,
+            "accel_lo": 0.10,
+        }
+    )
+    GAMMA: Dict[str, Any] = field(
+        default_factory=lambda: {"type": "none", "beta": 0.0, "R0": 0.0}
+    )
+    CALLBACKS_STRICT: bool = False
+    VALIDATORS_STRICT: bool = False
 
-    # --- Selector multiobjetivo ---
-    # Ponderaciones (se reescalan a 1 automáticamente)
-    "SELECTOR_WEIGHTS": {"w_si": 0.5, "w_dnfr": 0.3, "w_accel": 0.2},
-    # Umbrales hi/lo para decidir categorías (trabajan con |ΔNFR|_norm y |accel|_norm)
-    "SELECTOR_THRESHOLDS": {
-        "si_hi": 0.66, "si_lo": 0.33,
-        "dnfr_hi": 0.50, "dnfr_lo": 0.10,
-        "accel_hi": 0.50, "accel_lo": 0.10
-    },
-    # Callbacks Γ(R)
-    "GAMMA": {
-        "type": "none",  # 'none' | 'kuramoto_linear' | 'kuramoto_bandpass'
-        "beta": 0.0,
-        "R0": 0.0,
-    },
-    "CALLBACKS_STRICT": False,  # si True, un error en callback detiene; si False, se loguea y continúa
-    "VALIDATORS_STRICT": False, # si True, alerta si se clampa fuera de rango
-}
 
-# --- Retrocompatibilidad: alias deprecados ---
+@dataclass(frozen=True)
+class InitDefaults:
+    INIT_RANDOM_PHASE: bool = True
+    INIT_THETA_MIN: float = -math.pi
+    INIT_THETA_MAX: float = math.pi
+    INIT_VF_MODE: str = "uniform"
+    INIT_VF_MIN: float | None = None
+    INIT_VF_MAX: float | None = None
+    INIT_VF_MEAN: float = 0.5
+    INIT_VF_STD: float = 0.15
+    INIT_VF_CLAMP_TO_LIMITS: bool = True
+
+
+@dataclass(frozen=True)
+class RemeshDefaults:
+    EPS_DNFR_STABLE: float = 1e-3
+    EPS_DEPI_STABLE: float = 1e-3
+    FRACTION_STABLE_REMESH: float = 0.80
+    REMESH_COOLDOWN_VENTANA: int = 20
+    REMESH_COOLDOWN_TS: float = 0.0
+    REMESH_REQUIRE_STABILITY: bool = True
+    REMESH_STABILITY_WINDOW: int = 25
+    REMESH_MIN_PHASE_SYNC: float = 0.85
+    REMESH_MAX_GLYPH_DISR: float = 0.35
+    REMESH_MIN_SIGMA_MAG: float = 0.50
+    REMESH_MIN_KURAMOTO_R: float = 0.80
+    REMESH_MIN_SI_HI_FRAC: float = 0.50
+    REMESH_LOG_EVENTS: bool = True
+    REMESH_MODE: str = "knn"
+    REMESH_COMMUNITY_K: int = 2
+    REMESH_TAU_GLOBAL: int = 8
+    REMESH_TAU_LOCAL: int = 4
+    REMESH_ALPHA: float = 0.5
+    REMESH_ALPHA_HARD: bool = False
+
+
+@dataclass(frozen=True)
+class MetricDefaults:
+    PHASE_HISTORY_MAXLEN: int = 50
+    STOP_EARLY: Dict[str, Any] = field(
+        default_factory=lambda: {"enabled": False, "window": 25, "fraction": 0.90}
+    )
+    SIGMA: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "weight": "Si",      # "Si" | "EPI" | "1"
+            "smooth": 0.0,        # EMA sobre el vector global (0=off)
+            "history_key": "sigma_global",
+            "per_node": False,
+        }
+    )
+    TRACE: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "capture": [
+                "gamma",
+                "grammar",
+                "selector",
+                "dnfr_weights",
+                "si_weights",
+                "callbacks",
+                "thol_state",
+                "sigma",
+                "kuramoto",
+                "glifo_counts",
+            ],
+            "history_key": "trace_meta",
+        }
+    )
+    METRICS: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "save_by_node": True,
+            "normalize_series": False,
+        }
+    )
+    GRAMMAR_CANON: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "zhir_requires_oz_window": 3,
+            "zhir_dnfr_min": 0.05,
+            "thol_min_len": 2,
+            "thol_max_len": 6,
+            "thol_close_dnfr": 0.15,
+            "si_high": 0.66,
+        }
+    )
+    COHERENCE: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "scope": "neighbors",
+            "weights": {"phase": 0.34, "epi": 0.33, "vf": 0.20, "si": 0.13},
+            "self_on_diag": True,
+            "store_mode": "sparse",
+            "threshold": 0.0,
+            "history_key": "W_sparse",
+            "Wi_history_key": "W_i",
+            "stats_history_key": "W_stats",
+        }
+    )
+    DIAGNOSIS: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": True,
+            "window": 16,
+            "history_key": "nodal_diag",
+            "stable": {"Rloc_hi": 0.80, "dnfr_lo": 0.20, "persist": 3},
+            "dissonance": {"Rloc_lo": 0.40, "dnfr_hi": 0.50, "persist": 3},
+            "transition": {"persist": 2},
+            "compute_symmetry": True,
+            "include_typology": False,
+            "advice": {
+                "stable": ["Coherencia", "Acoplamiento", "Resonancia"],
+                "transition": ["Transición", "Resonancia", "Autoorganización"],
+                "dissonant": ["Silencio", "Contracción", "Mutación"],
+            },
+        }
+    )
+    EPI_SUPPORT_THR: float = 0.05
+    GLYPH_LOAD_WINDOW: int = 50
+    WBAR_WINDOW: int = 25
+
+
+# -------------------------
+# Construcción de diccionarios
+# -------------------------
+CORE_DEFAULTS = asdict(CoreDefaults())
+INIT_DEFAULTS = asdict(InitDefaults())
+REMESH_DEFAULTS = asdict(RemeshDefaults())
+_metric_defaults_obj = MetricDefaults()
+METRIC_DEFAULTS = asdict(_metric_defaults_obj)
+
+# Mapping proxies para acceso de solo lectura
+SIGMA = MappingProxyType(METRIC_DEFAULTS["SIGMA"])
+TRACE = MappingProxyType(METRIC_DEFAULTS["TRACE"])
+METRICS = MappingProxyType(METRIC_DEFAULTS["METRICS"])
+GRAMMAR_CANON = MappingProxyType(METRIC_DEFAULTS["GRAMMAR_CANON"])
+COHERENCE = MappingProxyType(METRIC_DEFAULTS["COHERENCE"])
+DIAGNOSIS = MappingProxyType(METRIC_DEFAULTS["DIAGNOSIS"])
+
+# Diccionario combinado exportado
+DEFAULTS: Dict[str, Any] = {}
+DEFAULTS.update(CORE_DEFAULTS)
+DEFAULTS.update(INIT_DEFAULTS)
+DEFAULTS.update(REMESH_DEFAULTS)
+DEFAULTS.update(METRIC_DEFAULTS)
+
+
+# -------------------------
+# Retrocompatibilidad y aliases
+# -------------------------
 # "REMESH_TAU" era el nombre original para la memoria de REMESH. Hoy se
-# desglosa en ``REMESH_TAU_GLOBAL`` y ``REMESH_TAU_LOCAL``. Conservamos el
-# alias para proyectos históricos pero se advierte su uso.
+# desglosa en ``REMESH_TAU_GLOBAL`` y ``REMESH_TAU_LOCAL``.
 ALIASES: Dict[str, tuple[str, ...]] = {
     "REMESH_TAU": ("REMESH_TAU_GLOBAL", "REMESH_TAU_LOCAL"),
 }
-
-# --- Configuraciones por defecto exportadas ---
-SIGMA = MappingProxyType(DEFAULTS.setdefault("SIGMA", {
-    "enabled": True,
-    "weight": "Si",      # "Si" | "EPI" | "1"
-    "smooth": 0.0,        # EMA sobre el vector global (0=off)
-    "history_key": "sigma_global",   # dónde guardar en G.graph['history']
-    "per_node": False,    # si True, guarda trayectoria σ por nodo (más pesado)
-}))
-
-TRACE = MappingProxyType(DEFAULTS.setdefault("TRACE", {
-    "enabled": True,
-    "capture": ["gamma", "grammar", "selector", "dnfr_weights", "si_weights", "callbacks", "thol_state", "sigma", "kuramoto", "glifo_counts"],
-    "history_key": "trace_meta",
-}))
-
-METRICS = MappingProxyType(DEFAULTS.setdefault("METRICS", {
-    "enabled": True,
-    "save_by_node": True,     # guarda Tg por nodo (más pesado)
-    "normalize_series": False # glifograma normalizado a fracción por paso
-}))
-
-# Gramática glífica canónica
-GRAMMAR_CANON = MappingProxyType(DEFAULTS.setdefault("GRAMMAR_CANON", {
-    "enabled": True,                # activar la gramática canónica
-    "zhir_requires_oz_window": 3,   # cuántos pasos atrás buscamos OZ
-    "zhir_dnfr_min": 0.05,          # si |ΔNFR|_norm < este valor, no permitimos ZHIR sin OZ
-    "thol_min_len": 2,
-    "thol_max_len": 6,
-    "thol_close_dnfr": 0.15,        # si el campo calma, cerramos con SHA/NUL
-    "si_high": 0.66,                # umbral para elegir NUL vs SHA al cerrar
-}))
-
-# --- Coherencia (W) ---
-COHERENCE = MappingProxyType(DEFAULTS.setdefault("COHERENCE", {
-    "enabled": True,
-    "scope": "neighbors",      # "neighbors" | "all"
-    "weights": {
-        "phase": 0.34,
-        "epi": 0.33,
-        "vf": 0.20,
-        "si": 0.13,
-    },
-    "self_on_diag": True,      # W_ii = 1.0
-    "store_mode": "sparse",   # "sparse" | "dense"
-    "threshold": 0.0,
-    "history_key": "W_sparse",
-    "Wi_history_key": "W_i",
-    "stats_history_key": "W_stats",
-}))
-
-# --- Diagnóstico nodal ---
-DIAGNOSIS = MappingProxyType(DEFAULTS.setdefault("DIAGNOSIS", {
-    "enabled": True,
-    "window": 16,
-    "history_key": "nodal_diag",
-    "stable":     {"Rloc_hi": 0.80, "dnfr_lo": 0.20, "persist": 3},
-    "dissonance": {"Rloc_lo": 0.40, "dnfr_hi": 0.50, "persist": 3},
-    "transition": {"persist": 2},
-    "compute_symmetry": True,
-    "include_typology": False,
-    "advice": {
-        "stable":     ["Coherencia", "Acoplamiento", "Resonancia"],
-        "transition": ["Transición", "Resonancia", "Autoorganización"],
-        "dissonant":  ["Silencio", "Contracción", "Mutación"],
-    },
-}))
 
 
 # -------------------------
@@ -269,24 +274,27 @@ DIAGNOSIS = MappingProxyType(DEFAULTS.setdefault("DIAGNOSIS", {
 # -------------------------
 
 def attach_defaults(G, override: bool = False) -> None:
-    """Escribe DEFAULTS en G.graph (sin sobreescribir si override=False)."""
+    """Escribe ``DEFAULTS`` combinados en ``G.graph``.
+
+    Si ``override`` es ``True`` se sobreescriben valores ya presentes.
+    """
     inject_defaults(G, DEFAULTS, override=override)
 
 
-def inject_defaults(G, defaults: Dict[str, Any] = DEFAULTS, override: bool = False) -> None:
-    """Alias de conveniencia para inyectar ``DEFAULTS`` en ``G.graph``.
+def inject_defaults(
+    G, defaults: Dict[str, Any] = DEFAULTS, override: bool = False
+) -> None:
+    """Inyecta ``defaults`` en ``G.graph``.
 
-    Permite pasar un diccionario de *defaults* alternativo y mantiene la
-    semántica de ``attach_defaults`` existente. Si ``override`` es ``True`` se
-    sobreescriben valores ya presentes.
+    ``defaults`` suele ser ``DEFAULTS``, que combina todos los sub-diccionarios.
+    Si ``override`` es ``True`` se sobreescriben valores ya presentes.
     """
     G.graph.setdefault("_tnfr_defaults_attached", False)
     for k, v in defaults.items():
         if override or k not in G.graph:
             G.graph[k] = v
     G.graph["_tnfr_defaults_attached"] = True
-    # Prepare deterministic node offset mapping once defaults are attached.
-    try:  # local import to avoid circular dependency at module import time
+    try:  # local import to evitar dependencia circular
         from .operators import _ensure_node_offset_map
 
         _ensure_node_offset_map(G)
@@ -295,20 +303,13 @@ def inject_defaults(G, defaults: Dict[str, Any] = DEFAULTS, override: bool = Fal
 
 
 def merge_overrides(G, **overrides) -> None:
-    """Aplica cambios puntuales a G.graph.
-    Útil para ajustar pesos sin tocar DEFAULTS globales.
-    """
+    """Aplica cambios puntuales a ``G.graph``."""
     for k, v in overrides.items():
         G.graph[k] = v
 
 
 def get_param(G, key: str):
-    """Recupera parámetro desde ``G.graph`` resolviendo aliases legados.
-
-    Si el ``key`` no está presente, se busca un alias en ``ALIASES`` y se
-    emite ``DeprecationWarning`` cuando se utiliza el nombre antiguo.
-    Finalmente se recurre a ``DEFAULTS``.
-    """
+    """Recupera parámetro desde ``G.graph`` resolviendo aliases legados."""
     if key in G.graph:
         return G.graph[key]
     for alias, targets in ALIASES.items():
@@ -323,14 +324,14 @@ def get_param(G, key: str):
 
 
 # Alias exportados por conveniencia (evita imports circulares)
-ALIAS_VF     = ("νf", "nu_f", "nu-f", "nu", "freq", "frequency")
-ALIAS_THETA  = ("θ", "theta", "fase", "phi", "phase")
-ALIAS_DNFR   = ("ΔNFR", "delta_nfr", "dnfr")
-ALIAS_EPI    = ("EPI", "psi", "PSI", "value")
+ALIAS_VF = ("νf", "nu_f", "nu-f", "nu", "freq", "frequency")
+ALIAS_THETA = ("θ", "theta", "fase", "phi", "phase")
+ALIAS_DNFR = ("ΔNFR", "delta_nfr", "dnfr")
+ALIAS_EPI = ("EPI", "psi", "PSI", "value")
 ALIAS_EPI_KIND = ("EPI_kind", "epi_kind", "source_glifo")
-ALIAS_SI     = ("Si", "sense_index", "S_i", "sense", "meaning_index")
-ALIAS_dEPI   = ("dEPI_dt", "dpsi_dt", "dEPI", "velocity")
-ALIAS_D2EPI  = ("d2EPI_dt2", "d2psi_dt2", "d2EPI", "accel")
-ALIAS_dVF    = ("dνf_dt", "dvf_dt", "dnu_dt", "dvf")
-ALIAS_D2VF   = ("d2νf_dt2", "d2vf_dt2", "d2nu_dt2", "B")
-ALIAS_dSI    = ("δSi", "delta_Si", "dSi")
+ALIAS_SI = ("Si", "sense_index", "S_i", "sense", "meaning_index")
+ALIAS_dEPI = ("dEPI_dt", "dpsi_dt", "dEPI", "velocity")
+ALIAS_D2EPI = ("d2EPI_dt2", "d2psi_dt2", "d2EPI", "accel")
+ALIAS_dVF = ("dνf_dt", "dvf_dt", "dnu_dt", "dvf")
+ALIAS_D2VF = ("d2νf_dt2", "d2vf_dt2", "d2nu_dt2", "B")
+ALIAS_dSI = ("δSi", "delta_Si", "dSi")

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -7,7 +7,7 @@ import math
 import random
 import networkx as nx
 
-from .constants import DEFAULTS
+from .constants import DEFAULTS, INIT_DEFAULTS
 
 
 def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
@@ -21,25 +21,31 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     ``EPI`` mediante ``INIT_EPI_VALUE``.
     """
     seed = int(G.graph.get("RANDOM_SEED", 0))
-    init_rand_phase = bool(G.graph.get("INIT_RANDOM_PHASE", DEFAULTS.get("INIT_RANDOM_PHASE", True)))
+    init_rand_phase = bool(
+        G.graph.get("INIT_RANDOM_PHASE", INIT_DEFAULTS["INIT_RANDOM_PHASE"])
+    )
 
-    th_min = float(G.graph.get("INIT_THETA_MIN", DEFAULTS.get("INIT_THETA_MIN", -math.pi)))
-    th_max = float(G.graph.get("INIT_THETA_MAX", DEFAULTS.get("INIT_THETA_MAX", math.pi)))
+    th_min = float(G.graph.get("INIT_THETA_MIN", INIT_DEFAULTS["INIT_THETA_MIN"]))
+    th_max = float(G.graph.get("INIT_THETA_MAX", INIT_DEFAULTS["INIT_THETA_MAX"]))
 
-    vf_mode = str(G.graph.get("INIT_VF_MODE", DEFAULTS.get("INIT_VF_MODE", "uniform"))).lower()
+    vf_mode = str(
+        G.graph.get("INIT_VF_MODE", INIT_DEFAULTS["INIT_VF_MODE"])
+    ).lower()
     vf_min_lim = float(G.graph.get("VF_MIN", DEFAULTS["VF_MIN"]))
     vf_max_lim = float(G.graph.get("VF_MAX", DEFAULTS["VF_MAX"]))
 
-    vf_uniform_min = G.graph.get("INIT_VF_MIN", DEFAULTS.get("INIT_VF_MIN", None))
-    vf_uniform_max = G.graph.get("INIT_VF_MAX", DEFAULTS.get("INIT_VF_MAX", None))
+    vf_uniform_min = G.graph.get("INIT_VF_MIN", INIT_DEFAULTS.get("INIT_VF_MIN"))
+    vf_uniform_max = G.graph.get("INIT_VF_MAX", INIT_DEFAULTS.get("INIT_VF_MAX"))
     if vf_uniform_min is None:
         vf_uniform_min = vf_min_lim
     if vf_uniform_max is None:
         vf_uniform_max = vf_max_lim
 
-    vf_mean = float(G.graph.get("INIT_VF_MEAN", DEFAULTS.get("INIT_VF_MEAN", 0.5)))
-    vf_std = float(G.graph.get("INIT_VF_STD", DEFAULTS.get("INIT_VF_STD", 0.15)))
-    clamp_to_limits = bool(G.graph.get("INIT_VF_CLAMP_TO_LIMITS", DEFAULTS.get("INIT_VF_CLAMP_TO_LIMITS", True)))
+    vf_mean = float(G.graph.get("INIT_VF_MEAN", INIT_DEFAULTS["INIT_VF_MEAN"]))
+    vf_std = float(G.graph.get("INIT_VF_STD", INIT_DEFAULTS["INIT_VF_STD"]))
+    clamp_to_limits = bool(
+        G.graph.get("INIT_VF_CLAMP_TO_LIMITS", INIT_DEFAULTS["INIT_VF_CLAMP_TO_LIMITS"])
+    )
 
     si_min = float(G.graph.get("INIT_SI_MIN", 0.4))
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))

--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -11,6 +11,7 @@ from math import cos
 
 from .constants import (
     DEFAULTS,
+    METRIC_DEFAULTS,
     ALIAS_EPI,
     ALIAS_THETA,
     ALIAS_DNFR,
@@ -158,7 +159,7 @@ def _metrics_step(G, *args, **kwargs):
     hist = ensure_history(G)
     dt = float(G.graph.get("DT", 1.0))
     t = float(G.graph.get("_t", 0.0))
-    thr = float(G.graph.get("EPI_SUPPORT_THR", DEFAULTS.get("EPI_SUPPORT_THR", 0.0)))
+    thr = float(G.graph.get("EPI_SUPPORT_THR", METRIC_DEFAULTS.get("EPI_SUPPORT_THR", 0.0)))
 
     save_by_node = bool(G.graph.get("METRICS", METRICS).get("save_by_node", True))
     counts, n_total, n_latent = _update_tg(G, hist, dt, save_by_node)

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,7 +8,7 @@ from typing import Dict, Any
 import math
 import statistics as st
 
-from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
+from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI, METRIC_DEFAULTS
 from .helpers import get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
 from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
 
@@ -116,6 +116,6 @@ def wbar(G, window: int | None = None) -> float:
         # fallback: coherencia instantánea
         return coherencia_global(G)
     if window is None:
-        window = int(G.graph.get("WBAR_WINDOW", 25))
+        window = int(G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25)))
     w = min(len(cs), max(1, int(window)))
     return float(sum(cs[-w:]) / w)

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import networkx as nx
 from collections import deque
 
-from .constants import DEFAULTS, attach_defaults, get_param
+from .constants import DEFAULTS, METRIC_DEFAULTS, attach_defaults, get_param
 from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
@@ -21,7 +21,7 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         from .constants import merge_overrides
         merge_overrides(G, **overrides)
     # Inicializaciones blandas
-    ph_len = int(G.graph.get("PHASE_HISTORY_MAXLEN", DEFAULTS.get("PHASE_HISTORY_MAXLEN", 50)))
+    ph_len = int(G.graph.get("PHASE_HISTORY_MAXLEN", METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"]))
     G.graph.setdefault("history", {
         "C_steps": [],
         "stable_frac": [],

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import pytest
 
-from tnfr.constants import inject_defaults, DEFAULTS
+from tnfr.constants import inject_defaults
 from tnfr.scenarios import build_graph
 from tnfr.dynamics import step
 
@@ -9,7 +9,7 @@ from tnfr.dynamics import step
 @pytest.mark.parametrize("method", ["euler", "rk4"])
 def test_epi_limits_preserved(method):
     G = build_graph(n=6, topology="ring", seed=1)
-    inject_defaults(G, DEFAULTS)
+    inject_defaults(G)
     G.graph["INTEGRATOR_METHOD"] = method
     G.graph["DT_MIN"] = 0.1
     G.graph["GAMMA"] = {"type": "none"}

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -2,12 +2,7 @@ from __future__ import annotations
 import math
 import pytest
 
-from tnfr.constants import inject_defaults, DEFAULTS
-from tnfr.scenarios import build_graph
-import math
-import pytest
-
-from tnfr.constants import inject_defaults, DEFAULTS
+from tnfr.constants import inject_defaults
 from tnfr.scenarios import build_graph
 from tnfr.dynamics import step, _update_history
 from tnfr.operators import aplicar_glifo, aplicar_remesh_si_estabilizacion_global
@@ -17,7 +12,7 @@ from tnfr.types import Glyph
 @pytest.fixture
 def G_small():
     G = build_graph(n=8, topology="ring", seed=7)
-    inject_defaults(G, DEFAULTS)
+    inject_defaults(G)
     _update_history(G)
     return G
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,6 @@ import pytest
 from tnfr.scenarios import build_graph
 from tnfr.constants import (
     inject_defaults,
-    DEFAULTS,
     ALIAS_EPI_KIND,
     ALIAS_EPI,
     ALIAS_VF,
@@ -14,7 +13,7 @@ from tnfr.config import load_config
 
 def _base_graph():
     G = build_graph(n=4, topology="ring", seed=1)
-    inject_defaults(G, DEFAULTS)
+    inject_defaults(G)
     return G
 
 


### PR DESCRIPTION
## Summary
- Organize global defaults into typed dataclasses and thematic dictionaries
- Update engine modules to read from the new default subsets
- Simplify tests to rely on `inject_defaults` without passing `DEFAULTS`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4d7fd1d208321b56bacada3c0155e