### PR TITLE
Use __getitem__ in HistoryDict.get

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -107,11 +107,12 @@ class HistoryDict(dict):
         return val
 
     def get(self, key, default=None):  # type: ignore[override]
-        if key in self:
-            val = super().get(key, default)
-            self._increment(key)
-            return val
-        return default
+        try:
+            val = super().__getitem__(key)
+        except KeyError:
+            return default
+        self._increment(key)
+        return val
 
     def tracked_get(self, key, default=None):
         if key in self:


### PR DESCRIPTION
## Summary
- Refactor HistoryDict.get to use `__getitem__` with KeyError handling

## Testing
- `pip install -e .`
- `pytest` *(fails: assert defaultdict ... != {} ; Failed: DID NOT RAISE <class 'ValueError'>)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8594b69883218b65776d336217a0