### PR TITLE
Handle string-like inputs in ensure_collection

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -125,8 +125,21 @@ def ensure_parent(path: str | Path) -> None:
 # -------------------------
 
 def ensure_collection(it: Iterable[T]) -> Collection[T]:
-    """Devuelve ``it`` si ya es ``Collection`` o ``list(it)`` en caso contrario."""
-    return it if isinstance(it, Collection) else list(it)
+    """Devuelve ``it`` si ya es ``Collection`` o ``list(it)`` en caso contrario.
+
+    Cadenas de texto y objetos *bytes* se tratan como un único elemento en
+    lugar de iterarse carácter a carácter. En esos casos se devuelve una lista
+    con dicho elemento. Si ``it`` no es iterable se lanza ``TypeError``.
+    """
+
+    if isinstance(it, Collection) and not isinstance(it, (str, bytes, bytearray)):
+        return it
+    if isinstance(it, (str, bytes, bytearray)):
+        return [it]
+    try:
+        return list(it)
+    except TypeError as exc:  # pragma: no cover - Defensive; unlikely with type hints
+        raise TypeError(f"{it!r} is not iterable") from exc
 
 # -------------------------
 # Utilidades numéricas

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -179,10 +179,8 @@ def play(G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None) -> N
 
     for op, payload in ops:
         if op == "TARGET":
-            if payload.nodes is None:
-                curr_target = list(_all_nodes(G))
-            else:
-                curr_target = list(payload.nodes)
+            nodes_src = _all_nodes(G) if payload.nodes is None else payload.nodes
+            curr_target = list(ensure_collection(nodes_src))
             trace.append({"t": float(G.graph.get("_t", 0.0)), "op": "TARGET", "n": len(curr_target)})
             continue
         if op == "WAIT":

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -1,0 +1,22 @@
+import pytest
+from tnfr.helpers import ensure_collection
+
+
+def test_wraps_string():
+    assert ensure_collection("node") == ["node"]
+
+
+def test_wraps_bytes():
+    data = b"node"
+    assert ensure_collection(data) == [data]
+
+
+def test_wraps_bytearray():
+    arr = bytearray(b"node")
+    assert ensure_collection(arr) == [arr]
+
+
+def test_non_iterable_error():
+    with pytest.raises(TypeError):
+        ensure_collection(42)  # type: ignore[arg-type]
+

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -58,6 +58,27 @@ def test_target_persists_across_wait(graph_canon):
     assert list(G.nodes[2]["hist_glifos"]) == [Glyph.AL.value]
     assert "hist_glifos" not in G.nodes[3]
 
+
+def test_target_accepts_string(graph_canon):
+    G = graph_canon()
+    # Add nodes that would be mistakenly targeted if the string were iterated
+    G.add_nodes_from(["node1", "n", "o", "d", "e", "1"])
+    play(G, seq(target("node1"), Glyph.AL), step_fn=_step_noop)
+    assert list(G.nodes["node1"]["hist_glifos"]) == [Glyph.AL.value]
+    for c in "node1":
+        assert "hist_glifos" not in G.nodes[c]
+
+
+def test_target_accepts_bytes(graph_canon):
+    G = graph_canon()
+    bname = b"node1"
+    codes = list(bname)
+    G.add_nodes_from([bname, *codes])
+    play(G, seq(target(bname), Glyph.AL), step_fn=_step_noop)
+    assert list(G.nodes[bname]["hist_glifos"]) == [Glyph.AL.value]
+    for code in codes:
+        assert "hist_glifos" not in G.nodes[code]
+
 def test_load_sequence_json_yaml(tmp_path):
     data = [
         "AL",


### PR DESCRIPTION
## Summary
- ensure_collection now wraps strings and bytes-like values as a single-element list
- TARGET handling uses ensure_collection so string node names target a single node
- add tests covering string, bytes, and bytearray inputs

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9537aa88321bdd79fc22be88131