### PR TITLE
Optimize history trimming and add tests

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -131,11 +131,13 @@ def ensure_history(G) -> Dict[str, Any]:
         hist = HistoryDict(hist, maxlen=maxlen)
         G.graph["history"] = hist
     if maxlen > 0:
-        while len(hist) > maxlen:
-            try:
-                hist.pop_least_used()
-            except KeyError:
-                break
+        excess = len(hist) - maxlen
+        if excess > 0:
+            for _ in range(excess):
+                try:
+                    hist.pop_least_used()
+                except KeyError:
+                    break
     return hist
 
 

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -58,3 +58,32 @@ def test_history_maxlen_override_respected(graph_canon):
     G.graph["HISTORY_MAXLEN"] = 3
     hist = ensure_history(G)
     assert hist._maxlen == 3
+
+
+def test_history_not_trimmed_when_equal_maxlen(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    G.graph["HISTORY_MAXLEN"] = 2
+
+    hist = ensure_history(G)
+    hist.setdefault("a", []).append(1)
+    hist.setdefault("b", []).append(2)
+
+    ensure_history(G)
+    assert len(hist) == 2
+    assert set(hist.keys()) == {"a", "b"}
+
+
+def test_history_not_trimmed_when_below_maxlen(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    G.graph["HISTORY_MAXLEN"] = 2
+
+    hist = ensure_history(G)
+    hist.setdefault("a", []).append(1)
+
+    ensure_history(G)
+    assert len(hist) == 1
+    assert "a" in hist


### PR DESCRIPTION
## Summary
- Trim history in `ensure_history` using a precomputed excess count and a for loop.
- Add tests to verify history is unaffected when at or below max length.

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src pytest tests/test_history_maxlen.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7940763008321aa3009df8e63d6a1