### PR TITLE
Use enumerate to simplify token position tracking

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -65,9 +65,7 @@ def _flatten_tokens(obj: Any):
 
 def _parse_tokens(obj: Any) -> List[Any]:
     out: List[Any] = []
-    pos = 0
-    for tok in _flatten_tokens(obj):
-        pos += 1
+    for pos, tok in enumerate(_flatten_tokens(obj), start=1):
         try:
             if isinstance(tok, dict):
                 if len(tok) != 1:


### PR DESCRIPTION
## Summary
- Simplify token position tracking in `_parse_tokens` using `enumerate`
- Preserve detailed error reporting with accurate token positions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76c0d4db8832197ce3e794c602672