### PR TITLE
refactor: centralize callback spec import

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -1,7 +1,7 @@
 """Callback registration and invocation helpers."""
 from __future__ import annotations
 
-from typing import Any, Callable, DefaultDict, TYPE_CHECKING
+from typing import Any, Callable, DefaultDict
 from enum import Enum
 from collections import defaultdict
 import logging
@@ -9,6 +9,7 @@ import logging
 import networkx as nx
 
 from .constants import DEFAULTS
+from .trace import CallbackSpec
 
 __all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
 
@@ -27,10 +28,7 @@ _CALLBACK_EVENTS: tuple[str, ...] = tuple(e.value for e in CallbackEvent)
 
 
 Callback = Callable[[nx.Graph, dict[str, Any]], None]
-if TYPE_CHECKING:  # pragma: no cover
-    from .trace import CallbackSpec
-
-CallbackRegistry = DefaultDict[str, list["CallbackSpec"]]
+CallbackRegistry = DefaultDict[str, list[CallbackSpec]]
 
 
 def _ensure_callbacks(G: nx.Graph) -> CallbackRegistry:
@@ -57,8 +55,6 @@ def _normalize_callback_entry(entry: Any) -> CallbackSpec | None:
         Normalized ``CallbackSpec`` or ``None`` if ``entry`` cannot be
         interpreted as a callback.
     """
-    from .trace import CallbackSpec
-
     if isinstance(entry, CallbackSpec):
         return entry
     if isinstance(entry, tuple):
@@ -125,8 +121,6 @@ def register_callback(
     if not callable(func):
         raise TypeError("func debe ser callable")
     cbs = _ensure_callbacks(G)
-
-    from .trace import CallbackSpec
 
     cb_name = name or getattr(func, "__name__", None)
     new_cb = CallbackSpec(cb_name, func)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -5,7 +5,7 @@ the graph whenever possible.  Callers are expected to treat returned
 structures as immutable snapshots.
 """
 from __future__ import annotations
-from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple
+from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple, TYPE_CHECKING
 import warnings
 
 
@@ -21,8 +21,10 @@ class _SigmaVectorFn(Protocol):
         ...
 
 from .constants import TRACE
-from .callback_utils import register_callback
 from .glyph_history import ensure_history, count_glyphs
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .callback_utils import register_callback
 
 
 class CallbackSpec(NamedTuple):
@@ -297,6 +299,8 @@ def register_trace(G) -> None:
     """
     if G.graph.get("_trace_registered"):
         return
+
+    from .callback_utils import register_callback
 
     register_callback(G, event="before_step", func=_trace_before, name="trace_before")
     register_callback(G, event="after_step", func=_trace_after, name="trace_after")


### PR DESCRIPTION
## Summary
- centralize CallbackSpec import in callback utilities
- avoid circular import by lazily importing register_callback in trace

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b781e5ccf48321af85f0e0a9058f23