### PR TITLE
refactor: simplify optional numpy import

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import math
 import random
-import importlib
 from collections import deque, OrderedDict
 from functools import lru_cache
 from typing import Dict, Any, Literal
@@ -76,22 +75,18 @@ logger = logging.getLogger(__name__)
 
 @lru_cache(maxsize=1)
 def _optional_numpy() -> Any | None:
-    """Intenta cargar ``numpy`` utilizando ``importlib``.
+    """Intenta importar ``numpy`` de forma perezosa.
 
     Si el paquete no está disponible, devuelve ``None``. El resultado se
     almacena en caché para evitar búsquedas repetidas.
     """
 
-    spec = importlib.util.find_spec("numpy")
-    if spec is None:  # pragma: no cover - dependency opcional
+    try:  # pragma: no cover - dependency opcional
+        import numpy  # type: ignore
+    except ImportError:  # pragma: no cover - dependency opcional
         return None
-
-    module = importlib.util.module_from_spec(spec)
-    loader = spec.loader
-    if loader is None:  # pragma: no cover - dependency opcional
-        return None
-    loader.exec_module(module)
-    return module
+    else:
+        return numpy
 
 
 def _np(*, warn: bool = False) -> Any | None:


### PR DESCRIPTION
## Summary
- replace importlib-based numpy lookup with direct try/except import
- drop explicit importlib dependency in dynamics module
- retain lru_cache and verify `_np` continues to handle missing numpy gracefully

## Testing
- `PYTHONPATH=src pytest`
- `python - <<'PY'
import sys
sys.path.insert(0, 'src')
from tnfr.dynamics import _np
print('module:', _np(warn=True))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb697aa62083218003747cb8fa2d34