### PR TITLE
Use order-independent checksum for node mapping

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -51,7 +51,8 @@ def _ensure_node_offset_map(G) -> Dict[Any, int]:
     """
 
     nodes = list(G.nodes())
-    checksum = hash(tuple(nodes))
+    # Use order-independent checksum based on node set to detect changes
+    checksum = (len(nodes), sum(hash(n) for n in nodes))
     mapping = G.graph.get("_node_offset_map")
     if mapping is None or G.graph.get("_node_offset_checksum") != checksum:
         if bool(G.graph.get("SORT_NODES", False)):


### PR DESCRIPTION
## Summary
- compute node set checksum using len/sum to ignore order
- keep mapping invalidation when node set changes

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b78500a9b08321962043379e0f1bd1