### PR TITLE
Use suffix variable in structured file error

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -85,7 +85,7 @@ def read_structured_file(path: Path) -> Any:
     """Lee un archivo JSON o YAML y devuelve los datos parseados."""
     suffix = path.suffix.lower()
     if suffix not in PARSERS:
-        raise ValueError(f"Extensión de archivo no soportada: {path.suffix}")
+        raise ValueError(f"Extensión de archivo no soportada: {suffix}")
     parser = PARSERS[suffix]
     try:
         text = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Use normalized `suffix` when reporting unsupported file extension in `read_structured_file`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b591c8b0b083219cc60090c81e95f9