### PR TITLE
Refactor jitter cache using LRU and add deterministic test

### DIFF
--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,32 +1,38 @@
 from tnfr.node import NodoNX
-from tnfr.operators import random_jitter, _GLOBAL_JITTER_CACHE
+from tnfr.operators import random_jitter, clear_jitter_cache
 from tnfr.operators import op_UM
 from tnfr.constants import attach_defaults
 import networkx as nx
 
 
 def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
-    _GLOBAL_JITTER_CACHE.clear()
+    clear_jitter_cache()
     G = graph_canon()
     G.add_node(0)
     n0 = NodoNX(G, 0)
 
-    # Without explicit cache: uses global cache and advances sequence
+    # Without explicit cache: uses global LRU cache and advances sequence
     j1 = random_jitter(n0, 0.5)
     j2 = random_jitter(n0, 0.5)
     assert j1 != j2
 
-    # With explicit cache: reproduces deterministic sequence
+    # Clearing the LRU cache reproduces the deterministic sequence
+    clear_jitter_cache()
+    j3 = random_jitter(n0, 0.5)
+    j4 = random_jitter(n0, 0.5)
+    assert [j3, j4] == [j1, j2]
+
+    # With explicit cache: reproduces deterministic sequence independently
     cache = {}
-    j3 = random_jitter(n0, 0.5, cache)
-    j4 = random_jitter(n0, 0.5, cache)
-    assert j3 == j1
-    assert j4 == j2
+    j5 = random_jitter(n0, 0.5, cache)
+    j6 = random_jitter(n0, 0.5, cache)
+    assert j5 == j1
+    assert j6 == j2
 
     # Replaying with a fresh cache reproduces the sequence
     cache2 = {}
     seq = [random_jitter(n0, 0.5, cache2) for _ in range(2)]
-    assert seq == [j3, j4]
+    assert seq == [j5, j6]
 
 
 def test_um_candidate_subset_proximity():


### PR DESCRIPTION
## Summary
- replace global jitter cache with `functools.lru_cache`
- document LRU eviction policy in `random_jitter`
- test deterministic jitter behaviour with cache clearing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5265ed7448321944ac69dc5cbdbeb