### PR TITLE
chore: remove unused grammar helper

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -278,18 +278,3 @@ def apply_glyph_with_grammar(
         apply_glyph(G, n, g_eff, window=window)
         on_applied_glyph(G, n, g_eff)
 
-
-# -------------------------
-# Integration with ``dynamics.step``: helper for selection+application
-# -------------------------
-
-
-def select_and_apply_with_grammar(G, n, selector, window: int) -> None:
-    """Apply canonical grammar over the selector's proposal.
-
-    The selector may include a **soft** grammar (pre-filter) such as
-    ``parametric_glyph_selector``; this function ensures the canonical
-    grammar has final precedence.
-    """
-    cand = selector(G, n)
-    apply_glyph_with_grammar(G, [n], cand, window)


### PR DESCRIPTION
## Summary
- remove `select_and_apply_with_grammar` helper from `grammar` module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb370e9e248321bd6efccf99b20a20