### PR TITLE
refactor: use update for graph overrides

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -70,8 +70,7 @@ def inject_defaults(
 
 def merge_overrides(G, **overrides) -> None:
     """Aplica cambios puntuales a ``G.graph``."""
-    for k, v in overrides.items():
-        G.graph[k] = v
+    G.graph.update(overrides)
 
 
 def get_param(G, key: str):


### PR DESCRIPTION
## Summary
- simplify `merge_overrides` by using `G.graph.update` to apply overrides in a single call

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b55d67cbcc83219ee0f9bb85bc348f