### PR TITLE
refactor: prune unused imports in observers

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -4,11 +4,10 @@ observers.py — TNFR canónica
 Observadores y métricas auxiliares.
 """
 from __future__ import annotations
-from typing import Dict, Any
 import math
 import statistics as st
 
-from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI, METRIC_DEFAULTS
+from .constants import ALIAS_DNFR, ALIAS_THETA, ALIAS_dEPI, METRIC_DEFAULTS
 from .helpers import get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
 from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
 


### PR DESCRIPTION
## Summary
- remove unused Dict and Any imports from observers
- drop unused ALIAS_EPI constant import

## Testing
- `pyflakes src/tnfr/observers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1bfaebc83219d4be370f5a8d975