### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from math import cos
 import cmath
-from typing import Dict, List, Tuple
+from typing import Dict
 
 from ..constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_SI, COHERENCE
 from ..helpers import register_callback, ensure_history, get_attr, clamp01


### PR DESCRIPTION
## Summary
- remove unused List and Tuple from typing import in coherence metrics

## Testing
- `pip install -e .`
- `pytest` *(fails: assert 4.6765999741182895e-05 <= (1.3840000065101776e-05 * 2))*

------
https://chatgpt.com/codex/tasks/task_e_68b5f91c8a808321923f57a6147445d8