### PR TITLE
Use dataclass slots for NodeState

### DIFF
--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Dict, Any
 
 
-@dataclass
+@dataclass(slots=True)
 class NodeState:
     EPI: float = 0.0
     vf: float = 1.0  # νf

--- a/tests/test_node_state_extra.py
+++ b/tests/test_node_state_extra.py
@@ -1,0 +1,8 @@
+from tnfr.types import NodeState
+
+
+def test_node_state_extra_access():
+    state = NodeState()
+    assert state.extra == {}
+    state.extra["foo"] = "bar"
+    assert state.extra["foo"] == "bar"


### PR DESCRIPTION
## Summary
- use dataclass slots for NodeState to avoid dynamic attributes
- add regression test to ensure NodeState.extra still functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb7301249483218d05911ae60d3db1