### PR TITLE
Centralize node set checksum utility

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -15,6 +15,8 @@ from typing import (
 import logging
 import math
 import json
+import hashlib
+import networkx as nx
 from json import JSONDecodeError
 from pathlib import Path
 
@@ -85,6 +87,7 @@ __all__ = [
     "compute_coherence",
     "compute_Si",
     "increment_edge_version",
+    "node_set_checksum",
 ]
 
 # -------------------------
@@ -133,6 +136,22 @@ def read_structured_file(path: Path) -> Any:
 def ensure_parent(path: str | Path) -> None:
     """Crea el directorio padre de ``path`` si hace falta."""
     Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+# -------------------------
+# Grafos
+# -------------------------
+
+
+def node_set_checksum(G: nx.Graph) -> str:
+    """Devuelve el SHA1 del conjunto de nodos de ``G`` ordenado."""
+
+    sha1 = hashlib.sha1()
+    for i, node_repr in enumerate(sorted(repr(n) for n in G.nodes())):
+        if i:
+            sha1.update(b"|")
+        sha1.update(node_repr.encode("utf-8"))
+    return sha1.hexdigest()
 
 
 # -------------------------

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -19,6 +19,7 @@ from .helpers import (
     set_attr,
     fase_media,
     increment_edge_version,
+    node_set_checksum,
 )
 from .callback_utils import invoke_callbacks
 
@@ -54,8 +55,7 @@ def _ensure_node_offset_map(G) -> Dict[Any, int]:
 
     nodes = list(G.nodes())
     # Use order-independent deterministic checksum based on node set
-    node_reprs = sorted(repr(n) for n in nodes)
-    checksum = hashlib.sha1("|".join(node_reprs).encode("utf-8")).hexdigest()
+    checksum = node_set_checksum(G)
     mapping = G.graph.get("_node_offset_map")
     if mapping is None or G.graph.get("_node_offset_checksum") != checksum:
         if bool(G.graph.get("SORT_NODES", False)):


### PR DESCRIPTION
## Summary
- add `node_set_checksum` helper for deterministic node set hashing
- reuse the helper in operator mapping and dynamics adjacency cache
- streamline imports and remove duplicated checksum logic

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a72da3483218ee43bff4355ea85