### PR TITLE
Validate THOL close glyph name before instantiation

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -63,14 +63,43 @@ def _parse_tokens(obj: Any) -> List[Any]:
     return out
 
 
+def parse_thol(spec: Dict[str, Any]) -> Any:
+    """Parsea la especificación de un bloque ``THOL``.
+
+    Parameters
+    ----------
+    spec:
+        Diccionario con las claves ``body``, ``repeat`` y ``close``.
+
+    Returns
+    -------
+    Any
+        Resultado de :func:`block` tras parsear los tokens del cuerpo.
+
+    Raises
+    ------
+    ValueError
+        Si ``close`` es una cadena que no corresponde a un nombre válido de
+        :class:`Glyph`.
+    """
+
+    close = spec.get("close")
+    if isinstance(close, str):
+        if close not in Glyph.__members__:
+            raise ValueError(f"Glifo de cierre desconocido: {close!r}")
+        close = Glyph[close]
+
+    return block(
+        *_parse_tokens(spec.get("body", [])),
+        repeat=int(spec.get("repeat", 1)),
+        close=close,
+    )
+
+
 TOKEN_MAP: Dict[str, Callable[[Any], Any]] = {
     "WAIT": lambda v: wait(int(v)),
     "TARGET": lambda v: target(v),
-    "THOL": lambda spec: block(
-        *_parse_tokens(spec.get("body", [])),
-        repeat=int(spec.get("repeat", 1)),
-        close=Glyph(spec.get("close")) if isinstance(spec.get("close"), str) else spec.get("close"),
-    ),
+    "THOL": parse_thol,
 }
 
 

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -24,3 +24,11 @@ def test_parse_tokens_key_error_context(monkeypatch):
     msg = str(exc.value)
     assert "posición 1" in msg
     assert "RAISE" in msg
+
+
+def test_thol_invalid_close():
+    with pytest.raises(ValueError) as exc:
+        _parse_tokens([{ "THOL": {"close": "XYZ"} }])
+    msg = str(exc.value)
+    assert "XYZ" in msg
+    assert "Glifo" in msg


### PR DESCRIPTION
## Summary
- Add dedicated `parse_thol` that validates the closing glyph exists before creating THOL blocks
- Reuse `parse_thol` in CLI `TOKEN_MAP`
- Test THOL parsing error for unknown closing glyph

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5bd5ad63483218e05c31060f96b30