### PR TITLE
Remove redundant pass after debug logging in dynamics

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -1231,7 +1231,6 @@ def _update_history(G) -> None:
     except (KeyError, AttributeError, TypeError) as exc:
         logger.debug("observer update failed: %s", exc)
         # observadores son opcionales; si fallan se ignoran
-        pass
   
     # --- nuevas series: Si agregado (media y colas) ---
     try:
@@ -1261,4 +1260,3 @@ def _update_history(G) -> None:
     except (KeyError, AttributeError, TypeError) as exc:
         logger.debug("Si aggregation failed: %s", exc)
         # si aún no se calculó Si este paso, no interrumpimos
-        pass


### PR DESCRIPTION
## Summary
- drop unnecessary `pass` statements after debug logging in `_update_history`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b77f6d3cac832184226ecb1f2e7b85