### PR TITLE
Use dedicated LRU cache for random generators

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -7,7 +7,7 @@ import math
 import random
 import hashlib
 import heapq
-from functools import wraps, lru_cache
+from functools import wraps
 import networkx as nx
 from networkx.algorithms import community as nx_comm
 
@@ -25,7 +25,7 @@ from .callback_utils import invoke_callbacks
 if TYPE_CHECKING:
     from .node import NodoProtocol
 from .types import Glyph
-from collections import deque
+from collections import deque, OrderedDict, namedtuple
 
 """Network operators.
 
@@ -83,17 +83,53 @@ def _jitter_base(seed: int, key: int) -> random.Random:
         return random.Random(str(seed_input))
 
 
-@lru_cache(maxsize=DEFAULTS["JITTER_CACHE_SIZE"])
-def _cached_rng(scope_id: int, seed: int, key: int) -> random.Random:
-    """Return cached ``random.Random`` for ``(seed, key)``.
+CacheInfo = namedtuple("CacheInfo", "hits misses maxsize currsize")
 
-    ``scope_id`` identifies the caching scope (typically a graph)."""
-    return _jitter_base(seed, key)
+
+class _RNGCache:
+    """LRU cache for ``random.Random`` instances."""
+
+    def __init__(self, maxsize: int) -> None:
+        self.maxsize = int(maxsize)
+        self._data: "OrderedDict[tuple[int, int, int], random.Random]" = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, scope_id: int, seed: int, key: int) -> random.Random:
+        cache_key = (scope_id, seed, key)
+        rng = self._data.get(cache_key)
+        if rng is not None:
+            self._data.move_to_end(cache_key)
+            self.hits += 1
+            return rng
+        self.misses += 1
+        rng = _jitter_base(seed, key)
+        self._data[cache_key] = rng
+        if len(self._data) > self.maxsize:
+            self._data.popitem(last=False)
+        return rng
+
+    def resize(self, maxsize: int) -> None:
+        self.maxsize = int(maxsize)
+        while len(self._data) > self.maxsize:
+            self._data.popitem(last=False)
+
+    def clear(self) -> None:
+        self._data.clear()
+        self.hits = 0
+        self.misses = 0
+
+    def cache_info(self) -> CacheInfo:
+        return CacheInfo(self.hits, self.misses, self.maxsize, len(self._data))
+
+
+# Global cache instance for jitter RNGs
+_cached_rng = _RNGCache(DEFAULTS["JITTER_CACHE_SIZE"])
 
 
 def clear_rng_cache() -> None:
     """Clear all cached RNGs."""
-    _cached_rng.cache_clear()
+    _cached_rng.clear()
 
 
 # Backwards compatibility
@@ -158,12 +194,9 @@ def random_jitter(
         if int(cache_size) <= 0:
             rng = _jitter_base(base_seed, seed_key)
         else:
-            global _cached_rng
             if _cached_rng.cache_info().maxsize != int(cache_size):
-                _cached_rng = lru_cache(maxsize=int(cache_size))(
-                    _cached_rng.__wrapped__
-                )
-            rng = _cached_rng(id(scope), base_seed, seed_key)
+                _cached_rng.resize(int(cache_size))
+            rng = _cached_rng.get(id(scope), base_seed, seed_key)
     else:
         rng = cache.get(seed_key)
         if rng is None:


### PR DESCRIPTION
## Summary
- implement `_RNGCache` LRU container for `random.Random` instances
- use cache resize instead of redecorating `_cached_rng`
- adjust RNG cache clearing to new container

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb286931bc8321b0a6461474a4c6d5