### PR TITLE
refactor: use list_mean for latency

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -30,7 +30,7 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
-from .helpers import read_structured_file
+from .helpers import read_structured_file, list_mean
 from .observers import attach_standard_observer
 from . import __version__
 
@@ -270,7 +270,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         if lat["value"]:
             logger.info(
                 "Latencia media: %s",
-                sum(lat["value"]) / max(1, len(lat["value"])) ,
+                list_mean(lat["value"], 0.0),
             )
     return 0
 
@@ -310,7 +310,7 @@ def cmd_metrics(args: argparse.Namespace) -> int:
 
     out = {
         "Tg_global": tg,
-        "latency_mean": (sum(lat["value"]) / max(1, len(lat["value"])) ) if lat["value"] else 0.0,
+        "latency_mean": list_mean(lat["value"], 0.0),
         "rose": rose,
         "glifogram": {k: v[:10] for k, v in glifo.items()},
     }


### PR DESCRIPTION
## Summary
- use `list_mean` to calculate mean latency in CLI metrics
- import helper for list-based mean computation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56714b2b08321a7746cf506743b8e