### PR TITLE
Optimize THOL body reversal in _flatten

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -142,10 +142,11 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
                 and item.force_close in {Glyph.SHA, Glyph.NUL}
                 else None
             )
+            body_rev = list(reversed(item.body))
             for _ in range(repeats):
                 if closing is not None:
                     stack.append(closing)
-                stack.extend(reversed(item.body))
+                stack.extend(body_rev)
             stack.append(THOL_SENTINEL)
             continue
 


### PR DESCRIPTION
## Summary
- Avoid redundant reversal of `THOL` block bodies during flattening
- Store reversed body once per `THOL` block and reuse

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7262fcf0832181af753e25b13192