### PR TITLE
Define exported names for CLI and node modules

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -34,6 +34,24 @@ from . import __version__
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "main",
+    "add_common_args",
+    "add_grammar_args",
+    "add_grammar_selector_args",
+    "add_history_export_args",
+    "add_canon_toggle",
+    "build_basic_graph",
+    "apply_cli_config",
+    "register_callbacks_and_observer",
+    "run_program",
+    "resolve_program",
+    "_build_graph_from_args",
+    "_load_sequence",
+    "_parse_tokens",
+    "TOKEN_MAP",
+]
+
 
 def _flatten_tokens(obj: Any):
     """Generador recursivo que rinde cada token en orden."""

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -28,6 +28,8 @@ from .helpers import (
 
 from .operators import apply_glyph_obj
 
+__all__ = ["NodoTNFR", "NodoNX", "NodoProtocol"]
+
 
 def _nx_attr_property(
     aliases,


### PR DESCRIPTION
## Summary
- declare public API in `tnfr.cli` via `__all__`
- expose node classes and protocol via `__all__` in `tnfr.node`
- verified repository imports use only exported names

## Testing
- `PYTHONPATH=src pytest tests/test_cli_* tests/test_node_*`


------
https://chatgpt.com/codex/tasks/task_e_68b763c41be8832195773caa5ae0466a