### PR TITLE
Handle deque in wbar

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import math
 import statistics as st
+from itertools import islice
 
 from .constants import ALIAS_THETA, METRIC_DEFAULTS
 from .helpers import (
@@ -110,4 +111,9 @@ def wbar(G, window: int | None = None) -> float:
     if window is None:
         window = int(G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25)))
     w = min(len(cs), max(1, int(window)))
-    return float(sum(cs[-w:]) / w)
+    if isinstance(cs, list):
+        tail = cs[-w:]
+    else:
+        start = len(cs) - w
+        tail = islice(cs, start, None)
+    return float(sum(tail) / w)

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,10 +1,11 @@
 """Pruebas de observers."""
 import math
 import statistics as st
+from collections import deque
 import pytest
 
 from tnfr.constants import ALIAS_THETA
-from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
+from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica, wbar
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
@@ -73,3 +74,10 @@ def test_sigma_vector_consistency():
     assert math.isclose(res["y"], y)
     assert math.isclose(res["mag"], mag)
     assert math.isclose(res["angle"], ang)
+
+
+def test_wbar_accepts_deque(graph_canon):
+    G = graph_canon()
+    cs = deque([0.1, 0.5, 0.9], maxlen=10)
+    G.graph["history"] = {"C_steps": cs}
+    assert wbar(G, window=2) == pytest.approx((0.5 + 0.9) / 2)


### PR DESCRIPTION
## Summary
- Support deque histories in `wbar` by slicing with `itertools.islice`
- Add regression test ensuring `wbar` works when `C_steps` is a deque

## Testing
- `pytest tests/test_observers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d1ad187483219342f33f45d7e84b