### PR TITLE
Remove count normalization in fase_media

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -374,7 +374,7 @@ def fase_media(obj, n=None) -> float:
         count += 1
     if count == 0:
         return getattr(node, "theta", 0.0)
-    return math.atan2(y / count, x / count)
+    return math.atan2(y, x)
 
 
 # -------------------------


### PR DESCRIPTION
## Summary
- Simplify `fase_media` by removing neighbor count normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b577781e308321b6dcfe6668562c7d