### PR TITLE
Ensure deg_i defined in DNFR loop

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -382,8 +382,7 @@ def _compute_dnfr_loops(G, data) -> None:
         deg_sum = None
         degs_list = None
     for i, node in enumerate(nodes):
-        if w_topo != 0 and deg_sum is not None:
-            deg_i = degs_list[i]
+        deg_i = degs_list[i] if degs_list is not None else 0.0
         for v in G.neighbors(node):
             j = idx[v]
             x[i] += cos_th[j]


### PR DESCRIPTION
## Summary
- fix `_compute_dnfr_loops` to always define `deg_i`

## Testing
- `flake8 src/tnfr/dynamics.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7966dd2fc832186aab4d703714d31