### PR TITLE
Use hash-based seed for jitter RNG

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -75,13 +75,8 @@ def _node_offset(G, n) -> int:
 def _jitter_base(seed: int, key: int) -> random.Random:
     """Return a ``random.Random`` instance seeded from ``seed`` and ``key``."""
     seed_input = (seed, key)
-    try:
-        # Python's ``random`` module does not officially support tuples as seeds,
-        # but future versions may. Attempt to use the tuple directly first and
-        # fall back to a string representation when unsupported.
-        return random.Random(seed_input)
-    except TypeError:
-        return random.Random(str(seed_input))
+    seed_int = hash(seed_input)
+    return random.Random(seed_int)
 
 
 def _make_rng_cache(maxsize: int):


### PR DESCRIPTION
## Summary
- derive jitter RNG seed from `hash((seed, key))`
- initialize `random.Random` with the hashed seed for consistency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb6e4a507883218d1db9cf737c8f6a