### PR TITLE
refactor: simplify callback registration

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -403,20 +403,18 @@ def _ensure_callbacks(G):
 
 def register_callback(
     G,
-    event: str | None = None,
+    event: str,
     func=None,
     *,
-    when: str | None = None,
     name: str | None = None,
 ):
     """Registra ``func`` como callback del ``event`` indicado.
 
     Permite tanto la forma posicional ``register_callback(G, "after_step", fn)``
-    como la forma con palabras clave ``register_callback(G, when="after_step", func=fn)``.
+    como la forma con palabras clave ``register_callback(G, event="after_step", func=fn)``.
     El parámetro ``name`` ahora se almacena junto con la función para facilitar
     su identificación.
     """
-    event = event or when
     if event not in ("before_step", "after_step", "on_remesh"):
         raise ValueError(f"Evento desconocido: {event}")
     if func is None:

--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -178,7 +178,7 @@ def _metrics_step(G, *args, **kwargs):
 # -------------
 
 def register_metrics_callbacks(G) -> None:
-    register_callback(G, when="after_step", func=_metrics_step, name="metrics_step")
+    register_callback(G, event="after_step", func=_metrics_step, name="metrics_step")
     # Nuevas funcionalidades canónicas
     register_coherence_callbacks(G)
     register_diagnosis_callbacks(G)
@@ -541,7 +541,7 @@ def _coherence_step(G, ctx=None):
 
 
 def register_coherence_callbacks(G) -> None:
-    register_callback(G, when="after_step", func=_coherence_step, name="coherence_step")
+    register_callback(G, event="after_step", func=_coherence_step, name="coherence_step")
 
 
 # =========================
@@ -683,6 +683,6 @@ def dissonance_events(G, ctx=None):
 
 
 def register_diagnosis_callbacks(G) -> None:
-    register_callback(G, when="after_step", func=_diagnosis_step, name="diagnosis_step")
-    register_callback(G, when="after_step", func=dissonance_events, name="dissonance_events")
+    register_callback(G, event="after_step", func=_diagnosis_step, name="diagnosis_step")
+    register_callback(G, event="after_step", func=dissonance_events, name="dissonance_events")
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -201,7 +201,7 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
 # -------------------------
 
 def register_sigma_callback(G) -> None:
-    register_callback(G, when="after_step", func=push_sigma_snapshot, name="sigma_snapshot")
+    register_callback(G, event="after_step", func=push_sigma_snapshot, name="sigma_snapshot")
 
 
 # -------------------------

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -155,7 +155,7 @@ def register_trace(G) -> None:
     if G.graph.get("_trace_registered"):
         return
 
-    register_callback(G, when="before_step", func=_trace_before, name="trace_before")
-    register_callback(G, when="after_step", func=_trace_after, name="trace_after")
+    register_callback(G, event="before_step", func=_trace_before, name="trace_before")
+    register_callback(G, event="after_step", func=_trace_after, name="trace_after")
 
     G.graph["_trace_registered"] = True

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -23,7 +23,7 @@ def test_trace_metadata_contains_callback_names(graph_canon):
     def foo(G, ctx):
         pass
 
-    register_callback(G, when="before_step", func=foo, name="custom_cb")
+    register_callback(G, event="before_step", func=foo, name="custom_cb")
     invoke_callbacks(G, "before_step")
 
     hist = G.graph["history"]["trace_meta"]


### PR DESCRIPTION
## Summary
- drop `when` parameter from `register_callback` and streamline docs
- update all callback registrations to use the single `event` parameter

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5075de2e083219e456b0a19cadb44