### PR TITLE
Refactor utilities and sync observers

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -34,17 +34,18 @@ def recent_glyph(nd: Dict[str, Any], glyph: str, window: int) -> bool:
     if window < 0:
         raise ValueError("window must be >= 0")
 
-    last = last_glyph(nd)
+    hist = nd.get("glyph_history")
+    if not hist:
+        return False
+
+    last = hist[-1]
     if window <= 1:
         return last == gl
     if last == gl:
         return True
 
-    hist = nd.get("glyph_history")
-    if hist:
-        window -= 1
-        return any(gl == reciente for reciente in islice(reversed(hist), window))
-    return False
+    window -= 1
+    return any(gl == reciente for reciente in islice(reversed(hist), window))
 
 
 class HistoryDict(dict):

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -147,19 +147,19 @@ def read_structured_file(path: Path) -> Any:
     if suffix not in PARSERS:
         raise ValueError(f"Extensión de archivo no soportada: {suffix}")
     parser = PARSERS[suffix]
+    error_map = {
+        OSError: "No se pudo leer {path}: {e}",
+        JSONDecodeError: "Error al parsear archivo JSON en {path}: {e}",
+        YAMLError: "Error al parsear archivo YAML en {path}: {e}",
+        TOMLDecodeError: "Error al parsear archivo TOML en {path}: {e}",
+        ImportError: "Dependencia faltante al parsear {path}: {e}",
+    }
     try:
         text = path.read_text(encoding="utf-8")
         return parser(text)
-    except OSError as e:
-        raise ValueError(f"No se pudo leer {path}: {e}") from e
-    except JSONDecodeError as e:
-        raise ValueError(f"Error al parsear archivo JSON en {path}: {e}") from e
-    except YAMLError as e:
-        raise ValueError(f"Error al parsear archivo YAML en {path}: {e}") from e
-    except TOMLDecodeError as e:
-        raise ValueError(f"Error al parsear archivo TOML en {path}: {e}") from e
-    except ImportError as e:
-        raise ValueError(f"Dependencia faltante al parsear {path}: {e}") from e
+    except tuple(error_map) as e:
+        msg = error_map.get(type(e), "Error al parsear {path}: {e}")
+        raise ValueError(msg.format(path=path, e=e)) from e
 
 
 def ensure_parent(path: str | Path) -> None:

--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -1,5 +1,7 @@
 """Registerable metrics."""
 
+from __future__ import annotations
+
 from .core import (
     register_metrics_callbacks,
     Tg_global,

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -1,7 +1,6 @@
 """Observer management."""
 
 from __future__ import annotations
-import math
 import statistics as st
 from statistics import pvariance
 from itertools import islice
@@ -61,27 +60,13 @@ def attach_standard_observer(G):
     return G
 
 
-def _phase_sums(G) -> tuple[float, float, int]:
-    """Return ``sumX``, ``sumY`` and the number of nodes."""
-    sumX = 0.0
-    sumY = 0.0
-    count = 0
-    for _, data in G.nodes(data=True):
-        th = get_attr(data, ALIAS_THETA, 0.0)
-        sumX += math.cos(th)
-        sumY += math.sin(th)
-        count += 1
-    return sumX, sumY, count
-
-
 def phase_sync(G) -> float:
-    sumX, sumY, count = _phase_sums(G)
-    if count == 0:
+    if G.number_of_nodes() == 0:
         return 1.0
-    th = math.atan2(sumY, sumX)
+    _, psi = kuramoto_R_psi(G)
     # varianza angular aproximada (0 = muy sincronizado)
     diffs = (
-        angle_diff(get_attr(data, ALIAS_THETA, 0.0), th)
+        angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
         for _, data in G.nodes(data=True)
     )
     var = pvariance(diffs)


### PR DESCRIPTION
## Summary
- add forward annotations import to metrics
- reuse Kuramoto phase calculation in phase_sync
- centralize structured file error handling
- simplify recent_glyph lookup and optimize jitter cache

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb8fafb96c83218bc20664188c2394