### PR TITLE
Remove deprecated sigma_vector_global alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-teoria-de-la-natur
 
 ---
 
+## Changelog
+
+* Removed deprecated alias `sigma_vector_global`; use `sigma_vector_from_graph` instead.
+
+---
+
 ## MIT License
 
 Copyright (c) 2025 TNFR - Teoría de la naturaleza fractral resonante

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 from typing import Dict, Iterable, List
 import math
-import warnings
 
 import networkx as nx
 
@@ -162,23 +161,6 @@ def sigma_vector_from_graph(
     vec, n = _sigma_from_vectors(vectors)
     vec["n"] = n
     return vec
-
-
-def sigma_vector_global(
-    G: nx.Graph, weight_mode: str | None = None
-) -> Dict[str, float]:
-    """Alias de :func:`sigma_vector_from_graph`.
-
-    .. deprecated:: 4.5.3
-       Use :func:`sigma_vector_from_graph` en su lugar.
-    """
-
-    warnings.warn(
-        "sigma_vector_global está deprecada; use sigma_vector_from_graph",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return sigma_vector_from_graph(G, weight_mode)
 
 
 # -------------------------


### PR DESCRIPTION
## Summary
- drop deprecated `sigma_vector_global` alias
- note alias removal in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c4c44908321979414515a44f591