### PR TITLE
Handle missing YAML dependency via ImportError

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -100,7 +100,7 @@ def _parse_json(text: str) -> Any:
 def _parse_yaml(text: str) -> Any:
     """Parsea ``text`` como YAML."""
     if not yaml:  # pragma: no cover - dependencia opcional
-        raise RuntimeError("pyyaml no está instalado")
+        raise ImportError("pyyaml no está instalado")
     return yaml.safe_load(text)
 
 
@@ -126,7 +126,7 @@ def read_structured_file(path: Path) -> Any:
         raise ValueError(f"Error al parsear archivo JSON en {path}: {e}") from e
     except YAMLError as e:
         raise ValueError(f"Error al parsear archivo YAML en {path}: {e}") from e
-    except RuntimeError as e:
+    except ImportError as e:
         raise ValueError(f"Dependencia faltante al parsear {path}: {e}") from e
 
 

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -59,7 +59,7 @@ def test_read_structured_file_missing_dependency(
     path.write_text("a: 1", encoding="utf-8")
 
     def fake_parser(_: str) -> None:
-        raise RuntimeError("pyyaml no está instalado")
+        raise ImportError("pyyaml no está instalado")
 
     monkeypatch.setitem(helpers.PARSERS, ".yaml", fake_parser)
 


### PR DESCRIPTION
## Summary
- raise ImportError in `_parse_yaml` when PyYAML isn't installed
- catch ImportError in `read_structured_file` for clearer dependency errors
- update tests to expect ImportError from missing YAML dependency

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba8b70c67c8321ac614e3771005c19