### PR TITLE
Use statistics fmean for list_mean

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -16,6 +16,7 @@ import logging
 import math
 import json
 import hashlib
+from statistics import fmean, StatisticsError
 import networkx as nx
 from json import JSONDecodeError
 from pathlib import Path
@@ -174,12 +175,10 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Promedio aritmético o ``default`` si ``xs`` está vacío."""
-    total = 0.0
-    count = 0
-    for x in xs:
-        total += x
-        count += 1
-    return total / count if count else default
+    try:
+        return fmean(xs)
+    except StatisticsError:
+        return default
 
 
 def _wrap_angle(a: float) -> float:

--- a/tests/test_list_mean.py
+++ b/tests/test_list_mean.py
@@ -1,0 +1,10 @@
+import pytest
+from tnfr.helpers import list_mean
+
+
+def test_list_mean_non_empty():
+    assert list_mean([1.0, 2.0, 3.0]) == pytest.approx(2.0)
+
+
+def test_list_mean_empty_returns_default():
+    assert list_mean([], default=5.0) == 5.0


### PR DESCRIPTION
## Summary
- Use `statistics.fmean` for computing averages in `list_mean`
- Handle empty iterable via `StatisticsError` and added regression tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4c6eb21c8321ab5222cb3f3f10a3