### PR TITLE
Reutiliza colecciones indexables en TARGET

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -195,7 +195,8 @@ def _handle_target(G, payload: TARGET, _curr_target, trace: deque, _step_fn):
         Collection of nodes to be used for subsequent operations.
     """
     nodes_src = _all_nodes(G) if payload.nodes is None else payload.nodes
-    curr_target = tuple(ensure_collection(nodes_src))
+    nodes = ensure_collection(nodes_src)
+    curr_target = nodes if isinstance(nodes, Sequence) else tuple(nodes)
     _record_trace(trace, G, "TARGET", n=len(curr_target))
     return curr_target
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,10 +1,21 @@
 """Pruebas de program."""
 
 import json
+from collections import deque
+
 import pytest
 
 from tnfr.cli import _load_sequence
-from tnfr.program import play, seq, block, wait, target, WAIT
+from tnfr.program import (
+    WAIT,
+    TARGET,
+    _handle_target,
+    block,
+    play,
+    seq,
+    target,
+    wait,
+)
 from tnfr.constants import get_param
 from tnfr.types import Glyph
 
@@ -88,6 +99,24 @@ def test_target_accepts_bytes(graph_canon):
     assert list(G.nodes[bname]["glyph_history"]) == [Glyph.AL.value]
     for code in codes:
         assert "glyph_history" not in G.nodes[code]
+
+
+def test_handle_target_reuses_sequence(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([1, 2])
+    nodes = [1]
+    trace = deque()
+    curr = _handle_target(G, TARGET(nodes), None, trace, None)
+    assert curr is nodes
+
+
+def test_handle_target_materializes_non_sequence(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([1, 2])
+    trace = deque()
+    nodes_view = G.nodes()
+    curr = _handle_target(G, TARGET(nodes_view), None, trace, None)
+    assert isinstance(curr, tuple)
 
 
 def test_load_sequence_json_yaml(tmp_path):


### PR DESCRIPTION
## Summary
- Evita materializar innecesariamente el conjunto objetivo si `nodes_src` ya es una secuencia indexable.
- Convierte a `tuple` únicamente cuando la colección resultante no es indexable.
- Añade pruebas para verificar la reutilización de secuencias y la materialización de vistas de nodos.

## Testing
- `pytest tests/test_program.py -k 'target_accepts_string or target_accepts_bytes or handle_target_reuses_sequence or handle_target_materializes_non_sequence' -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb308865ec8321b09f690aa899b91c