### PR TITLE
Use str.removeprefix for argument prefix stripping

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -197,7 +197,7 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
     """
 
     return {
-        k[len(prefix):]: v
+        k.removeprefix(prefix): v
         for k, v in vars(args).items()
         if k.startswith(prefix) and v is not None
     }


### PR DESCRIPTION
## Summary
- Simplify prefix handling in `_args_to_dict` by using `str.removeprefix`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b787b8a730832186b76fb3adf06d17