### PR TITLE
Improve utilities and metrics exports

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -39,7 +39,8 @@ def ensure_collection(
     """Return ``it`` if it's a ``Collection`` else materialize into ``tuple``.
 
     Strings and bytes are treated as single elements rather than iterables. If
-    ``it`` is not iterable, :class:`TypeError` is raised.
+    ``max_materialize`` es ``None``, se materializa el iterable completo sin
+    límite. Si ``it`` no es iterable, se lanza :class:`TypeError`.
     """
     if isinstance(it, Collection) and not isinstance(it, (str, bytes, bytearray)):
         return it
@@ -48,8 +49,9 @@ def ensure_collection(
     if max_materialize is not None and max_materialize < 0:
         raise ValueError("'max_materialize' must be non-negative")
     try:
-        limit = MAX_MATERIALIZE_DEFAULT if max_materialize is None else max_materialize
-        # Materialize at most ``limit`` items from the iterable
+        if max_materialize is None:
+            return tuple(it)
+        limit = max_materialize
         iterator = iter(it)
         data = tuple(islice(iterator, limit))
         extra = next(iterator, None)

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -50,6 +50,10 @@ ALIASES: Dict[str, tuple[str, ...]] = {
     "REMESH_TAU": ("REMESH_TAU_GLOBAL", "REMESH_TAU_LOCAL"),
 }
 
+_ALIAS_TARGET_TO_KEY: Dict[str, str] = {
+    target: alias for alias, targets in ALIASES.items() for target in targets
+}
+
 # -------------------------
 # Utilidades
 # -------------------------
@@ -95,14 +99,14 @@ def get_param(G, key: str):
     """Recupera parámetro desde ``G.graph`` resolviendo aliases legados."""
     if key in G.graph:
         return G.graph[key]
-    for alias, targets in ALIASES.items():
-        if key in targets and alias in G.graph:
-            warnings.warn(
-                f"'{alias}' es alias legado; usa '{key}'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return G.graph[alias]
+    alias = _ALIAS_TARGET_TO_KEY.get(key)
+    if alias and alias in G.graph:
+        warnings.warn(
+            f"'{alias}' es alias legado; usa '{key}'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return G.graph[alias]
     if key not in DEFAULTS:
         raise KeyError(f"Parámetro desconocido: '{key}'")
     return DEFAULTS[key]

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -112,7 +112,7 @@ def _cached_nodes_and_A(
 
     cache: OrderedDict = G.graph.setdefault("_dnfr_cache", OrderedDict())
     nodes_list = list(G.nodes())
-    checksum = node_set_checksum(G)
+    checksum = node_set_checksum(G, nodes_list)
 
     last_checksum = G.graph.get("_dnfr_nodes_checksum")
     if last_checksum != checksum:

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -33,6 +33,8 @@ def recent_glyph(nd: Dict[str, Any], glyph: str, window: int) -> bool:
     gl = str(glyph)
     if window < 0:
         raise ValueError("window must be >= 0")
+    if window == 0:
+        return False
 
     hist = nd.get("glyph_history")
     if not hist:

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -34,6 +34,7 @@ except ModuleNotFoundError:  # pragma: no cover
         from tomli import TOMLDecodeError  # type: ignore
     except ModuleNotFoundError:  # pragma: no cover
         tomllib = None  # type: ignore
+        TOMLDecodeError = Exception  # type: ignore[assignment]
 
 
 try:  # pragma: no cover - dependencia opcional

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -65,10 +65,12 @@ def phase_sync(G) -> float:
         return 1.0
     _, psi = kuramoto_R_psi(G)
     # varianza angular aproximada (0 = muy sincronizado)
-    diffs = (
+    diffs = [
         angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
         for _, data in G.nodes(data=True)
-    )
+    ]
+    # ``pvariance`` consumes the sequence twice; materialise to avoid repeated
+    # iteration over ``G.nodes`` when a generator is passed.
     var = pvariance(diffs)
     return 1.0 / (1.0 + var)
 

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -221,6 +221,11 @@ def play(G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None) -> N
         repeats the body and optionally forces closure with SHA/NUL.
       - Glyphs are applied via ``enforce_canonical_grammar``.
     """
+    if step_fn is None:
+        from . import dynamics
+
+        step_fn = dynamics.step
+
     ops = _flatten(sequence)
     curr_target: Optional[List[Node]] = None
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -80,12 +80,15 @@ def _sigma_from_vectors(
     """
 
     try:
-        vectors_iter = list(iter(vectors))
+        iterator = iter(vectors)
     except TypeError:
-        vectors_iter = [vectors]
+        iterator = iter([vectors])
 
-    cnt = len(vectors_iter)
-    acc = sum(vectors_iter, complex(0.0, 0.0))
+    cnt = 0
+    acc = complex(0.0, 0.0)
+    for z in iterator:
+        cnt += 1
+        acc += z
 
     if cnt <= 0:
         vec = {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": float(fallback_angle)}

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -50,10 +50,10 @@ def test_default_limit_enforced():
         ensure_collection(gen)
 
 
-def test_none_uses_default_limit():
+def test_none_disables_limit():
     gen = (i for i in range(1001))
-    with pytest.raises(ValueError):
-        ensure_collection(gen, max_materialize=None)
+    data = ensure_collection(gen, max_materialize=None)
+    assert len(data) == 1001
 
 
 def test_non_iterable_error():

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -19,6 +19,11 @@ def test_recent_glyph_window_one():
     assert recent_glyph(nd, "Y", window=1)
 
 
+def test_recent_glyph_window_zero():
+    nd = _make_node(["A", "B"], current="B")
+    assert not recent_glyph(nd, "B", window=0)
+
+
 def test_recent_glyph_history_lookup():
     nd = _make_node(["A", "B"], current="C")
     assert recent_glyph(nd, "B", window=2)


### PR DESCRIPTION
## Summary
- define TOMLDecodeError fallback when TOML libraries missing
- handle zero window in `recent_glyph` and add regression tests
- streamline dynamics, program, constants alias lookup and sigma exports
- allow unlimited materialisation in `ensure_collection`
- optimise observers and sense helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb958a4ec883219f8e701c88140983