### PR TITLE
chore: remove jitter cache alias

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -132,10 +132,6 @@ def clear_rng_cache() -> None:
     _cached_rng.clear()
 
 
-# Backwards compatibility
-clear_jitter_cache = clear_rng_cache
-
-
 _NodoNX = None
 
 


### PR DESCRIPTION
## Summary
- remove unused clear_jitter_cache alias

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3ed93000832189656016ffcbd3c7