### PR TITLE
refactor: use importlib util for optional numpy

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -6,7 +6,6 @@ import logging
 import math
 import random
 import importlib
-import importlib.util
 from collections import deque, OrderedDict
 from functools import lru_cache
 from typing import Dict, Any, Literal
@@ -86,7 +85,13 @@ def _optional_numpy() -> Any | None:
     spec = importlib.util.find_spec("numpy")
     if spec is None:  # pragma: no cover - dependency opcional
         return None
-    return importlib.import_module("numpy")
+
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    if loader is None:  # pragma: no cover - dependency opcional
+        return None
+    loader.exec_module(module)
+    return module
 
 
 def _np(*, warn: bool = False) -> Any | None:


### PR DESCRIPTION
## Summary
- simplify imports to rely on importlib
- refactor `_optional_numpy` to load numpy via importlib util functions

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb61ff575883219220c0103cb0daad