### PR TITLE
Handle reversed uniform bounds in initialization

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -14,7 +14,9 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     ``INIT_VF_MODE``, ``VF_MIN``, ``VF_MAX``, ``INIT_VF_MIN/MAX``,
     ``INIT_VF_MEAN``, ``INIT_VF_STD`` y ``INIT_VF_CLAMP_TO_LIMITS``.
     Se añaden rangos para ``Si`` vía ``INIT_SI_MIN`` y ``INIT_SI_MAX``, y para
-    ``EPI`` mediante ``INIT_EPI_VALUE``.
+    ``EPI`` mediante ``INIT_EPI_VALUE``. Si ``INIT_VF_MIN`` es mayor que
+    ``INIT_VF_MAX``, los valores se intercambian y se ajustan al rango
+    delimitado por ``VF_MIN``/``VF_MAX``.
     """
     seed = int(G.graph.get("RANDOM_SEED", 0))
     init_rand_phase = bool(
@@ -36,6 +38,10 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
         vf_uniform_min = vf_min_lim
     if vf_uniform_max is None:
         vf_uniform_max = vf_max_lim
+    if vf_uniform_min > vf_uniform_max:
+        vf_uniform_min, vf_uniform_max = vf_uniform_max, vf_uniform_min
+    vf_uniform_min = max(vf_uniform_min, vf_min_lim)
+    vf_uniform_max = min(vf_uniform_max, vf_max_lim)
 
     vf_mean = float(G.graph.get("INIT_VF_MEAN", INIT_DEFAULTS["INIT_VF_MEAN"]))
     vf_std = float(G.graph.get("INIT_VF_STD", INIT_DEFAULTS["INIT_VF_STD"]))

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -20,3 +20,34 @@ def test_init_node_attrs_reproducible():
     attrs2 = {n: (d["EPI"], d["θ"], d["νf"], d["Si"]) for n, d in G2.nodes(data=True)}
 
     assert attrs1 == attrs2
+
+
+def test_init_node_attrs_reversed_uniform_bounds():
+    seed = 2024
+    G1 = nx.path_graph(3)
+    attach_defaults(G1)
+    G1.graph.update(
+        {
+            "RANDOM_SEED": seed,
+            "INIT_VF_MODE": "uniform",
+            "INIT_VF_MIN": 0.8,
+            "INIT_VF_MAX": 0.2,
+        }
+    )
+    init_node_attrs(G1)
+    vfs1 = [d["νf"] for _, d in G1.nodes(data=True)]
+
+    G2 = nx.path_graph(3)
+    attach_defaults(G2)
+    G2.graph.update(
+        {
+            "RANDOM_SEED": seed,
+            "INIT_VF_MODE": "uniform",
+            "INIT_VF_MIN": 0.2,
+            "INIT_VF_MAX": 0.8,
+        }
+    )
+    init_node_attrs(G2)
+    vfs2 = [d["νf"] for _, d in G2.nodes(data=True)]
+
+    assert vfs1 == vfs2


### PR DESCRIPTION
## Summary
- clarify docstring to describe handling of conflicting velocity-factor bounds
- swap and clamp `INIT_VF_MIN/MAX` when misordered
- add regression test ensuring reversed bounds produce deterministic attributes

## Testing
- `pytest tests/test_initialization.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5dbebcc2483218b8cf2c3d8e707f1