### PR TITLE
Use ensure_history for program trace

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -10,6 +10,7 @@ from .grammar import apply_glyph_with_grammar
 from .sense import GLYPHS_CANONICAL_SET
 from .types import Glyph
 from .collections_utils import ensure_collection
+from .glyph_history import ensure_history
 
 # Basic types
 Node = Any
@@ -219,7 +220,7 @@ def play(G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None) -> N
     curr_target: Optional[List[Node]] = None
 
     # Traza de programa en history
-    history = G.graph.setdefault("history", {})
+    history = ensure_history(G)
     maxlen = int(get_param(G, "PROGRAM_TRACE_MAXLEN"))
     trace = history.get("program_trace")
     if not isinstance(trace, deque) or trace.maxlen != maxlen:


### PR DESCRIPTION
## Summary
- import ensure_history and use it for program trace

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b77607083483219b2c9820b0796f0e