### PR TITLE
Simplify last_glyph history lookup

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -7,8 +7,7 @@ from collections import deque, Counter
 import heapq
 from itertools import islice
 
-from .constants import ALIAS_EPI_KIND, get_param
-from .helpers import get_attr_str
+from .constants import get_param
 
 __all__ = [
     "HistoryDict",
@@ -181,16 +180,8 @@ def ensure_history(G) -> Dict[str, Any]:
 
 def last_glyph(nd: Dict[str, Any]) -> str | None:
     """Return the most recent glyph for node or ``None``."""
-    kind = get_attr_str(nd, ALIAS_EPI_KIND, "")
-    if kind:
-        return kind
     hist = nd.get("glyph_history")
-    if not hist:
-        return None
-    try:
-        return hist[-1]
-    except IndexError:
-        return None
+    return hist[-1] if hist else None
 
 
 def count_glyphs(G, window: int | None = None, *, last_only: bool = False) -> Counter:

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -4,16 +4,15 @@ import networkx as nx
 from collections import deque, Counter
 
 from tnfr.glyph_history import count_glyphs
-from tnfr.constants import ALIAS_EPI_KIND
 
 
 def test_count_glyphs_last_only_and_window():
     G = nx.Graph()
     G.add_node(0, glyph_history=deque(["A", "B"]))
-    G.add_node(1, **{ALIAS_EPI_KIND[0]: "C"})
+    G.add_node(1)
 
     last = count_glyphs(G, last_only=True)
-    assert last == Counter({"B": 1, "C": 1})
+    assert last == Counter({"B": 1})
 
     recent = count_glyphs(G, window=2)
     assert recent == Counter({"A": 1, "B": 1})

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -15,8 +15,8 @@ def _make_node(history, current=None, window=10):
 
 def test_recent_glyph_window_one():
     nd = _make_node(["Y"], current="X")
-    assert recent_glyph(nd, "X", 1)
-    assert not recent_glyph(nd, "Y", 1)
+    assert not recent_glyph(nd, "X", 1)
+    assert recent_glyph(nd, "Y", 1)
 
 
 def test_recent_glyph_history_lookup():


### PR DESCRIPTION
## Summary
- simplify `last_glyph` to read from `glyph_history` only
- update tests for new glyph semantics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tnfr')*
- `pytest tests/test_history.py tests/test_recent_glyph.py tests/test_count_glyphs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb82ccb0a08321a0ac2dde8f4792b7