### PR TITLE
Format codebase and fix flake8 warnings

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -1,5 +1,7 @@
 """TNFR public API."""
+
 from __future__ import annotations
+
 try:  # pragma: no cover
     from importlib.metadata import version, PackageNotFoundError
 except ImportError:  # pragma: no cover
@@ -23,7 +25,11 @@ from .ontosim import preparar_red
 from .observers import attach_standard_observer, kuramoto_order
 from .helpers import compute_coherence
 from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
-from .grammar import enforce_canonical_grammar, on_applied_glyph, apply_glyph_with_grammar
+from .grammar import (
+    enforce_canonical_grammar,
+    on_applied_glyph,
+    apply_glyph_with_grammar,
+)
 from .sense import (
     glyph_angle,
     glyph_unit,
@@ -39,13 +45,27 @@ from .sense import (
 from .constants_glyphs import GLYPHS_CANONICAL
 from .metrics import (
     register_metrics_callbacks,
-    Tg_global, Tg_by_node,
-    latency_series, glyphogram_series,
-    glyph_top, glyph_dwell_stats, export_history,
+    Tg_global,
+    Tg_by_node,
+    latency_series,
+    glyphogram_series,
+    glyph_top,
+    glyph_dwell_stats,
+    export_history,
 )
 from .operators import apply_topological_remesh
 from .trace import register_trace, CallbackSpec
-from .program import play, seq, block, target, wait, THOL, TARGET, WAIT, basic_canonical_example
+from .program import (
+    play,
+    seq,
+    block,
+    target,
+    wait,
+    THOL,
+    TARGET,
+    WAIT,
+    basic_canonical_example,
+)
 from .cli import main as cli_main
 from .scenarios import build_graph
 from .presets import get_preset
@@ -74,35 +94,71 @@ from .structural import (
 
 __all__ = [
     "preparar_red",
-    "step", "run", "set_delta_nfr_hook", "validate_canon",
-
-    "attach_standard_observer", "kuramoto_order", "compute_coherence",
-    "GAMMA_REGISTRY", "eval_gamma", "kuramoto_R_psi",
-    "enforce_canonical_grammar", "on_applied_glyph",
+    "step",
+    "run",
+    "set_delta_nfr_hook",
+    "validate_canon",
+    "attach_standard_observer",
+    "kuramoto_order",
+    "compute_coherence",
+    "GAMMA_REGISTRY",
+    "eval_gamma",
+    "kuramoto_R_psi",
+    "enforce_canonical_grammar",
+    "on_applied_glyph",
     "apply_glyph_with_grammar",
-    "GLYPHS_CANONICAL", "glyph_angle", "glyph_unit",
-    "sigma_vector_node", "sigma_vector_from_graph", "sigma_vector", "sigma_vector_global",
-    "push_sigma_snapshot", "sigma_series", "sigma_rose",
+    "GLYPHS_CANONICAL",
+    "glyph_angle",
+    "glyph_unit",
+    "sigma_vector_node",
+    "sigma_vector_from_graph",
+    "sigma_vector",
+    "sigma_vector_global",
+    "push_sigma_snapshot",
+    "sigma_series",
+    "sigma_rose",
     "register_sigma_callback",
     "register_metrics_callbacks",
-    "register_trace", "CallbackSpec",
-    "Tg_global", "Tg_by_node",
-    "latency_series", "glyphogram_series",
-    "glyph_top", "glyph_dwell_stats",
+    "register_trace",
+    "CallbackSpec",
+    "Tg_global",
+    "Tg_by_node",
+    "latency_series",
+    "glyphogram_series",
+    "glyph_top",
+    "glyph_dwell_stats",
     "export_history",
     "apply_topological_remesh",
-    "play", "seq", "block", "target", "wait", "THOL", "TARGET", "WAIT",
-    "cli_main", "build_graph", "get_preset", "NodeState",
+    "play",
+    "seq",
+    "block",
+    "target",
+    "wait",
+    "THOL",
+    "TARGET",
+    "WAIT",
+    "cli_main",
+    "build_graph",
+    "get_preset",
+    "NodeState",
     "basic_canonical_example",
     "create_nfr",
-    "Operador", "Emision", "Recepcion", "Coherencia", "Disonancia",
-    "Acoplamiento", "Resonancia", "Silencio", "Expansion", "Contraccion",
-    "Autoorganizacion", "Mutacion", "Transicion", "Recursividad",
-    "OPERADORES", "validate_sequence", "run_sequence",
+    "Operador",
+    "Emision",
+    "Recepcion",
+    "Coherencia",
+    "Disonancia",
+    "Acoplamiento",
+    "Resonancia",
+    "Silencio",
+    "Expansion",
+    "Contraccion",
+    "Autoorganizacion",
+    "Mutacion",
+    "Transicion",
+    "Recursividad",
+    "OPERADORES",
+    "validate_sequence",
+    "run_sequence",
     "__version__",
 ]
-
-
-
-
-

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -1,4 +1,5 @@
 """Callback registration and invocation helpers."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, DefaultDict, TYPE_CHECKING
@@ -30,7 +31,7 @@ _CALLBACK_EVENTS: tuple[str, ...] = tuple(e.value for e in CallbackEvent)
 
 
 Callback = Callable[[nx.Graph, dict[str, Any]], None]
-CallbackRegistry = DefaultDict[str, list['CallbackSpec']]
+CallbackRegistry = DefaultDict[str, list["CallbackSpec"]]
 
 
 def _ensure_callbacks(G: nx.Graph) -> CallbackRegistry:
@@ -42,7 +43,7 @@ def _ensure_callbacks(G: nx.Graph) -> CallbackRegistry:
     return cbs
 
 
-def _normalize_callback_entry(entry: Any) -> 'CallbackSpec | None':
+def _normalize_callback_entry(entry: Any) -> "CallbackSpec | None":
     """Normalize legacy callback entries into ``CallbackSpec``.
 
     Parameters
@@ -69,9 +70,7 @@ def _normalize_callback_entry(entry: Any) -> 'CallbackSpec | None':
             name = first
             fn = entry[1] if len(entry) > 1 else None
         else:
-            fn = first if callable(first) else (
-                entry[1] if len(entry) > 1 else None
-            )
+            fn = first if callable(first) else (entry[1] if len(entry) > 1 else None)
             name = getattr(fn, "__name__", None)
     else:
         fn = entry
@@ -140,9 +139,7 @@ def register_callback(
             continue
         if spec is not existing:
             existing_list[i] = spec
-        if spec.func is func or (
-            cb_name is not None and spec.name == cb_name
-        ):
+        if spec.func is func or (cb_name is not None and spec.name == cb_name):
             existing_list[i] = new_cb
             break
     else:
@@ -177,4 +174,3 @@ def invoke_callbacks(
                     "name": name,
                 }
             )
-

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -1,4 +1,5 @@
 """Interfaz de línea de comandos."""
+
 from __future__ import annotations
 import argparse
 import json
@@ -23,7 +24,13 @@ from .metrics import (
 from .trace import register_trace
 from .program import play, seq, block, wait, target
 from .types import Glyph
-from .dynamics import step, _update_history, default_glyph_selector, parametric_glyph_selector, validate_canon
+from .dynamics import (
+    step,
+    _update_history,
+    default_glyph_selector,
+    parametric_glyph_selector,
+    validate_canon,
+)
 from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
@@ -127,9 +134,7 @@ TOKEN_MAP: Dict[str, Callable[[Any], Any]] = {
 def _default(obj: Any) -> Any:
     if isinstance(obj, deque):
         return list(obj)
-    raise TypeError(
-        f"Object of type {obj.__class__.__name__} is not JSON serializable"
-    )
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
 
 
 def _save_json(path: str, data: Any) -> None:
@@ -142,7 +147,8 @@ def _save_json(path: str, data: Any) -> None:
 
 
 # Metadatos para las opciones de gramática y del glyph
-# Utiliza acciones y tipos estándar de ``argparse`` en lugar de conversores personalizados.
+# Utiliza acciones y tipos estándar de ``argparse`` en lugar de
+# conversores personalizados.
 GRAMMAR_ARG_SPECS = [
     ("--grammar.enabled", {"action": argparse.BooleanOptionalAction}),
     ("--grammar.zhir_requires_oz_window", {"type": int}),
@@ -256,7 +262,9 @@ def apply_cli_config(G: nx.Graph, args: argparse.Namespace) -> None:
 
     if hasattr(args, "selector"):
         G.graph["glyph_selector"] = (
-            default_glyph_selector if args.selector == "basic" else parametric_glyph_selector
+            default_glyph_selector
+            if args.selector == "basic"
+            else parametric_glyph_selector
         )
 
     if hasattr(args, "gamma_type"):
@@ -283,7 +291,9 @@ def _build_graph_from_args(args: argparse.Namespace) -> nx.Graph:
     return G
 
 
-def resolve_program(args: argparse.Namespace, default: Optional[Any] = None) -> Optional[Any]:
+def resolve_program(
+    args: argparse.Namespace, default: Optional[Any] = None
+) -> Optional[Any]:
     """Obtiene un programa a partir de un preset o un archivo de secuencia."""
     if getattr(args, "preset", None):
         return get_preset(args.preset)
@@ -295,15 +305,25 @@ def resolve_program(args: argparse.Namespace, default: Optional[Any] = None) -> 
 def add_common_args(parser: argparse.ArgumentParser) -> None:
     """Agrega los argumentos compartidos entre los subcomandos."""
     parser.add_argument("--nodes", type=int, default=24)
-    parser.add_argument("--topology", choices=["ring", "complete", "erdos"], default="ring")
+    parser.add_argument(
+        "--topology", choices=["ring", "complete", "erdos"], default="ring"
+    )
     parser.add_argument("--seed", type=int, default=1)
-    parser.add_argument("--p", type=float, default=None, help="Probabilidad de arista si topology=erdos")
-    parser.add_argument("--observer", action="store_true", help="Adjunta observador estándar")
+    parser.add_argument(
+        "--p", type=float, default=None, help="Probabilidad de arista si topology=erdos"
+    )
+    parser.add_argument(
+        "--observer", action="store_true", help="Adjunta observador estándar"
+    )
     parser.add_argument("--config", type=str, default=None)
     parser.add_argument("--dt", type=float, default=None)
     parser.add_argument("--integrator", choices=["euler", "rk4"], default=None)
-    parser.add_argument("--remesh-mode", choices=["knn", "mst", "community"], default=None)
-    parser.add_argument("--gamma-type", choices=list(GAMMA_REGISTRY.keys()), default="none")
+    parser.add_argument(
+        "--remesh-mode", choices=["knn", "mst", "community"], default=None
+    )
+    parser.add_argument(
+        "--gamma-type", choices=list(GAMMA_REGISTRY.keys()), default="none"
+    )
     parser.add_argument("--gamma-beta", type=float, default=0.0)
     parser.add_argument("--gamma-R0", type=float, default=0.0)
 
@@ -364,13 +384,19 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Resúmenes rápidos (si están activados)
     if G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get("enabled", True):
         Wstats = G.graph.get("history", {}).get(
-            G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get("stats_history_key", "W_stats"), []
+            G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get(
+                "stats_history_key", "W_stats"
+            ),
+            [],
         )
         if Wstats:
             logger.info("[COHERENCE] último paso: %s", Wstats[-1])
     if G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get("enabled", True):
         last_diag = G.graph.get("history", {}).get(
-            G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get("history_key", "nodal_diag"), []
+            G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get(
+                "history_key", "nodal_diag"
+            ),
+            [],
         )
         if last_diag:
             sample = list(last_diag[-1].values())[:3]
@@ -433,7 +459,9 @@ def cmd_metrics(args: argparse.Namespace) -> int:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout, force=True)
+    logging.basicConfig(
+        level=logging.INFO, format="%(message)s", stream=sys.stdout, force=True
+    )
 
     p = argparse.ArgumentParser(
         prog="tnfr",
@@ -441,13 +469,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         epilog=(
             "Ejemplo: tnfr sequence --sequence-file secuencia.json\n"
             "secuencia.json:\n"
-            "[\n  {\"WAIT\": 1},\n  {\"TARGET\": \"A\"}\n]"
+            '[\n  {"WAIT": 1},\n  {"TARGET": "A"}\n]'
         ),
     )
     p.add_argument("--version", action="store_true", help="muestra versión y sale")
     sub = p.add_subparsers(dest="cmd")
 
-    p_run = sub.add_parser("run", help="Correr escenario libre o preset y opcionalmente exportar history")
+    p_run = sub.add_parser(
+        "run", help="Correr escenario libre o preset y opcionalmente exportar history"
+    )
     add_common_args(p_run)
     p_run.add_argument("--steps", type=int, default=200)
     p_run.add_argument("--preset", type=str, default=None)
@@ -464,9 +494,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         epilog=(
             "Ejemplo de secuencia JSON:\n"
             "[\n"
-            "  \"A\",\n"
-            "  {\"WAIT\": 1},\n"
-            "  {\"THOL\": {\"body\": [\"A\", {\"WAIT\": 2}], \"repeat\": 2}}\n"
+            '  "A",\n'
+            '  {"WAIT": 1},\n'
+            '  {"THOL": {"body": ["A", {"WAIT": 2}], "repeat": 2}}\n'
             "]"
         ),
     )

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -1,4 +1,5 @@
 """Utilities for working with collections and weights."""
+
 from __future__ import annotations
 
 from typing import (
@@ -16,6 +17,7 @@ import math
 from itertools import islice
 
 from .value_utils import _convert_value
+
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
@@ -139,4 +141,3 @@ def mix_groups(
     for label, keys in groups.items():
         out[f"{prefix}{label}"] = sum(dist.get(k, 0.0) for k in keys)
     return out
-

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -1,4 +1,5 @@
 """Configuration utilities."""
+
 from __future__ import annotations
 from typing import Any, Dict
 from pathlib import Path

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -1,4 +1,5 @@
 """Shared constants."""
+
 from __future__ import annotations
 
 from collections import ChainMap
@@ -76,9 +77,7 @@ def inject_defaults(
     G.graph.setdefault("_tnfr_defaults_attached", False)
     for k, v in defaults.items():
         if override or k not in G.graph:
-            G.graph[k] = (
-                v if isinstance(v, IMMUTABLE_TYPES) else copy.deepcopy(v)
-            )
+            G.graph[k] = v if isinstance(v, IMMUTABLE_TYPES) else copy.deepcopy(v)
     G.graph["_tnfr_defaults_attached"] = True
     try:  # local import para evitar dependencia circular
         from ..operators import _ensure_node_offset_map

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -1,4 +1,5 @@
 """Constantes fundamentales."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict, field

--- a/src/tnfr/constants/init.py
+++ b/src/tnfr/constants/init.py
@@ -1,4 +1,5 @@
 """Initialization constants."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict

--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -1,4 +1,5 @@
 """Metric constants."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict, field
@@ -16,7 +17,7 @@ class MetricDefaults:
         default_factory=lambda: {
             "enabled": True,
             "weight": "Si",  # "Si" | "EPI" | "1"
-            "smooth": 0.0,    # EMA sobre el vector global (0=off)
+            "smooth": 0.0,  # EMA sobre el vector global (0=off)
             "history_key": "sigma_global",
             "per_node": False,
         }

--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -1,4 +1,5 @@
 """Glyphs predeterminados."""
+
 from __future__ import annotations
 
 import math
@@ -11,12 +12,12 @@ from .types import Glyph
 # -------------------------
 
 GLYPHS_CANONICAL: tuple[str, ...] = (
-    Glyph.AL.value,   # 0
-    Glyph.EN.value,   # 1
-    Glyph.IL.value,   # 2
-    Glyph.OZ.value,   # 3
-    Glyph.UM.value,   # 4
-    Glyph.RA.value,   # 5
+    Glyph.AL.value,  # 0
+    Glyph.EN.value,  # 1
+    Glyph.IL.value,  # 2
+    Glyph.OZ.value,  # 3
+    Glyph.UM.value,  # 4
+    Glyph.RA.value,  # 5
     Glyph.SHA.value,  # 6
     Glyph.VAL.value,  # 7
     Glyph.NUL.value,  # 8

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -1,4 +1,5 @@
 """Registro de gammas."""
+
 from __future__ import annotations
 from typing import Dict, Any, Tuple
 import math
@@ -12,7 +13,6 @@ from .helpers import get_attr
 logger = logging.getLogger(__name__)
 
 
-
 def _ensure_kuramoto_cache(G, t) -> None:
     """Cache ``(R, ψ)`` in ``G.graph`` for the current step ``t``.
 
@@ -20,11 +20,7 @@ def _ensure_kuramoto_cache(G, t) -> None:
     """
     nodes_sig = (len(G), int(G.graph.get("_edge_version", 0)))
     cache = G.graph.get("_kuramoto_cache")
-    if (
-        cache is None
-        or cache.get("t") != t
-        or cache.get("nodes_sig") != nodes_sig
-    ):
+    if cache is None or cache.get("t") != t or cache.get("nodes_sig") != nodes_sig:
         R, psi = kuramoto_R_psi(G)
         G.graph["_kuramoto_cache"] = {
             "t": t,
@@ -137,7 +133,6 @@ GAMMA_REGISTRY = {
 }
 
 
-
 def eval_gamma(
     G,
     node,
@@ -173,8 +168,10 @@ def eval_gamma(
     try:
         return float(fn(G, node, t, spec))
     except (KeyError, TypeError, ValueError):
-        level = log_level if log_level is not None else (
-            logging.ERROR if strict else logging.DEBUG
+        level = (
+            log_level
+            if log_level is not None
+            else (logging.ERROR if strict else logging.DEBUG)
         )
         logger.log(
             level,

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -1,4 +1,5 @@
 """Helpers for glyph history management."""
+
 from __future__ import annotations
 
 from typing import Dict, Any, Iterable
@@ -155,9 +156,7 @@ def last_glyph(nd: Dict[str, Any]) -> str | None:
         return None
 
 
-def count_glyphs(
-    G, window: int | None = None, *, last_only: bool = False
-) -> Counter:
+def count_glyphs(G, window: int | None = None, *, last_only: bool = False) -> Counter:
     """Count recent glyphs in the network."""
     counts: Counter[str] = Counter()
     for _, nd in G.nodes(data=True):
@@ -175,4 +174,3 @@ def count_glyphs(
                 seq = hist
         counts.update(seq)
     return counts
-

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -139,6 +139,7 @@ def _check_repeats(G, n, cand: str, cfg: Dict[str, Any]) -> str:
             return fb
     return cand
 
+
 def _check_force(
     G,
     n,
@@ -148,7 +149,8 @@ def _check_force(
     accessor: Callable[[Any, Dict[str, Any]], float],
     cfg_key: str,
 ) -> str:
-    """If repetition was blocked but ``accessor`` exceeds the threshold, restore ``original``."""
+    """If repetition was blocked but ``accessor`` exceeds the threshold,
+    restore ``original``."""
     if cand == original:
         return cand
     force_th = float(cfg.get(cfg_key, 0.60))

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -1,4 +1,5 @@
 """Funciones auxiliares."""
+
 from __future__ import annotations
 from typing import (
     Iterable,
@@ -22,8 +23,10 @@ try:  # pragma: no cover - dependencia opcional
     from yaml import YAMLError  # type: ignore
 except ImportError:  # pragma: no cover
     yaml = None
+
     class YAMLError(Exception):  # type: ignore
         pass
+
 
 from .constants import (
     DEFAULTS,
@@ -88,6 +91,7 @@ __all__ = [
 # Entrada/salida estructurada
 # -------------------------
 
+
 def _parse_json(text: str) -> Any:
     """Parsea ``text`` como JSON."""
     return json.loads(text)
@@ -123,14 +127,13 @@ def read_structured_file(path: Path) -> Any:
     except YAMLError as e:
         raise ValueError(f"Error al parsear archivo YAML en {path}: {e}") from e
     except RuntimeError as e:
-        raise ValueError(
-            f"Dependencia faltante al parsear {path}: {e}"
-        ) from e
+        raise ValueError(f"Dependencia faltante al parsear {path}: {e}") from e
 
 
 def ensure_parent(path: str | Path) -> None:
     """Crea el directorio padre de ``path`` si hace falta."""
     Path(path).parent.mkdir(parents=True, exist_ok=True)
+
 
 # -------------------------
 # Iterables y colecciones
@@ -138,6 +141,7 @@ def ensure_parent(path: str | Path) -> None:
 # -------------------------
 # Utilidades numéricas
 # -------------------------
+
 
 def clamp(x: float, a: float, b: float) -> float:
     """Constriñe ``x`` al intervalo cerrado [a, b]."""
@@ -165,6 +169,8 @@ def _wrap_angle(a: float) -> float:
 def angle_diff(a: float, b: float) -> float:
     """Diferencia mínima entre ``a`` y ``b`` en (-π, π]."""
     return _wrap_angle(a - b)
+
+
 # -------------------------
 # Acceso a atributos con alias
 # -------------------------
@@ -187,11 +193,10 @@ def alias_get(
     aliases: Sequence[str],
     conv: Callable[[Any], T],
     *,
-    default: None = ..., 
+    default: None = ...,
     strict: bool = False,
     log_level: int | None = None,
-) -> Optional[T]:
-    ...
+) -> Optional[T]: ...
 
 
 @overload
@@ -203,8 +208,7 @@ def alias_get(
     default: T,
     strict: bool = False,
     log_level: int | None = None,
-) -> T:
-    ...
+) -> T: ...
 
 
 def alias_get(
@@ -294,8 +298,7 @@ def _alias_get_set(
         *,
         strict: bool = False,
         log_level: int | None = None,
-    ) -> T:
-        ...
+    ) -> T: ...
 
     @overload
     def _get(
@@ -305,8 +308,7 @@ def _alias_get_set(
         *,
         strict: bool = False,
         log_level: int | None = None,
-    ) -> Optional[T]:
-        ...
+    ) -> Optional[T]: ...
 
     def _get(
         d: Dict[str, Any],
@@ -345,6 +347,7 @@ _set_attr_str = set_attr_str
 # Máximos globales con caché
 # -------------------------
 
+
 def _recompute_abs_max(G, aliases: Sequence[str]):
     """Recalcula y retorna ``(max_val, node)`` para ``aliases``."""
     node = max(
@@ -356,9 +359,7 @@ def _recompute_abs_max(G, aliases: Sequence[str]):
     return max_val, node
 
 
-def _update_cached_abs_max(
-    G, aliases: Sequence[str], n, value, *, key: str
-) -> None:
+def _update_cached_abs_max(G, aliases: Sequence[str], n, value, *, key: str) -> None:
     """Actualiza ``G.graph[key]`` y ``G.graph[f"{key}_node"]``."""
     node_key = f"{key}_node"
     val = abs(value)
@@ -396,6 +397,7 @@ def set_dnfr(G, n, value: float) -> None:
 # Normalizadores de ΔNFR y aceleración
 # -------------------------
 
+
 def compute_dnfr_accel_max(G) -> dict:
     """Calcula los máximos absolutos de |ΔNFR| y |d²EPI/dt²|.
 
@@ -410,9 +412,11 @@ def compute_dnfr_accel_max(G) -> dict:
         accel_max = max(accel_max, abs(get_attr(nd, ALIAS_D2EPI, 0.0)))
     return {"dnfr_max": float(dnfr_max), "accel_max": float(accel_max)}
 
+
 # -------------------------
 # Coherencia global
 # -------------------------
+
 
 def compute_coherence(G) -> float:
     """Calcula la coherencia global C(t) a partir de ΔNFR y dEPI."""
@@ -431,9 +435,11 @@ def compute_coherence(G) -> float:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)
 
+
 # -------------------------
 # Estadísticos vecinales
 # -------------------------
+
 
 def media_vecinal(G, n, aliases: Sequence[str], default: float = 0.0) -> float:
     """Media del atributo indicado por ``aliases`` en los vecinos de ``n``."""
@@ -482,9 +488,11 @@ from .glyph_history import (  # noqa: E402
     last_glyph,
     count_glyphs,
 )
+
 # -------------------------
 # Índice de sentido (Si)
 # -------------------------
+
 
 def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
     """Calcula Si por nodo y lo escribe en G.nodes[n]["Si"].
@@ -553,7 +561,7 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
         dnfr = get_attr(nd, ALIAS_DNFR, 0.0)
         dnfr_norm = clamp01(abs(dnfr) / dnfrmax)
 
-        Si = alpha*vf_norm + beta*(1.0 - disp_fase) + gamma*(1.0 - dnfr_norm)
+        Si = alpha * vf_norm + beta * (1.0 - disp_fase) + gamma * (1.0 - dnfr_norm)
         Si = clamp01(Si)
         out[n] = Si
         if inplace:

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -1,4 +1,5 @@
 """Node initialization."""
+
 from __future__ import annotations
 import random
 import networkx as nx
@@ -101,9 +102,7 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     th_min = float(G.graph.get("INIT_THETA_MIN", INIT_DEFAULTS["INIT_THETA_MIN"]))
     th_max = float(G.graph.get("INIT_THETA_MAX", INIT_DEFAULTS["INIT_THETA_MAX"]))
 
-    vf_mode = str(
-        G.graph.get("INIT_VF_MODE", INIT_DEFAULTS["INIT_VF_MODE"])
-    ).lower()
+    vf_mode = str(G.graph.get("INIT_VF_MODE", INIT_DEFAULTS["INIT_VF_MODE"])).lower()
     vf_min_lim = float(G.graph.get("VF_MIN", DEFAULTS["VF_MIN"]))
     vf_max_lim = float(G.graph.get("VF_MAX", DEFAULTS["VF_MAX"]))
 

--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -1,4 +1,5 @@
 """Registerable metrics."""
+
 from .core import (
     register_metrics_callbacks,
     Tg_global,

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -1,4 +1,5 @@
 """Coherence metrics."""
+
 from __future__ import annotations
 
 from math import cos
@@ -19,7 +20,9 @@ def _norm01(x, lo, hi):
 
 
 def _similarity_abs(a, b, lo, hi):
-    return 1.0 - _norm01(abs(float(a) - float(b)), 0.0, float(hi - lo) if hi > lo else 1.0)
+    return 1.0 - _norm01(
+        abs(float(a) - float(b)), 0.0, float(hi - lo) if hi > lo else 1.0
+    )
 
 
 def _coherence_components(G, ni, nj, epi_min, epi_max, vf_min, vf_max):
@@ -129,9 +132,7 @@ def coherence_matrix(G):
             if key in seen:
                 continue
             seen.add(key)
-            wij = _combine_components(
-                wnorm, G, u, v, epi_min, epi_max, vf_min, vf_max
-            )
+            wij = _combine_components(wnorm, G, u, v, epi_min, epi_max, vf_min, vf_max)
             add_entry(i, j, wij)
             add_entry(j, i, wij)
     else:
@@ -154,7 +155,7 @@ def coherence_matrix(G):
                     continue
                 vals.append(W[i][j])
     else:
-        for (i, j, w) in W:
+        for i, j, w in W:
             if i == j:
                 continue
             vals.append(w)
@@ -200,7 +201,11 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
         nodes_set = frozenset(G.nodes())
         if cache.get("nodes") != nodes_tuple or cache.get("set") != nodes_set:
             node_to_index = {v: i for i, v in enumerate(nodes_order)}
-            G.graph[cache_key] = {"nodes": nodes_tuple, "set": nodes_set, "map": node_to_index}
+            G.graph[cache_key] = {
+                "nodes": nodes_tuple,
+                "set": nodes_set,
+                "map": node_to_index,
+            }
         else:
             node_to_index = cache.get("map", {})
 
@@ -212,7 +217,7 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
         weights = W_row
     else:
         weights = [0.0] * len(nodes_order)
-        for (ii, jj, w) in W_row:
+        for ii, jj, w in W_row:
             if ii == i:
                 weights[jj] = w
 
@@ -235,4 +240,6 @@ def _coherence_step(G, ctx=None):
 
 
 def register_coherence_callbacks(G) -> None:
-    register_callback(G, event="after_step", func=_coherence_step, name="coherence_step")
+    register_callback(
+        G, event="after_step", func=_coherence_step, name="coherence_step"
+    )

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -1,4 +1,5 @@
 """Basic metrics."""
+
 from __future__ import annotations
 
 from collections import Counter, defaultdict
@@ -121,8 +122,10 @@ def _update_epi_support(G, hist, t, thr):
 
 def _update_morph_metrics(G, hist, counts, t):
     """Registra métricas morfosintácticas basadas en conteos glíficos."""
+
     def get_count(keys):
         return sum(counts.get(k, 0) for k in keys)
+
     total = max(1, sum(counts.values()))
     id_val = get_count(GLYPH_GROUPS.get("ID", ())) / total
     cm_val = get_count(GLYPH_GROUPS.get("CM", ())) / total
@@ -152,7 +155,9 @@ def _metrics_step(G, *args, **kwargs):
     hist = ensure_history(G)
     dt = float(G.graph.get("DT", 1.0))
     t = float(G.graph.get("_t", 0.0))
-    thr = float(G.graph.get("EPI_SUPPORT_THR", METRIC_DEFAULTS.get("EPI_SUPPORT_THR", 0.0)))
+    thr = float(
+        G.graph.get("EPI_SUPPORT_THR", METRIC_DEFAULTS.get("EPI_SUPPORT_THR", 0.0))
+    )
 
     save_by_node = bool(G.graph.get("METRICS", METRICS).get("save_by_node", True))
     counts, n_total, n_latent = _update_tg(G, hist, dt, save_by_node)
@@ -180,7 +185,8 @@ def register_metrics_callbacks(G) -> None:
 
 
 def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
-    """Total glyph time per class. If ``normalize=True``, return fractions of the total."""
+    """Total glyph time per class. If ``normalize=True``, return fractions
+    of the total."""
     hist = ensure_history(G)
     tg_total: Dict[str, float] = hist.tracked_get("Tg_total", {})
     total = sum(tg_total.values()) or 1.0
@@ -190,7 +196,8 @@ def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
 
 
 def Tg_by_node(G, n, normalize: bool = False) -> Dict[str, float | List[float]]:
-    """Per-node summary: if ``normalize`` return mean run per glyph; otherwise list runs."""
+    """Per-node summary: if ``normalize`` return mean run per glyph;
+    otherwise list runs."""
     hist = ensure_history(G)
     rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
     if not normalize:

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -1,4 +1,5 @@
 """Diagnostic metrics."""
+
 from __future__ import annotations
 
 from statistics import fmean
@@ -56,7 +57,9 @@ def _state_from_thresholds(Rloc, dnfr_n, cfg):
 
 def _recommendation(state, cfg):
     adv = cfg.get("advice", {})
-    key = {"estable": "stable", "transicion": "transition", "disonante": "dissonant"}[state]
+    key = {"estable": "stable", "transicion": "transition", "disonante": "dissonant"}[
+        state
+    ]
     return list(adv.get(key, []))
 
 
@@ -72,7 +75,9 @@ def _diagnosis_step(G, ctx=None):
     G.graph["_sel_norms"] = norms
     dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
     epi_vals = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in G.nodes()]
-    epi_min, epi_max = (min(epi_vals) if epi_vals else 0.0), (max(epi_vals) if epi_vals else 1.0)
+    epi_min, epi_max = (min(epi_vals) if epi_vals else 0.0), (
+        max(epi_vals) if epi_vals else 1.0
+    )
 
     CfgW = G.graph.get("COHERENCE", COHERENCE)
     Wkey = CfgW.get("Wi_history_key", "W_i")
@@ -106,11 +111,17 @@ def _diagnosis_step(G, ctx=None):
                 G, n, nodes_order=nodes, node_to_index=node_to_index
             )
 
-        symm = _symmetry_index(G, n, epi_min=epi_min, epi_max=epi_max) if dcfg.get("compute_symmetry", True) else None
+        symm = (
+            _symmetry_index(G, n, epi_min=epi_min, epi_max=epi_max)
+            if dcfg.get("compute_symmetry", True)
+            else None
+        )
         state = _state_from_thresholds(Rloc, dnfr_n, dcfg)
 
         alerts = []
-        if state == "disonante" and dnfr_n >= float(dcfg.get("dissonance", {}).get("dnfr_hi", 0.5)):
+        if state == "disonante" and dnfr_n >= float(
+            dcfg.get("dissonance", {}).get("dnfr_hi", 0.5)
+        ):
             alerts.append("high structural tension")
 
         advice = _recommendation(state, dcfg)
@@ -161,5 +172,9 @@ def dissonance_events(G, ctx=None):
 
 
 def register_diagnosis_callbacks(G) -> None:
-    register_callback(G, event="after_step", func=_diagnosis_step, name="diagnosis_step")
-    register_callback(G, event="after_step", func=dissonance_events, name="dissonance_events")
+    register_callback(
+        G, event="after_step", func=_diagnosis_step, name="diagnosis_step"
+    )
+    register_callback(
+        G, event="after_step", func=dissonance_events, name="dissonance_events"
+    )

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -1,4 +1,5 @@
 """Metrics export."""
+
 from __future__ import annotations
 
 import csv
@@ -56,7 +57,11 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     if fmt == "csv":
         specs = [
             ("_glyphogram.csv", ["t", *GLYPHS_CANONICAL], _iter_glif_rows(glyph)),
-            ("_sigma.csv", ["t", "x", "y", "mag", "angle"], _iter_sigma_rows(sigma_rows)),
+            (
+                "_sigma.csv",
+                ["t", "x", "y", "mag", "angle"],
+                _iter_sigma_rows(sigma_rows),
+            ),
         ]
         if morph:
             specs.append(
@@ -81,14 +86,20 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
                     "_epi_support.csv",
                     ["t", "size", "epi_norm"],
                     (
-                        [row.get("t"), row.get("size"), row.get("epi_norm")] for row in epi_supp
+                        [row.get("t"), row.get("size"), row.get("epi_norm")]
+                        for row in epi_supp
                     ),
                 )
             )
         for suffix, headers, rows in specs:
             _write_csv(base_path + suffix, headers, rows)
     else:
-        data = {"glyphogram": glyph, "sigma": sigma, "morph": morph, "epi_support": epi_supp}
+        data = {
+            "glyphogram": glyph,
+            "sigma": sigma,
+            "morph": morph,
+            "epi_support": epi_supp,
+        }
         json_path = base_path + ".json"
         ensure_parent(json_path)
         try:

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -1,4 +1,5 @@
 """Operaciones sobre nodos."""
+
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Deque, Dict, Iterable, Optional, Protocol, TypeVar
@@ -133,25 +134,19 @@ class NodoProtocol(Protocol):
     d2EPI: float
     graph: Dict[str, object]
 
-    def neighbors(self) -> Iterable[NodoProtocol | Hashable]:
-        ...
+    def neighbors(self) -> Iterable[NodoProtocol | Hashable]: ...
 
-    def push_glyph(self, glyph: str, window: int) -> None:
-        ...
+    def push_glyph(self, glyph: str, window: int) -> None: ...
 
-    def has_edge(self, other: "NodoProtocol") -> bool:
-        ...
+    def has_edge(self, other: "NodoProtocol") -> bool: ...
 
     def add_edge(
         self, other: "NodoProtocol", weight: float, *, overwrite: bool = False
-    ) -> None:
-        ...
+    ) -> None: ...
 
-    def offset(self) -> int:
-        ...
+    def offset(self) -> int: ...
 
-    def all_nodes(self) -> Iterable["NodoProtocol"]:
-        ...
+    def all_nodes(self) -> Iterable["NodoProtocol"]: ...
 
 
 @dataclass(eq=False)
@@ -172,7 +167,9 @@ class NodoTNFR:
     d2EPI: float = 0.0
     graph: Dict[str, object] = field(default_factory=dict)
     _neighbors: Dict["NodoTNFR", float] = field(default_factory=dict)
-    _glyph_history: Deque[str] = field(default_factory=lambda: deque(maxlen=DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 7)))
+    _glyph_history: Deque[str] = field(
+        default_factory=lambda: deque(maxlen=DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 7))
+    )
 
     def neighbors(self) -> Iterable["NodoTNFR"]:
         return self._neighbors.keys()
@@ -267,6 +264,7 @@ class NodoNX(NodoProtocol):
 
     def offset(self) -> int:
         from .operators import _node_offset
+
         return _node_offset(self.G, self.n)
 
     def all_nodes(self) -> Iterable[NodoProtocol]:

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -1,8 +1,8 @@
 """Observer management."""
+
 from __future__ import annotations
 import math
 import statistics as st
-from statistics import fmean as _fmean
 from itertools import islice
 from functools import partial
 
@@ -17,6 +17,7 @@ from .glyph_history import ensure_history, count_glyphs
 from .collections_utils import normalize_counter, mix_groups
 from .constants_glyphs import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
+
 
 # -------------------------
 # Observador estándar Γ(R)
@@ -67,12 +68,9 @@ def phase_sync(G) -> float:
         return 1.0
     th = math.atan2(sumY, sumX)
     # varianza angular aproximada (0 = muy sincronizado)
-    var = (
-        st.pvariance(angle_diff(f, th) for f in fases)
-        if count > 1
-        else 0.0
-    )
+    var = st.pvariance(angle_diff(f, th) for f in fases) if count > 1 else 0.0
     return 1.0 / (1.0 + var)
+
 
 def kuramoto_order(G) -> float:
     """R in [0,1], 1 means perfectly aligned phases."""
@@ -80,6 +78,7 @@ def kuramoto_order(G) -> float:
         return 1.0
     R, _ = kuramoto_R_psi(G)
     return float(R)
+
 
 def glyph_load(G, window: int | None = None) -> dict:
     """Return distribution of glyphs applied in the network.

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -1,4 +1,5 @@
 """Orquesta la simulación canónica."""
+
 from __future__ import annotations
 import networkx as nx
 from collections import deque
@@ -9,6 +10,7 @@ from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
 
 # API de alto nivel
+
 
 def preparar_red(
     G: nx.Graph,
@@ -32,31 +34,37 @@ def preparar_red(
     attach_defaults(G, override=override_defaults)
     if overrides:
         from .constants import merge_overrides
+
         merge_overrides(G, **overrides)
     # Inicializaciones blandas
-    ph_len = int(G.graph.get("PHASE_HISTORY_MAXLEN", METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"]))
-    G.graph.setdefault("history", {
-        "C_steps": [],
-        "stable_frac": [],
-        "phase_sync": [],
-        "kuramoto_R": [],
-        "sense_sigma_x": [],
-        "sense_sigma_y": [],
-        "sense_sigma_mag": [],
-        "sense_sigma_angle": [],
-        "iota": [],
-        "glyph_load_estab": [],
-        "glyph_load_disr": [],
-        "Si_mean": [],
-        "Si_hi_frac": [],
-        "Si_lo_frac": [],
-        "W_bar": [],
-        "phase_kG": [],
-        "phase_kL": [],
-        "phase_state": deque(maxlen=ph_len),
-        "phase_R": deque(maxlen=ph_len),
-        "phase_disr": deque(maxlen=ph_len),
-    })
+    ph_len = int(
+        G.graph.get("PHASE_HISTORY_MAXLEN", METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"])
+    )
+    G.graph.setdefault(
+        "history",
+        {
+            "C_steps": [],
+            "stable_frac": [],
+            "phase_sync": [],
+            "kuramoto_R": [],
+            "sense_sigma_x": [],
+            "sense_sigma_y": [],
+            "sense_sigma_mag": [],
+            "sense_sigma_angle": [],
+            "iota": [],
+            "glyph_load_estab": [],
+            "glyph_load_disr": [],
+            "Si_mean": [],
+            "Si_hi_frac": [],
+            "Si_lo_frac": [],
+            "W_bar": [],
+            "phase_kG": [],
+            "phase_kL": [],
+            "phase_state": deque(maxlen=ph_len),
+            "phase_R": deque(maxlen=ph_len),
+            "phase_disr": deque(maxlen=ph_len),
+        },
+    )
     # REMESH_TAU: alias legado resuelto por ``get_param``
     tau = int(get_param(G, "REMESH_TAU_GLOBAL"))
     maxlen = max(2 * tau + 5, 64)
@@ -65,30 +73,52 @@ def preparar_red(
     if G.graph.get("ATTACH_STD_OBSERVER", False):
         try:
             from .observers import attach_standard_observer
+
             attach_standard_observer(G)
         except ImportError as e:
             G.graph.setdefault("_callback_errors", []).append(
                 {"event": "attach_std_observer", "error": repr(e)}
             )
-    # Hook explícito para ΔNFR (se puede sustituir luego con dynamics.set_delta_nfr_hook)
+    # Hook explícito para ΔNFR (se puede sustituir luego con
+    # dynamics.set_delta_nfr_hook)
     G.graph.setdefault("compute_delta_nfr", default_compute_delta_nfr)
     G.graph.setdefault("_dnfr_hook_name", "default_compute_delta_nfr")
     # Callbacks Γ(R): before_step / after_step / on_remesh
-    G.graph.setdefault("callbacks", {
-        "before_step": [],
-        "after_step": [],
-        "on_remesh": [],
-    })
-    G.graph.setdefault("_CALLBACKS_DOC",
-        "Interfaz Γ(R): registrar pares (name, func) con firma (G, ctx) en callbacks['before_step'|'after_step'|'on_remesh']")
+    G.graph.setdefault(
+        "callbacks",
+        {
+            "before_step": [],
+            "after_step": [],
+            "on_remesh": [],
+        },
+    )
+    G.graph.setdefault(
+        "_CALLBACKS_DOC",
+        "Interfaz Γ(R): registrar pares (name, func) con firma (G, ctx) "
+        "en callbacks['before_step'|'after_step'|'on_remesh']",
+    )
 
     if init_attrs:
         init_node_attrs(G, override=True)
     return G
 
-def step(G: nx.Graph, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool = True) -> None:
+
+def step(
+    G: nx.Graph,
+    *,
+    dt: float | None = None,
+    use_Si: bool = True,
+    apply_glyphs: bool = True,
+) -> None:
     _step(G, dt=dt, use_Si=use_Si, apply_glyphs=apply_glyphs)
 
-def run(G: nx.Graph, steps: int, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool = True) -> None:
-    _run(G, steps=steps, dt=dt, use_Si=use_Si, apply_glyphs=apply_glyphs)
 
+def run(
+    G: nx.Graph,
+    steps: int,
+    *,
+    dt: float | None = None,
+    use_Si: bool = True,
+    apply_glyphs: bool = True,
+) -> None:
+    _run(G, steps=steps, dt=dt, use_Si=use_Si, apply_glyphs=apply_glyphs)

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -1,4 +1,5 @@
 """Configuraciones predefinidas."""
+
 from __future__ import annotations
 from .program import seq, block, wait, basic_canonical_example
 from .types import Glyph
@@ -24,8 +25,12 @@ _PRESETS = {
     + CIERRE_BASICO,
     "ejemplo_canonico": basic_canonical_example(),
     # Topologías fractales: expansión/contracción modular
-    "fractal_expand": seq(block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL), Glyph.RA),
-    "fractal_contract": seq(block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA), Glyph.RA),
+    "fractal_expand": seq(
+        block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL), Glyph.RA
+    ),
+    "fractal_contract": seq(
+        block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA), Glyph.RA
+    ),
 }
 
 

--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -1,4 +1,5 @@
 """Scenario generation."""
+
 from __future__ import annotations
 import networkx as nx
 
@@ -31,7 +32,9 @@ def build_graph(
         G = nx.gnp_random_graph(n, prob, seed=seed)
     else:
         valid = ["ring", "complete", "erdos"]
-        raise ValueError(f"Invalid topology '{topology}'. Valid options are: {', '.join(valid)}")
+        raise ValueError(
+            f"Invalid topology '{topology}'. Valid options are: {', '.join(valid)}"
+        )
 
     # Valores canónicos para inicialización
     inject_defaults(G)

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -1,4 +1,5 @@
 """Selección de glyphs."""
+
 from __future__ import annotations
 
 from typing import Any, Dict
@@ -87,13 +88,16 @@ def _selector_thresholds(G: nx.Graph) -> dict:
 
 
 def _norms_para_selector(G: nx.Graph) -> dict:
-    """Calcula y guarda en ``G.graph`` los máximos para normalizar |ΔNFR| y |d2EPI/dt2|."""
+    """Calcula y guarda en ``G.graph`` los máximos para normalizar
+    |ΔNFR| y |d2EPI/dt2|."""
     norms = compute_dnfr_accel_max(G)
     G.graph["_sel_norms"] = norms
     return norms
 
 
-def _calc_selector_score(Si: float, dnfr: float, accel: float, weights: Dict[str, float]) -> float:
+def _calc_selector_score(
+    Si: float, dnfr: float, accel: float, weights: Dict[str, float]
+) -> float:
     """Calcula un ``score`` ponderado asumiendo pesos ya normalizados."""
     return (
         weights["w_si"] * Si
@@ -123,4 +127,3 @@ def _apply_selector_hysteresis(
         if isinstance(prev, str) and prev in HYSTERESIS_GLYPHS:
             return prev
     return None
-

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -1,4 +1,5 @@
 """Sense calculations."""
+
 from __future__ import annotations
 from typing import Dict, Iterable, List
 import math
@@ -35,12 +36,13 @@ GLYPH_UNITS: Dict[str, complex] = {
 # Utilidades básicas
 # -------------------------
 
+
 def glyph_angle(g: str) -> float:
     return float(ANGLE_MAP.get(g, 0.0))
 
 
 def glyph_unit(g: str) -> complex:
-    return GLYPH_UNITS.get(g, 1+0j)
+    return GLYPH_UNITS.get(g, 1 + 0j)
 
 
 def _weight(nd, mode: str) -> float:
@@ -100,6 +102,7 @@ def _sigma_from_pairs(
     vectors = (glyph_unit(g) * float(w) for g, w in pairs)
     return _sigma_from_vectors(vectors, fallback_angle)
 
+
 def sigma_vector_node(G, n, weight_mode: str | None = None) -> Dict[str, float] | None:
     cfg = _sigma_cfg(G)
     nd = G.nodes[n]
@@ -127,14 +130,15 @@ def sigma_vector(dist: Dict[str, float]) -> Dict[str, float]:
 
     factor = len(SIGMA_ANGLE_KEYS) / total
     z_iter = (
-        glyph_unit(k) * float(dist.get(k, 0.0)) * factor
-        for k in SIGMA_ANGLE_KEYS
+        glyph_unit(k) * float(dist.get(k, 0.0)) * factor for k in SIGMA_ANGLE_KEYS
     )
     vec, _ = _sigma_from_vectors(z_iter)
     return vec
 
 
-def sigma_vector_from_graph(G: nx.Graph, weight_mode: str | None = None) -> Dict[str, float]:
+def sigma_vector_from_graph(
+    G: nx.Graph, weight_mode: str | None = None
+) -> Dict[str, float]:
     """Vector global del plano del sentido σ para un grafo.
 
     Parameters
@@ -156,16 +160,16 @@ def sigma_vector_from_graph(G: nx.Graph, weight_mode: str | None = None) -> Dict
     cfg = _sigma_cfg(G)
     weight_mode = weight_mode or cfg.get("weight", "Si")
     z_iter = (
-        nw[2]
-        for _, nd in G.nodes(data=True)
-        if (nw := _node_weight(nd, weight_mode))
+        nw[2] for _, nd in G.nodes(data=True) if (nw := _node_weight(nd, weight_mode))
     )
     vec, n = _sigma_from_vectors(z_iter)
     vec["n"] = n
     return vec
 
 
-def sigma_vector_global(G: nx.Graph, weight_mode: str | None = None) -> Dict[str, float]:
+def sigma_vector_global(
+    G: nx.Graph, weight_mode: str | None = None
+) -> Dict[str, float]:
     """Alias de :func:`sigma_vector_from_graph`.
 
     .. deprecated:: 4.5.3
@@ -184,6 +188,7 @@ def sigma_vector_global(G: nx.Graph, weight_mode: str | None = None) -> Dict[str
 # Historia / series
 # -------------------------
 
+
 def push_sigma_snapshot(G, t: float | None = None) -> None:
     cfg = _sigma_cfg(G)
     if not cfg.get("enabled", True):
@@ -198,8 +203,8 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
     alpha = float(cfg.get("smooth", 0.0))
     if alpha > 0 and hist.get(key):
         prev = hist[key][-1]
-        x = (1-alpha)*prev["x"] + alpha*sv["x"]
-        y = (1-alpha)*prev["y"] + alpha*sv["y"]
+        x = (1 - alpha) * prev["x"] + alpha * sv["x"]
+        y = (1 - alpha) * prev["y"] + alpha * sv["y"]
         mag = math.hypot(x, y)
         ang = math.atan2(y, x)
         sv = {"x": x, "y": y, "mag": mag, "angle": ang, "n": sv.get("n", 0)}
@@ -228,13 +233,17 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
 # Registro como callback automático (after_step)
 # -------------------------
 
+
 def register_sigma_callback(G) -> None:
-    register_callback(G, event="after_step", func=push_sigma_snapshot, name="sigma_snapshot")
+    register_callback(
+        G, event="after_step", func=push_sigma_snapshot, name="sigma_snapshot"
+    )
 
 
 # -------------------------
 # Series de utilidad
 # -------------------------
+
 
 def sigma_series(G, key: str | None = None) -> Dict[str, List[float]]:
     cfg = _sigma_cfg(G)
@@ -264,7 +273,8 @@ def sigma_rose(G, steps: int | None = None) -> Dict[str, int]:
                     agg[k] = int(agg.get(k, 0)) + int(v)
         return {g: int(agg.get(g, 0)) for g in GLYPHS_CANONICAL}
     agg: Dict[str, int] = {}
-    for row in counts[-int(steps):]:
+    start = -int(steps)
+    for row in counts[start:]:
         for k, v in row.items():
             if k != "t":
                 agg[k] = int(agg.get(k, 0)) + int(v)

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -1,4 +1,5 @@
 """Structural analysis."""
+
 from __future__ import annotations
 from typing import Iterable, Tuple, List
 import networkx as nx
@@ -15,6 +16,7 @@ from .constants import ALIAS_EPI, ALIAS_VF, ALIAS_THETA
 # ---------------------------------------------------------------------------
 # 1) Factoría NFR
 # ---------------------------------------------------------------------------
+
 
 def create_nfr(
     name: str,
@@ -36,7 +38,7 @@ def create_nfr(
             ALIAS_EPI[0]: float(epi),
             ALIAS_VF[0]: float(vf),
             ALIAS_THETA[0]: float(theta),
-        }
+        },
     )
     set_delta_nfr_hook(G, dnfr_hook)
     return G, name
@@ -216,4 +218,3 @@ def run_sequence(G: nx.Graph, node, ops: Iterable[Operador]) -> None:
         # recalculate the EPI value after each operator. The responsibility for
         # updating EPI now lies with the dynamics hook configured in
         # ``compute_delta_nfr`` or with external callers.
-

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -16,15 +16,11 @@ from .glyph_history import ensure_history, count_glyphs
 
 
 class _KuramotoFn(Protocol):
-    def __call__(self, G: Any) -> tuple[float, float]:
-        ...
+    def __call__(self, G: Any) -> tuple[float, float]: ...
 
 
 class _SigmaVectorFn(Protocol):
-    def __call__(
-        self, G: Any, weight_mode: str | None = None
-    ) -> Dict[str, float]:
-        ...
+    def __call__(self, G: Any, weight_mode: str | None = None) -> Dict[str, float]: ...
 
 
 class CallbackSpec(NamedTuple):
@@ -37,18 +33,22 @@ class CallbackSpec(NamedTuple):
 try:
     from .gamma import kuramoto_R_psi as _kuramoto_R_psi
 except ImportError:  # pragma: no cover
+
     def _kuramoto_R_psi(G: Any) -> tuple[float, float]:
         return 0.0, 0.0
+
 
 kuramoto_R_psi: _KuramotoFn = _kuramoto_R_psi
 
 try:
     from .sense import sigma_vector_from_graph as _sigma_vector_from_graph
 except ImportError:  # pragma: no cover
+
     def _sigma_vector_from_graph(
         G: Any, weight_mode: str | None = None
     ) -> Dict[str, float]:
         return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0.0}
+
 
 sigma_vector_from_graph: _SigmaVectorFn = _sigma_vector_from_graph
 
@@ -66,7 +66,9 @@ __all__ = [
 # -------------------------
 
 
-def _trace_setup(G) -> tuple[Optional[Dict[str, Any]], set[str], Optional[Dict[str, Any]], Optional[str]]:
+def _trace_setup(
+    G,
+) -> tuple[Optional[Dict[str, Any]], set[str], Optional[Dict[str, Any]], Optional[str]]:
     """Common configuration for trace snapshots.
 
     Returns the active configuration, capture set, history and key under
@@ -115,6 +117,7 @@ def _safe_graph_mapping(G, key: str) -> Optional[Dict[str, Any]]:
         return None
     return data.copy()
 
+
 # -------------------------
 # Builders
 # -------------------------
@@ -135,6 +138,7 @@ def _new_trace_meta(
 
     meta: Dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": phase}
     return meta, capture, hist, key
+
 
 # -------------------------
 # Snapshots

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -1,4 +1,5 @@
 """Definiciones de tipos."""
+
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
@@ -10,14 +11,20 @@ from .constants import VF_KEY, THETA_KEY
 @dataclass
 class NodeState:
     EPI: float = 0.0
-    vf: float = 1.0   # νf
+    vf: float = 1.0  # νf
     theta: float = 0.0  # θ
     Si: float = 0.5
     epi_kind: str = ""
     extra: Dict[str, Any] = field(default_factory=dict)
 
     def to_attrs(self) -> Dict[str, Any]:
-        d = {"EPI": self.EPI, VF_KEY: self.vf, THETA_KEY: self.theta, "Si": self.Si, "EPI_kind": self.epi_kind}
+        d = {
+            "EPI": self.EPI,
+            VF_KEY: self.vf,
+            THETA_KEY: self.theta,
+            "Si": self.Si,
+            "EPI_kind": self.epi_kind,
+        }
         d.update(self.extra)
         return d
 
@@ -38,4 +45,3 @@ class Glyph(str, Enum):
     ZHIR = "ZHIR"
     NAV = "NAV"
     REMESH = "REMESH"
-

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -13,8 +13,7 @@ EPS = 1e-9
 
 def _validate_epi_vf(G) -> None:
     cfg = {
-        k: float(get_param(G, k))
-        for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
+        k: float(get_param(G, k)) for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
     }
     for n, data in G.nodes(data=True):
         epi = get_attr(data, ALIAS_EPI, 0.0, strict=True)

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -1,4 +1,5 @@
 """Utilities for value conversion."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, TypeVar
@@ -28,8 +29,10 @@ def _convert_value(
     try:
         return True, conv(value)
     except (ValueError, TypeError) as exc:
-        level = log_level if log_level is not None else (
-            logging.ERROR if strict else logging.DEBUG
+        level = (
+            log_level
+            if log_level is not None
+            else (logging.ERROR if strict else logging.DEBUG)
         )
         if key is not None:
             logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Utilidades de pruebas."""
+
 import pytest
 import networkx as nx
 
@@ -15,4 +16,3 @@ def graph_canon():
         return G
 
     return _factory
-

--- a/tests/test_alias_get_default.py
+++ b/tests/test_alias_get_default.py
@@ -1,4 +1,5 @@
 """Pruebas de alias get default."""
+
 from tnfr.helpers import alias_get
 
 

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -1,4 +1,5 @@
 """Pruebas de alias get strict."""
+
 import logging
 import pytest
 from tnfr.helpers import alias_get

--- a/tests/test_alias_helpers_threadsafe.py
+++ b/tests/test_alias_helpers_threadsafe.py
@@ -1,4 +1,5 @@
 """Pruebas de alias helpers threadsafe."""
+
 from concurrent.futures import ThreadPoolExecutor
 
 from tnfr.helpers import alias_get, alias_set

--- a/tests/test_alias_set_error.py
+++ b/tests/test_alias_set_error.py
@@ -1,6 +1,8 @@
 """Pruebas de alias_set para conversiones nulas."""
+
 import pytest
 from tnfr.helpers import alias_set
+
 
 def test_alias_set_raises_value_error_on_none():
     """alias_set debe lanzar ValueError si la conversión produce None."""

--- a/tests/test_canon.py
+++ b/tests/test_canon.py
@@ -1,4 +1,5 @@
 """Pruebas de canon."""
+
 from tnfr.scenarios import build_graph
 from tnfr.dynamics import validate_canon
 from tnfr.constants import VF_KEY, THETA_KEY

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -1,4 +1,5 @@
 """Pruebas de cli history."""
+
 from tnfr.cli import main
 import json
 
@@ -15,7 +16,9 @@ def test_cli_run_save_history(tmp_path):
 def test_cli_run_export_history(tmp_path):
     base = tmp_path / "other" / "history"
     assert not base.parent.exists()
-    rc = main(["run", "--nodes", "5", "--steps", "0", "--export-history-base", str(base)])
+    rc = main(
+        ["run", "--nodes", "5", "--steps", "0", "--export-history-base", str(base)]
+    )
     assert rc == 0
     data = json.loads((base.with_suffix(".json")).read_text())
     assert isinstance(data, dict)

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -1,4 +1,5 @@
 """Pruebas de cli sanity."""
+
 from __future__ import annotations
 import argparse
 from tnfr.cli import main, add_common_args, add_grammar_args, _build_graph_from_args
@@ -18,7 +19,7 @@ def test_cli_metrics_runs(tmp_path):
 
 def test_cli_sequence_file(tmp_path):
     seq_file = tmp_path / "seq.json"
-    seq_file.write_text("[{\"WAIT\": 1}]", encoding="utf-8")
+    seq_file.write_text('[{"WAIT": 1}]', encoding="utf-8")
     rc = main(["sequence", "--sequence-file", str(seq_file), "--nodes", "5"])
     assert rc == 0
 
@@ -31,7 +32,9 @@ def test_cli_version(capsys):
 
 
 def test_cli_run_erdos_p():
-    rc = main(["run", "--topology", "erdos", "--p", "0.9", "--nodes", "5", "--steps", "1"])
+    rc = main(
+        ["run", "--topology", "erdos", "--p", "0.9", "--nodes", "5", "--steps", "1"]
+    )
     assert rc == 0
 
 

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -1,4 +1,5 @@
 """Pruebas de load_config y apply_config."""
+
 import json
 import networkx as nx
 import pytest

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -1,9 +1,11 @@
 """Pruebas de count glyphs."""
+
 import networkx as nx
 from collections import deque, Counter
 
 from tnfr.glyph_history import count_glyphs
 from tnfr.constants import ALIAS_EPI_KIND
+
 
 def test_count_glyphs_last_only_and_window():
     G = nx.Graph()

--- a/tests/test_defaults_integrity.py
+++ b/tests/test_defaults_integrity.py
@@ -1,4 +1,5 @@
 """Pruebas de defaults integrity."""
+
 from collections import ChainMap
 
 from tnfr.constants import (

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -1,4 +1,5 @@
 """Pruebas de dnfr cache."""
+
 import pytest
 import networkx as nx
 
@@ -64,4 +65,3 @@ def test_cache_invalidated_on_node_rename():
     default_compute_delta_nfr(G)
 
     assert set(G.nodes) == {0, 1, 9}
-

--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -1,4 +1,5 @@
 """Pruebas de dnfr precompute."""
+
 import pytest
 import networkx as nx
 

--- a/tests/test_dynamics_benchmark.py
+++ b/tests/test_dynamics_benchmark.py
@@ -1,10 +1,12 @@
 """Pruebas de dynamics benchmark."""
+
 import time
 import networkx as nx
 import pytest
 
 from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF
+
 
 @pytest.mark.slow
 def test_default_compute_delta_nfr_performance():

--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -1,4 +1,5 @@
 """Pruebas de dynamics vectorized."""
+
 import pytest
 import networkx as nx
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,4 +1,5 @@
 """Pruebas de edge cases."""
+
 import pytest
 from tnfr.node import NodoTNFR
 from tnfr.operators import op_EN

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -57,4 +57,3 @@ def test_none_uses_default_limit():
 def test_non_iterable_error():
     with pytest.raises(TypeError):
         ensure_collection(42)  # type: ignore[arg-type]
-

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -1,4 +1,5 @@
 """Pruebas de export history."""
+
 import json
 
 from tnfr.metrics import export_history
@@ -60,6 +61,7 @@ def test_export_history_truncates_sigma(tmp_path, graph_canon):
     export_history(G, str(base), fmt="csv")
     sigma_path = base.parent / (base.name + "_sigma.csv")
     import csv
+
     with open(sigma_path, newline="") as f:
         rows = list(csv.reader(f))
     assert rows[1] == ["0", "1", "3", "4", "7"]

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,4 +1,5 @@
 """Pruebas de gamma."""
+
 import math
 import logging
 import pytest

--- a/tests/test_glyph_helpers.py
+++ b/tests/test_glyph_helpers.py
@@ -1,4 +1,5 @@
 """Pruebas para normalización y mezcla de conteos glíficos."""
+
 from collections import Counter
 
 from tnfr.collections_utils import normalize_counter, mix_groups

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,4 +1,5 @@
 """Pruebas de grammar."""
+
 from collections import deque
 
 from tnfr.constants import attach_defaults
@@ -6,7 +7,15 @@ from tnfr.grammar import (
     enforce_canonical_grammar,
     on_applied_glyph,
     apply_glyph_with_grammar,
-    AL, EN, IL, OZ, ZHIR, THOL, SHA, NUL, NAV,
+    AL,
+    EN,
+    IL,
+    OZ,
+    ZHIR,
+    THOL,
+    SHA,
+    NUL,
+    NAV,
 )
 
 
@@ -15,7 +24,7 @@ def test_compatibility_fallback(graph_canon):
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
-    nd['glyph_history'] = deque([AL])
+    nd["glyph_history"] = deque([AL])
     assert enforce_canonical_grammar(G, 0, IL) == EN
 
 
@@ -24,10 +33,10 @@ def test_precondition_oz_to_zhir(graph_canon):
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
-    nd['glyph_history'] = deque([NAV])
-    nd['ΔNFR'] = 0.0
+    nd["glyph_history"] = deque([NAV])
+    nd["ΔNFR"] = 0.0
     assert enforce_canonical_grammar(G, 0, ZHIR) == OZ
-    nd['glyph_history'] = deque([OZ])
+    nd["glyph_history"] = deque([OZ])
     assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
 
 
@@ -36,15 +45,15 @@ def test_thol_closure(graph_canon):
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
-    nd['glyph_history'] = deque([THOL])
+    nd["glyph_history"] = deque([THOL])
     on_applied_glyph(G, 0, THOL)
-    st = nd['_GRAM']
-    st['thol_len'] = 2
-    nd['ΔNFR'] = 0.0
-    nd['Si'] = 0.7
+    st = nd["_GRAM"]
+    st["thol_len"] = 2
+    nd["ΔNFR"] = 0.0
+    nd["Si"] = 0.7
     assert enforce_canonical_grammar(G, 0, EN) == NUL
-    nd['Si'] = 0.1
-    st['thol_len'] = 2
+    nd["Si"] = 0.1
+    st["thol_len"] = 2
     assert enforce_canonical_grammar(G, 0, EN) == SHA
 
 
@@ -53,28 +62,26 @@ def test_repeat_window_and_force(graph_canon):
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
-    nd['glyph_history'] = deque([ZHIR.value, 'OZ'])
-    G.graph['GRAMMAR'] = {
-        'window': 3,
-        'avoid_repeats': ['ZHIR'],
-        'force_dnfr': 0.5,
-        'force_accel': 0.8,
-        'fallbacks': {'ZHIR': 'NAV'},
+    nd["glyph_history"] = deque([ZHIR.value, "OZ"])
+    G.graph["GRAMMAR"] = {
+        "window": 3,
+        "avoid_repeats": ["ZHIR"],
+        "force_dnfr": 0.5,
+        "force_accel": 0.8,
+        "fallbacks": {"ZHIR": "NAV"},
     }
-    G.graph['_sel_norms'] = {'dnfr_max': 1.0, 'accel_max': 1.0}
+    G.graph["_sel_norms"] = {"dnfr_max": 1.0, "accel_max": 1.0}
 
-    nd['ΔNFR'] = 0.0
-    nd['d2EPI_dt2'] = 0.0
+    nd["ΔNFR"] = 0.0
+    nd["d2EPI_dt2"] = 0.0
     assert enforce_canonical_grammar(G, 0, ZHIR) == NAV
 
-    nd['ΔNFR'] = 0.6
+    nd["ΔNFR"] = 0.6
     assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
 
-    nd['ΔNFR'] = 0.0
-    nd['d2EPI_dt2'] = 0.9
+    nd["ΔNFR"] = 0.0
+    nd["d2EPI_dt2"] = 0.9
     assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
-
-
 
 
 def test_repeat_invalid_fallback_string(graph_canon):
@@ -82,11 +89,11 @@ def test_repeat_invalid_fallback_string(graph_canon):
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
-    nd['glyph_history'] = deque([ZHIR.value])
-    G.graph['GRAMMAR'] = {
-        'window': 3,
-        'avoid_repeats': ['ZHIR'],
-        'fallbacks': {'ZHIR': 'NOPE'},
+    nd["glyph_history"] = deque([ZHIR.value])
+    G.graph["GRAMMAR"] = {
+        "window": 3,
+        "avoid_repeats": ["ZHIR"],
+        "fallbacks": {"ZHIR": "NOPE"},
     }
     assert enforce_canonical_grammar(G, 0, ZHIR) == IL
 
@@ -96,28 +103,29 @@ def test_repeat_invalid_fallback_type(graph_canon):
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
-    nd['glyph_history'] = deque([ZHIR.value])
+    nd["glyph_history"] = deque([ZHIR.value])
     obj = object()
-    G.graph['GRAMMAR'] = {
-        'window': 3,
-        'avoid_repeats': ['ZHIR'],
-        'fallbacks': {'ZHIR': obj},
+    G.graph["GRAMMAR"] = {
+        "window": 3,
+        "avoid_repeats": ["ZHIR"],
+        "fallbacks": {"ZHIR": obj},
     }
     assert enforce_canonical_grammar(G, 0, ZHIR) == IL
+
 
 def test_lag_counters_enforced(graph_canon):
     G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
-    G.graph['AL_MAX_LAG'] = 2
-    G.graph['EN_MAX_LAG'] = 2
+    G.graph["AL_MAX_LAG"] = 2
+    G.graph["EN_MAX_LAG"] = 2
     from tnfr.dynamics import step
 
     for _ in range(6):
         step(G)
-        hist = G.graph['history']
-        assert all(v <= 2 for v in hist['since_AL'].values())
-        assert all(v <= 2 for v in hist['since_EN'].values())
+        hist = G.graph["history"]
+        assert all(v <= 2 for v in hist["since_AL"].values())
+        assert all(v <= 2 for v in hist["since_EN"].values())
 
 
 def test_apply_glyph_with_grammar_equivalence(graph_canon):
@@ -131,6 +139,7 @@ def test_apply_glyph_with_grammar_equivalence(graph_canon):
     # Aplicación manual
     g_eff = enforce_canonical_grammar(G_manual, 0, ZHIR)
     from tnfr.operators import apply_glyph
+
     apply_glyph(G_manual, 0, g_eff, window=1)
     on_applied_glyph(G_manual, 0, g_eff)
 
@@ -145,29 +154,29 @@ def test_apply_glyph_with_grammar_multiple_nodes(graph_canon):
     G.add_node(0, theta=0.0)
     G.add_node(1)
     attach_defaults(G)
-    G.nodes[0]['glyph_history'] = deque([OZ])
+    G.nodes[0]["glyph_history"] = deque([OZ])
 
     apply_glyph_with_grammar(G, [0, 1], ZHIR, 1)
 
-    assert G.nodes[0]['glyph_history'][-1] == ZHIR
-    assert G.nodes[1]['glyph_history'][-1] == OZ
+    assert G.nodes[0]["glyph_history"][-1] == ZHIR
+    assert G.nodes[1]["glyph_history"][-1] == OZ
 
 
 def test_apply_glyph_with_grammar_accepts_iterables(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
     attach_defaults(G)
-    G.nodes[0]['glyph_history'] = deque([OZ])
-    G.nodes[1]['glyph_history'] = deque([OZ])
+    G.nodes[0]["glyph_history"] = deque([OZ])
+    G.nodes[1]["glyph_history"] = deque([OZ])
     apply_glyph_with_grammar(G, G.nodes(), ZHIR, 1)
-    assert G.nodes[0]['glyph_history'][-1] == ZHIR
-    assert G.nodes[1]['glyph_history'][-1] == ZHIR
+    assert G.nodes[0]["glyph_history"][-1] == ZHIR
+    assert G.nodes[1]["glyph_history"][-1] == ZHIR
 
     G2 = graph_canon()
     G2.add_nodes_from([0, 1])
     attach_defaults(G2)
-    G2.nodes[0]['glyph_history'] = deque([OZ])
-    G2.nodes[1]['glyph_history'] = deque([OZ])
+    G2.nodes[0]["glyph_history"] = deque([OZ])
+    G2.nodes[1]["glyph_history"] = deque([OZ])
     apply_glyph_with_grammar(G2, (n for n in G2.nodes()), ZHIR, 1)
-    assert G2.nodes[0]['glyph_history'][-1] == ZHIR
-    assert G2.nodes[1]['glyph_history'][-1] == ZHIR
+    assert G2.nodes[0]["glyph_history"][-1] == ZHIR
+    assert G2.nodes[1]["glyph_history"][-1] == ZHIR

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,4 +1,5 @@
 """Pruebas de history."""
+
 import pytest
 
 from tnfr.dynamics import _update_history

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -1,4 +1,5 @@
 """Pruebas de compactación de _heap en HistoryDict."""
+
 from tnfr.glyph_history import HistoryDict
 
 

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -1,4 +1,5 @@
 """Pruebas de history maxlen."""
+
 from collections import deque
 
 from tnfr.constants import attach_defaults

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -1,4 +1,5 @@
 """Pruebas de history series."""
+
 from tnfr.constants import attach_defaults
 from tnfr.dynamics import step
 from tnfr.gamma import GAMMA_REGISTRY

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,4 +1,5 @@
 """Pruebas de initialization."""
+
 import networkx as nx
 
 from tnfr.initialization import init_node_attrs
@@ -12,13 +13,17 @@ def test_init_node_attrs_reproducible():
     attach_defaults(G1)
     G1.graph["RANDOM_SEED"] = seed
     init_node_attrs(G1)
-    attrs1 = {n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G1.nodes(data=True)}
+    attrs1 = {
+        n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G1.nodes(data=True)
+    }
 
     G2 = nx.path_graph(5)
     attach_defaults(G2)
     G2.graph["RANDOM_SEED"] = seed
     init_node_attrs(G2)
-    attrs2 = {n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G2.nodes(data=True)}
+    attrs2 = {
+        n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G2.nodes(data=True)
+    }
 
     assert attrs1 == attrs2
 

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -1,4 +1,5 @@
 """Pruebas de integrators."""
+
 from __future__ import annotations
 import pytest
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,4 +1,5 @@
 """Pruebas de invariants."""
+
 from __future__ import annotations
 import math
 import pytest
@@ -59,7 +60,9 @@ def test_conservation_under_IL_SHA(G_small):
 
 
 def test_remesh_cooldown_if_present(G_small):
-    cooldown = G_small.graph.get("REMESH_COOLDOWN", G_small.graph.get("REMESH_COOLDOWN_VENTANA", None))
+    cooldown = G_small.graph.get(
+        "REMESH_COOLDOWN", G_small.graph.get("REMESH_COOLDOWN_VENTANA", None)
+    )
     if cooldown is None:
         pytest.skip("No hay REMESH_COOLDOWN definido en el motor")
 
@@ -69,7 +72,10 @@ def test_remesh_cooldown_if_present(G_small):
     tau_g = int(G_small.graph.get("REMESH_TAU_GLOBAL", 0))
     snap = {n: G_small.nodes[n].get("EPI", 0.0) for n in G_small.nodes()}
     from collections import deque
-    G_small.graph["_epi_hist"] = deque([snap.copy() for _ in range(tau_g + 1)], maxlen=tau_g + 1)
+
+    G_small.graph["_epi_hist"] = deque(
+        [snap.copy() for _ in range(tau_g + 1)], maxlen=tau_g + 1
+    )
 
     apply_remesh_if_globally_stable(G_small)
     events = list(G_small.graph.get("history", {}).get("remesh_events", []))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
 """Pruebas de metrics."""
+
 import pytest
 import networkx as nx
 

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -1,4 +1,5 @@
 """Pruebas de nav."""
+
 import pytest
 
 from tnfr.constants import attach_defaults

--- a/tests/test_node_all_nodes.py
+++ b/tests/test_node_all_nodes.py
@@ -1,4 +1,5 @@
 """Pruebas de node all nodes."""
+
 from tnfr.node import NodoTNFR
 
 
@@ -11,4 +12,3 @@ def test_all_nodes_returns_full_list():
 
     assert set(a.all_nodes()) == {a, b}
     assert set(b.all_nodes()) == {a, b}
-

--- a/tests/test_node_sample.py
+++ b/tests/test_node_sample.py
@@ -1,4 +1,5 @@
 """Pruebas de node sample."""
+
 from tnfr.dynamics import step
 from tnfr.constants import attach_defaults
 import networkx as nx
@@ -57,7 +58,11 @@ print(json.dumps(G.graph["_node_sample"]))
 """
     env = dict(os.environ, PYTHONHASHSEED=str(hashseed))
     result = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
     )
     return json.loads(result.stdout)
 

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -1,4 +1,5 @@
 """Pruebas de node weights."""
+
 import math
 import pytest
 import networkx as nx

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -1,4 +1,5 @@
 """Tests for normalize_weights helper."""
+
 import math
 import pytest
 from tnfr.collections_utils import normalize_weights

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,4 +1,5 @@
 """Pruebas de observers."""
+
 import math
 import statistics as st
 from collections import deque
@@ -12,6 +13,7 @@ from tnfr.constants_glyphs import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, set_attr
 from tnfr.callback_utils import CallbackEvent
 from tnfr.observers import attach_standard_observer
+
 
 def test_phase_observers_match_manual_calculation(graph_canon):
     G = graph_canon()
@@ -49,7 +51,9 @@ def test_glyph_load_uses_module_constants(monkeypatch, graph_canon):
     G.add_node(1, glyph_history=["B"])
 
     # Patch constants to custom categories
-    monkeypatch.setattr("tnfr.observers.GLYPH_GROUPS", {"estabilizadores": ["A"], "disruptivos": ["B"]})
+    monkeypatch.setattr(
+        "tnfr.observers.GLYPH_GROUPS", {"estabilizadores": ["A"], "disruptivos": ["B"]}
+    )
 
     dist = glyph_load(G)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,4 +1,5 @@
 """Pruebas de operators."""
+
 from tnfr.node import NodoNX
 from tnfr.operators import random_jitter, clear_rng_cache
 import tnfr.operators as operators
@@ -74,7 +75,7 @@ def test_rng_cache_lru_purge(graph_canon):
 
     j0 = random_jitter(n0, 0.5)
     j1 = random_jitter(n1, 0.5)
-    j2 = random_jitter(n2, 0.5)
+    random_jitter(n2, 0.5)
 
     j1b = random_jitter(n1, 0.5)
     assert j1b != j1
@@ -85,7 +86,8 @@ def test_rng_cache_lru_purge(graph_canon):
 
 
 def test_rng_cache_does_not_reference_graph(graph_canon):
-    import gc, weakref
+    import gc
+    import weakref
 
     clear_rng_cache()
     G = graph_canon()

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -1,4 +1,5 @@
 """Pruebas de parse tokens errors."""
+
 from __future__ import annotations
 
 import pytest
@@ -28,7 +29,7 @@ def test_parse_tokens_key_error_context(monkeypatch):
 
 def test_thol_invalid_close():
     with pytest.raises(ValueError) as exc:
-        _parse_tokens([{ "THOL": {"close": "XYZ"} }])
+        _parse_tokens([{"THOL": {"close": "XYZ"}}])
     msg = str(exc.value)
     assert "XYZ" in msg
     assert "Glyph" in msg

--- a/tests/test_preparar_red.py
+++ b/tests/test_preparar_red.py
@@ -6,11 +6,10 @@ from tnfr.ontosim import preparar_red
 def test_preparar_red_init_attrs_por_defecto():
     G = nx.path_graph(3)
     preparar_red(G)
-    assert all('θ' in d for _, d in G.nodes(data=True))
+    assert all("θ" in d for _, d in G.nodes(data=True))
 
 
 def test_preparar_red_sin_init_attrs():
     G = nx.path_graph(3)
     preparar_red(G, init_attrs=False)
-    assert all('θ' not in d for _, d in G.nodes(data=True))
-
+    assert all("θ" not in d for _, d in G.nodes(data=True))

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,4 +1,5 @@
 """Pruebas de program."""
+
 import json
 import pytest
 
@@ -87,6 +88,7 @@ def test_target_accepts_bytes(graph_canon):
     assert list(G.nodes[bname]["glyph_history"]) == [Glyph.AL.value]
     for code in codes:
         assert "glyph_history" not in G.nodes[code]
+
 
 def test_load_sequence_json_yaml(tmp_path):
     data = [

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -1,4 +1,5 @@
 """Pruebas de read structured file errors."""
+
 import pytest
 from pathlib import Path
 import tnfr.helpers as helpers
@@ -13,7 +14,9 @@ def test_read_structured_file_missing_file(tmp_path: Path):
     assert str(path) in str(excinfo.value)
 
 
-def test_read_structured_file_permission_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_read_structured_file_permission_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     path = tmp_path / "forbidden.json"
     original_open = Path.open
 
@@ -49,7 +52,9 @@ def test_read_structured_file_corrupt_yaml(tmp_path: Path):
     assert str(path) in msg
 
 
-def test_read_structured_file_missing_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_read_structured_file_missing_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     path = tmp_path / "data.yaml"
     path.write_text("a: 1", encoding="utf-8")
 

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -1,4 +1,5 @@
 """Pruebas de recent_glyph."""
+
 from tnfr.glyph_history import push_glyph, recent_glyph
 from tnfr.constants import ALIAS_EPI_KIND
 

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -1,4 +1,5 @@
 """Pruebas de register callback."""
+
 import pytest
 
 from tnfr.callback_utils import register_callback, invoke_callbacks, CallbackEvent

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,4 +1,5 @@
 """Pruebas de remesh."""
+
 from collections import deque
 
 from tnfr.constants import attach_defaults
@@ -46,4 +47,3 @@ def test_remesh_alpha_hard_ignores_glyph_factor(graph_canon):
     meta = G.graph.get("_REMESH_META", {})
     assert meta.get("alpha") == 0.7
     assert G.graph.get("_REMESH_ALPHA_SRC") == "REMESH_ALPHA"
-

--- a/tests/test_remesh_community.py
+++ b/tests/test_remesh_community.py
@@ -1,4 +1,5 @@
 """Pruebas de remesh community."""
+
 import networkx as nx
 from tnfr.constants import attach_defaults
 from tnfr.operators import apply_topological_remesh
@@ -6,7 +7,7 @@ from tnfr.operators import apply_topological_remesh
 
 def test_remesh_community_reduces_nodes_and_preserves_connectivity(graph_canon):
     G = graph_canon()
-    G.add_edges_from([(0,1),(1,2),(2,0),(3,4),(4,5),(5,3),(2,3)])
+    G.add_edges_from([(0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 3), (2, 3)])
     attach_defaults(G)
     for n in G.nodes():
         G.nodes[n]["EPI"] = float(n)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,4 +1,5 @@
 """Pruebas de scenarios."""
+
 import pytest
 import networkx as nx
 
@@ -37,4 +38,3 @@ def test_random_seed_reflects_value():
     seed = 123
     G = build_graph(n=5, seed=seed)
     assert G.graph["RANDOM_SEED"] == seed
-

--- a/tests/test_selector_norms.py
+++ b/tests/test_selector_norms.py
@@ -1,4 +1,5 @@
 """Pruebas de selector norms."""
+
 from tnfr.dynamics import step, default_glyph_selector, parametric_glyph_selector
 from tnfr.constants.core import SELECTOR_THRESHOLD_DEFAULTS
 

--- a/tests/test_selector_utils.py
+++ b/tests/test_selector_utils.py
@@ -1,4 +1,5 @@
 """Pruebas de selector utils."""
+
 import networkx as nx
 import pytest
 

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -1,4 +1,5 @@
 """Pruebas de sense."""
+
 import time
 import networkx as nx
 import pytest

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -1,4 +1,5 @@
 """Pruebas de structural."""
+
 import networkx as nx
 
 from tnfr.structural import (
@@ -73,4 +74,3 @@ def test_thol_closed_by_silencio():
     names = [op.name for op in ops]
     ok, msg = validate_sequence(names)
     assert ok, msg
-

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,4 +1,5 @@
 """Pruebas de trace."""
+
 import pytest
 
 from tnfr.trace import (

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -1,4 +1,5 @@
 """Pruebas de update tg performance."""
+
 import time
 from collections import Counter, defaultdict
 
@@ -78,4 +79,3 @@ def test_update_tg_matches_naive(graph_canon):
     assert n_latent_opt == n_latent_ref
     assert hist_opt == hist_ref
     assert t_opt <= t_ref * 2
-

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,5 @@
 """Pruebas de validators."""
+
 import pytest
 from tnfr.scenarios import build_graph
 from tnfr.constants import (
@@ -60,7 +61,7 @@ def test_validator_glyph_valido():
 
 def test_read_structured_file_json(tmp_path):
     path = tmp_path / "cfg.json"
-    path.write_text("{\"x\": 1}", encoding="utf-8")
+    path.write_text('{"x": 1}', encoding="utf-8")
     data = read_structured_file(path)
     assert data == {"x": 1}
 
@@ -74,6 +75,6 @@ def test_read_structured_file_invalid_extension(tmp_path):
 
 def test_load_config_json(tmp_path):
     path = tmp_path / "cfg.json"
-    path.write_text("{\"a\": 5}", encoding="utf-8")
+    path.write_text('{"a": 5}', encoding="utf-8")
     data = load_config(path)
     assert data["a"] == 5

--- a/tests/test_vf_coherencia.py
+++ b/tests/test_vf_coherencia.py
@@ -1,4 +1,5 @@
 """Pruebas de vf coherencia."""
+
 import pytest
 
 from tnfr.constants import attach_defaults


### PR DESCRIPTION
## Summary
- Run Black across the codebase to enforce 88-character line limits and normalize spacing
- Wrap long comments/docstrings and remove unused imports to satisfy flake8
- Clean up tests and slices to avoid lint errors

## Testing
- `flake8 --max-line-length=88 src tests`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b79b23288c8321b3b772f0c316f714