### PR TITLE
Use relative import for clamp

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -4,7 +4,7 @@ import random
 import networkx as nx
 
 from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
-from tnfr.helpers import clamp
+from .helpers import clamp
 
 
 def _init_phase(


### PR DESCRIPTION
## Summary
- Use a relative import for `clamp` in `initialization.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b781426d448321865c5079c5b41155