### PR TITLE
refactor: simplify callback registration

### DIFF
--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -1,4 +1,6 @@
 """Pruebas de register callback."""
+import pytest
+
 from tnfr.callback_utils import register_callback, CallbackEvent
 
 
@@ -22,3 +24,13 @@ def test_register_callback_replaces_existing(graph_canon):
     # same function with different name should also replace existing
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="other")
     assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("other", cb2)]
+
+
+def test_register_callback_rejects_tuple(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        pass
+
+    with pytest.raises(TypeError):
+        register_callback(G, event=CallbackEvent.BEFORE_STEP, func=("cb", cb))


### PR DESCRIPTION
## Summary
- remove tuple-based registration and require a callable `func`
- add strict typing and examples in `register_callback`
- verify tuple usage is rejected

## Testing
- `PYTHONPATH=src pytest tests/test_register_callback.py tests/test_trace.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b760a44dd88321a173310ddf52aaf2