### PR TITLE
Compact heap after popping entries

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -122,7 +122,9 @@ class HistoryDict(dict):
             cnt, key = heapq.heappop(self._heap)
             if self._counts.get(key) == cnt and key in self:
                 self._counts.pop(key, None)
-                return super().pop(key)
+                value = super().pop(key)
+                self._maybe_compact()
+                return value
         raise KeyError("HistoryDict is empty")
 
 

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -27,3 +27,13 @@ def test_get_does_not_track_usage():
     assert hist.get("a") == 1
     assert hist._counts == counts_before
     assert hist._heap == heap_before
+
+
+def test_heap_compaction_after_deletions():
+    hist = HistoryDict()
+    for i in range(10):
+        hist[f"k{i}"] = i
+        _ = hist[f"k{i}"]
+    for _ in range(5):
+        hist.pop_least_used()
+        assert len(hist._heap) <= len(hist) * 2


### PR DESCRIPTION
## Summary
- Compact the internal heap in `HistoryDict.pop_least_used` after removing an entry to keep it bounded
- Add regression test ensuring heap stays within size limits after repeated deletions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77b67f7e48321b9d9d820bcb3139b