### PR TITLE
Require tuple aliases for helper functions

### DIFF
--- a/tests/test_alias_tuple_required.py
+++ b/tests/test_alias_tuple_required.py
@@ -1,0 +1,14 @@
+"""Pruebas de validación de alias como tuplas."""
+
+import pytest
+from tnfr.helpers import alias_get, alias_set
+
+
+def test_alias_get_requires_tuple():
+    with pytest.raises(TypeError):
+        alias_get({}, ["x"], int)
+
+
+def test_alias_set_requires_tuple():
+    with pytest.raises(TypeError):
+        alias_set({}, ["x"], int, 1)


### PR DESCRIPTION
## Summary
- enforce tuple-only aliases in helper API by removing dynamic conversions
- document alias tuple requirement and update related helpers
- add regression tests for list inputs to alias helpers

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb57ef7820832185da816ebfc81f54