### PR TITLE
Ensure RANDOM_SEED always matches provided value

### DIFF
--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -36,6 +36,6 @@ def build_graph(
     # Valores canónicos para inicialización
     inject_defaults(G)
     if seed is not None:
-        G.graph.setdefault("RANDOM_SEED", int(seed))
+        G.graph["RANDOM_SEED"] = int(seed)
     init_node_attrs(G, override=True)
     return G

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -32,3 +32,9 @@ def test_build_graph_invalid_p():
     with pytest.raises(ValueError):
         build_graph(n=5, topology="erdos", p=1.5)
 
+
+def test_random_seed_reflects_value():
+    seed = 123
+    G = build_graph(n=5, seed=seed)
+    assert G.graph["RANDOM_SEED"] == seed
+


### PR DESCRIPTION
## Summary
- Set `RANDOM_SEED` directly on scenario graphs
- Test that `RANDOM_SEED` reflects the provided seed

## Testing
- `pytest tests/test_scenarios.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6b8184a44832186fc0b095fb60fdb