### PR TITLE
Use stable hash for jitter RNG

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -73,9 +73,15 @@ def _node_offset(G, n) -> int:
 
 
 def _jitter_base(seed: int, key: int) -> random.Random:
-    """Return a ``random.Random`` instance seeded from ``seed`` and ``key``."""
+    """Return a ``random.Random`` instance seeded from ``seed`` and ``key``.
+
+    A stable ``blake2b`` hash is used so the derived seed is reproducible
+    across Python processes.
+    """
     seed_input = (seed, key)
-    seed_int = hash(seed_input)
+    seed_int = int.from_bytes(
+        hashlib.blake2b(repr(seed_input).encode()).digest()[:8], "big"
+    )
     return random.Random(seed_int)
 
 


### PR DESCRIPTION
## Summary
- Replace built-in `hash` with stable `blake2b`-based hash for jitter RNG seeds
- Note reproducible seed behavior across Python processes

## Testing
- `pytest` *(fails: test_save_by_node_flag_keeps_metrics_equal, test_validator_glyph_invalido)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8918d550832183f0e669807ee857