### PR TITLE
Refactor CLI helpers for clarity

### DIFF
--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -38,6 +38,13 @@ def test_cli_run_erdos_p():
     assert rc == 0
 
 
+def test_cli_run_summary(capsys):
+    rc = main(["run", "--nodes", "5", "--steps", "1", "--summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Tg global" in out
+
+
 def test_grammar_args_help_group(capsys):
     parser = argparse.ArgumentParser()
     add_grammar_args(parser)


### PR DESCRIPTION
## Summary
- Extract repeated run summary logic into private helper
- Modularize CLI parser setup with dedicated functions
- Add test covering run command with summary output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b79def92008321967aa9111121cf14