### PR TITLE
refactor: simplify defaults union

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -33,13 +33,13 @@ IMMUTABLE_TYPES = (
 )
 
 # Diccionario combinado exportado
-DEFAULTS: Dict[str, Any] = dict(
-    ChainMap(
-        dict(METRIC_DEFAULTS),
-        dict(REMESH_DEFAULTS),
-        dict(INIT_DEFAULTS),
-        dict(CORE_DEFAULTS),
-    )
+# Unimos los diccionarios en orden de menor a mayor prioridad para que los
+# valores de ``METRIC_DEFAULTS`` sobrescriban al resto, como hacía ``ChainMap``.
+DEFAULTS: Dict[str, Any] = (
+    CORE_DEFAULTS
+    | INIT_DEFAULTS
+    | REMESH_DEFAULTS
+    | METRIC_DEFAULTS
 )
 
 # -------------------------


### PR DESCRIPTION
## Summary
- refactor defaults construction by using dictionary union operator for clarity

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb61326f188321b1f8b2880e1f32bb