### PR TITLE
Use clamp helper in initialization

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -4,6 +4,7 @@ import random
 import networkx as nx
 
 from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
+from tnfr.helpers import clamp
 
 
 def _init_phase(
@@ -57,7 +58,7 @@ def _init_vf(
     else:
         vf = float(nd.get(VF_KEY, 0.5))
     if clamp_to_limits:
-        vf = min(max(vf, vf_min_lim), vf_max_lim)
+        vf = clamp(vf, vf_min_lim, vf_max_lim)
     if override or VF_KEY not in nd:
         nd[VF_KEY] = float(vf)
 


### PR DESCRIPTION
## Summary
- import `clamp` from `tnfr.helpers` for use in node initialization
- apply `clamp` to constrain `vf` within limits instead of manual `min`/`max`

## Testing
- `PYTHONPATH=src pytest tests/test_initialization.py`


------
https://chatgpt.com/codex/tasks/task_e_68b76d58c1508321bb4b5e13386e4eb8