### PR TITLE
Use get_param for history maxlen

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -32,6 +32,7 @@ from .constants import (
     ALIAS_SI,
     ALIAS_EPI_KIND,
     ALIAS_D2EPI,
+    get_param,
 )
 
 T = TypeVar("T")
@@ -522,7 +523,7 @@ def ensure_history(G) -> Dict[str, Any]:
     del máximo permitido.
     """
 
-    maxlen = int(G.graph.get("HISTORY_MAXLEN", DEFAULTS.get("HISTORY_MAXLEN", 0)))
+    maxlen = int(G.graph.get("HISTORY_MAXLEN", get_param(G, "HISTORY_MAXLEN")))
     hist = G.graph.get("history")
     if not isinstance(hist, HistoryDict) or hist._maxlen != maxlen:
         hist = HistoryDict(hist, maxlen=maxlen)

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -45,3 +45,16 @@ def test_history_least_used_removed(graph_canon):
     ensure_history(G)
     assert len(hist) == 2
     assert "a" in hist
+
+
+def test_history_maxlen_override_respected(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+
+    hist = ensure_history(G)
+    assert hist._maxlen == 0
+
+    G.graph["HISTORY_MAXLEN"] = 3
+    hist = ensure_history(G)
+    assert hist._maxlen == 3


### PR DESCRIPTION
## Summary
- use `get_param` to fetch `HISTORY_MAXLEN`
- test that `HISTORY_MAXLEN` graph overrides are honored

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c9d585c083219166aa2dd40527aa