### PR TITLE
Clarify RNG cache priming in operator tests

### DIFF
--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -75,7 +75,7 @@ def test_rng_cache_lru_purge(graph_canon):
 
     j0 = random_jitter(n0, 0.5)
     j1 = random_jitter(n1, 0.5)
-    random_jitter(n2, 0.5)
+    random_jitter(n2, 0.5)  # Populate cache for n2 without keeping the value
 
     j1b = random_jitter(n1, 0.5)
     assert j1b != j1


### PR DESCRIPTION
## Summary
- Document why the jitter for `n2` is invoked without storing in `test_rng_cache_lru_purge`

## Testing
- `flake8 tests/test_operators.py`


------
https://chatgpt.com/codex/tasks/task_e_68b79c6060d88321898f6c0977954209