### PR TITLE
Expose canonical glyph set

### DIFF
--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -26,6 +26,8 @@ GLYPHS_CANONICAL: tuple[str, ...] = (
     Glyph.REMESH.value,  # 12
 )
 
+GLYPHS_CANONICAL_SET: set[str] = set(GLYPHS_CANONICAL)
+
 ESTABILIZADORES = (
     Glyph.IL.value,
     Glyph.RA.value,
@@ -79,6 +81,7 @@ ANGLE_MAP: Dict[str, float] = {
 
 __all__ = [
     "GLYPHS_CANONICAL",
+    "GLYPHS_CANONICAL_SET",
     "ESTABILIZADORES",
     "DISRUPTIVOS",
     "GLYPH_GROUPS",

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -7,7 +7,7 @@ from collections import deque
 
 from .constants import get_param
 from .grammar import apply_glyph_with_grammar
-from .sense import GLYPHS_CANONICAL_SET
+from .constants_glyphs import GLYPHS_CANONICAL_SET
 from .types import Glyph
 from .collections_utils import ensure_collection
 from .glyph_history import ensure_history

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -19,12 +19,12 @@ from .constants_glyphs import (
     ESTABILIZADORES,
     DISRUPTIVOS,
     GLYPHS_CANONICAL,
+    GLYPHS_CANONICAL_SET,
 )
 
 # -------------------------
 # Canon: orden circular de glyphs y ángulos
 # -------------------------
-GLYPHS_CANONICAL_SET: set[str] = set(GLYPHS_CANONICAL)
 
 # Glyphs relevantes para el plano Σ de observadores de sentido
 SIGMA_ANGLE_KEYS: tuple[str, ...] = tuple(ESTABILIZADORES + DISRUPTIVOS)

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from .constants import ALIAS_EPI, ALIAS_VF, get_param
 from .helpers import get_attr
 from .glyph_history import last_glyph
-from .sense import sigma_vector_from_graph, GLYPHS_CANONICAL_SET
+from .sense import sigma_vector_from_graph
+from .constants_glyphs import GLYPHS_CANONICAL_SET
 
 
 def _validate_epi_vf(G) -> None:


### PR DESCRIPTION
## Summary
- expose `GLYPHS_CANONICAL_SET` in `constants_glyphs`
- use shared `GLYPHS_CANONICAL_SET` in `sense`
- update imports in `program` and `validators`

## Testing
- `pip install -e .`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7859799f88321b46b0a7e0e094ea9