### PR TITLE
Refactor dominant glyph selection to use max

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -225,14 +225,8 @@ def _select_dominant_glyph(
     node: NodoProtocol, neigh: Iterable[NodoProtocol]
 ) -> Optional[str]:
     """Return the epi_kind with the highest |EPI| among node and its neighbors."""
-    best_mag = abs(node.EPI)
-    best_kind = node.epi_kind
-    for v in neigh:
-        epi_abs = abs(v.EPI)
-        if epi_abs > best_mag:
-            best_mag = epi_abs
-            best_kind = v.epi_kind
-    return best_kind
+    best = max(neigh, key=lambda v: abs(v.EPI), default=None)
+    return best.epi_kind if best and abs(best.EPI) > abs(node.EPI) else node.epi_kind
 
 
 def _mix_epi_with_neighbors(

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,7 +1,8 @@
 """Pruebas de operators."""
 
 from tnfr.node import NodoNX
-from tnfr.operators import random_jitter, clear_rng_cache, apply_glyph
+from tnfr.operators import random_jitter, clear_rng_cache, apply_glyph, _select_dominant_glyph
+from types import SimpleNamespace
 import tnfr.operators as operators
 from tnfr.constants import attach_defaults
 import networkx as nx
@@ -120,3 +121,23 @@ def test_um_candidate_subset_proximity():
     assert G.has_edge(0, 1)
     assert G.has_edge(0, 2)
     assert not G.has_edge(0, 3)
+
+
+def test_select_dominant_glyph_prefers_higher_epi():
+    node = SimpleNamespace(EPI=1.0, epi_kind="self")
+    neigh = [
+        SimpleNamespace(EPI=-3.0, epi_kind="n1"),
+        SimpleNamespace(EPI=2.0, epi_kind="n2"),
+    ]
+    assert _select_dominant_glyph(node, neigh) == "n1"
+
+
+def test_select_dominant_glyph_returns_node_kind_on_tie():
+    node = SimpleNamespace(EPI=1.0, epi_kind="self")
+    neigh = [SimpleNamespace(EPI=-1.0, epi_kind="n1")]
+    assert _select_dominant_glyph(node, neigh) == "self"
+
+
+def test_select_dominant_glyph_no_neighbors():
+    node = SimpleNamespace(EPI=1.0, epi_kind="self")
+    assert _select_dominant_glyph(node, []) == "self"


### PR DESCRIPTION
## Summary
- simplify _select_dominant_glyph with `max`
- add tests covering neighbor dominance, ties, and empty neighbor lists

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb4e1b02288321a6f4305e2bf7f257