### PR TITLE
refactor: centralize gamma parameter parsing

### DIFF
--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -39,6 +39,19 @@ def test_gamma_bandpass_eval(graph_canon):
     assert pytest.approx(g3, rel=1e-6) == -0.25
 
 
+def test_gamma_linear_string_params(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([0, 1])
+    attach_defaults(G)
+    merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": "1.0", "R0": "0.0"})
+    for n in G.nodes():
+        G.nodes[n]["θ"] = 0.0
+    g0 = eval_gamma(G, 0, t=0.0)
+    g1 = eval_gamma(G, 1, t=0.0)
+    assert pytest.approx(g0, rel=1e-6) == 1.0
+    assert pytest.approx(g1, rel=1e-6) == 1.0
+
+
 def test_gamma_tanh_eval(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1, 2, 3])
@@ -57,6 +70,20 @@ def test_gamma_tanh_eval(graph_canon):
     assert pytest.approx(g3, rel=1e-6) == -expected
 
 
+def test_gamma_bandpass_string_params(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([0, 1, 2, 3])
+    attach_defaults(G)
+    merge_overrides(G, GAMMA={"type": "kuramoto_bandpass", "beta": "1.0"})
+    for n in [0, 1, 2]:
+        G.nodes[n]["θ"] = 0.0
+    G.nodes[3]["θ"] = math.pi
+    g0 = eval_gamma(G, 0, t=0.0)
+    g3 = eval_gamma(G, 3, t=0.0)
+    assert pytest.approx(g0, rel=1e-6) == 0.25
+    assert pytest.approx(g3, rel=1e-6) == -0.25
+
+
 def test_gamma_harmonic_eval(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
@@ -70,6 +97,24 @@ def test_gamma_harmonic_eval(graph_canon):
     g1 = eval_gamma(G, 1, t=math.pi / 2)
     assert pytest.approx(g0, rel=1e-6) == 1.0
     assert pytest.approx(g1, rel=1e-6) == 1.0
+
+
+def test_gamma_tanh_string_params(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([0, 1, 2, 3])
+    attach_defaults(G)
+    merge_overrides(
+        G,
+        GAMMA={"type": "kuramoto_tanh", "beta": "1.0", "k": "1.0", "R0": "0.0"},
+    )
+    for n in [0, 1, 2]:
+        G.nodes[n]["θ"] = 0.0
+    G.nodes[3]["θ"] = math.pi
+    expected = math.tanh(0.5)
+    g0 = eval_gamma(G, 0, t=0.0)
+    g3 = eval_gamma(G, 3, t=0.0)
+    assert pytest.approx(g0, rel=1e-6) == expected
+    assert pytest.approx(g3, rel=1e-6) == -expected
 
 
 def test_kuramoto_cache_invalidation_on_version(graph_canon):
@@ -87,6 +132,22 @@ def test_kuramoto_cache_invalidation_on_version(graph_canon):
     g_after = eval_gamma(G, 0, t=0.0)
 
     assert g_after != pytest.approx(g_before)
+
+
+def test_gamma_harmonic_string_params(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([0, 1])
+    attach_defaults(G)
+    merge_overrides(
+        G,
+        GAMMA={"type": "harmonic", "beta": "1.0", "omega": "1.0", "phi": "0.0"},
+    )
+    for n in G.nodes():
+        G.nodes[n]["θ"] = 0.0
+    g0 = eval_gamma(G, 0, t=math.pi / 2)
+    g1 = eval_gamma(G, 1, t=math.pi / 2)
+    assert pytest.approx(g0, rel=1e-6) == 1.0
+    assert pytest.approx(g1, rel=1e-6) == 1.0
 
 
 def test_eval_gamma_logs_and_strict_mode(graph_canon, caplog):


### PR DESCRIPTION
## Summary
- add private `_gamma_params` helper to normalize Γ parameters
- call helper from Kuramoto and harmonic gamma functions to avoid duplication
- test parameter normalization across gamma implementations

## Testing
- `PYTHONPATH=src pytest tests/test_gamma.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb5f43d064832194c94a36500d1993