### PR TITLE
Refactor history persistence logic and extend CLI tests

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -225,12 +225,12 @@ def _attach_callbacks(G: nx.Graph) -> None:
 
 def _persist_history(G: nx.Graph, args: argparse.Namespace) -> None:
     """Guardar o exportar el histórico si se solicitó."""
-    if getattr(args, "save_history", None):
-        path = args.save_history
-        _save_json(path, G.graph.get("history", {}))
-    if getattr(args, "export_history_base", None):
-        base = args.export_history_base
-        export_history(G, base, fmt=getattr(args, "export_format", "json"))
+    if args.save_history or args.export_history_base:
+        history = G.graph.get("history", {})
+        if args.save_history:
+            _save_json(args.save_history, history)
+        if args.export_history_base:
+            export_history(G, args.export_history_base, fmt=args.export_format)
 
 
 def build_basic_graph(args: argparse.Namespace) -> nx.Graph:

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -24,6 +24,29 @@ def test_cli_run_export_history(tmp_path):
     assert isinstance(data, dict)
 
 
+def test_cli_run_save_and_export_history(tmp_path):
+    save_path = tmp_path / "hist.json"
+    export_base = tmp_path / "history"
+    rc = main(
+        [
+            "run",
+            "--nodes",
+            "5",
+            "--steps",
+            "0",
+            "--save-history",
+            str(save_path),
+            "--export-history-base",
+            str(export_base),
+        ]
+    )
+    assert rc == 0
+    data_save = json.loads(save_path.read_text())
+    data_export = json.loads((export_base.with_suffix(".json")).read_text())
+    assert isinstance(data_save, dict)
+    assert isinstance(data_export, dict)
+
+
 def test_cli_sequence_save_history(tmp_path):
     path = tmp_path / "non" / "existing" / "hist.json"
     assert not path.parent.exists()
@@ -40,3 +63,17 @@ def test_cli_sequence_export_history(tmp_path):
     assert rc == 0
     data = json.loads((base.with_suffix(".json")).read_text())
     assert isinstance(data, dict)
+
+
+def test_cli_run_no_history_args(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rc = main(["run", "--nodes", "5", "--steps", "0"])
+    assert rc == 0
+    assert not any(tmp_path.iterdir())
+
+
+def test_cli_sequence_no_history_args(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rc = main(["sequence", "--nodes", "5"])
+    assert rc == 0
+    assert not any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- unify `_persist_history` logic and use direct argument attributes
- add CLI tests for combined history saving/exporting and for absence of history args

## Testing
- `PYTHONPATH=src pytest tests/test_cli_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb76abfa2883218f2ef8e92263127e