### PR TITLE
Refine phase sync calculation

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -64,10 +64,10 @@ def phase_sync(G) -> float:
     count = len(fases)
     if count == 0:
         return 1.0
-    th = math.atan2(sumY / count, sumX / count)
+    th = math.atan2(sumY, sumX)
     # varianza angular aproximada (0 = muy sincronizado)
     var = (
-        st.pvariance([angle_diff(f, th) for f in fases])
+        st.pvariance(angle_diff(f, th) for f in fases)
         if count > 1
         else 0.0
     )

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -22,8 +22,8 @@ def test_phase_observers_match_manual_calculation(graph_canon):
 
     X = [math.cos(th) for th in angles]
     Y = [math.sin(th) for th in angles]
-    th_mean = math.atan2(sum(Y) / len(Y), sum(X) / len(X))
-    var = st.pvariance([angle_diff(th, th_mean) for th in angles])
+    th_mean = math.atan2(sum(Y), sum(X))
+    var = st.pvariance(angle_diff(th, th_mean) for th in angles)
     expected_sync = 1.0 / (1.0 + var)
     assert math.isclose(phase_sync(G), expected_sync)
 


### PR DESCRIPTION
## Summary
- simplify phase mean calculation by avoiding unnecessary normalization in phase_sync
- use generator expression when computing angular variance
- adjust observer tests to match new calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b752aa99d48321bef251770de1d4bc