### PR TITLE
Optimize recent_glyph lookup using last_glyph

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -30,15 +30,26 @@ def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
 
 def recent_glyph(nd: Dict[str, Any], glyph: str, ventana: int) -> bool:
     """Return ``True`` if ``glyph`` appeared in last ``ventana`` emissions."""
-    hist = nd.get("glyph_history")
     gl = str(glyph)
     if ventana < 0:
         raise ValueError("ventana debe ser >= 0")
-    if hist and ventana > 0:
-        for reciente in islice(reversed(hist), ventana):
+
+    last = last_glyph(nd)
+    if ventana <= 1:
+        return last == gl
+    if last == gl:
+        return True
+
+    hist = nd.get("glyph_history")
+    if hist:
+        if hist and hist[-1] == last:
+            history_iter = islice(reversed(hist), 1, ventana)
+        else:
+            history_iter = islice(reversed(hist), ventana - 1)
+        for reciente in history_iter:
             if gl == reciente:
                 return True
-    return get_attr_str(nd, ALIAS_EPI_KIND, "") == gl
+    return False
 
 
 class HistoryDict(dict):

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -1,0 +1,25 @@
+"""Pruebas de recent_glyph."""
+from tnfr.glyph_history import push_glyph, recent_glyph
+from tnfr.constants import ALIAS_EPI_KIND
+
+
+def _make_node(history, current=None, window=10):
+    nd = {}
+    for g in history:
+        push_glyph(nd, g, window)
+    if current is not None:
+        nd[ALIAS_EPI_KIND[0]] = current
+    return nd
+
+
+def test_recent_glyph_window_one():
+    nd = _make_node(["Y"], current="X")
+    assert recent_glyph(nd, "X", 1)
+    assert not recent_glyph(nd, "Y", 1)
+
+
+def test_recent_glyph_history_lookup():
+    nd = _make_node(["A", "B"], current="C")
+    assert recent_glyph(nd, "B", 2)
+    assert not recent_glyph(nd, "A", 2)
+    assert recent_glyph(nd, "A", 3)


### PR DESCRIPTION
## Summary
- Use `last_glyph` for single-element windows and as the starting point for larger history searches in `recent_glyph`
- Add tests covering `recent_glyph` window logic

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7745ee55483218d9b073e78697c03