### PR TITLE
Refactor helpers into specialized modules

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -1,0 +1,82 @@
+"""Callback registration and invocation helpers."""
+from __future__ import annotations
+
+from typing import Callable, Any, Optional
+from enum import Enum
+from collections import defaultdict
+
+from .constants import DEFAULTS
+
+__all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
+
+
+class CallbackEvent(str, Enum):
+    """Supported callback events."""
+
+    BEFORE_STEP = "before_step"
+    AFTER_STEP = "after_step"
+    ON_REMESH = "on_remesh"
+
+
+_CALLBACK_EVENTS = tuple(e.value for e in CallbackEvent)
+
+
+def _ensure_callbacks(G):
+    """Ensure the callback structure in ``G.graph``."""
+    cbs = G.graph.get("callbacks")
+    if not isinstance(cbs, defaultdict):
+        cbs = defaultdict(list, cbs or {})
+        G.graph["callbacks"] = cbs
+    return cbs
+
+
+def register_callback(
+    G,
+    event: CallbackEvent | str,
+    func: Optional[Callable] = None,
+    *,
+    name: str | None = None,
+):
+    """Register ``func`` as callback for ``event``."""
+    if event not in _CALLBACK_EVENTS:
+        raise ValueError(f"Evento desconocido: {event}")
+    if func is None:
+        raise TypeError("func es obligatorio")
+    cbs = _ensure_callbacks(G)
+
+    if isinstance(func, tuple):
+        cb_name, func = func
+    else:
+        cb_name = name or getattr(func, "__name__", None)
+
+    new_cb = (cb_name, func)
+
+    for i, (existing_name, existing_fn) in enumerate(cbs[event]):
+        if existing_fn is func or (cb_name is not None and existing_name == cb_name):
+            cbs[event][i] = new_cb
+            break
+    else:
+        cbs[event].append(new_cb)
+
+    return func
+
+
+def invoke_callbacks(G, event: CallbackEvent | str, ctx: dict | None = None):
+    """Invoke all callbacks registered for ``event`` with context ``ctx``."""
+    cbs = _ensure_callbacks(G).get(event, [])
+    strict = bool(G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"]))
+    ctx = ctx or {}
+    for name, fn in list(cbs):
+        try:
+            fn(G, ctx)
+        except (KeyError, ValueError, TypeError) as e:
+            if strict:
+                raise
+            G.graph.setdefault("_callback_errors", []).append({
+                "event": event,
+                "step": ctx.get("step"),
+                "error": repr(e),
+                "fn": repr(fn),
+                "name": name,
+            })
+

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -28,7 +28,8 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
-from .helpers import read_structured_file, list_mean, ensure_parent
+from .io_utils import read_structured_file, ensure_parent
+from .helpers import list_mean
 from .observers import attach_standard_observer
 from . import __version__
 

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -1,0 +1,162 @@
+"""Utilities for working with collections and weights."""
+from __future__ import annotations
+
+from typing import (
+    Iterable,
+    Sequence,
+    Dict,
+    Any,
+    Callable,
+    TypeVar,
+    Mapping,
+    Optional,
+    Collection,
+    cast,
+)
+import logging
+import math
+from itertools import islice
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MAX_MATERIALIZE_DEFAULT",
+    "ensure_collection",
+    "normalize_weights",
+    "normalize_counter",
+    "mix_groups",
+]
+
+MAX_MATERIALIZE_DEFAULT = 1000  # default materialization limit in ensure_collection
+
+
+def ensure_collection(
+    it: Iterable[T], *, max_materialize: int | None = MAX_MATERIALIZE_DEFAULT
+) -> Collection[T]:
+    """Return ``it`` if it's a ``Collection`` else materialize into ``tuple``.
+
+    Strings and bytes are treated as single elements rather than iterables. If
+    ``it`` is not iterable, :class:`TypeError` is raised.
+    """
+    if isinstance(it, Collection) and not isinstance(it, (str, bytes, bytearray)):
+        return it
+    if isinstance(it, (str, bytes, bytearray)):
+        return cast(Collection[T], (it,))
+    if max_materialize is not None and max_materialize < 0:
+        raise ValueError("'max_materialize' must be non-negative")
+    try:
+        limit = MAX_MATERIALIZE_DEFAULT if max_materialize is None else max_materialize
+        data = tuple(islice(it, limit))
+        extra = next(it, None)
+        if extra is not None:
+            raise ValueError(f"Iterable materialization exceeded {limit} items")
+        return data
+    except TypeError as exc:
+        raise TypeError(f"{it!r} is not iterable") from exc
+
+
+def _convert_value(
+    value: Any,
+    conv: Callable[[Any], T],
+    *,
+    strict: bool = False,
+    key: str | None = None,
+    log_level: int | None = None,
+) -> tuple[bool, T | None]:
+    """Try to convert ``value`` using ``conv`` handling errors."""
+    try:
+        return True, conv(value)
+    except (ValueError, TypeError) as exc:
+        level = log_level if log_level is not None else (
+            logging.ERROR if strict else logging.DEBUG
+        )
+        if key is not None:
+            logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)
+        else:
+            logger.log(level, "No se pudo convertir el valor: %s", exc)
+        if strict:
+            raise
+        return False, None
+
+
+def normalize_weights(
+    dict_like: Dict[str, Any],
+    keys: Iterable[str],
+    default: float = 0.0,
+    *,
+    error_on_negative: bool = False,
+) -> Dict[str, float]:
+    """Normalize ``keys`` in ``dict_like`` so their sum is 1."""
+    keys = list(keys)
+    default_float = float(default)
+
+    weights = _convert_weights(dict_like, keys, default_float, error_on_negative)
+    _validate_weights(weights, error_on_negative)
+    return _normalize_distribution(weights, keys)
+
+
+def _convert_weights(
+    dict_like: Mapping[str, Any],
+    keys: Iterable[str],
+    default_float: float,
+    error_on_negative: bool,
+) -> Dict[str, float]:
+    def _to_float(k: str) -> float:
+        val = dict_like.get(k, default_float)
+        ok, converted = _convert_value(
+            val,
+            float,
+            strict=error_on_negative,
+            key=k,
+            log_level=logging.WARNING,
+        )
+        return converted if ok and converted is not None else default_float
+
+    return {k: _to_float(k) for k in keys}
+
+
+def _validate_weights(weights: Mapping[str, float], error_on_negative: bool) -> None:
+    negatives = {k: v for k, v in weights.items() if v < 0}
+    if not negatives:
+        return
+    if error_on_negative:
+        raise ValueError(f"Pesos negativos detectados: {negatives}")
+    logger.warning("Pesos negativos detectados: %s", negatives)
+
+
+def _normalize_distribution(
+    weights: Mapping[str, float], keys: Sequence[str]
+) -> Dict[str, float]:
+    total = math.fsum(weights.values())
+    n = len(keys)
+    if total <= 0:
+        if n == 0:
+            return {}
+        uniform = 1.0 / n
+        return {k: uniform for k in keys}
+    return {k: v / total for k, v in weights.items()}
+
+
+def normalize_counter(counts: Mapping[str, int]) -> tuple[Dict[str, float], int]:
+    """Normalize a ``Counter`` returning proportions and total."""
+    total = sum(counts.values())
+    if total <= 0:
+        return {}, 0
+    dist = {k: v / total for k, v in counts.items() if v}
+    return dist, total
+
+
+def mix_groups(
+    dist: Mapping[str, float],
+    groups: Mapping[str, Iterable[str]],
+    *,
+    prefix: str = "_",
+) -> Dict[str, float]:
+    """Aggregate values of ``dist`` according to ``groups``."""
+    out: Dict[str, float] = dict(dist)
+    for label, keys in groups.items():
+        out[f"{prefix}{label}"] = sum(dist.get(k, 0.0) for k in keys)
+    return out
+

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from typing import Any, Dict
 from pathlib import Path
-from .helpers import read_structured_file
+from .io_utils import read_structured_file
 
 from .constants import inject_defaults
 

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -34,9 +34,11 @@ from .gamma import eval_gamma
 from .helpers import (
      clamp, clamp01, list_mean, angle_diff,
      get_attr, set_attr, get_attr_str, set_attr_str, media_vecinal, fase_media,
-     invoke_callbacks, reciente_glifo, set_vf, set_dnfr, compute_Si, normalize_weights,
-     ensure_history, compute_coherence, compute_dnfr_accel_max,
+     set_vf, set_dnfr, compute_Si, compute_coherence, compute_dnfr_accel_max,
 )
+from .callback_utils import invoke_callbacks
+from .glyph_history import reciente_glifo, ensure_history
+from .collections_utils import normalize_weights
 from .selector import (
     _selector_thresholds,
     _norms_para_selector,

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -1,0 +1,168 @@
+"""Helpers for glyph history management."""
+from __future__ import annotations
+
+from typing import Dict, Any, Iterable
+from collections import deque, Counter
+import heapq
+from itertools import islice
+
+from .constants import ALIAS_EPI_KIND, get_param
+from .helpers import get_attr_str
+
+__all__ = [
+    "HistoryDict",
+    "push_glifo",
+    "reciente_glifo",
+    "ensure_history",
+    "last_glifo",
+    "count_glyphs",
+]
+
+
+def push_glifo(nd: Dict[str, Any], glifo: str, window: int) -> None:
+    """Add ``glifo`` to node history with maximum size ``window``."""
+    hist = nd.get("hist_glifos")
+    if hist is None or hist.maxlen != window:
+        hist = deque(hist or [], maxlen=window)
+        nd["hist_glifos"] = hist
+    hist.append(str(glifo))
+
+
+def reciente_glifo(nd: Dict[str, Any], glifo: str, ventana: int) -> bool:
+    """Return ``True`` if ``glifo`` appeared in last ``ventana`` emissions."""
+    hist = nd.get("hist_glifos")
+    gl = str(glifo)
+    if ventana < 0:
+        raise ValueError("ventana debe ser >= 0")
+    if hist and ventana > 0:
+        for reciente in islice(reversed(hist), ventana):
+            if gl == reciente:
+                return True
+    return get_attr_str(nd, ALIAS_EPI_KIND, "") == gl
+
+
+class HistoryDict(dict):
+    """Dict specialized for bounded history series and usage counts."""
+
+    def __init__(self, data: Dict[str, Any] | None = None, *, maxlen: int = 0):
+        super().__init__(data or {})
+        self._maxlen = maxlen
+        self._counts: Dict[str, int] = {}
+        self._heap: list[tuple[int, str]] = []
+        if self._maxlen > 0:
+            for k, v in list(self.items()):
+                if isinstance(v, list):
+                    self[k] = deque(v, maxlen=self._maxlen)
+                self._counts.setdefault(k, 0)
+                heapq.heappush(self._heap, (0, k))
+
+    def _compact_heap(self) -> None:
+        self._heap = [
+            (cnt, k)
+            for cnt, k in self._heap
+            if k in self and self._counts.get(k) == cnt
+        ]
+        heapq.heapify(self._heap)
+
+    def _maybe_compact(self) -> None:
+        if len(self._heap) > len(self) * 2:
+            self._compact_heap()
+
+    def _increment(self, key: str) -> None:
+        cnt = self._counts.get(key, 0) + 1
+        self._counts[key] = cnt
+        heapq.heappush(self._heap, (cnt, key))
+        self._maybe_compact()
+
+    def __getitem__(self, key):  # type: ignore[override]
+        val = super().__getitem__(key)
+        self._increment(key)
+        return val
+
+    def get(self, key, default=None):  # type: ignore[override]
+        return super().get(key, default)
+
+    def tracked_get(self, key, default=None):
+        if key in self:
+            return self[key]
+        return default
+
+    def __setitem__(self, key, value):  # type: ignore[override]
+        super().__setitem__(key, value)
+        self._counts.setdefault(key, 0)
+        heapq.heappush(self._heap, (self._counts[key], key))
+        self._maybe_compact()
+
+    def setdefault(self, key, default=None):  # type: ignore[override]
+        if self._maxlen > 0 and isinstance(default, list):
+            default = deque(default, maxlen=self._maxlen)
+        if key in self:
+            val = self[key]
+        else:
+            val = super().setdefault(key, default)
+            if self._maxlen > 0 and isinstance(val, list):
+                val = deque(val, maxlen=self._maxlen)
+                super().__setitem__(key, val)
+        self._increment(key)
+        return val
+
+    def pop_least_used(self) -> Any:
+        while self._heap:
+            cnt, key = heapq.heappop(self._heap)
+            if self._counts.get(key) == cnt and key in self:
+                self._counts.pop(key, None)
+                return super().pop(key)
+        raise KeyError("HistoryDict is empty")
+
+
+def ensure_history(G) -> Dict[str, Any]:
+    """Ensure ``G.graph['history']`` exists and return it."""
+    maxlen = int(G.graph.get("HISTORY_MAXLEN", get_param(G, "HISTORY_MAXLEN")))
+    hist = G.graph.get("history")
+    if not isinstance(hist, HistoryDict) or hist._maxlen != maxlen:
+        hist = HistoryDict(hist, maxlen=maxlen)
+        G.graph["history"] = hist
+    if maxlen > 0:
+        while len(hist) > maxlen:
+            try:
+                hist.pop_least_used()
+            except KeyError:
+                break
+    return hist
+
+
+def last_glifo(nd: Dict[str, Any]) -> str | None:
+    """Return the most recent glyph for node or ``None``."""
+    kind = get_attr_str(nd, ALIAS_EPI_KIND, "")
+    if kind:
+        return kind
+    hist = nd.get("hist_glifos")
+    if not hist:
+        return None
+    try:
+        return hist[-1]
+    except IndexError:
+        return None
+
+
+def count_glyphs(
+    G, window: int | None = None, *, last_only: bool = False
+) -> Counter:
+    """Count recent glyphs in the network."""
+    counts: Counter[str] = Counter()
+    for _, nd in G.nodes(data=True):
+        if last_only:
+            g = last_glifo(nd)
+            seq: Iterable[str] = [g] if g else []
+        else:
+            hist = nd.get("hist_glifos")
+            if not hist:
+                continue
+            if window is not None and window > 0:
+                window_int = int(window)
+                seq = islice(reversed(hist), window_int)
+            else:
+                seq = hist
+        counts.update(seq)
+    return counts
+

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -11,7 +11,8 @@ from .constants import (
     ALIAS_D2EPI,
     get_param,
 )
-from .helpers import get_attr, clamp01, reciente_glifo
+from .helpers import get_attr, clamp01
+from .glyph_history import reciente_glifo
 from .types import Glyph
 
 logger = logging.getLogger(__name__)

--- a/src/tnfr/io_utils.py
+++ b/src/tnfr/io_utils.py
@@ -1,0 +1,69 @@
+"""Utilities for reading and writing structured files."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+import json
+from json import JSONDecodeError
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+    from yaml import YAMLError  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None
+
+    class YAMLError(Exception):  # type: ignore
+        pass
+
+
+__all__ = ["read_structured_file", "ensure_parent"]
+
+
+def _parse_json(text: str) -> Any:
+    """Parse ``text`` as JSON."""
+    return json.loads(text)
+
+
+def _parse_yaml(text: str) -> Any:
+    """Parse ``text`` as YAML."""
+    if not yaml:  # pragma: no cover - optional dependency
+        raise RuntimeError("pyyaml no está instalado")
+    return yaml.safe_load(text)
+
+
+PARSERS: Dict[str, Callable[[str], Any]] = {
+    ".json": _parse_json,
+    ".yaml": _parse_yaml,
+    ".yml": _parse_yaml,
+}
+
+
+def read_structured_file(path: Path) -> Any:
+    """Read a JSON or YAML file and return the parsed data."""
+    suffix = path.suffix.lower()
+    if suffix not in PARSERS:
+        raise ValueError(f"Extensión de archivo no soportada: {suffix}")
+    parser = PARSERS[suffix]
+    if not path.is_file():
+        raise ValueError(f"El archivo no existe: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except PermissionError as e:
+        raise ValueError(f"Permiso denegado al leer {path}: {e}") from e
+    except FileNotFoundError as e:  # pragma: no cover - unlikely race
+        raise ValueError(f"El archivo no existe: {path}") from e
+
+    try:
+        return parser(text)
+    except JSONDecodeError as e:
+        raise ValueError(f"Error al parsear archivo JSON en {path}: {e}") from e
+    except YAMLError as e:
+        raise ValueError(f"Error al parsear archivo YAML en {path}: {e}") from e
+    except RuntimeError as e:
+        raise ValueError(f"Dependencia faltante al parsear {path}: {e}") from e
+
+
+def ensure_parent(path: str | Path) -> None:
+    """Create the parent directory for ``path`` if needed."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -6,7 +6,9 @@ import cmath
 from typing import Dict
 
 from ..constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_SI, COHERENCE
-from ..helpers import register_callback, ensure_history, get_attr, clamp01
+from ..callback_utils import register_callback
+from ..glyph_history import ensure_history
+from ..helpers import get_attr, clamp01
 
 
 def _norm01(x, lo, hi):

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -7,7 +7,9 @@ from typing import Any, Dict, List, Tuple
 import heapq
 
 from ..constants import METRIC_DEFAULTS, ALIAS_EPI, METRICS
-from ..helpers import register_callback, ensure_history, last_glifo, get_attr
+from ..callback_utils import register_callback
+from ..glyph_history import ensure_history, last_glifo
+from ..helpers import get_attr
 from ..constants_glifos import GLYPHS_CANONICAL, GLYPH_GROUPS
 from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from statistics import fmean
 
 from ..constants import ALIAS_EPI, ALIAS_VF, ALIAS_DNFR, ALIAS_SI, DIAGNOSIS, COHERENCE
+from ..callback_utils import register_callback
+from ..glyph_history import ensure_history
 from ..helpers import (
-    register_callback,
-    ensure_history,
     get_attr,
     clamp01,
     compute_dnfr_accel_max,

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import csv
 import json
 
-from ..helpers import ensure_history, ensure_parent
+from ..glyph_history import ensure_history
+from ..io_utils import ensure_parent
 from ..constants_glifos import GLYPHS_CANONICAL
 from .core import glifogram_series
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -15,8 +15,8 @@ from .constants import (
     ALIAS_DNFR,
     ALIAS_D2EPI,
 )
+from .glyph_history import push_glifo
 from .helpers import (
-    push_glifo,
     get_attr,
     get_attr_str,
     set_attr,

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,14 +8,12 @@ from functools import partial
 from .constants import ALIAS_THETA, METRIC_DEFAULTS
 from .helpers import (
     get_attr,
-    register_callback,
     angle_diff,
-    ensure_history,
-    count_glyphs,
     compute_coherence,
-    normalize_counter,
-    mix_groups,
 )
+from .callback_utils import register_callback
+from .glyph_history import ensure_history, count_glyphs
+from .collections_utils import normalize_counter, mix_groups
 from .constants_glifos import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
 

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -14,13 +14,13 @@ from networkx.algorithms import community as nx_comm
 from .constants import DEFAULTS, REMESH_DEFAULTS, ALIAS_EPI, get_param
 from .helpers import (
     list_mean,
-    invoke_callbacks,
     angle_diff,
     get_attr,
     set_attr,
     fase_media,
     increment_edge_version,
 )
+from .callback_utils import invoke_callbacks
 if TYPE_CHECKING:
     from .node import NodoProtocol
 from .types import Glyph

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -11,11 +11,9 @@ from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
 from .helpers import (
     get_attr,
     clamp01,
-    register_callback,
-    ensure_history,
-    last_glifo,
-    count_glyphs,
 )
+from .callback_utils import register_callback
+from .glyph_history import ensure_history, last_glifo, count_glyphs
 from .constants_glifos import (
     ANGLE_MAP,
     ESTABILIZADORES,

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -15,7 +15,8 @@ class _SigmaVectorFn(Protocol):
         ...
 
 from .constants import TRACE
-from .helpers import register_callback, ensure_history, count_glyphs
+from .callback_utils import register_callback
+from .glyph_history import ensure_history, count_glyphs
 
 try:
     from .gamma import kuramoto_R_psi as _kuramoto_R_psi

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from tnfr.cli import main, add_common_args, add_grammar_args, _build_graph_from_args
 from tnfr.constants import METRIC_DEFAULTS
-from tnfr.helpers import read_structured_file
+from tnfr.io_utils import read_structured_file
 from tnfr import __version__
 
 

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -2,7 +2,7 @@
 import networkx as nx
 from collections import deque, Counter
 
-from tnfr.helpers import count_glyphs
+from tnfr.glyph_history import count_glyphs
 from tnfr.constants import ALIAS_EPI_KIND
 
 def test_count_glyphs_last_only_and_window():

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -1,5 +1,5 @@
 import pytest
-from tnfr.helpers import ensure_collection
+from tnfr.collections_utils import ensure_collection
 
 
 def test_wraps_string():

--- a/tests/test_glyph_helpers.py
+++ b/tests/test_glyph_helpers.py
@@ -1,7 +1,7 @@
 """Pruebas para normalización y mezcla de conteos glíficos."""
 from collections import Counter
 
-from tnfr.helpers import normalize_counter, mix_groups
+from tnfr.collections_utils import normalize_counter, mix_groups
 
 
 def test_normalize_counter():

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -1,5 +1,5 @@
 """Pruebas de compactación de _heap en HistoryDict."""
-from tnfr.helpers import HistoryDict
+from tnfr.glyph_history import HistoryDict
 
 
 def test_heap_compaction_single_key():

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -2,7 +2,7 @@
 from collections import deque
 
 from tnfr.constants import attach_defaults
-from tnfr.helpers import ensure_history
+from tnfr.glyph_history import ensure_history
 
 
 def test_history_maxlen_and_cleanup(graph_canon):

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -1,7 +1,7 @@
 """Tests for normalize_weights helper."""
 import math
 import pytest
-from tnfr.helpers import normalize_weights
+from tnfr.collections_utils import normalize_weights
 
 
 def test_normalize_weights_warns_on_negative_value(caplog):

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -9,7 +9,8 @@ from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica, wbar
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
-from tnfr.helpers import angle_diff, set_attr, CallbackEvent
+from tnfr.helpers import angle_diff, set_attr
+from tnfr.callback_utils import CallbackEvent
 from tnfr.observers import attach_standard_observer
 
 def test_phase_observers_match_manual_calculation(graph_canon):

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -3,7 +3,7 @@ import pytest
 from pathlib import Path
 import tnfr.helpers as helpers
 
-from tnfr.helpers import read_structured_file
+from tnfr.io_utils import read_structured_file
 
 
 def test_read_structured_file_missing_file(tmp_path: Path):

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -1,5 +1,5 @@
 """Pruebas de register callback."""
-from tnfr.helpers import register_callback, CallbackEvent
+from tnfr.callback_utils import register_callback, CallbackEvent
 
 
 def test_register_callback_replaces_existing(graph_canon):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,6 +1,6 @@
 """Pruebas de trace."""
 from tnfr.trace import register_trace
-from tnfr.helpers import register_callback, invoke_callbacks
+from tnfr.callback_utils import register_callback, invoke_callbacks
 
 
 def test_register_trace_idempotent(graph_canon):

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -3,7 +3,7 @@ import time
 from collections import Counter, defaultdict
 
 from tnfr.constants import attach_defaults
-from tnfr.helpers import last_glifo
+from tnfr.glyph_history import last_glifo
 from tnfr.metrics import _update_tg, _tg_state
 from tnfr.metrics.core import LATENT_GLYPH, TgCurr, TgRun
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,8 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.helpers import set_attr_str, set_attr, read_structured_file
+from tnfr.helpers import set_attr_str, set_attr
+from tnfr.io_utils import read_structured_file
 from tnfr.config import load_config
 
 


### PR DESCRIPTION
## Summary
- factor file I/O helpers into `io_utils`
- split collection utilities and weight normalization into `collections_utils`
- move glyph history and callbacks to dedicated modules
- update imports across code and tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b713e4f4688321ad9183b1bfe47b66