### PR TITLE
feat: allow configurable log level

### DIFF
--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -1,13 +1,21 @@
 """Pruebas de alias get strict."""
+import logging
 import pytest
 from tnfr.helpers import alias_get
 
 
 def test_alias_get_logs_on_error(caplog):
     d = {"x": "abc"}
-    with caplog.at_level("WARNING"):
+    with caplog.at_level(logging.DEBUG):
         result = alias_get(d, ["x"], int)
     assert result is None
+    assert any("No se pudo convertir" in m for m in caplog.messages)
+
+
+def test_alias_get_custom_log_level(caplog):
+    d = {"x": "abc"}
+    with caplog.at_level(logging.WARNING):
+        alias_get(d, ["x"], int, log_level=logging.WARNING)
     assert any("No se pudo convertir" in m for m in caplog.messages)
 
 

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -77,9 +77,14 @@ def test_eval_gamma_logs_and_strict_mode(graph_canon, caplog):
     merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": "bad"})
 
     caplog.clear()
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.DEBUG):
         g = eval_gamma(G, 0, t=0.0)
     assert g == 0.0
+    assert any("Fallo al evaluar" in rec.message for rec in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        eval_gamma(G, 0, t=0.0, log_level=logging.WARNING)
     assert any("Fallo al evaluar" in rec.message for rec in caplog.records)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- log debug by default when strict=False
- accept optional `log_level` to override logging level
- update tests to cover configurable logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5d410a024832187c809bbd0aa58a5