### PR TITLE
Handle non-positive windows in glyph history counts

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -35,6 +35,7 @@ from .dynamics import step, run
 from .ontosim import preparar_red
 from .structural import create_nfr
 from .types import NodeState
+from .trace import CallbackSpec  # re-exported for tests
 
 __all__ = [
     "__version__",

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -185,7 +185,12 @@ def last_glyph(nd: Dict[str, Any]) -> str | None:
 
 
 def count_glyphs(G, window: int | None = None, *, last_only: bool = False) -> Counter:
-    """Count recent glyphs in the network."""
+    """Count recent glyphs in the network.
+
+    If ``window`` is ``None``, the full history for each node is used. When
+    ``window`` is less than or equal to zero, no glyphs are counted for any
+    node.
+    """
     counts: Counter[str] = Counter()
     for _, nd in G.nodes(data=True):
         if last_only:
@@ -195,9 +200,12 @@ def count_glyphs(G, window: int | None = None, *, last_only: bool = False) -> Co
             hist = nd.get("glyph_history")
             if not hist:
                 continue
-            if window is not None and window > 0:
+            if window is not None:
                 window_int = int(window)
-                seq = islice(reversed(hist), window_int)
+                if window_int > 0:
+                    seq = islice(reversed(hist), window_int)
+                else:
+                    seq = []
             else:
                 seq = hist
         counts.update(seq)

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -16,3 +16,12 @@ def test_count_glyphs_last_only_and_window():
 
     recent = count_glyphs(G, window=2)
     assert recent == Counter({"A": 1, "B": 1})
+
+
+def test_count_glyphs_non_positive_window():
+    G = nx.Graph()
+    G.add_node(0, glyph_history=deque(["A", "B"]))
+    G.add_node(1, glyph_history=deque(["C"]))
+
+    assert count_glyphs(G, window=0) == Counter()
+    assert count_glyphs(G, window=-1) == Counter()

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -7,8 +7,8 @@ from tnfr.trace import (
     _callback_names,
     gamma_field,
     grammar_field,
+    CallbackSpec,
 )
-from tnfr import CallbackSpec
 from tnfr.callback_utils import register_callback, invoke_callbacks
 
 


### PR DESCRIPTION
## Summary
- ensure `count_glyphs` returns no glyphs when `window <= 0`
- expose `CallbackSpec` at package root and adjust trace tests
- cover non-positive window cases in `count_glyphs` tests

## Testing
- `pytest` *(fails: AssertionError in tests/test_metrics.py::test_save_by_node_flag_keeps_metrics_equal, Failed: DID NOT RAISE ValueError in tests/test_validators.py::test_validator_glyph_invalido)*

------
https://chatgpt.com/codex/tasks/task_e_68bb83b7f1208321875c48171ddb6181