### PR TITLE
Remove unused operator wrappers from API

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -462,31 +462,6 @@ _NAME_TO_OP = {
 }
 
 
-def _wrap(fn):
-    @wraps(fn)
-    def inner(obj, n=None):
-        NodoNX = _get_NodoNX()
-        node = obj if n is None else NodoNX(obj, n)
-        return fn(node)
-
-    return inner
-
-
-op_AL = _wrap(_op_AL)
-op_EN = _wrap(_op_EN)
-op_IL = _wrap(_op_IL)
-op_OZ = _wrap(_op_OZ)
-op_UM = _wrap(_op_UM)
-op_RA = _wrap(_op_RA)
-op_SHA = _wrap(_op_SHA)
-op_VAL = _wrap(_op_VAL)
-op_NUL = _wrap(_op_NUL)
-op_THOL = _wrap(_op_THOL)
-op_ZHIR = _wrap(_op_ZHIR)
-op_NAV = _wrap(_op_NAV)
-op_REMESH = _wrap(_op_REMESH)
-
-
 def apply_glyph_obj(
     node: NodoProtocol, glyph: Glyph | str, *, window: Optional[int] = None
 ) -> None:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2,7 +2,6 @@
 
 import pytest
 from tnfr.node import NodoTNFR
-from tnfr.operators import op_EN
 from tnfr.types import Glyph
 
 from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
@@ -46,7 +45,7 @@ def test_dnfr_weights_normalization(graph_canon):
 
 def test_op_en_sets_epi_kind_on_isolated_node():
     node = NodoTNFR(EPI=1.0)
-    op_EN(node)
+    node.apply_glyph("EN")
     assert node.EPI == 1.0
     assert node.epi_kind == Glyph.EN.value
 

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tnfr.constants import attach_defaults
-from tnfr.operators import op_NAV
+from tnfr.operators import apply_glyph
 
 
 def test_nav_converges_to_vf_without_jitter(graph_canon):
@@ -14,7 +14,7 @@ def test_nav_converges_to_vf_without_jitter(graph_canon):
     nd["ΔNFR"] = 0.2
     nd["νf"] = 1.0
     G.graph["GLYPH_FACTORS"]["NAV_jitter"] = 0.0
-    op_NAV(G, 0)
+    apply_glyph(G, 0, "NAV")
     eta = G.graph["GLYPH_FACTORS"]["NAV_eta"]
     expected = (1 - eta) * 0.2 + eta * 1.0
     assert nd["ΔNFR"] == pytest.approx(expected)
@@ -29,5 +29,5 @@ def test_nav_strict_sets_dnfr_to_vf(graph_canon):
     nd["νf"] = 0.8
     G.graph["GLYPH_FACTORS"]["NAV_jitter"] = 0.0
     G.graph["NAV_STRICT"] = True
-    op_NAV(G, 0)
+    apply_glyph(G, 0, "NAV")
     assert nd["ΔNFR"] == pytest.approx(0.8)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,9 +1,8 @@
 """Pruebas de operators."""
 
 from tnfr.node import NodoNX
-from tnfr.operators import random_jitter, clear_rng_cache
+from tnfr.operators import random_jitter, clear_rng_cache, apply_glyph
 import tnfr.operators as operators
-from tnfr.operators import op_UM
 from tnfr.constants import attach_defaults
 import networkx as nx
 import pytest
@@ -116,7 +115,7 @@ def test_um_candidate_subset_proximity():
     G.graph["UM_CANDIDATE_COUNT"] = 2
     G.graph["UM_CANDIDATE_MODE"] = "proximity"
 
-    op_UM(G, 0)
+    apply_glyph(G, 0, "UM")
 
     assert G.has_edge(0, 1)
     assert G.has_edge(0, 2)


### PR DESCRIPTION
## Summary
- drop op_* convenience wrappers from operators module
- switch tests to use the generic `apply_glyph` helper

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb3f699d688321a9b4f52e4f01721f