### PR TITLE
refactor: document materialization limit in ensure_collection

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -47,9 +47,10 @@ def ensure_collection(
         raise ValueError("'max_materialize' must be non-negative")
     try:
         limit = MAX_MATERIALIZE_DEFAULT if max_materialize is None else max_materialize
-        it = iter(it)
-        data = tuple(islice(it, limit))
-        extra = next(it, None)
+        # Materialize at most ``limit`` items from the iterable
+        iterator = iter(it)
+        data = tuple(islice(iterator, limit))
+        extra = next(iterator, None)
         if extra is not None:
             raise ValueError(f"Iterable materialization exceeded {limit} items")
         return data


### PR DESCRIPTION
## Summary
- avoid reassigning input iterable in `ensure_collection`
- document the materialization limit when materializing iterables

## Testing
- `pytest tests/test_ensure_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7618aee988321a18e57aedfe473a3