### PR TITLE
docs: fix args_to_dict docstring

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -114,7 +114,8 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
         Namespace produced by ``argparse``.
     prefix:
         Prefix to match against the argument names.  It must include the
-        trailing underscore, for example ``"grammar_"``.
+        trailing underscore, for example ``"grammar_"``.  Options with this
+        prefix are defined in :data:`GRAMMAR_ARG_SPECS`.
 
     Returns
     -------
@@ -123,9 +124,9 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
 
     Examples
     --------
-    >>> ns = argparse.Namespace(grammar_enabled=True, grammar_thol_min=2, other=1)
+    >>> ns = argparse.Namespace(grammar_enabled=True, grammar_thol_min_len=2, other=1)
     >>> _args_to_dict(ns, "grammar_")
-    {'enabled': True, 'thol_min': 2}
+    {'enabled': True, 'thol_min_len': 2}
     """
 
     return {


### PR DESCRIPTION
## Summary
- clarify `_args_to_dict` docstring to reference `GRAMMAR_ARG_SPECS`
- update example with valid grammar option `grammar_thol_min_len`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56d6e1068832192b1a958e5e5c977