### PR TITLE
Refactor helpers and tracing utilities

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -39,6 +39,13 @@ def _ensure_callbacks(G: "nx.Graph") -> CallbackRegistry:
     if not isinstance(cbs, defaultdict):
         cbs = defaultdict(list, cbs or {})
         G.graph["callbacks"] = cbs
+    for event in list(cbs):
+        lst = cbs[event]
+        cbs[event] = [
+            spec
+            for entry in lst
+            if (spec := _normalize_callback_entry(entry)) is not None
+        ]
     return cbs
 
 
@@ -122,12 +129,7 @@ def register_callback(
     new_cb = CallbackSpec(cb_name, func)
 
     existing_list = cbs[event]
-    for i, existing in enumerate(existing_list):
-        spec = _normalize_callback_entry(existing)
-        if spec is None:
-            continue
-        if spec is not existing:
-            existing_list[i] = spec
+    for i, spec in enumerate(existing_list):
         if spec.func is func or (cb_name is not None and spec.name == cb_name):
             existing_list[i] = new_cb
             break

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -157,14 +157,16 @@ def ensure_history(G) -> Dict[str, Any]:
     ``HISTORY_MAXLEN`` must be non-negative and ``HISTORY_COMPACT_EVERY``
     must be a positive integer; otherwise a :class:`ValueError` is raised.
     """
-    maxlen = int(G.graph.get("HISTORY_MAXLEN", get_param(G, "HISTORY_MAXLEN")))
+    if "HISTORY_MAXLEN" in G.graph:
+        maxlen = int(G.graph["HISTORY_MAXLEN"])
+    else:
+        maxlen = int(get_param(G, "HISTORY_MAXLEN"))
     if maxlen < 0:
         raise ValueError("HISTORY_MAXLEN must be >= 0")
-    compact_every = int(
-        G.graph.get(
-            "HISTORY_COMPACT_EVERY", get_param(G, "HISTORY_COMPACT_EVERY")
-        )
-    )
+    if "HISTORY_COMPACT_EVERY" in G.graph:
+        compact_every = int(G.graph["HISTORY_COMPACT_EVERY"])
+    else:
+        compact_every = int(get_param(G, "HISTORY_COMPACT_EVERY"))
     if compact_every <= 0:
         raise ValueError("HISTORY_COMPACT_EVERY must be > 0")
     hist = G.graph.get("history")

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -7,7 +7,7 @@ import math
 import random
 import hashlib
 import heapq
-from functools import lru_cache
+from functools import lru_cache, cache
 import networkx as nx
 from networkx.algorithms import community as nx_comm
 
@@ -55,7 +55,7 @@ def _ensure_node_offset_map(G) -> Dict[Any, int]:
 
     nodes = list(G.nodes())
     # Use order-independent deterministic checksum based on node set
-    checksum = node_set_checksum(G)
+    checksum = node_set_checksum(G, nodes)
     mapping = G.graph.get("_node_offset_map")
     if mapping is None or G.graph.get("_node_offset_checksum") != checksum:
         if bool(G.graph.get("SORT_NODES", False)):
@@ -105,7 +105,7 @@ def clear_rng_cache() -> None:
     _cached_rng.cache_clear()
 
 
-@lru_cache()
+@cache
 def _get_NodoNX():
     """Lazy importer for ``NodoNX`` to avoid circular dependencies."""
     from .node import NodoNX

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -117,6 +117,12 @@ def _safe_graph_mapping(G, key: str) -> Optional[Dict[str, Any]]:
     return data.copy()
 
 
+def mapping_field(G, graph_key: str, out_key: str) -> Dict[str, Any]:
+    """Helper to copy mappings from ``G.graph`` into trace output."""
+    mapping = _safe_graph_mapping(G, graph_key)
+    return {out_key: mapping} if mapping is not None else {}
+
+
 # -------------------------
 # Builders
 # -------------------------
@@ -167,26 +173,15 @@ def _trace_capture(
 
 
 def gamma_field(G):
-    """Return Γ configuration.
+    """Return Γ configuration."""
 
-    The underlying mapping is shallow-copied from ``G.graph`` to avoid
-    accidental mutation.  Consumers should treat the returned dict as
-    immutable.
-    """
-
-    gam = _safe_graph_mapping(G, "GAMMA")
-    return {"gamma": gam} if gam is not None else {}
+    return mapping_field(G, "GAMMA", "gamma")
 
 
 def grammar_field(G):
-    """Return canonical grammar configuration.
+    """Return canonical grammar configuration."""
 
-    A shallow copy of ``G.graph['GRAMMAR_CANON']`` is returned and must be
-    considered read-only by callers.
-    """
-
-    gram = _safe_graph_mapping(G, "GRAMMAR_CANON")
-    return {"grammar": gram} if gram is not None else {}
+    return mapping_field(G, "GRAMMAR_CANON", "grammar")
 
 
 def selector_field(G):
@@ -195,28 +190,20 @@ def selector_field(G):
 
 
 def dnfr_weights_field(G):
-    """Return ΔNFR mix declared in the engine.
+    """Return ΔNFR mix declared in the engine."""
 
-    The mapping is copied only when present.  Treat the returned dict as
-    immutable.
-    """
-
-    mix = _safe_graph_mapping(G, "DNFR_WEIGHTS")
-    return {"dnfr_weights": mix} if mix is not None else {}
+    return mapping_field(G, "DNFR_WEIGHTS", "dnfr_weights")
 
 
 def si_weights_field(G):
-    """Return sense-plane weights and sensitivity.
+    """Return sense-plane weights and sensitivity."""
 
-    Uses shallow copies of the respective graph mappings; callers must not
-    mutate the returned dictionaries.
-    """
-
-    weights = _safe_graph_mapping(G, "_Si_weights")
-    sensitivity = _safe_graph_mapping(G, "_Si_sensitivity")
     return {
-        "si_weights": weights if weights is not None else {},
-        "si_sensitivity": sensitivity if sensitivity is not None else {},
+        **(mapping_field(G, "_Si_weights", "si_weights") or {"si_weights": {}}),
+        **(
+            mapping_field(G, "_Si_sensitivity", "si_sensitivity")
+            or {"si_sensitivity": {}}
+        ),
     }
 
 


### PR DESCRIPTION
## Summary
- Improve structured file parsing to honor subclass-specific errors and reuse node lists when hashing
- Optimize node offset mapping and simplify cached imports
- Guard history defaults, consolidate trace mapping helpers, and streamline callback registration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb9303a31883219288b668a55957ce