### PR TITLE
chore: remove unused Any import

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -1,7 +1,7 @@
 """Callback registration and invocation helpers."""
 from __future__ import annotations
 
-from typing import Callable, Any, Optional
+from typing import Callable, Optional
 from enum import Enum
 from collections import defaultdict
 import logging


### PR DESCRIPTION
## Summary
- remove unused `Any` typing import in callback_utils

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74d9a0ab48321a447ce520626098f