### PR TITLE
chore: remove unused ALIAS_EPI import

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, Set, Iterable, Optional
 
 from .constants import (
     DEFAULTS,
-    ALIAS_SI, ALIAS_DNFR, ALIAS_EPI,
+    ALIAS_SI, ALIAS_DNFR,
     get_param,
 )
 from .helpers import get_attr, clamp01, reciente_glifo


### PR DESCRIPTION
## Summary
- remove unused ALIAS_EPI import from grammar module

## Testing
- `pyflakes src/tnfr/grammar.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4ef5f4d008321b85d74f15cbb6e42