### PR TITLE
Enforce immutable alias tuples

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -172,17 +172,21 @@ def angle_diff(a: float, b: float) -> float:
 # -------------------------
 # Acceso a atributos con alias
 # -------------------------
-def _validate_aliases(aliases: Sequence[str]) -> Sequence[str]:
-    """Return ``aliases`` ensuring it's a non-empty sequence of strings."""
+def _validate_aliases(aliases: Sequence[str]) -> tuple[str, ...]:
+    """Return ``aliases`` as a tuple of strings.
+
+    A pre-existing tuple is returned unchanged; other sequences are converted to
+    tuples. The result is guaranteed to be a non-empty tuple of strings.
+    """
 
     if isinstance(aliases, str) or not isinstance(aliases, Sequence):
         raise TypeError("'aliases' must be a sequence of strings")
-    aliases = list(aliases)
-    if not aliases:
+    seq = aliases if isinstance(aliases, tuple) else tuple(aliases)
+    if not seq:
         raise ValueError("'aliases' must contain at least one key")
-    if not all(isinstance(a, str) for a in aliases):
+    if not all(isinstance(a, str) for a in seq):
         raise TypeError("'aliases' must be a sequence of strings")
-    return aliases
+    return seq
 
 
 @overload
@@ -220,9 +224,8 @@ def alias_get(
 ) -> Optional[T]:
     """Busca en ``d`` la primera clave de ``aliases`` y retorna el valor convertido.
 
-    ``aliases`` debe ser una secuencia (idealmente una tupla) de claves. No se
-    realiza ninguna conversión interna, por lo que pasar una cadena única
-    resultará en un error.
+    ``aliases`` debe ser una **tupla inmutable** de claves previamente validada.
+    Pasar una cadena única provocará un error.
 
     Si ninguna de las claves está presente o la conversión falla, devuelve
     ``default`` convertido (o ``None`` si ``default`` es ``None``).
@@ -254,8 +257,8 @@ def alias_set(
 ) -> T:
     """Asigna ``value`` convertido a la primera clave disponible de ``aliases``.
 
-    ``aliases`` debe ser una secuencia (idealmente una tupla) de claves y no se
-    transforma internamente.
+    ``aliases`` debe ser una **tupla inmutable** de claves previamente
+    validada; no se realizan copias ni transformaciones.
     """
     aliases = _validate_aliases(aliases)
     _, val = _convert_value(value, conv, strict=True)

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -49,8 +49,8 @@ def _nx_attr_property(
     Parameters
     ----------
     aliases:
-        Alias or tuple of aliases used to access the attribute in the
-        underlying ``networkx`` node.
+        Tupla inmutable de aliases usados para acceder al atributo en el nodo
+        ``networkx`` subyacente.
     default:
         Value returned when the attribute is missing.
     getter, setter:

--- a/tests/test_alias_get_default.py
+++ b/tests/test_alias_get_default.py
@@ -1,10 +1,11 @@
 """Pruebas de alias get default."""
 
-from tnfr.helpers import alias_get
+from tnfr.helpers import alias_get, _validate_aliases
 
 
 def test_alias_get_default_none_returns_none():
     d = {}
-    result = alias_get(d, ["x"], int, default=None)
+    aliases = _validate_aliases(("x",))
+    result = alias_get(d, aliases, int, default=None)
     assert result is None
     assert d == {}

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -2,25 +2,28 @@
 
 import logging
 import pytest
-from tnfr.helpers import alias_get
+from tnfr.helpers import alias_get, _validate_aliases
 
 
 def test_alias_get_logs_on_error(caplog):
     d = {"x": "abc"}
+    aliases = _validate_aliases(("x",))
     with caplog.at_level(logging.DEBUG):
-        result = alias_get(d, ["x"], int)
+        result = alias_get(d, aliases, int)
     assert result is None
     assert any("No se pudo convertir" in m for m in caplog.messages)
 
 
 def test_alias_get_custom_log_level(caplog):
     d = {"x": "abc"}
+    aliases = _validate_aliases(("x",))
     with caplog.at_level(logging.WARNING):
-        alias_get(d, ["x"], int, log_level=logging.WARNING)
+        alias_get(d, aliases, int, log_level=logging.WARNING)
     assert any("No se pudo convertir" in m for m in caplog.messages)
 
 
 def test_alias_get_strict_raises():
     d = {"x": "abc"}
+    aliases = _validate_aliases(("x",))
     with pytest.raises(ValueError):
-        alias_get(d, ["x"], int, strict=True)
+        alias_get(d, aliases, int, strict=True)

--- a/tests/test_alias_helpers_threadsafe.py
+++ b/tests/test_alias_helpers_threadsafe.py
@@ -2,12 +2,12 @@
 
 from concurrent.futures import ThreadPoolExecutor
 
-from tnfr.helpers import alias_get, alias_set
+from tnfr.helpers import alias_get, alias_set, _validate_aliases
 
 
 def _worker(i):
     d = {}
-    aliases = [f"k{i}", f"a{i}"]
+    aliases = _validate_aliases((f"k{i}", f"a{i}"))
     alias_set(d, aliases, int, i)
     return alias_get(d, aliases, int)
 

--- a/tests/test_alias_set_error.py
+++ b/tests/test_alias_set_error.py
@@ -1,10 +1,11 @@
 """Pruebas de alias_set para conversiones nulas."""
 
 import pytest
-from tnfr.helpers import alias_set
+from tnfr.helpers import alias_set, _validate_aliases
 
 
 def test_alias_set_raises_value_error_on_none():
     """alias_set debe lanzar ValueError si la conversión produce None."""
+    aliases = _validate_aliases(("x",))
     with pytest.raises(ValueError):
-        alias_set({}, ["x"], lambda v: None, 123)
+        alias_set({}, aliases, lambda v: None, 123)


### PR DESCRIPTION
## Summary
- Document that alias parameters must be immutable tuples.
- Optimize `_validate_aliases` to reuse valid tuples and skip conversion.
- Update tests and helpers to pass pre-validated tuples.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba93571c588321acbbe194bf0185f1