### PR TITLE
Use Glyph enum for latent glyph

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -12,11 +12,12 @@ from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, last_glyph
 from ..helpers import get_attr
 from ..constants_glyphs import GLYPHS_CANONICAL, GLYPH_GROUPS
+from ..types import Glyph
 from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks
 
 
-LATENT_GLYPH = "SHA"
+LATENT_GLYPH = Glyph.SHA.value
 TgCurr = "curr"
 TgRun = "run"
 


### PR DESCRIPTION
## Summary
- use `Glyph.SHA.value` to define `LATENT_GLYPH`
- import Glyph enum in metrics core module

## Testing
- `pytest` *(fails: cannot import name 'CallbackSpec' from 'tnfr')*


------
https://chatgpt.com/codex/tasks/task_e_68bb81b200908321ada6ea7fd301542c