### PR TITLE
Handle uneven sigma series using zip_longest

### DIFF
--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+from itertools import zip_longest
 
 from ..glyph_history import ensure_history
 from ..helpers import ensure_parent
@@ -43,14 +44,16 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     sigma_y = hist.tracked_get("sense_sigma_y", [])
     sigma_mag = hist.tracked_get("sense_sigma_mag", [])
     sigma_angle = hist.tracked_get("sense_sigma_angle", [])
-    sigma_rows = list(zip(sigma_x, sigma_y, sigma_mag, sigma_angle))
-    sigma = {"t": [], "sigma_x": [], "sigma_y": [], "mag": [], "angle": []}
-    for t, (x, y, m, a) in enumerate(sigma_rows):
-        sigma["t"].append(t)
-        sigma["sigma_x"].append(x)
-        sigma["sigma_y"].append(y)
-        sigma["mag"].append(m)
-        sigma["angle"].append(a)
+    sigma_rows = list(
+        zip_longest(sigma_x, sigma_y, sigma_mag, sigma_angle, fillvalue=0)
+    )
+    sigma = {
+        "t": list(range(len(sigma_rows))),
+        "sigma_x": [x for x, _, _, _ in sigma_rows],
+        "sigma_y": [y for _, y, _, _ in sigma_rows],
+        "mag": [m for _, _, m, _ in sigma_rows],
+        "angle": [a for _, _, _, a in sigma_rows],
+    }
     morph = hist.tracked_get("morph", [])
     epi_supp = hist.tracked_get("EPI_support", [])
     fmt = fmt.lower()

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -50,7 +50,7 @@ def test_export_history_json_contains_optional(tmp_path, graph_canon):
     assert data["epi_support"]
 
 
-def test_export_history_truncates_sigma(tmp_path, graph_canon):
+def test_export_history_extends_sigma(tmp_path, graph_canon):
     base = tmp_path / "short" / "run"
     G = graph_canon()
     hist = G.graph.setdefault("history", {})
@@ -65,4 +65,6 @@ def test_export_history_truncates_sigma(tmp_path, graph_canon):
     with open(sigma_path, newline="") as f:
         rows = list(csv.reader(f))
     assert rows[1] == ["0", "1", "3", "4", "7"]
-    assert len(rows) == 2
+    assert rows[2] == ["1", "2", "0", "5", "8"]
+    assert rows[3] == ["2", "0", "0", "6", "0"]
+    assert len(rows) == 4


### PR DESCRIPTION
## Summary
- use `itertools.zip_longest` to align sigma components and build time series via comprehension
- adjust export test to expect zero-padded sigma output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5a95c9148321b06f95af854bbad4