### PR TITLE
Refactor selector hysteresis glyphs constant

### DIFF
--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -7,6 +7,9 @@ import networkx as nx
 from .constants import DEFAULTS, ALIAS_DNFR, ALIAS_D2EPI
 from .helpers import clamp01, get_attr
 
+
+HYSTERESIS_GLYPHS = ("IL", "OZ", "ZHIR", "THOL", "NAV", "RA")
+
 __all__ = [
     "_selector_thresholds",
     "_norms_para_selector",
@@ -85,7 +88,7 @@ def _apply_selector_hysteresis(
         hist = nd.get("hist_glifos")
         if hist:
             prev = hist[-1]
-            if isinstance(prev, str) and prev in ("IL", "OZ", "ZHIR", "THOL", "NAV", "RA"):
+            if isinstance(prev, str) and prev in HYSTERESIS_GLYPHS:
                 return prev
     return None
 


### PR DESCRIPTION
## Summary
- centralize hysteresis glyphs in a module constant
- reuse HYSTERESIS_GLYPHS in `_apply_selector_hysteresis`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a03ced7883218c2c69eb0188e662