### PR TITLE
Validate non-negative edge weights

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -147,6 +147,9 @@ class NodoTNFR:
             return
         if other in self._neighbors and not overwrite:
             return
+        weight = float(weight)
+        if weight < 0:
+            raise ValueError("Edge weight must be non-negative")
         self._neighbors[other] = weight
         other._neighbors[self] = weight
 
@@ -212,7 +215,10 @@ class NodoNX(NodoProtocol):
         if isinstance(other, NodoNX):
             if self.G.has_edge(self.n, other.n) and not overwrite:
                 return
-            self.G.add_edge(self.n, other.n, weight=float(weight))
+            weight = float(weight)
+            if weight < 0:
+                raise ValueError("Edge weight must be non-negative")
+            self.G.add_edge(self.n, other.n, weight=weight)
         else:
             raise NotImplementedError
 

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -1,5 +1,7 @@
 import math
-from tnfr.node import NodoTNFR
+import pytest
+import networkx as nx
+from tnfr.node import NodoTNFR, NodoNX
 
 
 def test_add_edge_stores_weight():
@@ -35,3 +37,23 @@ def test_add_edge_overwrite():
     a.add_edge(b, weight=2.0, overwrite=True)
     assert math.isclose(a.edge_weight(b), 2.0)
     assert math.isclose(b.edge_weight(a), 2.0)
+
+
+def test_add_edge_rejects_negative_weight():
+    a = NodoTNFR()
+    b = NodoTNFR()
+    with pytest.raises(ValueError):
+        a.add_edge(b, weight=-1.0)
+    assert not a.has_edge(b)
+    assert not b.has_edge(a)
+
+
+def test_add_edge_rejects_negative_weight_nx():
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_node(1)
+    a = NodoNX(G, 0)
+    b = NodoNX(G, 1)
+    with pytest.raises(ValueError):
+        a.add_edge(b, weight=-0.5)
+    assert not a.has_edge(b)


### PR DESCRIPTION
## Summary
- ensure NodoTNFR and NodoNX reject negative edge weights
- cover edge weight validation with new tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a6af8e908321808ad2eb5dc762df