### PR TITLE
feat: add graph-scoped cache with size limit

### DIFF
--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -1,7 +1,7 @@
 import pytest
 import networkx as nx
 
-from tnfr.dynamics import default_compute_delta_nfr, _cached_nodes_and_A
+from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
 from tnfr.helpers import get_attr
 
@@ -23,16 +23,31 @@ def test_cache_invalidated_on_graph_change(vectorized):
 
     G = _setup_graph()
     G.graph["vectorized_dnfr"] = vectorized
-    default_compute_delta_nfr(G)
-    assert _cached_nodes_and_A.cache_info().currsize == 1
+    default_compute_delta_nfr(G, cache_size=2)
+    assert len(G.graph.get("_dnfr_cache", {})) == 1
     before = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
 
     G.add_edge(2, 3)  # Cambia número de nodos y aristas
     G.graph["vectorized_dnfr"] = vectorized
-    default_compute_delta_nfr(G)
-    assert _cached_nodes_and_A.cache_info().currsize == 1
+    default_compute_delta_nfr(G, cache_size=2)
+    assert len(G.graph.get("_dnfr_cache", {})) == 2
     after = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
 
     assert len(after) == 4
     assert before[2] != pytest.approx(after[2])
+
+    G.add_edge(3, 4)
+    G.graph["vectorized_dnfr"] = vectorized
+    default_compute_delta_nfr(G, cache_size=2)
+    assert len(G.graph.get("_dnfr_cache", {})) == 2
+
+
+def test_cache_is_per_graph():
+    G1 = _setup_graph()
+    G2 = _setup_graph()
+    default_compute_delta_nfr(G1)
+    default_compute_delta_nfr(G2)
+    assert G1.graph["_dnfr_cache"] is not G2.graph["_dnfr_cache"]
+    assert len(G1.graph["_dnfr_cache"]) == 1
+    assert len(G2.graph["_dnfr_cache"]) == 1
 


### PR DESCRIPTION
## Summary
- cache ΔNFR graph data inside each graph with optional size limit
- expose `cache_size` parameter to control cache and purge old entries
- test cache invalidation, purging and per-graph isolation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b599185f3c8321a6d6ab9d9ba8a3b8