### PR TITLE
refactor: streamline glyph pushing

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -190,9 +190,7 @@ class NodoTNFR:
         _add_edge_tnfr(self.graph, self, other, weight, overwrite)
 
     def push_glyph(self, glyph: str, window: int) -> None:
-        nd = {"glyph_history": self._glyph_history}
-        push_glyph(nd, glyph, window)
-        self._glyph_history = nd["glyph_history"]
+        push_glyph({"glyph_history": self._glyph_history}, glyph, window)
         self.epi_kind = glyph
 
     def offset(self) -> int:


### PR DESCRIPTION
## Summary
- simplify NodoTNFR glyph pushing by operating directly on `_glyph_history`
- ensure `epi_kind` updated after glyph push

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b773a2e9f08321878393237c1891d1