### PR TITLE
Refactor list_mean to avoid tuple conversion

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -14,7 +14,6 @@ from typing import (
 )
 import logging
 import math
-from statistics import fmean
 import json
 from json import JSONDecodeError
 from pathlib import Path
@@ -156,8 +155,12 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Promedio aritmético o ``default`` si ``xs`` está vacío."""
-    seq = tuple(xs)
-    return fmean(seq) if seq else default
+    total = 0.0
+    count = 0
+    for x in xs:
+        total += x
+        count += 1
+    return total / count if count else default
 
 
 def _wrap_angle(a: float) -> float:


### PR DESCRIPTION
## Summary
- Rework `list_mean` to accumulate total and count in a loop without converting inputs to a tuple
- Drop `statistics.fmean` dependency now that the mean is computed manually

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb44a1fa3c832180295758593ab585