### PR TITLE
feat: stable node checksum

### DIFF
--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -1,0 +1,19 @@
+import networkx as nx
+
+from tnfr.helpers import node_set_checksum
+
+
+def build_graph():
+    class Foo:
+        def __init__(self, value):
+            self.value = value
+    G = nx.Graph()
+    G.add_node(Foo(1))
+    G.add_node(Foo(2))
+    return G
+
+
+def test_node_set_checksum_object_stable():
+    checksum1 = node_set_checksum(build_graph())
+    checksum2 = node_set_checksum(build_graph())
+    assert checksum1 == checksum2


### PR DESCRIPTION
## Summary
- use stable JSON serialization for node checksums
- test checksum stability with object-based nodes

## Testing
- `PYTHONPATH=src pytest tests/test_node_set_checksum.py -q`
- `PYTHONPATH=src pytest tests/test_gamma.py tests/test_operators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7617787083219a6ec21c97103036