### PR TITLE
Centraliza umbrales del selector

### DIFF
--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -6,6 +6,16 @@ from typing import Dict, Any, Mapping
 from types import MappingProxyType
 
 
+SELECTOR_THRESHOLD_DEFAULTS = {
+    "si_hi": 0.66,
+    "si_lo": 0.33,
+    "dnfr_hi": 0.50,
+    "dnfr_lo": 0.10,
+    "accel_hi": 0.50,
+    "accel_lo": 0.10,
+}
+
+
 @dataclass(frozen=True)
 class CoreDefaults:
     DT: float = 1.0
@@ -89,14 +99,7 @@ class CoreDefaults:
         default_factory=lambda: {"w_si": 0.5, "w_dnfr": 0.3, "w_accel": 0.2}
     )
     SELECTOR_THRESHOLDS: Dict[str, float] = field(
-        default_factory=lambda: {
-            "si_hi": 0.66,
-            "si_lo": 0.33,
-            "dnfr_hi": 0.50,
-            "dnfr_lo": 0.10,
-            "accel_hi": 0.50,
-            "accel_lo": 0.10,
-        }
+        default_factory=lambda: dict(SELECTOR_THRESHOLD_DEFAULTS)
     )
     GAMMA: Dict[str, Any] = field(
         default_factory=lambda: {"type": "none", "beta": 0.0, "R0": 0.0}

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import networkx as nx
 
 from .constants import DEFAULTS
+from .constants.core import SELECTOR_THRESHOLD_DEFAULTS
 from .helpers import clamp01, compute_dnfr_accel_max
 from .collections_utils import normalize_weights
 
@@ -47,12 +48,40 @@ def _selector_thresholds(G: nx.Graph) -> dict:
         return clamp01(float(val))
 
     specs = [
-        ("si_hi", thr_def.get("hi", glyph_defaults.get("hi", 0.66)), "hi"),
-        ("si_lo", thr_def.get("lo", glyph_defaults.get("lo", 0.33)), "lo"),
-        ("dnfr_hi", sel_defaults.get("dnfr_hi", 0.5), None),
-        ("dnfr_lo", sel_defaults.get("dnfr_lo", 0.1), None),
-        ("accel_hi", sel_defaults.get("accel_hi", 0.5), None),
-        ("accel_lo", sel_defaults.get("accel_lo", 0.1), None),
+        (
+            "si_hi",
+            thr_def.get(
+                "hi", glyph_defaults.get("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"])
+            ),
+            "hi",
+        ),
+        (
+            "si_lo",
+            thr_def.get(
+                "lo", glyph_defaults.get("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"])
+            ),
+            "lo",
+        ),
+        (
+            "dnfr_hi",
+            sel_defaults.get("dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]),
+            None,
+        ),
+        (
+            "dnfr_lo",
+            sel_defaults.get("dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]),
+            None,
+        ),
+        (
+            "accel_hi",
+            sel_defaults.get("accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]),
+            None,
+        ),
+        (
+            "accel_lo",
+            sel_defaults.get("accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]),
+            None,
+        ),
     ]
 
     return {key: _get_threshold(key, default, legacy) for key, default, legacy in specs}

--- a/tests/test_selector_norms.py
+++ b/tests/test_selector_norms.py
@@ -1,5 +1,6 @@
 """Pruebas de selector norms."""
 from tnfr.dynamics import step, default_glyph_selector, parametric_glyph_selector
+from tnfr.constants.core import SELECTOR_THRESHOLD_DEFAULTS
 
 
 def _make_graph(graph_canon):
@@ -8,6 +9,7 @@ def _make_graph(graph_canon):
     G.add_edge(0, 1)
     G.graph["GRAMMAR_CANON"] = {"enabled": False}
     G.graph.update(EPI_MIN=0.0, EPI_MAX=1.0, VF_MIN=0.0, VF_MAX=1.0)
+    G.graph["SELECTOR_THRESHOLDS"] = dict(SELECTOR_THRESHOLD_DEFAULTS)
     return G
 
 

--- a/tests/test_selector_utils.py
+++ b/tests/test_selector_utils.py
@@ -8,6 +8,7 @@ from tnfr.selector import (
     _apply_selector_hysteresis,
 )
 from tnfr.constants import DEFAULTS, ALIAS_DNFR, ALIAS_D2EPI
+from tnfr.constants.core import SELECTOR_THRESHOLD_DEFAULTS
 from tnfr.helpers import clamp01
 
 
@@ -21,7 +22,9 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
         float(
             thr_sel.get(
                 "si_hi",
-                thr_def.get("hi", glyph_defaults.get("hi", 0.66)),
+                thr_def.get(
+                    "hi", glyph_defaults.get("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"])
+                ),
             )
         )
     )
@@ -29,35 +32,41 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
         float(
             thr_sel.get(
                 "si_lo",
-                thr_def.get("lo", glyph_defaults.get("lo", 0.33)),
+                thr_def.get(
+                    "lo", glyph_defaults.get("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"])
+                ),
             )
         )
     )
     dnfr_hi = clamp01(
         float(
             thr_sel.get(
-                "dnfr_hi", sel_defaults.get("dnfr_hi", 0.5)
+                "dnfr_hi",
+                sel_defaults.get("dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]),
             )
         )
     )
     dnfr_lo = clamp01(
         float(
             thr_sel.get(
-                "dnfr_lo", sel_defaults.get("dnfr_lo", 0.1)
+                "dnfr_lo",
+                sel_defaults.get("dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]),
             )
         )
     )
     acc_hi = clamp01(
         float(
             thr_sel.get(
-                "accel_hi", sel_defaults.get("accel_hi", 0.5)
+                "accel_hi",
+                sel_defaults.get("accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]),
             )
         )
     )
     acc_lo = clamp01(
         float(
             thr_sel.get(
-                "accel_lo", sel_defaults.get("accel_lo", 0.1)
+                "accel_lo",
+                sel_defaults.get("accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]),
             )
         )
     )


### PR DESCRIPTION
## Summary
- Añade subdiccionario `SELECTOR_THRESHOLD_DEFAULTS` para unificar los umbrales por defecto
- Usa el nuevo subdict en `selector._selector_thresholds` evitando valores codificados
- Actualiza pruebas de utilidades y normas del selector a los nuevos umbrales

## Testing
- `PYTHONPATH=src pytest tests/test_selector_norms.py tests/test_selector_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68b768e280f88321b50f325264b23f90