### PR TITLE
Improve coherence normalization

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -15,8 +15,7 @@ from ..helpers import get_attr, clamp01
 def _norm01(x, lo, hi):
     if hi <= lo:
         return 0.0
-    v = (float(x) - float(lo)) / (float(hi) - float(lo))
-    return 0.0 if v < 0 else (1.0 if v > 1.0 else v)
+    return clamp01((float(x) - float(lo)) / (float(hi) - float(lo)))
 
 
 def _similarity_abs(a, b, lo, hi):


### PR DESCRIPTION
## Summary
- Simplify `_norm01` in coherence metrics using `clamp01`

## Testing
- `PYTHONPATH=src pytest tests/test_coherence_cache.py tests/test_vf_coherencia.py tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb6881629483219d7886c80662f0b8