### PR TITLE
Compact HistoryDict heap to prevent unbounded growth

### DIFF
--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -1,0 +1,19 @@
+"""Pruebas de compactación de _heap en HistoryDict."""
+from tnfr.helpers import HistoryDict
+
+
+def test_heap_compaction_single_key():
+    hist = HistoryDict()
+    hist["a"] = 0
+    for _ in range(100):
+        _ = hist["a"]
+    assert len(hist._heap) <= len(hist) * 2
+
+
+def test_heap_compaction_many_keys():
+    hist = HistoryDict()
+    for i in range(10):
+        hist[f"k{i}"] = i
+    for i in range(1000):
+        _ = hist[f"k{i % 10}"]
+    assert len(hist._heap) <= len(hist) * 2


### PR DESCRIPTION
## Summary
- Add `_compact_heap` and `_maybe_compact` methods to `HistoryDict` to purge stale heap entries when the heap size exceeds twice the number of keys
- Ensure heap compaction runs on key increments and assignments to keep memory usage bounded
- Add tests simulating heavy access patterns to verify heap size remains limited

## Testing
- `pytest tests/test_history_heap_cleanup.py tests/test_history_maxlen.py tests/test_history.py tests/test_history_series.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0cf02d48321a7c51fcd31fa1c29