### PR TITLE
Remove integrar method from NodoTNFR

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -201,9 +201,6 @@ class NodoTNFR:
     def apply_glyph(self, glyph: str, window: Optional[int] = None) -> None:
         apply_glyph_obj(self, glyph, window=window)
 
-    def integrar(self, dt: float) -> None:
-        self.EPI += self.dnfr * dt
-
 
 class NodoNX(NodoProtocol):
     """Adaptador para nodos ``networkx``."""


### PR DESCRIPTION
## Summary
- remove unused `integrar` method from `NodoTNFR` class

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb38abcf148321a28fa7ae35e2aadb