### PR TITLE
style: format CANON_FALLBACK mapping

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -62,7 +62,18 @@ CANON_COMPAT: Dict[Glyph, Set[Glyph]] = {
 
 # Fallbacks canónicos si una transición no está permitida
 CANON_FALLBACK: Dict[Glyph, Glyph] = {
-    AL: EN, EN: IL, IL: RA, UM: RA, RA: IL, VAL: RA, OZ: ZHIR, ZHIR: IL, NAV: RA, SHA: AL, NUL: AL, THOL: NAV,
+    AL: EN,
+    EN: IL,
+    IL: RA,
+    NAV: RA,
+    NUL: AL,
+    OZ: ZHIR,
+    RA: IL,
+    SHA: AL,
+    THOL: NAV,
+    UM: RA,
+    VAL: RA,
+    ZHIR: IL,
 }
 
 # -------------------------


### PR DESCRIPTION
## Summary
- list each CANON_FALLBACK entry on its own line in alphabetical order

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59f69f35883218c802b52d8773d6f