### PR TITLE
Validate non-negative HISTORY_MAXLEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ pip install tnfr
 ## History configuration
 
 Recorded series are stored under `G.graph['history']`. Set `HISTORY_MAXLEN` in
-the graph (or override the default) to keep only the most recent entries. When
-the limit is positive the library uses bounded `deque` objects and removes the
+the graph (or override the default) to keep only the most recent entries. The
+value must be non‑negative; negative values raise ``ValueError``. When the
+limit is positive the library uses bounded `deque` objects and removes the
 least populated series when the number of history keys grows beyond the limit.
 
 ### Random node sampling

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -125,8 +125,14 @@ class HistoryDict(dict):
 
 
 def ensure_history(G) -> Dict[str, Any]:
-    """Ensure ``G.graph['history']`` exists and return it."""
+    """Ensure ``G.graph['history']`` exists and return it.
+
+    ``HISTORY_MAXLEN`` must be a non-negative integer; otherwise a
+    :class:`ValueError` is raised.
+    """
     maxlen = int(G.graph.get("HISTORY_MAXLEN", get_param(G, "HISTORY_MAXLEN")))
+    if maxlen < 0:
+        raise ValueError("HISTORY_MAXLEN must be >= 0")
     hist = G.graph.get("history")
     if not isinstance(hist, HistoryDict) or hist._maxlen != maxlen:
         hist = HistoryDict(hist, maxlen=maxlen)

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -2,6 +2,8 @@
 
 from collections import deque
 
+import pytest
+
 from tnfr.constants import attach_defaults
 from tnfr.glyph_history import ensure_history
 
@@ -88,3 +90,12 @@ def test_history_not_trimmed_when_below_maxlen(graph_canon):
     ensure_history(G)
     assert len(hist) == 1
     assert "a" in hist
+
+
+def test_history_negative_maxlen_raises(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    G.graph["HISTORY_MAXLEN"] = -1
+    with pytest.raises(ValueError):
+        ensure_history(G)


### PR DESCRIPTION
## Summary
- Guard ensure_history against negative HISTORY_MAXLEN values and document requirement.
- Clarify HISTORY_MAXLEN constraint in README.
- Add regression test for negative HISTORY_MAXLEN.

## Testing
- `python -m py_compile src/tnfr/glyph_history.py tests/test_history_maxlen.py`
- `PYTHONPATH=$PWD/src pytest tests/test_history_maxlen.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5dc257bc8321b2d62ffade37101c