### PR TITLE
Annotate edge weight validation

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -78,7 +78,7 @@ def _nx_attr_property(
     return property(fget, fset)
 
 
-def _add_edge_common(n1, n2, weight):
+def _add_edge_common(n1, n2, weight) -> Optional[float]:
     """Validate basic edge constraints.
 
     Returns the parsed weight if the edge can be added. ``None`` is returned


### PR DESCRIPTION
## Summary
- type-annotate `_add_edge_common` to show optional float return when validating edges
- ensure edge creation helpers handle skipped edges

## Testing
- `pytest tests/test_node_weights.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb68f258d48321922545ab935cc7e6