### PR TITLE
refactor: remove unused symmetry index parameter

### DIFF
--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -30,7 +30,8 @@ def _dnfr_norm(nd, dnfr_max):
     return 1.0 if x > 1 else x
 
 
-def _symmetry_index(G, n, k=3, epi_min=None, epi_max=None):
+def _symmetry_index(G, n, epi_min: float | None = None, epi_max: float | None = None):
+    """Compute the symmetry index for node ``n`` based on EPI values."""
     nd = G.nodes[n]
     epi_i = get_attr(nd, ALIAS_EPI, 0.0)
     vec = list(G.neighbors(n))


### PR DESCRIPTION
## Summary
- remove unused `k` argument from `_symmetry_index`
- document and type optional bounds for `_symmetry_index`

## Testing
- `PYTHONPATH=src pytest` *(fails: tests/test_update_tg_performance.py::test_update_tg_matches_naive - assert 7.537600004070555e-05 <= (3.6392999845702434e-05 * 2))*

------
https://chatgpt.com/codex/tasks/task_e_68b7934589708321b768db671d2783f3