### PR TITLE
Define public API for observers

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -19,6 +19,18 @@ from .constants_glyphs import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
 
 
+__all__ = [
+    "attach_standard_observer",
+    "std_before",
+    "std_after",
+    "std_on_remesh",
+    "phase_sync",
+    "kuramoto_order",
+    "glyph_load",
+    "wbar",
+]
+
+
 # -------------------------
 # Observador estándar Γ(R)
 # -------------------------


### PR DESCRIPTION
## Summary
- declare explicit `__all__` in `tnfr.observers` to expose observer helpers and metrics

## Testing
- `PYTHONPATH=src pytest` (fails: `test_update_tg_performance.py::test_update_tg_matches_naive` timing assertion)
- `PYTHONPATH=src pytest tests/test_update_tg_performance.py::test_update_tg_matches_naive`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c512d588321acd28c9903d8bb97