### PR TITLE
Centralize glyph constants

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -15,11 +15,18 @@ from .helpers import compute_coherence
 from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
 from .grammar import enforce_canonical_grammar, on_applied_glifo, apply_glyph_with_grammar
 from .sense import (
-    GLYPHS_CANONICAL, glyph_angle, glyph_unit,
-    sigma_vector_node, sigma_vector_from_graph, sigma_vector, sigma_vector_global,
-    push_sigma_snapshot, sigma_series, sigma_rose,
+    glyph_angle,
+    glyph_unit,
+    sigma_vector_node,
+    sigma_vector_from_graph,
+    sigma_vector,
+    sigma_vector_global,
+    push_sigma_snapshot,
+    sigma_series,
+    sigma_rose,
     register_sigma_callback,
 )
+from .constants_glifos import GLYPHS_CANONICAL
 from .metrics import (
     register_metrics_callbacks,
     Tg_global, Tg_by_node,

--- a/src/tnfr/constants_glifos.py
+++ b/src/tnfr/constants_glifos.py
@@ -7,8 +7,24 @@ from typing import Dict
 from .types import Glyph
 
 # -------------------------
-# Clasificaciones funcionales de glifos
+# Orden canónico y clasificaciones funcionales
 # -------------------------
+
+GLYPHS_CANONICAL: tuple[str, ...] = (
+    Glyph.AL.value,   # 0
+    Glyph.EN.value,   # 1
+    Glyph.IL.value,   # 2
+    Glyph.OZ.value,   # 3
+    Glyph.UM.value,   # 4
+    Glyph.RA.value,   # 5
+    Glyph.SHA.value,  # 6
+    Glyph.VAL.value,  # 7
+    Glyph.NUL.value,  # 8
+    Glyph.THOL.value, # 9
+    Glyph.ZHIR.value, # 10
+    Glyph.NAV.value,  # 11
+    Glyph.REMESH.value,  # 12
+)
 
 ESTABILIZADORES = (
     Glyph.IL.value,
@@ -60,3 +76,11 @@ ANGLE_MAP: Dict[str, float] = {
     Glyph.SHA.value: 3 * math.pi / 4,
     Glyph.REMESH.value: 24 * math.pi / 13,
 }
+
+__all__ = [
+    "GLYPHS_CANONICAL",
+    "ESTABILIZADORES",
+    "DISRUPTIVOS",
+    "GLYPH_GROUPS",
+    "ANGLE_MAP",
+]

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -8,8 +8,7 @@ import heapq
 
 from ..constants import METRIC_DEFAULTS, ALIAS_EPI, METRICS
 from ..helpers import register_callback, ensure_history, last_glifo, get_attr
-from ..sense import GLYPHS_CANONICAL
-from ..constants_glifos import GLYPH_GROUPS
+from ..constants_glifos import GLYPHS_CANONICAL, GLYPH_GROUPS
 from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks
 

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -6,7 +6,7 @@ import json
 from typing import Dict, List
 
 from ..helpers import ensure_history, ensure_parent
-from ..sense import GLYPHS_CANONICAL
+from ..constants_glifos import GLYPHS_CANONICAL
 from .core import glifogram_series
 
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -1,6 +1,6 @@
 """Cálculos de sentido."""
 from __future__ import annotations
-from typing import Dict, List, Iterable
+from typing import Dict, Iterable
 import math
 import warnings
 from collections import Counter
@@ -16,28 +16,16 @@ from .helpers import (
     last_glifo,
     count_glyphs,
 )
-from .types import Glyph
-from .constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
+from .constants_glifos import (
+    ANGLE_MAP,
+    ESTABILIZADORES,
+    DISRUPTIVOS,
+    GLYPHS_CANONICAL,
+)
 
 # -------------------------
 # Canon: orden circular de glifos y ángulos
 # -------------------------
-GLYPHS_CANONICAL: List[str] = [
-    Glyph.AL.value,   # 0
-    Glyph.EN.value,   # 1
-    Glyph.IL.value,   # 2
-    Glyph.OZ.value,   # 3
-    Glyph.UM.value,   # 4
-    Glyph.RA.value,   # 5
-    Glyph.SHA.value,  # 6
-    Glyph.VAL.value,  # 7
-    Glyph.NUL.value,  # 8
-    Glyph.THOL.value, # 9
-    Glyph.ZHIR.value, # 10
-    Glyph.NAV.value,  # 11
-    Glyph.REMESH.value # 12
-]
-
 GLYPHS_CANONICAL_SET: set[str] = set(GLYPHS_CANONICAL)
 
 # Glifos relevantes para el plano Σ de observadores de sentido


### PR DESCRIPTION
## Summary
- centralize glyph classification constants in `constants_glifos`
- use shared glyph constants across sense and metrics modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ebd966488321853bd88ac9ca67b2