### PR TITLE
Refactor history export CLI options using specification list

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -154,6 +154,23 @@ GRAMMAR_ARG_SPECS = [
     ("--glyph.hysteresis_window", {"type": int}),
 ]
 
+# Especificaciones para opciones relacionadas con el histórico
+HISTORY_ARG_SPECS = [
+    ("--save-history", {"dest": "save_history", "type": str, "default": None}),
+    (
+        "--export-history-base",
+        {"dest": "export_history_base", "type": str, "default": None},
+    ),
+    (
+        "--export-format",
+        {
+            "dest": "export_format",
+            "choices": ["csv", "json"],
+            "default": "json",
+        },
+    ),
+]
+
 
 def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
     """Extract arguments matching a prefix.
@@ -307,13 +324,8 @@ def add_grammar_selector_args(parser: argparse.ArgumentParser) -> None:
 
 def add_history_export_args(parser: argparse.ArgumentParser) -> None:
     """Agrega los argumentos para guardar o exportar el histórico."""
-    parser.add_argument("--save-history", dest="save_history", type=str, default=None)
-    parser.add_argument(
-        "--export-history-base", dest="export_history_base", type=str, default=None
-    )
-    parser.add_argument(
-        "--export-format", dest="export_format", choices=["csv", "json"], default="json"
-    )
+    for opt, kwargs in HISTORY_ARG_SPECS:
+        parser.add_argument(opt, **kwargs)
 
 
 def add_canon_toggle(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -19,3 +19,21 @@ def test_cli_run_export_history(tmp_path):
     assert rc == 0
     data = json.loads((base.with_suffix(".json")).read_text())
     assert isinstance(data, dict)
+
+
+def test_cli_sequence_save_history(tmp_path):
+    path = tmp_path / "non" / "existing" / "hist.json"
+    assert not path.parent.exists()
+    rc = main(["sequence", "--nodes", "5", "--save-history", str(path)])
+    assert rc == 0
+    data = json.loads(path.read_text())
+    assert isinstance(data, dict)
+
+
+def test_cli_sequence_export_history(tmp_path):
+    base = tmp_path / "other" / "history"
+    assert not base.parent.exists()
+    rc = main(["sequence", "--nodes", "5", "--export-history-base", str(base)])
+    assert rc == 0
+    data = json.loads((base.with_suffix(".json")).read_text())
+    assert isinstance(data, dict)


### PR DESCRIPTION
## Summary
- Centralize history export CLI arguments in `HISTORY_ARG_SPECS`
- Register history options by iterating specs
- Extend CLI history tests to cover `sequence` subcommand

## Testing
- `PYTHONPATH=src pytest tests/test_cli_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7700ad3dc8321a82b85f8fa13a3a9