### PR TITLE
Handle empty callback tuples in trace utility

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -62,9 +62,15 @@ def _callback_names(callbacks: list) -> list[str]:
     names: list[str] = []
     for item in callbacks:
         if isinstance(item, tuple):
-            name = item[0]
-            if not isinstance(name, str):
-                func = item[1] if len(item) > 1 else None
+            if not item:
+                # skip empty tuples
+                continue
+            first = item[0]
+            if isinstance(first, str):
+                name = first
+            else:
+                # no explicit name, fall back to the function's name
+                func = first if callable(first) else (item[1] if len(item) > 1 else None)
                 name = getattr(func, "__name__", "fn")
         else:
             name = getattr(item, "__name__", "fn")

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,5 +1,5 @@
 """Pruebas de trace."""
-from tnfr.trace import register_trace
+from tnfr.trace import register_trace, _callback_names
 from tnfr.callback_utils import register_callback, invoke_callbacks
 
 
@@ -47,3 +47,13 @@ def test_trace_sigma_no_glyphs(graph_canon):
         "mag": 0.0,
         "angle": 0.0,
     }
+
+
+def test_callback_names_empty_tuple():
+    """Los tuples vacíos son ignorados y no causan errores."""
+
+    def foo():
+        pass
+
+    names = _callback_names([(), (foo,)])
+    assert names == ["foo"]


### PR DESCRIPTION
## Summary
- Avoid crashes in `_callback_names` by skipping empty tuples and deriving names from callback functions when explicit names are absent.
- Add tests ensuring `_callback_names` handles empty tuple entries gracefully.

## Testing
- `PYTHONPATH=src pytest tests/test_trace.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7170464088321a851fb5b3f91ddcd