### PR TITLE
Simplify history trimming in glyph history

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -142,13 +142,8 @@ def ensure_history(G) -> Dict[str, Any]:
         hist = HistoryDict(hist, maxlen=maxlen)
         G.graph["history"] = hist
     if maxlen > 0:
-        excess = len(hist) - maxlen
-        if excess > 0:
-            for _ in range(excess):
-                try:
-                    hist.pop_least_used()
-                except KeyError:
-                    break
+        while len(hist) > maxlen:
+            hist.pop_least_used()
     return hist
 
 


### PR DESCRIPTION
## Summary
- Refactor `ensure_history` to trim histories with a simple `while` loop

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6414d27083219d900ec526388189