### PR TITLE
refactor: remove io_utils compatibility layer

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -28,8 +28,7 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
-from .io_utils import read_structured_file, ensure_parent
-from .helpers import list_mean
+from .helpers import read_structured_file, ensure_parent, list_mean
 from .observers import attach_standard_observer
 from . import __version__
 

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from typing import Any, Dict
 from pathlib import Path
-from .io_utils import read_structured_file
+from .helpers import read_structured_file
 
 from .constants import inject_defaults
 

--- a/src/tnfr/io_utils.py
+++ b/src/tnfr/io_utils.py
@@ -1,7 +1,0 @@
-"""Compatibility layer for structured file helpers."""
-from __future__ import annotations
-
-from .helpers import read_structured_file, ensure_parent
-
-__all__ = ["read_structured_file", "ensure_parent"]
-

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -5,7 +5,7 @@ import csv
 import json
 
 from ..glyph_history import ensure_history
-from ..io_utils import ensure_parent
+from ..helpers import ensure_parent
 from ..constants_glyphs import GLYPHS_CANONICAL
 from .core import glyphogram_series
 

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from tnfr.cli import main, add_common_args, add_grammar_args, _build_graph_from_args
 from tnfr.constants import METRIC_DEFAULTS
-from tnfr.io_utils import read_structured_file
+from tnfr.helpers import read_structured_file
 from tnfr import __version__
 
 

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -3,7 +3,7 @@ import pytest
 from pathlib import Path
 import tnfr.helpers as helpers
 
-from tnfr.io_utils import read_structured_file
+from tnfr.helpers import read_structured_file
 
 
 def test_read_structured_file_missing_file(tmp_path: Path):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,8 +8,7 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.helpers import set_attr_str, set_attr
-from tnfr.io_utils import read_structured_file
+from tnfr.helpers import set_attr_str, set_attr, read_structured_file
 from tnfr.config import load_config
 
 


### PR DESCRIPTION
## Summary
- remove obsolete `io_utils` module
- import file utilities from `helpers`
- update tests and metrics export to new import

## Testing
- `PYTHONPATH=src pytest tests/test_read_structured_file_errors.py tests/test_validators.py tests/test_cli_sanity.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75f69e928832198e25ebf493894fb