### PR TITLE
Clarify NodoNX.neighbors docstring

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -236,9 +236,10 @@ class NodoNX(NodoProtocol):
         return node
 
     def neighbors(self) -> Iterable[Hashable]:
-        """Itera identificadores de vecinos.
+        """Itera identificadores (IDs) de vecinos.
 
-        Usa :meth:`from_graph` para obtener instancias ``NodoNX`` cacheadas.
+        Si se necesitan objetos ``NodoNX``, envolver cada ID resultante con
+        :meth:`from_graph` para obtener la instancia cacheada correspondiente.
         """
         return self.G.neighbors(self.n)
 


### PR DESCRIPTION
## Summary
- Clarify that `NodoNX.neighbors` yields neighbor IDs
- Document how to wrap IDs with `NodoNX.from_graph` for cached node objects

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb5559920c8321bbdd8b1b006cd8cf