### PR TITLE
Invalidate dnfr cache when node set changes

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -90,10 +90,19 @@ def _cached_nodes_and_A(
     antigua."""
 
     cache: OrderedDict = G.graph.setdefault("_dnfr_cache", OrderedDict())
-    key = (int(G.graph.get("_edge_version", 0)), G.number_of_nodes())
+    # El checksum depende del conjunto de nodos, ignorando el orden.
+    nodes_list = list(G.nodes())
+    checksum = hash(tuple(sorted(hash(n) for n in nodes_list)))
+
+    last_checksum = G.graph.get("_dnfr_nodes_checksum")
+    if last_checksum != checksum:
+        cache.clear()
+        G.graph["_dnfr_nodes_checksum"] = checksum
+
+    key = (int(G.graph.get("_edge_version", 0)), len(nodes_list), checksum)
     nodes_and_A = cache.get(key)
     if nodes_and_A is None:
-        nodes = list(G.nodes())
+        nodes = nodes_list
         if np is not None:
             A = nx.to_numpy_array(G, nodelist=nodes, weight=None, dtype=float)
         else:

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -32,7 +32,7 @@ def test_cache_invalidated_on_graph_change(vectorized):
     increment_edge_version(G)
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
-    assert len(G.graph.get("_dnfr_cache", {})) == 2
+    assert len(G.graph.get("_dnfr_cache", {})) == 1
     after = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
 
     assert len(after) == 4
@@ -42,7 +42,7 @@ def test_cache_invalidated_on_graph_change(vectorized):
     increment_edge_version(G)
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
-    assert len(G.graph.get("_dnfr_cache", {})) == 2
+    assert len(G.graph.get("_dnfr_cache", {})) == 1
 
 
 def test_cache_is_per_graph():
@@ -53,4 +53,15 @@ def test_cache_is_per_graph():
     assert G1.graph["_dnfr_cache"] is not G2.graph["_dnfr_cache"]
     assert len(G1.graph["_dnfr_cache"]) == 1
     assert len(G2.graph["_dnfr_cache"]) == 1
+
+
+def test_cache_invalidated_on_node_rename():
+    G = _setup_graph()
+    default_compute_delta_nfr(G)
+    assert set(G.nodes) == {0, 1, 2}
+
+    nx.relabel_nodes(G, {2: 9}, copy=False)
+    default_compute_delta_nfr(G)
+
+    assert set(G.nodes) == {0, 1, 9}
 


### PR DESCRIPTION
## Summary
- incorporate node checksum into `_cached_nodes_and_A` cache key and clear cache on node set changes
- update dnfr cache tests for new invalidation behavior
- add regression test for cache invalidation when nodes are renamed

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0e531488321848a5ba5b7e29595