### PR TITLE
Refactor DNFR gradient computation into shared helper

### DIFF
--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -23,6 +23,9 @@ def test_strategies_share_precomputed_data():
     data = _prepare_dnfr_data(G)
     _compute_dnfr_loops(G, data)
     dnfr_loop = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+    expected = [0.1, -0.05, 0.0, -0.05, 0.1]
+    assert dnfr_loop == pytest.approx(expected)
     _compute_dnfr_numpy(G, data)
     dnfr_vec = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+    assert dnfr_vec == pytest.approx(expected)
     assert dnfr_loop == pytest.approx(dnfr_vec)

--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -17,16 +17,12 @@ def _setup_graph():
     return G
 
 
-def _run(G, vectorized):
+@pytest.mark.parametrize("vectorized", [False, True])
+def test_default_compute_delta_nfr_paths(vectorized):
+    if vectorized:
+        pytest.importorskip("numpy")
+    G = _setup_graph()
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G)
-    return [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
-
-
-def test_vectorized_equals_loop():
-    pytest.importorskip("numpy")
-    G1 = _setup_graph()
-    G2 = _setup_graph()
-    dnfr_loop = _run(G1, False)
-    dnfr_vec = _run(G2, True)
-    assert dnfr_loop == pytest.approx(dnfr_vec)
+    dnfr = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+    assert dnfr == pytest.approx([0.1, -0.05, 0.0, -0.05, 0.1])


### PR DESCRIPTION
## Summary
- centralize DNFR gradient calculation in `_apply_dnfr_gradients`
- simplify `_compute_dnfr_numpy` and `_compute_dnfr_loops` to gather neighbourhood data and delegate to helper
- extend tests to validate loop and vectorized paths

## Testing
- `PYTHONPATH=src pytest tests/test_dnfr_precompute.py::test_strategies_share_precomputed_data tests/test_dynamics_vectorized.py::test_default_compute_delta_nfr_paths -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1d4dd488321b0fe35ef4c1998cd