### PR TITLE
refactor: remove NodeState.to_attrs

### DIFF
--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Any
 
-from .constants import VF_KEY, THETA_KEY
-
 
 @dataclass
 class NodeState:
@@ -16,17 +14,6 @@ class NodeState:
     Si: float = 0.5
     epi_kind: str = ""
     extra: Dict[str, Any] = field(default_factory=dict)
-
-    def to_attrs(self) -> Dict[str, Any]:
-        d = {
-            "EPI": self.EPI,
-            VF_KEY: self.vf,
-            THETA_KEY: self.theta,
-            "Si": self.Si,
-            "EPI_kind": self.epi_kind,
-        }
-        d.update(self.extra)
-        return d
 
 
 class Glyph(str, Enum):


### PR DESCRIPTION
## Summary
- drop unused `to_attrs` helper in `NodeState`
- rely on direct dataclass fields for node attribute construction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb40c4fd208321b37b20f428ff1dbc