### PR TITLE
Group grammar CLI options

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -226,9 +226,10 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
 
 def add_grammar_args(parser: argparse.ArgumentParser) -> None:
     """Agrega las opciones de gramática y de histéresis del glifo."""
+    group = parser.add_argument_group("Grammar")
     for opt, typ in GRAMMAR_ARG_SPECS:
         dest = opt.lstrip("-").replace(".", "_")
-        parser.add_argument(opt, dest=dest, type=typ, default=None)
+        group.add_argument(opt, dest=dest, type=typ, default=None)
 
 
 def add_history_export_args(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -35,6 +35,15 @@ def test_cli_run_erdos_p():
     assert rc == 0
 
 
+def test_grammar_args_help_group(capsys):
+    parser = argparse.ArgumentParser()
+    add_grammar_args(parser)
+    parser.print_help()
+    out = capsys.readouterr().out
+    assert "Grammar" in out
+    assert "--grammar.enabled" in out
+
+
 def test_args_to_dict_nested_options():
     parser = argparse.ArgumentParser()
     add_common_args(parser)


### PR DESCRIPTION
## Summary
- group grammar-related CLI flags under a dedicated "Grammar" argument group
- cover help grouping with a CLI test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b437eca88321a844c0d98bcc0db5