### PR TITLE
chore: remove ChainMap import from constants

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import ChainMap
 from typing import Any, Dict
 import copy
 import warnings


### PR DESCRIPTION
## Summary
- drop unused ChainMap import from `tnfr.constants`

## Testing
- `pytest tests/test_defaults_integrity.py`
- `pytest` *(fails: test_save_by_node_flag_keeps_metrics_equal, test_validator_glyph_invalido)*

------
https://chatgpt.com/codex/tasks/task_e_68bb87d25c988321a5b041a460ec4ab9