### PR TITLE
chore: lazy import networkx

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -7,11 +7,10 @@ from enum import Enum
 from collections import defaultdict
 import logging
 
-import networkx as nx
-
 from .constants import DEFAULTS
 
 if TYPE_CHECKING:  # pragma: no cover
+    import networkx as nx
     from . import CallbackSpec
 
 __all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
@@ -30,11 +29,11 @@ class CallbackEvent(str, Enum):
 _CALLBACK_EVENTS: tuple[str, ...] = tuple(e.value for e in CallbackEvent)
 
 
-Callback = Callable[[nx.Graph, dict[str, Any]], None]
+Callback = Callable[["nx.Graph", dict[str, Any]], None]
 CallbackRegistry = DefaultDict[str, list["CallbackSpec"]]
 
 
-def _ensure_callbacks(G: nx.Graph) -> CallbackRegistry:
+def _ensure_callbacks(G: "nx.Graph") -> CallbackRegistry:
     """Ensure the callback structure in ``G.graph``."""
     cbs = G.graph.get("callbacks")
     if not isinstance(cbs, defaultdict):
@@ -74,7 +73,7 @@ def _normalize_callback_entry(entry: Any) -> "CallbackSpec | None":
 
 
 def register_callback(
-    G: nx.Graph,
+    G: "nx.Graph",
     event: CallbackEvent | str,
     func: Callback,
     *,
@@ -142,7 +141,7 @@ def register_callback(
 
 
 def invoke_callbacks(
-    G: nx.Graph, event: CallbackEvent | str, ctx: dict[str, Any] | None = None
+    G: "nx.Graph", event: CallbackEvent | str, ctx: dict[str, Any] | None = None
 ) -> None:
     """Invoke all callbacks registered for ``event`` with context ``ctx``."""
     if isinstance(event, CallbackEvent):

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -5,11 +5,12 @@ import argparse
 import json
 import logging
 import sys
-from typing import Any, Dict, List, Optional, Callable
+from typing import Any, Dict, List, Optional, Callable, TYPE_CHECKING
 from pathlib import Path
 from collections import deque
 
-import networkx as nx
+if TYPE_CHECKING:  # pragma: no cover
+    import networkx as nx
 
 from .constants import inject_defaults, DEFAULTS, METRIC_DEFAULTS
 from .sense import register_sigma_callback, sigma_rose
@@ -216,7 +217,7 @@ def _load_sequence(path: Path) -> List[Any]:
     return seq(*_parse_tokens(data))
 
 
-def _attach_callbacks(G: nx.Graph) -> None:
+def _attach_callbacks(G: "nx.Graph") -> None:
     inject_defaults(G, DEFAULTS)
     register_sigma_callback(G)
     register_metrics_callbacks(G)
@@ -224,7 +225,7 @@ def _attach_callbacks(G: nx.Graph) -> None:
     _update_history(G)
 
 
-def _persist_history(G: nx.Graph, args: argparse.Namespace) -> None:
+def _persist_history(G: "nx.Graph", args: argparse.Namespace) -> None:
     """Guardar o exportar el histórico si se solicitó."""
     if args.save_history or args.export_history_base:
         history = G.graph.get("history", {})
@@ -234,12 +235,12 @@ def _persist_history(G: nx.Graph, args: argparse.Namespace) -> None:
             export_history(G, args.export_history_base, fmt=args.export_format)
 
 
-def build_basic_graph(args: argparse.Namespace) -> nx.Graph:
+def build_basic_graph(args: argparse.Namespace) -> "nx.Graph":
     """Construye el grafo base a partir de los argumentos del CLI."""
     return build_graph(n=args.nodes, topology=args.topology, seed=args.seed, p=args.p)
 
 
-def apply_cli_config(G: nx.Graph, args: argparse.Namespace) -> None:
+def apply_cli_config(G: "nx.Graph", args: argparse.Namespace) -> None:
     """Aplica configuraciones provenientes del CLI o de archivos externos."""
     if args.config:
         apply_config(G, Path(args.config))
@@ -276,7 +277,7 @@ def apply_cli_config(G: nx.Graph, args: argparse.Namespace) -> None:
         }
 
 
-def register_callbacks_and_observer(G: nx.Graph, args: argparse.Namespace) -> None:
+def register_callbacks_and_observer(G: "nx.Graph", args: argparse.Namespace) -> None:
     """Registra callbacks y observadores estándar."""
     _attach_callbacks(G)
     if args.observer:
@@ -284,7 +285,7 @@ def register_callbacks_and_observer(G: nx.Graph, args: argparse.Namespace) -> No
     validate_canon(G)
 
 
-def _build_graph_from_args(args: argparse.Namespace) -> nx.Graph:
+def _build_graph_from_args(args: argparse.Namespace) -> "nx.Graph":
     """Construye un grafo configurado a partir de los argumentos del CLI."""
     G = build_basic_graph(args)
     apply_cli_config(G, args)
@@ -410,8 +411,8 @@ def _add_metrics_parser(sub: argparse._SubParsersAction) -> None:
 
 
 def run_program(
-    G: Optional[nx.Graph], program: Optional[Any], args: argparse.Namespace
-) -> nx.Graph:
+    G: Optional["nx.Graph"], program: Optional[Any], args: argparse.Namespace
+) -> "nx.Graph":
     """Construir el grafo si es necesario, ejecutar un programa y guardar historial."""
     if G is None:
         G = _build_graph_from_args(args)
@@ -427,7 +428,7 @@ def run_program(
     return G
 
 
-def _log_run_summaries(G: nx.Graph, args: argparse.Namespace) -> None:
+def _log_run_summaries(G: "nx.Graph", args: argparse.Namespace) -> None:
     """Registrar resúmenes rápidos y métricas opcionales."""
 
     if G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get("enabled", True):

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -11,15 +11,18 @@ from typing import (
     Optional,
     overload,
     Protocol,
+    TYPE_CHECKING,
 )
 import logging
 import math
 import json
 import hashlib
 from statistics import fmean, StatisticsError
-import networkx as nx
 from json import JSONDecodeError
 from pathlib import Path
+
+if TYPE_CHECKING:  # pragma: no cover
+    import networkx as nx
 
 try:  # pragma: no cover - dependencia opcional
     import tomllib  # type: ignore[attr-defined]
@@ -188,7 +191,7 @@ def _stable_json(obj: Any) -> Any:
     return obj.__class__.__qualname__
 
 
-def node_set_checksum(G: nx.Graph) -> str:
+def node_set_checksum(G: "nx.Graph") -> str:
     """Devuelve el SHA1 del conjunto de nodos de ``G`` ordenado.
 
     Cada nodo se serializa a JSON con claves ordenadas y evitando incluir

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 import random
-import networkx as nx
+from typing import TYPE_CHECKING
 
 from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
 from .helpers import clamp
+
+if TYPE_CHECKING:  # pragma: no cover
+    import networkx as nx
 
 
 def _init_phase(
@@ -82,7 +85,7 @@ def _init_si_epi(
         nd["Si"] = float(si)
 
 
-def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
+def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
     """Inicializa EPI, θ, νf y Si en los nodos de ``G``.
 
     Los parámetros pueden personalizarse mediante entradas en ``G.graph``:

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -1,24 +1,27 @@
 """Orquesta la simulación canónica."""
 
 from __future__ import annotations
-import networkx as nx
 from collections import deque
+from typing import TYPE_CHECKING
 
 from .constants import METRIC_DEFAULTS, attach_defaults, get_param
 from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
 
+if TYPE_CHECKING:  # pragma: no cover
+    import networkx as nx
+
 # API de alto nivel
 
 
 def preparar_red(
-    G: nx.Graph,
+    G: "nx.Graph",
     *,
     init_attrs: bool = True,
     override_defaults: bool = False,
     **overrides,
-) -> nx.Graph:
+) -> "nx.Graph":
     """Prepara ``G`` para simulación.
 
     Parameters
@@ -104,7 +107,7 @@ def preparar_red(
 
 
 def step(
-    G: nx.Graph,
+    G: "nx.Graph",
     *,
     dt: float | None = None,
     use_Si: bool = True,
@@ -114,7 +117,7 @@ def step(
 
 
 def run(
-    G: nx.Graph,
+    G: "nx.Graph",
     steps: int,
     *,
     dt: float | None = None,

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 from collections.abc import Sequence
 
-import networkx as nx
+if TYPE_CHECKING:  # pragma: no cover
+    import networkx as nx
 
 from .constants import DEFAULTS
 from .constants.core import SELECTOR_THRESHOLD_DEFAULTS
@@ -22,7 +23,7 @@ __all__ = [
 ]
 
 
-def _selector_thresholds(G: nx.Graph) -> dict:
+def _selector_thresholds(G: "nx.Graph") -> dict:
     """Retorna umbrales normalizados hi/lo para Si, ΔNFR y aceleración.
 
     Combina ``SELECTOR_THRESHOLDS`` con ``GLYPH_THRESHOLDS`` (legado) para
@@ -87,7 +88,7 @@ def _selector_thresholds(G: nx.Graph) -> dict:
     return {key: _get_threshold(key, default, legacy) for key, default, legacy in specs}
 
 
-def _norms_para_selector(G: nx.Graph) -> dict:
+def _norms_para_selector(G: "nx.Graph") -> dict:
     """Calcula y guarda en ``G.graph`` los máximos para normalizar
     |ΔNFR| y |d2EPI/dt2|."""
     norms = compute_dnfr_accel_max(G)


### PR DESCRIPTION
## Summary
- wrap networkx imports under TYPE_CHECKING
- annotate networkx types as forward references

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'tnfr' then ImportError: cannot import name 'CallbackSpec' - but after installing, tests error in test_trace)*

------
https://chatgpt.com/codex/tasks/task_e_68bb80a80fe483218effb91239aea2b7