### PR TITLE
chore: suppress unused CallbackSpec import

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -35,7 +35,7 @@ from .dynamics import step, run
 from .ontosim import preparar_red
 from .structural import create_nfr
 from .types import NodeState
-from .trace import CallbackSpec  # re-exported for tests
+from .trace import CallbackSpec  # re-exported for tests  # noqa: F401
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## Summary
- mark `CallbackSpec` import in `__init__` as intentionally unused

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbee2bca4883218a4322cf0f45ddd1