### PR TITLE
Handle non-iterator iterables in ensure_collection

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -48,6 +48,7 @@ def ensure_collection(
         raise ValueError("'max_materialize' must be non-negative")
     try:
         limit = MAX_MATERIALIZE_DEFAULT if max_materialize is None else max_materialize
+        it = iter(it)
         data = tuple(islice(it, limit))
         extra = next(it, None)
         if extra is not None:

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -16,6 +16,15 @@ def test_wraps_bytearray():
     assert ensure_collection(arr) == (arr,)
 
 
+def test_iterable_not_iterator_materialized():
+    class CustomIterable:
+        def __iter__(self):
+            return (i for i in range(3))
+
+    it = CustomIterable()
+    assert ensure_collection(it, max_materialize=3) == (0, 1, 2)
+
+
 def test_max_materialize_limit():
     gen = (i for i in range(5))
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- ensure `ensure_collection` converts input to an iterator before materializing
- add regression test for iterable that produces a fresh generator on each iteration

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b737c19e8c832183622398584fb602