### PR TITLE
Pretty-print JSON export

### DIFF
--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -64,4 +64,4 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     else:
         data = {"glifogram": glifo, "sigma": sigma, "morph": morph, "epi_support": epi_supp}
         with open(base_path + ".json", "w", encoding="utf-8") as f:
-            json.dump(data, f)
+            json.dump(data, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- Pretty-print exported history JSON and preserve non-ASCII characters.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5218e127083218a3c8d12bbb284f5