### PR TITLE
feat: add configurable history compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ the graph (or override the default) to keep only the most recent entries. The
 value must be non‑negative; negative values raise ``ValueError``. When the
 limit is positive the library uses bounded `deque` objects and removes the
 least populated series when the number of history keys grows beyond the limit.
+Compaction of internal usage counters happens every
+``HISTORY_COMPACT_EVERY`` accesses, which can also be adjusted through
+``G.graph``.
 
 ### Random node sampling
 

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -109,6 +109,7 @@ class CoreDefaults:
     VALIDATORS_STRICT: bool = False
     PROGRAM_TRACE_MAXLEN: int = 50
     HISTORY_MAXLEN: int = 0
+    HISTORY_COMPACT_EVERY: int = 100
 
 
 @dataclass(frozen=True)

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -49,11 +49,30 @@ def recent_glyph(nd: Dict[str, Any], glyph: str, ventana: int) -> bool:
 
 
 class HistoryDict(dict):
-    """Dict specialized for bounded history series and usage counts."""
+    """Dict specialized for bounded history series and usage counts.
 
-    def __init__(self, data: Dict[str, Any] | None = None, *, maxlen: int = 0):
+    Parameters
+    ----------
+    data:
+        Initial mapping to populate the dictionary.
+    maxlen:
+        Maximum length for history lists stored as values.
+    compact_every:
+        Number of heap operations after which the internal heap is compacted.
+        Higher values reduce the frequency of compaction. The default is 100.
+    """
+
+    def __init__(
+        self,
+        data: Dict[str, Any] | None = None,
+        *,
+        maxlen: int = 0,
+        compact_every: int = 100,
+    ) -> None:
         super().__init__(data or {})
         self._maxlen = maxlen
+        self._compact_every = max(1, int(compact_every))
+        self._ops = 0
         self._counts: Dict[str, int] = {}
         self._heap: list[tuple[int, str]] = []
         if self._maxlen > 0:
@@ -72,8 +91,10 @@ class HistoryDict(dict):
         heapq.heapify(self._heap)
 
     def _maybe_compact(self) -> None:
-        if len(self._heap) > len(self) * 2:
+        self._ops += 1
+        if self._ops >= self._compact_every and len(self._heap) > len(self) * 2:
             self._compact_heap()
+            self._ops = 0
 
     def _increment(self, key: str) -> None:
         cnt = self._counts.get(key, 0) + 1
@@ -131,15 +152,26 @@ class HistoryDict(dict):
 def ensure_history(G) -> Dict[str, Any]:
     """Ensure ``G.graph['history']`` exists and return it.
 
-    ``HISTORY_MAXLEN`` must be a non-negative integer; otherwise a
-    :class:`ValueError` is raised.
+    ``HISTORY_MAXLEN`` must be non-negative and ``HISTORY_COMPACT_EVERY``
+    must be a positive integer; otherwise a :class:`ValueError` is raised.
     """
     maxlen = int(G.graph.get("HISTORY_MAXLEN", get_param(G, "HISTORY_MAXLEN")))
     if maxlen < 0:
         raise ValueError("HISTORY_MAXLEN must be >= 0")
+    compact_every = int(
+        G.graph.get(
+            "HISTORY_COMPACT_EVERY", get_param(G, "HISTORY_COMPACT_EVERY")
+        )
+    )
+    if compact_every <= 0:
+        raise ValueError("HISTORY_COMPACT_EVERY must be > 0")
     hist = G.graph.get("history")
-    if not isinstance(hist, HistoryDict) or hist._maxlen != maxlen:
-        hist = HistoryDict(hist, maxlen=maxlen)
+    if (
+        not isinstance(hist, HistoryDict)
+        or hist._maxlen != maxlen
+        or hist._compact_every != compact_every
+    ):
+        hist = HistoryDict(hist, maxlen=maxlen, compact_every=compact_every)
         G.graph["history"] = hist
     if maxlen > 0:
         while len(hist) > maxlen:


### PR DESCRIPTION
## Summary
- track heap operations in `HistoryDict`
- add `HISTORY_COMPACT_EVERY` to tune compaction frequency
- document usage history compaction

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb71749a048321aa3e2a6567f8ef2b