### PR TITLE
Avoid __doc__ reassignment in alias helpers

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -355,9 +355,6 @@ def _alias_get_set(
         """Establece un atributo usando :func:`alias_set`."""
         return alias_set(d, aliases, conv, value)
 
-    _get.__doc__ = f"Obtiene un atributo {desc} usando :func:`alias_get`."
-    _set.__doc__ = f"Establece un atributo {desc} usando :func:`alias_set`."
-
     return _get, _set
 
 


### PR DESCRIPTION
## Summary
- remove __doc__ assignments in `_alias_get_set`
- keep docstrings defined when declaring nested alias helpers

## Testing
- `ruff check src/tnfr/helpers.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb37d9d87c8321bee9c0ba2bd8a7f6