### PR TITLE
Refactor reciente_glifo for efficient glyph lookup

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -396,8 +396,10 @@ def reciente_glifo(nd: Dict[str, Any], glifo: str, ventana: int) -> bool:
     gl = str(glifo)
     if ventana < 0:
         raise ValueError("ventana debe ser >= 0")
-    if hist and ventana > 0 and gl in list(hist)[-ventana:]:
-        return True
+    if hist and ventana > 0:
+        for reciente in islice(reversed(hist), ventana):
+            if gl == reciente:
+                return True
     # fallback al glifo dominante actual
     return get_attr_str(nd, ALIAS_EPI_KIND, "") == gl
 


### PR DESCRIPTION
## Summary
- Avoid list creation in `reciente_glifo` by iterating with `islice(reversed(hist), ventana)`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b576c88cb08321b0fbdf7a108c398b