### PR TITLE
Remove unused VF derivative aliases from dynamics

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -32,8 +32,6 @@ from .constants import (
     ALIAS_SI,
     ALIAS_dEPI,
     ALIAS_D2EPI,
-    ALIAS_dVF,
-    ALIAS_D2VF,
     ALIAS_dSI,
     ALIAS_EPI_KIND,
     get_param,


### PR DESCRIPTION
## Summary
- cleanup `tnfr.dynamics` by removing unused ALIAS_dVF and ALIAS_D2VF imports

## Testing
- `python -m py_compile src/tnfr/dynamics.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbeea17a1c8321acc1466fe3c514b8