### PR TITLE
refactor: reuse graph builder for CLI runs

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -332,9 +332,7 @@ def run_program(
 ) -> nx.Graph:
     """Construir el grafo si es necesario, ejecutar un programa y guardar historial."""
     if G is None:
-        G = build_basic_graph(args)
-        apply_cli_config(G, args)
-        register_callbacks_and_observer(G, args)
+        G = _build_graph_from_args(args)
 
     if program is None:
         steps = int(getattr(args, "steps", 100) or 100)


### PR DESCRIPTION
## Summary
- reuse `_build_graph_from_args` inside `run_program`

## Testing
- `PYTHONPATH=src pytest tests/test_cli_sanity.py -q`
- `PYTHONPATH=src pytest tests/test_cli_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76ca6e9148321b3ee75d6b914efcd