### PR TITLE
Handle file read errors with OSError

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -113,17 +113,11 @@ def read_structured_file(path: Path) -> Any:
     if suffix not in PARSERS:
         raise ValueError(f"Extensión de archivo no soportada: {suffix}")
     parser = PARSERS[suffix]
-    if not path.is_file():
-        raise ValueError(f"El archivo no existe: {path}")
     try:
         text = path.read_text(encoding="utf-8")
-    except PermissionError as e:
-        raise ValueError(f"Permiso denegado al leer {path}: {e}") from e
-    except FileNotFoundError as e:  # pragma: no cover - carrera improbable
-        raise ValueError(f"El archivo no existe: {path}") from e
-
-    try:
         return parser(text)
+    except OSError as e:
+        raise ValueError(f"No se pudo leer {path}: {e}") from e
     except JSONDecodeError as e:
         raise ValueError(f"Error al parsear archivo JSON en {path}: {e}") from e
     except YAMLError as e:


### PR DESCRIPTION
## Summary
- simplify `read_structured_file` by reading and parsing in a single try block
- catch `OSError` and raise `ValueError` with file path

## Testing
- `PYTHONPATH=src pytest tests/test_read_structured_file_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68b76872869c8321826900b3746eec0c