### PR TITLE
Avoid draining iterables past materialization limit

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -54,10 +54,7 @@ def ensure_collection(
         data = tuple(islice(iterator, limit))
         extra = next(iterator, None)
         if extra is not None:
-            total = limit + 1 + sum(1 for _ in iterator)
-            raise ValueError(
-                f"Iterable materialization exceeded {limit} items (total {total})"
-            )
+            raise ValueError(f"Iterable con más de {limit} elementos")
         return data
     except TypeError as exc:
         raise TypeError(f"{it!r} is not iterable") from exc

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -27,8 +27,10 @@ def test_iterable_not_iterator_materialized():
 
 def test_max_materialize_limit():
     gen = (i for i in range(5))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         ensure_collection(gen, max_materialize=3)
+    assert str(exc.value) == "Iterable con más de 3 elementos"
+    assert list(gen) == [4]
 
 
 def test_materialization_at_limit_allowed():


### PR DESCRIPTION
## Summary
- Raise an error as soon as ensure_collection detects extra elements
- Emit a concise error message indicating the iterable has more than the allowed elements
- Verify leftover items and error message in ensure_collection tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb51c6761083218091e08d36531758