### PR TITLE
Refactor DNFR loop to use enumerate

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -188,8 +188,7 @@ def _compute_dnfr_loops(G, data) -> None:
     degs = data["degs"]
     cos_th = [math.cos(t) for t in theta]
     sin_th = [math.sin(t) for t in theta]
-    for n in nodes:
-        i = idx[n]
+    for i, n in enumerate(nodes):
         th_i = theta[i]
         epi_i = epi[i]
         vf_i = vf[i]


### PR DESCRIPTION
## Summary
- Simplify main DNFR loop by iterating with `enumerate(nodes)`
- Remove redundant node index lookup for current node while keeping neighbor mapping

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5010cb9d4832193407515c201aa0b