### PR TITLE
Refactor list_mean to manual accumulation

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -16,7 +16,6 @@ import logging
 import math
 import json
 import hashlib
-from statistics import fmean, StatisticsError
 import networkx as nx
 from json import JSONDecodeError
 from pathlib import Path
@@ -175,10 +174,12 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Promedio aritmético o ``default`` si ``xs`` está vacío."""
-    try:
-        return fmean(xs)
-    except StatisticsError:
-        return default
+    total = 0.0
+    count = 0
+    for x in xs:
+        total += x
+        count += 1
+    return total / count if count > 0 else default
 
 
 def _wrap_angle(a: float) -> float:


### PR DESCRIPTION
## Summary
- replace `fmean` call and exception handling with manual cumulative average in `list_mean`
- drop unused `statistics` imports

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb514d11948321b7a28d439e685434