### PR TITLE
Validate non-negative max_materialize

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -176,8 +176,9 @@ def ensure_collection(
     max_materialize:
         Número máximo de elementos a materializar cuando ``it`` no es una
         colección. Si el iterable produce más de ``max_materialize`` elementos
-        se lanza :class:`ValueError`. Si se omite o se pasa ``None`` se aplica
-        el límite por defecto de ``MAX_MATERIALIZE_DEFAULT`` elementos.
+        se lanza :class:`ValueError`. Debe ser un entero no negativo o
+        ``None``. Si se omite o se pasa ``None`` se aplica el límite por
+        defecto de ``MAX_MATERIALIZE_DEFAULT`` elementos.
 
     Notes
     -----
@@ -190,6 +191,8 @@ def ensure_collection(
         return it
     if isinstance(it, (str, bytes, bytearray)):
         return cast(Collection[T], (it,))
+    if max_materialize is not None and max_materialize < 0:
+        raise ValueError("'max_materialize' must be non-negative")
     try:
         limit = (
             MAX_MATERIALIZE_DEFAULT if max_materialize is None else max_materialize

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -22,6 +22,12 @@ def test_max_materialize_limit():
         ensure_collection(gen, max_materialize=3)
 
 
+def test_negative_max_materialize_error():
+    gen = (i for i in range(5))
+    with pytest.raises(ValueError):
+        ensure_collection(gen, max_materialize=-1)
+
+
 def test_default_limit_enforced():
     gen = (i for i in range(1001))
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- raise `ValueError` when `ensure_collection` receives a negative `max_materialize`
- document that `max_materialize` must be non-negative or `None`
- add tests for negative `max_materialize`

## Testing
- `PYTHONPATH=src pytest tests/test_ensure_collection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71061622083219d5f06b6aad24802