### PR TITLE
Fix inline comment spacing in constants_glyphs

### DIFF
--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -20,8 +20,8 @@ GLYPHS_CANONICAL: tuple[str, ...] = (
     Glyph.SHA.value,  # 6
     Glyph.VAL.value,  # 7
     Glyph.NUL.value,  # 8
-    Glyph.THOL.value, # 9
-    Glyph.ZHIR.value, # 10
+    Glyph.THOL.value,  # 9
+    Glyph.ZHIR.value,  # 10
     Glyph.NAV.value,  # 11
     Glyph.REMESH.value,  # 12
 )


### PR DESCRIPTION
## Summary
- ensure two spaces precede inline comments in `GLYPHS_CANONICAL`

## Testing
- `flake8 src/tnfr/constants_glyphs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b79967a80c83219c0b1dcde891d28b