### PR TITLE
Refactor helpers and standardize callbacks

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -8,10 +8,10 @@ from collections import defaultdict
 import logging
 
 from .constants import DEFAULTS
+from .trace import CallbackSpec
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
-    from . import CallbackSpec
 
 __all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
 
@@ -54,7 +54,6 @@ def _normalize_callback_entry(entry: Any) -> "CallbackSpec | None":
     ``None`` is returned when ``entry`` does not match any of the accepted
     formats.  The original ``entry`` is never mutated.
     """
-    from . import CallbackSpec
 
     if isinstance(entry, CallbackSpec):
         return entry
@@ -114,12 +113,10 @@ def register_callback(
     if isinstance(event, CallbackEvent):
         event = event.value
     if event not in _CALLBACK_EVENTS:
-        raise ValueError(f"Evento desconocido: {event}")
+        raise ValueError(f"Unknown event: {event}")
     if not callable(func):
-        raise TypeError("func debe ser callable")
+        raise TypeError("func must be callable")
     cbs = _ensure_callbacks(G)
-
-    from . import CallbackSpec
 
     cb_name = name or getattr(func, "__name__", None)
     new_cb = CallbackSpec(cb_name, func)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import warnings
 from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple
 
-from .callback_utils import register_callback
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs
 
@@ -317,6 +316,8 @@ def register_trace(G) -> None:
     """
     if G.graph.get("_trace_registered"):
         return
+
+    from .callback_utils import register_callback
 
     register_callback(G, event="before_step", func=_trace_before, name="trace_before")
     register_callback(G, event="after_step", func=_trace_after, name="trace_after")

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -1,6 +1,7 @@
 """Pruebas de compactación de _heap en HistoryDict."""
 
 from tnfr.glyph_history import HistoryDict
+import pytest
 
 
 def test_heap_compaction_single_key():
@@ -47,3 +48,9 @@ def test_heap_compaction_after_deletions():
     for _ in range(5):
         hist.pop_least_used()
         assert len(hist._heap) <= len(hist) * 2
+
+
+def test_pop_least_used_empty_message():
+    hist = HistoryDict()
+    with pytest.raises(KeyError, match="HistoryDict is empty; cannot pop least used"):
+        hist.pop_least_used()

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -15,12 +15,12 @@ def _make_node(history, current=None, window=10):
 
 def test_recent_glyph_window_one():
     nd = _make_node(["Y"], current="X")
-    assert not recent_glyph(nd, "X", 1)
-    assert recent_glyph(nd, "Y", 1)
+    assert not recent_glyph(nd, "X", window=1)
+    assert recent_glyph(nd, "Y", window=1)
 
 
 def test_recent_glyph_history_lookup():
     nd = _make_node(["A", "B"], current="C")
-    assert recent_glyph(nd, "B", 2)
-    assert not recent_glyph(nd, "A", 2)
-    assert recent_glyph(nd, "A", 3)
+    assert recent_glyph(nd, "B", window=2)
+    assert not recent_glyph(nd, "A", window=2)
+    assert recent_glyph(nd, "A", window=3)

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -33,7 +33,7 @@ def test_register_callback_rejects_tuple(graph_canon):
     def cb(G, ctx):
         pass
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="must be callable"):
         register_callback(G, event=CallbackEvent.BEFORE_STEP, func=("cb", cb))
 
 
@@ -47,3 +47,13 @@ def test_enum_registration_and_invocation(graph_canon):
     ctx = {"called": 0}
     invoke_callbacks(G, CallbackEvent.AFTER_STEP, ctx)
     assert ctx["called"] == 1
+
+
+def test_register_callback_unknown_event(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        pass
+
+    with pytest.raises(ValueError, match="Unknown event"):
+        register_callback(G, event="nope", func=cb)


### PR DESCRIPTION
## Summary
- Move `CallbackSpec` import to module scope and unify callback registration errors
- Consolidate alias helpers with shared lookup and clearer default conversion handling
- Rename `recent_glyph` parameter and streamline `HistoryDict` usage tracking
- Add generic `add_edge` utility and simplify RNG caching with `lru_cache`

## Testing
- `PYTHONPATH=src pytest tests/test_register_callback.py tests/test_recent_glyph.py tests/test_history_heap_cleanup.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb8cfdf5208321a295a20b8e16d073