### PR TITLE
Refine alias validation and cover invalid sequences

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -257,12 +257,13 @@ def _validate_aliases(aliases: Sequence[str]) -> tuple[str, ...]:
     """
 
     if isinstance(aliases, str) or not isinstance(aliases, Sequence):
-        raise TypeError("'aliases' must be a sequence of strings")
+        raise TypeError("'aliases' must be a non-string sequence")
+
     seq = aliases if isinstance(aliases, tuple) else tuple(aliases)
-    if not seq:
-        raise ValueError("'aliases' must contain at least one key")
-    if not all(isinstance(a, str) for a in seq):
-        raise TypeError("'aliases' must be a sequence of strings")
+    if not seq or any(not isinstance(a, str) for a in seq):
+        if not seq:
+            raise ValueError("'aliases' must contain at least one key")
+        raise TypeError("'aliases' elements must be strings")
     return seq
 
 

--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tnfr.helpers import _validate_aliases
+
+
+def test_rejects_string():
+    with pytest.raises(TypeError):
+        _validate_aliases("abc")
+
+
+def test_rejects_empty_iterable():
+    with pytest.raises(ValueError):
+        _validate_aliases([])
+
+
+def test_rejects_non_string_elements():
+    with pytest.raises(TypeError):
+        _validate_aliases(["a", 1])


### PR DESCRIPTION
## Summary
- Consolidate `_validate_aliases` checks to ensure aliases are a non-empty tuple of strings with clear error messages
- Add tests verifying `_validate_aliases` rejects strings, empty iterables, and non-string elements

## Testing
- `PYTHONPATH=src pytest tests/test_validate_aliases.py tests/test_alias_sequence.py tests/test_alias_helpers_threadsafe.py -q`
- `PYTHONPATH=src pytest -q` *(fails: ImportError: cannot import name 'CallbackSpec' from 'tnfr')*


------
https://chatgpt.com/codex/tasks/task_e_68bb7b893d848321aa010c5e246d574f