### PR TITLE
chore: rely on default graph parameters

### DIFF
--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import networkx as nx
 
-from .constants import inject_defaults, DEFAULTS
+from .constants import inject_defaults
 from .initialization import init_node_attrs
 
 
@@ -28,7 +28,7 @@ def build_graph(
         raise ValueError(f"Invalid topology '{topology}'. Valid options are: {', '.join(valid)}")
 
     # Valores canónicos para inicialización
-    inject_defaults(G, DEFAULTS)
+    inject_defaults(G)
     if seed is not None:
         G.graph.setdefault("RANDOM_SEED", int(seed))
     init_node_attrs(G, override=True)


### PR DESCRIPTION
## Summary
- Simplify build_graph by letting inject_defaults use its internal defaults

## Testing
- `pytest tests/test_scenarios.py tests/test_canon.py tests/test_cli_sanity.py tests/test_invariants.py tests/test_integrators.py tests/test_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56e1876b48321a7bf1dde275439ae