### PR TITLE
Normalize CallbackEvent enums in callback utilities

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -120,6 +120,8 @@ def register_callback(
     >>> ctx["called"]
     1
     """
+    if isinstance(event, CallbackEvent):
+        event = event.value
     if event not in _CALLBACK_EVENTS:
         raise ValueError(f"Evento desconocido: {event}")
     if not callable(func):
@@ -153,6 +155,8 @@ def invoke_callbacks(
     G: nx.Graph, event: CallbackEvent | str, ctx: dict[str, Any] | None = None
 ) -> None:
     """Invoke all callbacks registered for ``event`` with context ``ctx``."""
+    if isinstance(event, CallbackEvent):
+        event = event.value
     cbs = _ensure_callbacks(G).get(event, [])
     strict = bool(G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"]))
     ctx = ctx or {}

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -1,7 +1,7 @@
 """Pruebas de register callback."""
 import pytest
 
-from tnfr.callback_utils import register_callback, CallbackEvent
+from tnfr.callback_utils import register_callback, invoke_callbacks, CallbackEvent
 
 
 def test_register_callback_replaces_existing(graph_canon):
@@ -15,15 +15,15 @@ def test_register_callback_replaces_existing(graph_canon):
 
     # initial registration
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb1, name="cb")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("cb", cb1)]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [("cb", cb1)]
 
     # same name should replace existing
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="cb")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("cb", cb2)]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [("cb", cb2)]
 
     # same function with different name should also replace existing
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="other")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("other", cb2)]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [("other", cb2)]
 
 
 def test_register_callback_rejects_tuple(graph_canon):
@@ -34,3 +34,15 @@ def test_register_callback_rejects_tuple(graph_canon):
 
     with pytest.raises(TypeError):
         register_callback(G, event=CallbackEvent.BEFORE_STEP, func=("cb", cb))
+
+
+def test_enum_registration_and_invocation(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        ctx["called"] += 1
+
+    register_callback(G, CallbackEvent.AFTER_STEP, cb)
+    ctx = {"called": 0}
+    invoke_callbacks(G, CallbackEvent.AFTER_STEP, ctx)
+    assert ctx["called"] == 1


### PR DESCRIPTION
## Summary
- Normalize `CallbackEvent` enums to their string values in `register_callback` and `invoke_callbacks`
- Update callback registry tests for string keys and add enum registration/invocation test

## Testing
- `PYTHONPATH=src pytest tests/test_register_callback.py -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b78fc303e083218e602ae21e58a689