### PR TITLE
Avoid unnecessary tuple allocations in TARGET handler

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -1,6 +1,6 @@
 """Lenguaje de programación TNFR."""
 from __future__ import annotations
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union, Collection
 from dataclasses import dataclass
 from contextlib import contextmanager
 from collections import deque
@@ -167,8 +167,15 @@ def _record_trace(trace: deque, G, op: str, **data) -> None:
 
 
 def _handle_target(G, payload: TARGET, _curr_target, trace: deque, _step_fn):
+    """Handle a ``TARGET`` token and return the active node set.
+
+    Returns
+    -------
+    Collection[Node]
+        Collection of nodes to be used for subsequent operations.
+    """
     nodes_src = _all_nodes(G) if payload.nodes is None else payload.nodes
-    curr_target = tuple(nodes_src)
+    curr_target = nodes_src if isinstance(nodes_src, Collection) else tuple(nodes_src)
     _record_trace(trace, G, "TARGET", n=len(curr_target))
     return curr_target
 


### PR DESCRIPTION
## Summary
- Use existing node collections in TARGET handler and only materialise to tuple when necessary
- Clarify `_handle_target` return type in docstring

## Testing
- `PYTHONPATH=src pytest`
- `python - <<'PY'
import sys
sys.path.append('src')
import networkx as nx
from collections import deque
from tnfr.program import _handle_target, TARGET
import tracemalloc
N=100000
G=nx.path_graph(N)
trace=deque()
tracemalloc.start()
_handle_target(G, TARGET(nodes=G.nodes), None, trace, None)
current, peak = tracemalloc.get_traced_memory()
print('peak bytes', peak)
tracemalloc.stop()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b70532622c8321b86e14b31afbc373