### PR TITLE
Refactor gamma registry to include Kuramoto flag

### DIFF
--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -21,5 +21,6 @@ def test_gamma_kuramoto_tanh_registry(graph_canon):
     G.nodes[0]["θ"] = 0.0
     G.nodes[1]["θ"] = 0.0
     cfg = {"type": "kuramoto_tanh", "beta": 0.5, "k": 2.0, "R0": 0.0}
-    val = GAMMA_REGISTRY["kuramoto_tanh"](G, 0, 0.0, cfg)
+    gamma_fn, _ = GAMMA_REGISTRY["kuramoto_tanh"]
+    val = gamma_fn(G, 0, 0.0, cfg)
     assert abs(val) <= cfg["beta"]


### PR DESCRIPTION
## Summary
- Track whether gamma functions need Kuramoto precomputation via `(fn, needs_kuramoto)` tuples in `GAMMA_REGISTRY`
- Use the flag in `eval_gamma` instead of hard-coded type checks
- Adjust tests for new registry structure

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3eaad2c8321abb72d9ad2caaafa