### PR TITLE
refactor: centralize Tg literals

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -13,6 +13,11 @@ from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks
 
 
+LATENT_GLYPH = "SHA"
+TgCurr = "curr"
+TgRun = "run"
+
+
 # -------------
 # Utilidades internas
 # -------------
@@ -22,7 +27,7 @@ def _tg_state(nd: Dict[str, Any]) -> Dict[str, Any]:
     """Estructura interna por nodo para acumular tiempos de corrida por glifo.
     Campos: curr (glifo actual), run (tiempo acumulado en el glifo actual)
     """
-    return nd.setdefault("_Tg", {"curr": None, "run": 0.0})
+    return nd.setdefault("_Tg", {TgCurr: None, TgRun: 0.0})
 
 
 # -------------
@@ -44,9 +49,9 @@ def _update_tg(G, hist, dt, save_by_node: bool):
 
     last = last_glifo
     tg_state = _tg_state
-    latent = "SHA"
-    curr_key = "curr"
-    run_key = "run"
+    latent = LATENT_GLYPH
+    curr_key = TgCurr
+    run_key = TgRun
 
     for n, nd in G.nodes(data=True):
         g = last(nd)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,13 +5,14 @@ import networkx as nx
 from tnfr.constants import attach_defaults, ALIAS_EPI
 from tnfr.helpers import get_attr
 from tnfr.metrics import _metrics_step, _update_latency_index, _update_epi_support
+from tnfr.metrics.core import LATENT_GLYPH
 
 
 def test_pp_val_zero_when_no_remesh(graph_canon):
     """PP metric should be 0.0 when no REMESH events occur."""
     G = graph_canon()
     # Nodo en estado SHA, pero sin eventos REMESH
-    G.add_node(0, EPI_kind="SHA")
+    G.add_node(0, EPI_kind=LATENT_GLYPH)
     attach_defaults(G)
 
     _metrics_step(G)
@@ -45,7 +46,7 @@ def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
 
     for G in (G_true, G_false):
         G.add_node(0, EPI_kind="OZ")
-        G.add_node(1, EPI_kind="SHA")
+        G.add_node(1, EPI_kind=LATENT_GLYPH)
         attach_defaults(G)
         G.graph["_t"] = 0
         _metrics_step(G)

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -5,6 +5,7 @@ from collections import Counter, defaultdict
 from tnfr.constants import attach_defaults
 from tnfr.helpers import last_glifo
 from tnfr.metrics import _update_tg, _tg_state
+from tnfr.metrics.core import LATENT_GLYPH, TgCurr, TgRun
 
 
 def _update_tg_naive(G, hist, dt, save_by_node):
@@ -23,26 +24,26 @@ def _update_tg_naive(G, hist, dt, save_by_node):
             continue
 
         n_total += 1
-        if g == "SHA":
+        if g == LATENT_GLYPH:
             n_latent += 1
 
         counts[g] += 1
 
         st = _tg_state(nd)
-        if st["curr"] is None:
-            st["curr"] = g
-            st["run"] = dt
-        elif g == st["curr"]:
-            st["run"] += dt
+        if st[TgCurr] is None:
+            st[TgCurr] = g
+            st[TgRun] = dt
+        elif g == st[TgCurr]:
+            st[TgRun] += dt
         else:
-            prev = st["curr"]
-            dur = float(st["run"])
+            prev = st[TgCurr]
+            dur = float(st[TgRun])
             tg_total[prev] += dur
             if save_by_node:
                 rec = tg_by_node.setdefault(n, defaultdict(list))
                 rec[prev].append(dur)
-            st["curr"] = g
-            st["run"] = dt
+            st[TgCurr] = g
+            st[TgRun] = dt
 
     return counts, n_total, n_latent
 
@@ -54,10 +55,10 @@ def test_update_tg_matches_naive(graph_canon):
 
     for G in (G_opt, G_ref):
         G.add_node(0, EPI_kind="OZ")
-        G.add_node(1, EPI_kind="SHA")
+        G.add_node(1, EPI_kind=LATENT_GLYPH)
         G.add_node(2, EPI_kind="NAV")
         G.add_node(3, EPI_kind="OZ")
-        G.add_node(4, EPI_kind="SHA")
+        G.add_node(4, EPI_kind=LATENT_GLYPH)
         attach_defaults(G)
 
     hist_opt = {}


### PR DESCRIPTION
## Summary
- add constants for latent glyph and Tg state keys
- use constants in Tg update helper
- adjust tests to rely on shared constants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a8ffd6fc8321b1d43ccb76c7102d