### PR TITLE
Refactor THOL flattening and add nested block test

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -119,7 +119,7 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
     when ``THOL`` blocks are nested.
     """
     ops: List[Tuple[str, Any]] = []
-    stack: Deque[Any] = deque(seq)
+    stack: Deque[Any] = deque(reversed(seq))
 
     while stack:
         item = stack.pop()
@@ -142,12 +142,11 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
                 and item.force_close in {Glyph.SHA, Glyph.NUL}
                 else None
             )
-            stack.append(THOL_SENTINEL)
             for _ in range(repeats):
-                for tok in item.body:
-                    stack.append(tok)
-            if closing is not None:
-                stack.append(closing)
+                if closing is not None:
+                    stack.append(closing)
+                stack.extend(reversed(item.body))
+            stack.append(THOL_SENTINEL)
             continue
 
         # item should be a glyph
@@ -155,7 +154,6 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
         if g not in GLYPHS_CANONICAL_SET:
             raise ValueError(f"Non-canonical glyph: {g}")
         ops.append(("GLYPH", g))
-    ops.reverse()
     return ops
 
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -10,6 +10,7 @@ from tnfr.program import (
     WAIT,
     TARGET,
     _handle_target,
+    _flatten,
     block,
     play,
     seq,
@@ -159,3 +160,25 @@ def test_block_force_close_invalid_type_raises(graph_canon, bad):
     program = seq(block(Glyph.AL, close=bad))
     with pytest.raises(ValueError):
         play(G, program, step_fn=_step_noop)
+
+
+def test_flatten_nested_blocks_preserves_order():
+    program = seq(
+        block(
+            block(Glyph.AL, Glyph.RA, repeat=2, close=Glyph.NUL),
+            Glyph.ZHIR,
+        )
+    )
+    ops = _flatten(program)
+    expected = [
+        ("THOL", Glyph.THOL.value),
+        ("THOL", Glyph.THOL.value),
+        ("GLYPH", Glyph.AL.value),
+        ("GLYPH", Glyph.RA.value),
+        ("GLYPH", Glyph.NUL.value),
+        ("GLYPH", Glyph.AL.value),
+        ("GLYPH", Glyph.RA.value),
+        ("GLYPH", Glyph.NUL.value),
+        ("GLYPH", Glyph.ZHIR.value),
+    ]
+    assert ops == expected


### PR DESCRIPTION
## Summary
- Refactor `_flatten` to use a reversed stack approach and append THOL sentinels after body repetitions.
- Insert optional closing glyph after each repeated body and streamline stack handling.
- Add regression test ensuring nested THOL blocks preserve glyph order.

## Testing
- `PYTHONPATH=src pytest tests/test_program.py::test_flatten_nested_blocks_preserves_order -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5b623cac8321a547872730d4ee7e