### PR TITLE
Use order-independent node checksum

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -54,7 +54,7 @@ def _ensure_node_offset_map(G) -> Dict[Any, int]:
 
     nodes = list(G.nodes())
     # Use order-independent checksum based on node set to detect changes
-    checksum = (len(nodes), sum(hash(n) for n in nodes))
+    checksum = hash(frozenset(nodes))
     mapping = G.graph.get("_node_offset_map")
     if mapping is None or G.graph.get("_node_offset_checksum") != checksum:
         if bool(G.graph.get("SORT_NODES", False)):


### PR DESCRIPTION
## Summary
- Replace hash summation with `hash(frozenset(nodes))` for order-independent node checks
- Update checksum comparison to utilize new hashing approach

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb27963550832198a2f2a9980e34ee