### PR TITLE
Ensure THOL close token uses Glyph

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -124,7 +124,7 @@ def _load_sequence(path: Path) -> List[Any]:
         "THOL": lambda spec: block(
             *parse_tokens(spec.get("body", [])),
             repeat=int(spec.get("repeat", 1)),
-            close=spec.get("close"),
+            close=Glyph(spec.get("close")) if isinstance(spec.get("close"), str) else spec.get("close"),
         ),
     }
 


### PR DESCRIPTION
## Summary
- Cast `close` values to `Glyph` when parsing THOL tokens

## Testing
- `PYTHONPATH=src pytest tests/test_program.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e14a524883219757b6dd711bedec