### PR TITLE
Expose CallbackSpec through package API

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -44,7 +44,7 @@ from .metrics import (
     glyph_top, glyph_dwell_stats, export_history,
 )
 from .operators import apply_topological_remesh
-from .trace import register_trace
+from .trace import register_trace, CallbackSpec
 from .program import play, seq, block, target, wait, THOL, TARGET, WAIT, basic_canonical_example
 from .cli import main as cli_main
 from .scenarios import build_graph
@@ -85,7 +85,7 @@ __all__ = [
     "push_sigma_snapshot", "sigma_series", "sigma_rose",
     "register_sigma_callback",
     "register_metrics_callbacks",
-    "register_trace",
+    "register_trace", "CallbackSpec",
     "Tg_global", "Tg_by_node",
     "latency_series", "glyphogram_series",
     "glyph_top", "glyph_dwell_stats",

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -1,7 +1,7 @@
 """Callback registration and invocation helpers."""
 from __future__ import annotations
 
-from typing import Any, Callable, DefaultDict
+from typing import Any, Callable, DefaultDict, TYPE_CHECKING
 from enum import Enum
 from collections import defaultdict
 import logging
@@ -9,7 +9,9 @@ import logging
 import networkx as nx
 
 from .constants import DEFAULTS
-from .trace import CallbackSpec
+
+if TYPE_CHECKING:  # pragma: no cover
+    from . import CallbackSpec
 
 __all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
 
@@ -28,7 +30,7 @@ _CALLBACK_EVENTS: tuple[str, ...] = tuple(e.value for e in CallbackEvent)
 
 
 Callback = Callable[[nx.Graph, dict[str, Any]], None]
-CallbackRegistry = DefaultDict[str, list[CallbackSpec]]
+CallbackRegistry = DefaultDict[str, list['CallbackSpec']]
 
 
 def _ensure_callbacks(G: nx.Graph) -> CallbackRegistry:
@@ -40,7 +42,7 @@ def _ensure_callbacks(G: nx.Graph) -> CallbackRegistry:
     return cbs
 
 
-def _normalize_callback_entry(entry: Any) -> CallbackSpec | None:
+def _normalize_callback_entry(entry: Any) -> 'CallbackSpec | None':
     """Normalize legacy callback entries into ``CallbackSpec``.
 
     Parameters
@@ -55,6 +57,8 @@ def _normalize_callback_entry(entry: Any) -> CallbackSpec | None:
         Normalized ``CallbackSpec`` or ``None`` if ``entry`` cannot be
         interpreted as a callback.
     """
+    from . import CallbackSpec
+
     if isinstance(entry, CallbackSpec):
         return entry
     if isinstance(entry, tuple):
@@ -121,6 +125,8 @@ def register_callback(
     if not callable(func):
         raise TypeError("func debe ser callable")
     cbs = _ensure_callbacks(G)
+
+    from . import CallbackSpec
 
     cb_name = name or getattr(func, "__name__", None)
     new_cb = CallbackSpec(cb_name, func)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -51,6 +51,15 @@ except ImportError:  # pragma: no cover
 
 sigma_vector_from_graph: _SigmaVectorFn = _sigma_vector_from_graph
 
+# Public exports for this module
+__all__ = [
+    "CallbackSpec",
+    "register_trace",
+    "_callback_names",
+    "gamma_field",
+    "grammar_field",
+]
+
 # -------------------------
 # Helpers
 # -------------------------

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -6,8 +6,8 @@ from tnfr.trace import (
     _callback_names,
     gamma_field,
     grammar_field,
-    CallbackSpec,
 )
+from tnfr import CallbackSpec
 from tnfr.callback_utils import register_callback, invoke_callbacks
 
 


### PR DESCRIPTION
## Summary
- Export `CallbackSpec` from `tnfr.trace` via `__all__`
- Re-export `CallbackSpec` in package `__init__`
- Import `CallbackSpec` lazily within callback utilities to avoid circular deps
- Update tests to use top-level `CallbackSpec` entry point

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b788378dec83218b3eca6532b655f5