### PR TITLE
Simplify sigma vector aggregation

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -80,17 +80,13 @@ def _sigma_from_vectors(
     ``vectors`` may be a single complex number or an iterable of them.
     """
 
-    acc = complex(0.0, 0.0)
-    cnt = 0
-
-    if isinstance(vectors, complex):
+    try:
+        vectors_iter = list(iter(vectors))
+    except TypeError:
         vectors_iter = [vectors]
-    else:
-        vectors_iter = vectors
 
-    for z in vectors_iter:
-        acc += z
-        cnt += 1
+    cnt = len(vectors_iter)
+    acc = sum(vectors_iter, complex(0.0, 0.0))
 
     if cnt <= 0:
         vec = {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": float(fallback_angle)}


### PR DESCRIPTION
## Summary
- Refactor `_sigma_from_vectors` to handle single values via `iter` fallback
- Compute vector aggregates using `sum` and `len`

## Testing
- `pytest tests/test_sense.py`
- `pytest` *(fails: ImportError: cannot import name 'CallbackSpec' from 'tnfr')*

------
https://chatgpt.com/codex/tasks/task_e_68bb82507ed083219a998523477b28e6