### PR TITLE
Clarify default materialization limit comment

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -29,8 +29,7 @@ logger = logging.getLogger(__name__)
 PI = math.pi
 TWO_PI = 2 * PI
 
-MAX_MATERIALIZE_DEFAULT = 1000
-"""Límite por defecto de elementos a materializar en :func:`ensure_collection`."""
+MAX_MATERIALIZE_DEFAULT = 1000  # Límite por defecto de elementos a materializar en :func:`ensure_collection`.
 
 try:  # pragma: no cover - dependencia opcional
     import yaml  # type: ignore


### PR DESCRIPTION
## Summary
- clarify the purpose of MAX_MATERIALIZE_DEFAULT by replacing a stray string with an inline comment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b711e501d48321bb8a780bd80823c3