### PR TITLE
Refactor history pruning to use generator

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -443,8 +443,8 @@ def ensure_history(G) -> Dict[str, Any]:
         G.graph["history"] = hist
 
     if maxlen > 0 and len(hist) > maxlen:
-        candidates = [k for k, v in hist.items() if isinstance(v, (list, deque))]
-        exceso = len(candidates) - maxlen
+        candidates = (k for k, v in hist.items() if isinstance(v, (list, deque)))
+        exceso = sum(1 for v in hist.values() if isinstance(v, (list, deque))) - maxlen
         if exceso > 0:
             for k in heapq.nsmallest(
                 exceso, candidates, key=lambda k: len(hist.get(k, []))


### PR DESCRIPTION
## Summary
- Replace list comprehension with generator in `ensure_history` for candidate key selection
- Call `heapq.nsmallest` directly on the generator and compute candidate count lazily

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57804d5908321b10444a2672b70d5