### PR TITLE
refactor: use generator for sigma vectors

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -168,11 +168,11 @@ def sigma_vector_from_graph(
 
     cfg = _sigma_cfg(G)
     weight_mode = weight_mode or cfg.get("weight", "Si")
-    vectors = []
-    for _, nd in G.nodes(data=True):
-        nw = _node_weight(nd, weight_mode)
-        if nw:
-            vectors.append(nw[2])
+    vectors = (
+        nw[2]
+        for _, nd in G.nodes(data=True)
+        if (nw := _node_weight(nd, weight_mode))
+    )
     vec, n = _sigma_from_vectors(vectors)
     vec["n"] = n
     return vec


### PR DESCRIPTION
## Summary
- compute sigma vectors directly from a generator instead of a list
- keep `_sigma_from_vectors` returning total count

## Testing
- `PYTHONPATH=src pytest tests/test_sense.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb59ec95dc8321bc0fd87c99dc9106