### PR TITLE
Validate THOL force_close type

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -131,7 +131,13 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
             ops.append(("THOL", Glyph.THOL.value))
 
             repeats = max(1, int(item.repeat))
-            closing = item.force_close if item.force_close in (Glyph.SHA, Glyph.NUL) else None
+            if item.force_close is not None and not isinstance(item.force_close, Glyph):
+                raise ValueError("force_close must be a Glyph")
+            closing = (
+                item.force_close
+                if isinstance(item.force_close, Glyph) and item.force_close in {Glyph.SHA, Glyph.NUL}
+                else None
+            )
             # El cierre explícito debe ejecutarse al final, por lo que se
             # coloca en la pila antes de expandir el cuerpo.
             if closing is not None:

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -110,3 +110,12 @@ def test_load_sequence_repeated_calls(tmp_path):
     expected = seq("AL", block("OZ", "EN", "RA"), wait(1))
     for _ in range(5):
         assert _load_sequence(path) == expected
+
+
+@pytest.mark.parametrize("bad", ["SHA", 123])
+def test_block_force_close_invalid_type_raises(graph_canon, bad):
+    G = graph_canon()
+    G.add_node(1)
+    program = seq(block(Glyph.AL, close=bad))
+    with pytest.raises(ValueError):
+        play(G, program, step_fn=_step_noop)


### PR DESCRIPTION
## Summary
- ensure THOL force_close only accepts Glyph and allowed closures
- test that invalid force_close types raise ValueError

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a6ef5ddc832189aab0109fd4c330