### PR TITLE
feat: add sigma_vector_from_graph

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -18,7 +18,7 @@ from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
 from .grammar import enforce_canonical_grammar, on_applied_glifo, apply_glyph_with_grammar
 from .sense import (
     GLYPHS_CANONICAL, glyph_angle, glyph_unit,
-    sigma_vector_node, sigma_vector_global, sigma_vector,
+    sigma_vector_node, sigma_vector_from_graph, sigma_vector, sigma_vector_global,
     push_sigma_snapshot, sigma_series, sigma_rose,
     register_sigma_callback,
 )
@@ -66,7 +66,7 @@ __all__ = [
     "enforce_canonical_grammar", "on_applied_glifo",
     "apply_glyph_with_grammar",
     "GLYPHS_CANONICAL", "glyph_angle", "glyph_unit",
-    "sigma_vector_node", "sigma_vector_global", "sigma_vector",
+    "sigma_vector_node", "sigma_vector_from_graph", "sigma_vector", "sigma_vector_global",
     "push_sigma_snapshot", "sigma_series", "sigma_rose",
     "register_sigma_callback",
     "register_metrics_callbacks",

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -12,9 +12,9 @@ except ImportError:  # pragma: no cover
         return 0.0, 0.0
 
 try:
-    from .sense import sigma_vector_global
+    from .sense import sigma_vector_from_graph
 except ImportError:  # pragma: no cover
-    def sigma_vector_global(G, *args, **kwargs):
+    def sigma_vector_from_graph(G, *args, **kwargs):
         return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 # -------------------------
@@ -116,7 +116,7 @@ def _trace_after(G, *args, **kwargs):
         meta["kuramoto"] = {"R": float(R), "psi": float(psi)}
 
     if "sigma" in capture:
-        sv = sigma_vector_global(G)
+        sv = sigma_vector_from_graph(G)
         meta["sigma"] = {
             "x": float(sv.get("x", 0.0)),
             "y": float(sv.get("y", 0.0)),

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from .constants import ALIAS_EPI, ALIAS_VF, get_param
 from .helpers import get_attr
-from .sense import sigma_vector_global, GLYPHS_CANONICAL
+from .sense import sigma_vector_from_graph, GLYPHS_CANONICAL
 from .helpers import last_glifo
 
 
@@ -23,7 +23,7 @@ def _validate_epi_vf(G) -> None:
 
 
 def _validate_sigma(G) -> None:
-    sv = sigma_vector_global(G)
+    sv = sigma_vector_from_graph(G)
     if sv.get("mag", 0.0) > 1.0 + 1e-9:
         raise ValueError("Norma de σ excede 1")
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -12,11 +12,11 @@ def test_empty_graph_handling(graph_canon):
     update_epi_via_nodal_equation(G)  # should not raise
 
 
-def test_sigma_vector_global_empty_graph(graph_canon):
+def test_sigma_vector_from_graph_empty_graph(graph_canon):
     G = graph_canon()
-    from tnfr.sense import sigma_vector_global
+    from tnfr.sense import sigma_vector_from_graph
 
-    sv = sigma_vector_global(G)
+    sv = sigma_vector_from_graph(G)
     assert sv == {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -5,7 +5,7 @@ import pytest
 from tnfr.constants import ALIAS_THETA
 from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
 from tnfr.gamma import kuramoto_R_psi
-from tnfr.sense import sigma_vector_global, sigma_vector
+from tnfr.sense import sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, set_attr
 
@@ -58,7 +58,6 @@ def test_sigma_vector_consistency():
     # Distribución ficticia de glifos
     dist = {"IL": 0.4, "RA": 0.3, "ZHIR": 0.1, "AL": 0.2, "_count": 10}
 
-    res_global = sigma_vector_global(dist)
     res = sigma_vector(dist)
 
     # Cálculo esperado con el mapa de ángulos canónico
@@ -70,8 +69,7 @@ def test_sigma_vector_consistency():
     mag = math.hypot(x, y)
     ang = math.atan2(y, x)
 
-    for res_ in (res_global, res):
-        assert math.isclose(res_["x"], x)
-        assert math.isclose(res_["y"], y)
-        assert math.isclose(res_["mag"], mag)
-        assert math.isclose(res_["angle"], ang)
+    assert math.isclose(res["x"], x)
+    assert math.isclose(res["y"], y)
+    assert math.isclose(res["mag"], mag)
+    assert math.isclose(res["angle"], ang)

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -1,7 +1,7 @@
 import networkx as nx
 import pytest
 
-from tnfr.sense import sigma_vector_node, sigma_vector_global
+from tnfr.sense import sigma_vector_node, sigma_vector_from_graph
 from tnfr.types import Glyph
 
 
@@ -23,10 +23,10 @@ def test_sigma_vector_node_paths():
     assert sv_epi["mag"] == pytest.approx(2 * sv_si["mag"])
 
 
-def test_sigma_vector_global_paths():
+def test_sigma_vector_from_graph_paths():
     G = _make_graph()
-    sv_si = sigma_vector_global(G)
-    sv_epi = sigma_vector_global(G, weight_mode="EPI")
+    sv_si = sigma_vector_from_graph(G)
+    sv_epi = sigma_vector_from_graph(G, weight_mode="EPI")
     assert sv_si["n"] == 1
     assert sv_epi["n"] == 1
     assert sv_epi["mag"] == pytest.approx(2 * sv_si["mag"])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -39,7 +39,7 @@ def test_validator_sigma_norm(monkeypatch):
     def fake_sigma(G):
         return {"mag": 1.5}
 
-    monkeypatch.setattr("tnfr.validators.sigma_vector_global", fake_sigma)
+    monkeypatch.setattr("tnfr.validators.sigma_vector_from_graph", fake_sigma)
     with pytest.raises(ValueError):
         run_validators(G)
 


### PR DESCRIPTION
## Summary
- add sigma_vector_from_graph for NetworkX graphs
- keep sigma_vector for distributions and deprecate sigma_vector_global alias
- update validators, trace and tests to use new function

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5981dbc048321b77cd25a73fbf415