### PR TITLE
Handle non-mapping GAMMA specifications

### DIFF
--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -5,6 +5,8 @@ from typing import Dict, Any, Tuple
 import math
 import cmath
 import logging
+import warnings
+from collections.abc import Mapping
 
 from .constants import ALIAS_THETA
 from .helpers import get_attr
@@ -152,7 +154,17 @@ def eval_gamma(
     ``strict`` is ``False``. If omitted, ``logging.ERROR`` is used in
     strict mode and ``logging.DEBUG`` otherwise.
     """
-    spec = G.graph.get("GAMMA", {"type": "none"})
+    spec = G.graph.get("GAMMA")
+    if spec is None:
+        spec = {"type": "none"}
+    elif not isinstance(spec, Mapping):
+        warnings.warn(
+            "G.graph['GAMMA'] no es un mapeo; se usa {'type': 'none'}",
+            UserWarning,
+            stacklevel=2,
+        )
+        spec = {"type": "none"}
+
     spec_type = spec.get("type", "none")
     reg_entry = GAMMA_REGISTRY.get(spec_type)
     if reg_entry is None:

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -110,6 +110,16 @@ def test_eval_gamma_logs_and_strict_mode(graph_canon, caplog):
         eval_gamma(G, 0, t=0.0, strict=True)
 
 
+def test_eval_gamma_non_mapping_warns(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([0])
+    attach_defaults(G)
+    G.graph["GAMMA"] = "not a dict"
+    with pytest.warns(UserWarning):
+        g = eval_gamma(G, 0, t=0.0)
+    assert g == 0.0
+
+
 def test_eval_gamma_unknown_type_warning_and_strict(graph_canon, caplog):
     G = graph_canon()
     G.add_nodes_from([0])


### PR DESCRIPTION
## Summary
- warn and default to `{"type": "none"}` when `G.graph['GAMMA']` is not a mapping
- cover invalid `GAMMA` inputs with a regression test

## Testing
- `PYTHONPATH=src pytest tests/test_gamma.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb573d963c832193a9c77f5ed2d5a4