### PR TITLE
Track usage in HistoryDict.get

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -87,7 +87,11 @@ class HistoryDict(dict):
         return val
 
     def get(self, key, default=None):  # type: ignore[override]
-        return super().get(key, default)
+        if key in self:
+            val = super().get(key, default)
+            self._increment(key)
+            return val
+        return default
 
     def tracked_get(self, key, default=None):
         if key in self:

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -20,12 +20,21 @@ def test_heap_compaction_many_keys():
     assert len(hist._heap) <= len(hist) * 2
 
 
-def test_get_does_not_track_usage():
+def test_get_tracks_usage():
     hist = HistoryDict()
     hist["a"] = 1
     counts_before = dict(hist._counts)
     heap_before = list(hist._heap)
     assert hist.get("a") == 1
+    assert hist._counts["a"] == counts_before["a"] + 1
+    assert hist._heap != heap_before
+
+
+def test_get_missing_key_no_usage():
+    hist = HistoryDict()
+    counts_before = dict(hist._counts)
+    heap_before = list(hist._heap)
+    assert hist.get("missing") is None
     assert hist._counts == counts_before
     assert hist._heap == heap_before
 


### PR DESCRIPTION
## Summary
- increment usage counter when HistoryDict.get retrieves an existing key
- test HistoryDict.get for both existing and missing keys

## Testing
- `pytest tests/test_history_heap_cleanup.py tests/test_history_maxlen.py tests/test_history_series.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb633925cc8321b72d69bb7bb434a1