### PR TITLE
style: fix spacing in remesh community test

### DIFF
--- a/tests/test_remesh_community.py
+++ b/tests/test_remesh_community.py
@@ -5,9 +5,19 @@ from tnfr.constants import attach_defaults
 from tnfr.operators import apply_topological_remesh
 
 
-def test_remesh_community_reduces_nodes_and_preserves_connectivity(graph_canon):
+def test_remesh_community_reduces_nodes_and_preserves_connectivity(
+    graph_canon,
+):
     G = graph_canon()
-    G.add_edges_from([(0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 3), (2, 3)])
+    G.add_edges_from([
+        (0, 1),
+        (1, 2),
+        (2, 0),
+        (3, 4),
+        (4, 5),
+        (5, 3),
+        (2, 3),
+    ])
     attach_defaults(G)
     for n in G.nodes():
         G.nodes[n]["EPI"] = float(n)


### PR DESCRIPTION
## Summary
- ensure edge list uses spaces after commas
- format long test definition and edge list for clarity

## Testing
- `flake8 tests/test_remesh_community.py`


------
https://chatgpt.com/codex/tasks/task_e_68b79d4794f08321b68f96a619f15839