### PR TITLE
chore: trim public API

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -1,4 +1,15 @@
-"""TNFR public API."""
+"""Minimal public API for :mod:`tnfr`.
+
+This package only re-exports a handful of high level helpers.  Most
+functionality lives in submodules that should be imported directly, for
+example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or
+:mod:`tnfr.program`.  Recommended entry points are:
+
+- ``step`` and ``run`` in :mod:`tnfr.dynamics`
+- ``preparar_red`` in :mod:`tnfr.ontosim`
+- ``create_nfr`` in :mod:`tnfr.structural`
+- ``NodeState`` in :mod:`tnfr.types`
+"""
 
 from __future__ import annotations
 
@@ -19,146 +30,18 @@ except PackageNotFoundError:  # pragma: no cover
     except (OSError, KeyError, ValueError):  # pragma: no cover
         __version__ = "0+unknown"
 
-# Public API re-exports
-from .dynamics import step, run, set_delta_nfr_hook, validate_canon
+# Minimal public API re-exports
+from .dynamics import step, run
 from .ontosim import preparar_red
-from .observers import attach_standard_observer, kuramoto_order
-from .helpers import compute_coherence
-from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
-from .grammar import (
-    enforce_canonical_grammar,
-    on_applied_glyph,
-    apply_glyph_with_grammar,
-)
-from .sense import (
-    glyph_angle,
-    glyph_unit,
-    sigma_vector_node,
-    sigma_vector_from_graph,
-    sigma_vector,
-    sigma_vector_global,
-    push_sigma_snapshot,
-    sigma_series,
-    sigma_rose,
-    register_sigma_callback,
-)
-from .constants_glyphs import GLYPHS_CANONICAL
-from .metrics import (
-    register_metrics_callbacks,
-    Tg_global,
-    Tg_by_node,
-    latency_series,
-    glyphogram_series,
-    glyph_top,
-    glyph_dwell_stats,
-    export_history,
-)
-from .operators import apply_topological_remesh
-from .trace import register_trace, CallbackSpec
-from .program import (
-    play,
-    seq,
-    block,
-    target,
-    wait,
-    THOL,
-    TARGET,
-    WAIT,
-    basic_canonical_example,
-)
-from .cli import main as cli_main
-from .scenarios import build_graph
-from .presets import get_preset
+from .structural import create_nfr
 from .types import NodeState
-from .structural import (
-    create_nfr,
-    Operador,
-    Emision,
-    Recepcion,
-    Coherencia,
-    Disonancia,
-    Acoplamiento,
-    Resonancia,
-    Silencio,
-    Expansion,
-    Contraccion,
-    Autoorganizacion,
-    Mutacion,
-    Transicion,
-    Recursividad,
-    OPERADORES,
-    validate_sequence,
-    run_sequence,
-)
-
 
 __all__ = [
-    "preparar_red",
+    "__version__",
     "step",
     "run",
-    "set_delta_nfr_hook",
-    "validate_canon",
-    "attach_standard_observer",
-    "kuramoto_order",
-    "compute_coherence",
-    "GAMMA_REGISTRY",
-    "eval_gamma",
-    "kuramoto_R_psi",
-    "enforce_canonical_grammar",
-    "on_applied_glyph",
-    "apply_glyph_with_grammar",
-    "GLYPHS_CANONICAL",
-    "glyph_angle",
-    "glyph_unit",
-    "sigma_vector_node",
-    "sigma_vector_from_graph",
-    "sigma_vector",
-    "sigma_vector_global",
-    "push_sigma_snapshot",
-    "sigma_series",
-    "sigma_rose",
-    "register_sigma_callback",
-    "register_metrics_callbacks",
-    "register_trace",
-    "CallbackSpec",
-    "Tg_global",
-    "Tg_by_node",
-    "latency_series",
-    "glyphogram_series",
-    "glyph_top",
-    "glyph_dwell_stats",
-    "export_history",
-    "apply_topological_remesh",
-    "play",
-    "seq",
-    "block",
-    "target",
-    "wait",
-    "THOL",
-    "TARGET",
-    "WAIT",
-    "cli_main",
-    "build_graph",
-    "get_preset",
-    "NodeState",
-    "basic_canonical_example",
+    "preparar_red",
     "create_nfr",
-    "Operador",
-    "Emision",
-    "Recepcion",
-    "Coherencia",
-    "Disonancia",
-    "Acoplamiento",
-    "Resonancia",
-    "Silencio",
-    "Expansion",
-    "Contraccion",
-    "Autoorganizacion",
-    "Mutacion",
-    "Transicion",
-    "Recursividad",
-    "OPERADORES",
-    "validate_sequence",
-    "run_sequence",
-    "__version__",
+    "NodeState",
 ]
+

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,19 @@
+import tnfr
+
+
+def test_public_exports():
+    expected = {'__version__', 'step', 'run', 'preparar_red', 'create_nfr', 'NodeState'}
+    assert set(tnfr.__all__) == expected
+
+
+def test_basic_flow():
+    G, n = tnfr.create_nfr('n1')
+    tnfr.preparar_red(G)
+    tnfr.step(G)
+    tnfr.run(G, steps=2)
+    assert len(G.graph['history']['C_steps']) == 3
+    assert isinstance(tnfr.NodeState(), tnfr.NodeState)
+
+
+def test_removed_name():
+    assert not hasattr(tnfr, 'apply_topological_remesh')


### PR DESCRIPTION
## Summary
- expose only minimal helpers in tnfr package: step, run, preparar_red, create_nfr and NodeState
- document recommended submodules instead of re-exporting everything
- add tests for new public surface

## Testing
- `PYTHONPATH=src pytest tests/test_public_api.py tests/test_cli_sanity.py::test_cli_version -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7a79cb308321811f27bb65ad4b80