### PR TITLE
Report total length when ensure_collection exceeds limit

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -52,7 +52,10 @@ def ensure_collection(
         data = tuple(islice(iterator, limit))
         extra = next(iterator, None)
         if extra is not None:
-            raise ValueError(f"Iterable materialization exceeded {limit} items")
+            total = limit + 1 + sum(1 for _ in iterator)
+            raise ValueError(
+                f"Iterable materialization exceeded {limit} items (total {total})"
+            )
         return data
     except TypeError as exc:
         raise TypeError(f"{it!r} is not iterable") from exc


### PR DESCRIPTION
## Summary
- capture full length when `ensure_collection` exceeds `max_materialize`
- include total length in `ValueError` for easier diagnosis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b782ca3bc88321b81a4d2b9eb3ccf1