### PR TITLE
Use pvariance for phase synchronization variance

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import math
 import statistics as st
+from statistics import pvariance
 from itertools import islice
 from functools import partial
 
@@ -79,16 +80,11 @@ def phase_sync(G) -> float:
         return 1.0
     th = math.atan2(sumY, sumX)
     # varianza angular aproximada (0 = muy sincronizado)
-    mean = 0.0
-    m2 = 0.0
-    n = 0
-    for _, data in G.nodes(data=True):
-        diff = angle_diff(get_attr(data, ALIAS_THETA, 0.0), th)
-        n += 1
-        delta = diff - mean
-        mean += delta / n
-        m2 += delta * (diff - mean)
-    var = m2 / n if n > 1 else 0.0
+    diffs = (
+        angle_diff(get_attr(data, ALIAS_THETA, 0.0), th)
+        for _, data in G.nodes(data=True)
+    )
+    var = pvariance(diffs)
     return 1.0 / (1.0 + var)
 
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -27,10 +27,23 @@ def test_phase_observers_match_manual_calculation(graph_canon):
     th_mean = math.atan2(sum(Y), sum(X))
     var = st.pvariance(angle_diff(th, th_mean) for th in angles)
     expected_sync = 1.0 / (1.0 + var)
-    assert math.isclose(phase_sync(G), expected_sync)
+    ps = phase_sync(G)
+    assert 0.0 <= ps <= 1.0
+    assert math.isclose(ps, expected_sync)
 
     R = ((sum(X) ** 2 + sum(Y) ** 2) ** 0.5) / len(angles)
     assert math.isclose(kuramoto_order(G), float(R))
+
+
+def test_phase_sync_bounds(graph_canon):
+    G = graph_canon()
+    angles = [0.1, 1.2, -2.5, 3.6]
+    for idx, th in enumerate(angles):
+        G.add_node(idx)
+        set_attr(G.nodes[idx], ALIAS_THETA, th)
+
+    ps = phase_sync(G)
+    assert 0.0 <= ps <= 1.0
 
 
 def test_kuramoto_order_matches_kuramoto_R_psi(graph_canon):


### PR DESCRIPTION
## Summary
- import `statistics.pvariance` and use it to compute phase variance
- add tests ensuring `phase_sync` stays in `[0, 1]`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e7668808321bc827f49caaa5db2