### PR TITLE
Use statistics.fmean for list mean

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -16,6 +16,7 @@ import logging
 import math
 import json
 import hashlib
+from statistics import fmean, StatisticsError
 import networkx as nx
 from json import JSONDecodeError
 from pathlib import Path
@@ -174,12 +175,10 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Promedio aritmético o ``default`` si ``xs`` está vacío."""
-    total = 0.0
-    count = 0
-    for x in xs:
-        total += x
-        count += 1
-    return total / count if count > 0 else default
+    try:
+        return fmean(xs)
+    except StatisticsError:
+        return default
 
 
 def _wrap_angle(a: float) -> float:

--- a/tests/test_list_mean.py
+++ b/tests/test_list_mean.py
@@ -8,3 +8,11 @@ def test_list_mean_non_empty():
 
 def test_list_mean_empty_returns_default():
     assert list_mean([], default=5.0) == 5.0
+
+
+def test_list_mean_generator():
+    assert list_mean(x for x in (1.0, 2.0, 3.0)) == pytest.approx(2.0)
+
+
+def test_list_mean_empty_generator_returns_default():
+    assert list_mean((x for x in ()), default=3.3) == pytest.approx(3.3)


### PR DESCRIPTION
## Summary
- use `statistics.fmean` in `list_mean` with empty-sequence fallback
- test generator and empty generator cases for `list_mean`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb59224bf08321bd1bf4de98d3a7aa