### PR TITLE
Refactoriza historial con callbacks de métricas

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -21,13 +21,13 @@ from .metrics import (
     glyphogram_series,
     glyph_top,
     export_history,
+    _metrics_step,
 )
 from .trace import register_trace
 from .program import play, seq, block, wait, target
 from .types import Glyph
 from .dynamics import (
     step,
-    _update_history,
     default_glyph_selector,
     parametric_glyph_selector,
     validate_canon,
@@ -222,7 +222,7 @@ def _attach_callbacks(G: "nx.Graph") -> None:
     register_sigma_callback(G)
     register_metrics_callbacks(G)
     register_trace(G)
-    _update_history(G)
+    _metrics_step(G)
 
 
 def _persist_history(G: "nx.Graph", args: argparse.Namespace) -> None:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from tnfr.dynamics import _update_history
+from tnfr.metrics import _metrics_step
 
 
 def test_phase_sync_and_kuramoto_recorded(graph_canon):
     G = graph_canon()
     G.add_node(1, theta=0.0)
     G.add_node(2, theta=0.0)
-    _update_history(G)
+    _metrics_step(G)
     hist = G.graph.get("history", {})
     assert hist["phase_sync"][-1] == pytest.approx(1.0)
     assert "kuramoto_R" in hist

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -2,6 +2,7 @@
 
 from tnfr.constants import attach_defaults
 from tnfr.dynamics import step
+from tnfr.metrics import register_metrics_callbacks
 from tnfr.gamma import GAMMA_REGISTRY
 
 
@@ -9,6 +10,7 @@ def test_history_delta_si_and_B(graph_canon):
     G = graph_canon()
     G.add_node(0, EPI=0.0, νf=0.5, θ=0.0)
     attach_defaults(G)
+    register_metrics_callbacks(G)
     step(G, apply_glyphs=False)
     step(G, apply_glyphs=False)
     hist = G.graph.get("history", {})

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -6,7 +6,8 @@ import pytest
 
 from tnfr.constants import inject_defaults
 from tnfr.scenarios import build_graph
-from tnfr.dynamics import step, _update_history
+from tnfr.dynamics import step
+from tnfr.metrics import register_metrics_callbacks, _metrics_step
 from tnfr.operators import apply_glyph, apply_remesh_if_globally_stable
 from tnfr.types import Glyph
 
@@ -15,7 +16,8 @@ from tnfr.types import Glyph
 def G_small():
     G = build_graph(n=8, topology="ring", seed=7)
     inject_defaults(G)
-    _update_history(G)
+    register_metrics_callbacks(G)
+    _metrics_step(G)
     return G
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -49,9 +49,13 @@ def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
         G.add_node(0, EPI_kind="OZ")
         G.add_node(1, EPI_kind=LATENT_GLYPH)
         attach_defaults(G)
+        for n in G.nodes():
+            nd = G.nodes[n]
+            nd["glyph_history"] = [nd.get("EPI_kind")]
         G.graph["_t"] = 0
         _metrics_step(G)
         G.nodes[0]["EPI_kind"] = "NAV"
+        G.nodes[0].setdefault("glyph_history", []).append("NAV")
         G.graph["_t"] = 1
         _metrics_step(G)
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,5 @@
 import tnfr
+from tnfr.metrics import register_metrics_callbacks
 
 
 def test_public_exports():
@@ -9,6 +10,7 @@ def test_public_exports():
 def test_basic_flow():
     G, n = tnfr.create_nfr('n1')
     tnfr.preparar_red(G)
+    register_metrics_callbacks(G)
     tnfr.step(G)
     tnfr.run(G, steps=2)
     assert len(G.graph['history']['C_steps']) == 3

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -58,6 +58,7 @@ def test_validator_glyph_invalido():
     G = _base_graph()
     n0 = list(G.nodes())[0]
     set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
+    G.nodes[n0]["glyph_history"] = ["INVALID"]
     with pytest.raises(ValueError):
         run_validators(G)
 


### PR DESCRIPTION
## Summary
- traslada la actualización del histórico a `tnfr.metrics._metrics_step`
- reemplaza `_update_history` por `_update_epi_hist` en la dinámica
- ajusta pruebas y CLI para usar `register_metrics_callbacks`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb899b80c48321bee2830299183543