### PR TITLE
test(cli): cover args_to_dict None filtering

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -193,7 +193,8 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
     Returns
     -------
     dict
-        Mapping of argument names with the prefix stripped.
+        Mapping of argument names with the prefix stripped. Only entries
+        whose values are not ``None`` are included.
 
     Examples
     --------

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 import argparse
-from tnfr.cli import main, add_common_args, add_grammar_args, _build_graph_from_args
+from tnfr.cli import (
+    main,
+    add_common_args,
+    add_grammar_args,
+    _build_graph_from_args,
+    _args_to_dict,
+)
 from tnfr.constants import METRIC_DEFAULTS
 from tnfr.helpers import read_structured_file
 from tnfr import __version__
@@ -72,3 +78,11 @@ def test_args_to_dict_nested_options():
     assert canon["enabled"] is True
     assert canon["thol_min_len"] == 7
     assert METRIC_DEFAULTS["GRAMMAR_CANON"]["thol_min_len"] == 2
+
+
+def test_args_to_dict_filters_none_values():
+    parser = argparse.ArgumentParser()
+    add_grammar_args(parser)
+    args = parser.parse_args(["--grammar.enabled"])
+    result = _args_to_dict(args, "grammar_")
+    assert result == {"enabled": True}


### PR DESCRIPTION
## Summary
- document that `_args_to_dict` drops entries whose value is `None`
- add regression test ensuring `None` values are ignored by `_args_to_dict`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7740714083219b42b567196c4ead