### PR TITLE
Handle mismatched sigma lengths in export

### DIFF
--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -22,13 +22,17 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     hist = ensure_history(G)
     ensure_parent(base_path)
     glifo = glifogram_series(G)
+    sigma_x = hist.get("sense_sigma_x", [])
+    sigma_y = hist.get("sense_sigma_y", [])
     sigma_mag = hist.get("sense_sigma_mag", [])
+    sigma_angle = hist.get("sense_sigma_angle", [])
+    min_len = min(len(sigma_x), len(sigma_y), len(sigma_mag), len(sigma_angle))
     sigma = {
-        "t": list(range(len(sigma_mag))),
-        "sigma_x": hist.get("sense_sigma_x", []),
-        "sigma_y": hist.get("sense_sigma_y", []),
-        "mag": sigma_mag,
-        "angle": hist.get("sense_sigma_angle", []),
+        "t": list(range(min_len)),
+        "sigma_x": sigma_x[:min_len],
+        "sigma_y": sigma_y[:min_len],
+        "mag": sigma_mag[:min_len],
+        "angle": sigma_angle[:min_len],
     }
     morph = hist.get("morph", [])
     epi_supp = hist.get("EPI_support", [])
@@ -43,8 +47,10 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
         _write_csv(base_path + "_glifogram.csv", ["t", *GLYPHS_CANONICAL], glif_rows)
 
         sigma_rows = [
-            [t, sigma["sigma_x"][i], sigma["sigma_y"][i], sigma["mag"][i], sigma["angle"][i]]
-            for i, t in enumerate(sigma["t"])
+            [t, x, y, m, a]
+            for t, x, y, m, a in zip(
+                sigma["t"], sigma["sigma_x"], sigma["sigma_y"], sigma["mag"], sigma["angle"]
+            )
         ]
         _write_csv(base_path + "_sigma.csv", ["t", "x", "y", "mag", "angle"], sigma_rows)
 

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -46,3 +46,20 @@ def test_export_history_json_contains_optional(tmp_path, graph_canon):
     data = json.loads((base.with_suffix(".json")).read_text())
     assert data["morph"]
     assert data["epi_support"]
+
+
+def test_export_history_truncates_sigma(tmp_path, graph_canon):
+    base = tmp_path / "short" / "run"
+    G = graph_canon()
+    hist = G.graph.setdefault("history", {})
+    hist["sense_sigma_x"] = [1, 2]
+    hist["sense_sigma_y"] = [3]
+    hist["sense_sigma_mag"] = [4, 5, 6]
+    hist["sense_sigma_angle"] = [7, 8]
+    export_history(G, str(base), fmt="csv")
+    sigma_path = base.parent / (base.name + "_sigma.csv")
+    import csv
+    with open(sigma_path, newline="") as f:
+        rows = list(csv.reader(f))
+    assert rows[1] == ["0", "1", "3", "4", "7"]
+    assert len(rows) == 2


### PR DESCRIPTION
## Summary
- Trim sigma component histories to the common minimum length when exporting
- Use zipped iteration to write sigma rows safely
- Add test ensuring export truncates uneven sigma arrays

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b571dc15d483219a033c7af24248e5