### PR TITLE
refactor: split glyph distribution helpers

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -1,6 +1,6 @@
 """Funciones auxiliares."""
 from __future__ import annotations
-from typing import Iterable, Sequence, Dict, Any, Callable, TypeVar
+from typing import Iterable, Sequence, Dict, Any, Callable, TypeVar, Mapping
 from collections.abc import Collection
 import logging
 import math
@@ -60,6 +60,8 @@ __all__ = [
     "ensure_history",
     "last_glifo",
     "count_glyphs",
+    "normalize_counter",
+    "mix_groups",
     "register_callback",
     "invoke_callbacks",
     "compute_dnfr_accel_max",
@@ -713,6 +715,36 @@ def count_glyphs(
                 seq = hist
         counts.update(seq)
     return counts
+
+
+def normalize_counter(counts: Mapping[str, int]) -> tuple[Dict[str, float], int]:
+    """Normaliza un ``Counter`` y devuelve proporciones y total.
+
+    Si la suma total es cero, retorna ``({}, 0)``.
+    """
+    total = sum(counts.values())
+    if total <= 0:
+        return {}, 0
+    dist = {k: v / total for k, v in counts.items() if v}
+    return dist, total
+
+
+def mix_groups(
+    dist: Mapping[str, float],
+    groups: Mapping[str, Iterable[str]],
+    *,
+    prefix: str = "_",
+) -> Dict[str, float]:
+    """Agrega valores de ``dist`` según agrupaciones.
+
+    ``groups`` debe mapear nombres de grupo a iterables de claves presentes en
+    ``dist``. Cada grupo se añadirá al resultado con el nombre
+    ``prefix + label``.
+    """
+    out: Dict[str, float] = dict(dist)
+    for label, keys in groups.items():
+        out[f"{prefix}{label}"] = sum(dist.get(k, 0.0) for k in keys)
+    return out
 
 # -------------------------
 # Callbacks Γ(R)

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -13,6 +13,8 @@ from .helpers import (
     ensure_history,
     count_glyphs,
     compute_coherence,
+    normalize_counter,
+    mix_groups,
 )
 from .constants_glifos import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
@@ -86,17 +88,10 @@ def carga_glifica(G, window: int | None = None) -> dict:
     Retorna un dict con proporciones por glifo y agregados útiles.
     """
     total = count_glyphs(G, window=window, last_only=(window == 1))
-    count = sum(total.values())
+    dist, count = normalize_counter(total)
     if count == 0:
         return {"_count": 0}
-
-
-    # Proporciones por glifo
-    dist = {k: v / count for k, v in total.items()}
-
-    for label, glyphs in GLYPH_GROUPS.items():
-        dist[f"_{label}"] = sum(dist.get(k, 0.0) for k in glyphs)
-
+    dist = mix_groups(dist, GLYPH_GROUPS)
     dist["_count"] = count
     return dist
 

--- a/tests/test_glyph_helpers.py
+++ b/tests/test_glyph_helpers.py
@@ -1,0 +1,24 @@
+"""Pruebas para normalización y mezcla de conteos glíficos."""
+from collections import Counter
+
+from tnfr.helpers import normalize_counter, mix_groups
+
+
+def test_normalize_counter():
+    counts = Counter({"A": 2, "B": 1})
+    dist, total = normalize_counter(counts)
+    assert total == 3
+    assert dist == {"A": 2 / 3, "B": 1 / 3}
+
+    empty_dist, empty_total = normalize_counter(Counter())
+    assert empty_total == 0
+    assert empty_dist == {}
+
+
+def test_mix_groups():
+    dist = {"A": 0.5, "B": 0.5}
+    groups = {"ab": ("A", "B")}
+    mixed = mix_groups(dist, groups)
+    assert mixed["_ab"] == 1.0
+    # se conserva la distribución original
+    assert mixed["A"] == 0.5


### PR DESCRIPTION
## Summary
- add `normalize_counter` and `mix_groups` to separate glyph counting, normalization and mixing
- reuse helpers in `carga_glifica`
- cover helpers with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b68afd76d88321a5c3df6acf031c2c