### PR TITLE
chore: adopt English naming

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -17,7 +17,7 @@ from .helpers import (
     angle_diff,
     get_attr,
     set_attr,
-    fase_media,
+    neighbor_phase_mean,
     increment_edge_version,
     node_set_checksum,
 )
@@ -279,7 +279,7 @@ def _op_UM(node: NodoProtocol) -> None:  # UM — Coupling
     gf = get_glyph_factors(node)
     k = float(gf.get("UM_theta_push", 0.25))
     th = node.theta
-    thL = fase_media(node)
+    thL = neighbor_phase_mean(node)
     d = angle_diff(thL, th)
     node.theta = th + k * d
 

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -5,18 +5,18 @@ import pytest
 
 from tnfr.constants import ALIAS_DNFR, ALIAS_SI, ALIAS_THETA, ALIAS_VF
 from tnfr.helpers import (
-    calcular_Si_nodo,
+    compute_Si_node,
     get_attr,
-    obtener_pesos_si,
-    precalcular_trigonometría,
+    get_Si_weights,
+    precompute_trigonometry,
     set_attr,
 )
 
 
-def test_obtener_pesos_si_normalization():
+def test_get_si_weights_normalization():
     G = nx.Graph()
     G.graph["SI_WEIGHTS"] = {"alpha": 2, "beta": 1, "gamma": 1}
-    alpha, beta, gamma = obtener_pesos_si(G)
+    alpha, beta, gamma = get_Si_weights(G)
     assert (alpha, beta, gamma) == pytest.approx((0.5, 0.25, 0.25))
     assert G.graph["_Si_weights"] == {"alpha": alpha, "beta": beta, "gamma": gamma}
     assert G.graph["_Si_sensitivity"] == {
@@ -26,12 +26,12 @@ def test_obtener_pesos_si_normalization():
     }
 
 
-def test_precalcular_trigonometria():
+def test_precompute_trigonometry():
     G = nx.Graph()
     G.add_nodes_from([1, 2])
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, math.pi / 2)
-    cos_th, sin_th, thetas = precalcular_trigonometría(G)
+    cos_th, sin_th, thetas = precompute_trigonometry(G)
     assert cos_th[1] == pytest.approx(1.0)
     assert sin_th[1] == pytest.approx(0.0)
     assert cos_th[2] == pytest.approx(0.0, abs=1e-8)
@@ -39,16 +39,16 @@ def test_precalcular_trigonometria():
     assert thetas[2] == pytest.approx(math.pi / 2)
 
 
-def test_calcular_Si_nodo():
+def test_compute_Si_node():
     G = nx.Graph()
     G.add_edge(1, 2)
     set_attr(G.nodes[1], ALIAS_VF, 0.5)
     set_attr(G.nodes[1], ALIAS_DNFR, 0.2)
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, 0.0)
-    cos_th, sin_th, thetas = precalcular_trigonometría(G)
+    cos_th, sin_th, thetas = precompute_trigonometry(G)
     neighbors = {n: list(G.neighbors(n)) for n in G}
-    Si = calcular_Si_nodo(
+    Si = compute_Si_node(
         1,
         G.nodes[1],
         alpha=0.5,


### PR DESCRIPTION
## Summary
- use English names for helper functions like `neighbor_mean` and `neighbor_phase_mean`
- translate Si utilities to `get_Si_weights`, `precompute_trigonometry`, and `compute_Si_node`
- rename dynamics routines to `coordinate_global_local_phase` and `adapt_vf_by_coherence`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'CallbackSpec' from 'tnfr')*

------
https://chatgpt.com/codex/tasks/task_e_68bb7c138e20832194171382fad1950a