### PR TITLE
Use immutable mapping for core defaults

### DIFF
--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict, field
-from typing import Dict, Any
+from typing import Dict, Any, Mapping
+from types import MappingProxyType
 
 
 @dataclass(frozen=True)
@@ -129,7 +130,12 @@ class RemeshDefaults:
     REMESH_ALPHA_HARD: bool = False
 
 
-CORE_DEFAULTS = asdict(CoreDefaults())
-REMESH_DEFAULTS = asdict(RemeshDefaults())
+_core_defaults = asdict(CoreDefaults())
+_remesh_defaults = asdict(RemeshDefaults())
 
-DEFAULTS_PART: Dict[str, Any] = CORE_DEFAULTS | REMESH_DEFAULTS
+CORE_DEFAULTS = MappingProxyType(_core_defaults)
+REMESH_DEFAULTS = MappingProxyType(_remesh_defaults)
+
+DEFAULTS_PART: Mapping[str, Any] = MappingProxyType(
+    {**_core_defaults, **_remesh_defaults}
+)


### PR DESCRIPTION
## Summary
- Protect core constant dictionaries by wrapping them with `MappingProxyType`
- Expose combined defaults as a read-only mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5bfd4365483219286c47619c73575