### PR TITLE
refactor: streamline trace callback import

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -5,7 +5,7 @@ the graph whenever possible.  Callers are expected to treat returned
 structures as immutable snapshots.
 """
 from __future__ import annotations
-from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple
 import warnings
 
 
@@ -22,9 +22,6 @@ class _SigmaVectorFn(Protocol):
 
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs
-
-if TYPE_CHECKING:  # pragma: no cover
-    from .callback_utils import register_callback
 
 
 class CallbackSpec(NamedTuple):


### PR DESCRIPTION
## Summary
- simplify typing imports in trace helper
- import trace callback lazily inside `register_trace`

## Testing
- `flake8 --select=F src/tnfr/trace.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b797f8bd108321b94937eebfb3f047