### PR TITLE
Add ASCII key constants for phase and frequency keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Engine for **modeling, simulation and measurement** of multiscale structural coh
 
 In practical terms, `tnfr` lets you:
 
-* Model **Resonant Fractal Nodes (NFR)** with parameters for **frequency** (νf), **phase** (θ), and **form** (EPI).
+* Model **Resonant Fractal Nodes (NFR)** with parameters for **frequency** (νf), **phase** (θ), and **form** (EPI). Use the ASCII constants `VF_KEY` and `THETA_KEY` to reference these attributes programmatically; the Unicode names remain available as aliases.
 * Apply **structural operators** to start, stabilize, propagate, or reconfigure coherence.
 * **Simulate** nodal dynamics with discrete/continuous integrators.
 * **Measure** global coherence C(t), nodal gradient ΔNFR, and the **Sense Index** (Si).

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -107,9 +107,13 @@ def get_param(G, key: str):
     return DEFAULTS[key]
 
 
+# Claves canónicas con nombres ASCII
+VF_KEY = "νf"
+THETA_KEY = "θ"
+
 # Alias exportados por conveniencia (evita imports circulares)
-ALIAS_VF = ("νf", "nu_f", "nu-f", "nu", "freq", "frequency")
-ALIAS_THETA = ("θ", "theta", "fase", "phi", "phase")
+ALIAS_VF = (VF_KEY, "nu_f", "nu-f", "nu", "freq", "frequency")
+ALIAS_THETA = (THETA_KEY, "theta", "fase", "phi", "phase")
 ALIAS_DNFR = ("ΔNFR", "delta_nfr", "dnfr")
 ALIAS_EPI = ("EPI", "psi", "PSI", "value")
 ALIAS_EPI_KIND = ("EPI_kind", "epi_kind", "source_glifo")
@@ -137,6 +141,8 @@ __all__ = [
     "inject_defaults",
     "merge_overrides",
     "get_param",
+    "VF_KEY",
+    "THETA_KEY",
     "ALIAS_VF",
     "ALIAS_THETA",
     "ALIAS_DNFR",

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import networkx as nx
 
-from .constants import DEFAULTS, INIT_DEFAULTS
+from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
 
 
 def _init_phase(
@@ -17,13 +17,13 @@ def _init_phase(
 ) -> None:
     """Inicializa ``θ`` en ``nd``."""
     if random_phase:
-        if override or "θ" not in nd:
-            nd["θ"] = rng.uniform(th_min, th_max)
+        if override or THETA_KEY not in nd:
+            nd[THETA_KEY] = rng.uniform(th_min, th_max)
     else:
         if override:
-            nd["θ"] = 0.0
+            nd[THETA_KEY] = 0.0
         else:
-            nd.setdefault("θ", 0.0)
+            nd.setdefault(THETA_KEY, 0.0)
 
 
 def _init_vf(
@@ -55,11 +55,11 @@ def _init_vf(
                 vf_max_lim,
             )
     else:
-        vf = float(nd.get("νf", 0.5))
+        vf = float(nd.get(VF_KEY, 0.5))
     if clamp_to_limits:
         vf = min(max(vf, vf_min_lim), vf_max_lim)
-    if override or "νf" not in nd:
-        nd["νf"] = float(vf)
+    if override or VF_KEY not in nd:
+        nd[VF_KEY] = float(vf)
 
 
 def _init_si_epi(

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 
 from statistics import fmean
 
-from ..constants import ALIAS_EPI, ALIAS_VF, ALIAS_DNFR, ALIAS_SI, DIAGNOSIS, COHERENCE
+from ..constants import (
+    ALIAS_EPI,
+    ALIAS_VF,
+    ALIAS_DNFR,
+    ALIAS_SI,
+    DIAGNOSIS,
+    COHERENCE,
+    VF_KEY,
+)
 from ..callback_utils import register_callback
 from ..glyph_history import ensure_history
 from ..helpers import (
@@ -110,7 +118,7 @@ def _diagnosis_step(G, ctx=None):
             "node": n,
             "Si": Si,
             "EPI": EPI,
-            "νf": vf,
+            VF_KEY: vf,
             "dnfr_norm": dnfr_n,
             "W_i": (Wi_last[i] if (Wi_last and i < len(Wi_last)) else None),
             "R_local": Rloc,

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Any
 
+from .constants import VF_KEY, THETA_KEY
+
 
 @dataclass
 class NodeState:
@@ -15,7 +17,7 @@ class NodeState:
     extra: Dict[str, Any] = field(default_factory=dict)
 
     def to_attrs(self) -> Dict[str, Any]:
-        d = {"EPI": self.EPI, "νf": self.vf, "θ": self.theta, "Si": self.Si, "EPI_kind": self.epi_kind}
+        d = {"EPI": self.EPI, VF_KEY: self.vf, THETA_KEY: self.theta, "Si": self.Si, "EPI_kind": self.epi_kind}
         d.update(self.extra)
         return d
 

--- a/tests/test_canon.py
+++ b/tests/test_canon.py
@@ -1,6 +1,7 @@
 """Pruebas de canon."""
 from tnfr.scenarios import build_graph
 from tnfr.dynamics import validate_canon
+from tnfr.constants import VF_KEY, THETA_KEY
 
 
 def test_build_graph_vf_within_limits():
@@ -8,7 +9,7 @@ def test_build_graph_vf_within_limits():
     vf_min = G.graph["VF_MIN"]
     vf_max = G.graph["VF_MAX"]
     for n in G.nodes():
-        vf = G.nodes[n]["νf"]
+        vf = G.nodes[n][VF_KEY]
         assert vf_min <= vf <= vf_max
 
 
@@ -16,9 +17,9 @@ def test_validate_canon_clamps():
     G = build_graph(n=5, topology="ring", seed=1)
     for n in G.nodes():
         nd = G.nodes[n]
-        nd["νf"] = 2.0
+        nd[VF_KEY] = 2.0
         nd["EPI"] = 2.0
-        nd["θ"] = 5.0
+        nd[THETA_KEY] = 5.0
     validate_canon(G)
     vf_min = G.graph["VF_MIN"]
     vf_max = G.graph["VF_MAX"]
@@ -26,6 +27,6 @@ def test_validate_canon_clamps():
     epi_max = G.graph["EPI_MAX"]
     for n in G.nodes():
         nd = G.nodes[n]
-        assert vf_min <= nd["νf"] <= vf_max
+        assert vf_min <= nd[VF_KEY] <= vf_max
         assert epi_min <= nd["EPI"] <= epi_max
-        assert -3.1416 <= nd["θ"] <= 3.1416
+        assert -3.1416 <= nd[THETA_KEY] <= 3.1416

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2,7 +2,8 @@
 import networkx as nx
 
 from tnfr.initialization import init_node_attrs
-from tnfr.constants import attach_defaults
+from tnfr.constants import attach_defaults, VF_KEY, THETA_KEY, ALIAS_VF, ALIAS_THETA
+from tnfr.helpers import get_attr
 
 
 def test_init_node_attrs_reproducible():
@@ -11,13 +12,13 @@ def test_init_node_attrs_reproducible():
     attach_defaults(G1)
     G1.graph["RANDOM_SEED"] = seed
     init_node_attrs(G1)
-    attrs1 = {n: (d["EPI"], d["θ"], d["νf"], d["Si"]) for n, d in G1.nodes(data=True)}
+    attrs1 = {n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G1.nodes(data=True)}
 
     G2 = nx.path_graph(5)
     attach_defaults(G2)
     G2.graph["RANDOM_SEED"] = seed
     init_node_attrs(G2)
-    attrs2 = {n: (d["EPI"], d["θ"], d["νf"], d["Si"]) for n, d in G2.nodes(data=True)}
+    attrs2 = {n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G2.nodes(data=True)}
 
     assert attrs1 == attrs2
 
@@ -35,7 +36,7 @@ def test_init_node_attrs_reversed_uniform_bounds():
         }
     )
     init_node_attrs(G1)
-    vfs1 = [d["νf"] for _, d in G1.nodes(data=True)]
+    vfs1 = [d[VF_KEY] for _, d in G1.nodes(data=True)]
 
     G2 = nx.path_graph(3)
     attach_defaults(G2)
@@ -48,6 +49,18 @@ def test_init_node_attrs_reversed_uniform_bounds():
         }
     )
     init_node_attrs(G2)
-    vfs2 = [d["νf"] for _, d in G2.nodes(data=True)]
+    vfs2 = [d[VF_KEY] for _, d in G2.nodes(data=True)]
 
     assert vfs1 == vfs2
+
+
+def test_init_node_attrs_alias_access():
+    G = nx.path_graph(2)
+    attach_defaults(G)
+    init_node_attrs(G)
+    for _, d in G.nodes(data=True):
+        d_ascii = {"nu_f": d[VF_KEY], "theta": d[THETA_KEY]}
+        assert get_attr(d, ALIAS_VF, 0.0) == d[VF_KEY]
+        assert get_attr(d, ALIAS_THETA, 0.0) == d[THETA_KEY]
+        assert get_attr(d_ascii, ALIAS_VF, 0.0) == d[VF_KEY]
+        assert get_attr(d_ascii, ALIAS_THETA, 0.0) == d[THETA_KEY]


### PR DESCRIPTION
## Summary
- add `VF_KEY` and `THETA_KEY` constants mapping to canonical Unicode keys and expose them via aliases
- refactor node initialization, types, and diagnostics to reference ASCII constants
- document new constants and test both ASCII and Unicode attribute forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72cd9211083219c55db772ef7deb9