### PR TITLE
Format codebase to satisfy flake8 line length

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -25,7 +25,9 @@ except PackageNotFoundError:  # pragma: no cover
         import tomllib
         from pathlib import Path
 
-        with (Path(__file__).resolve().parents[2] / "pyproject.toml").open("rb") as f:
+        with (Path(__file__).resolve().parents[2] / "pyproject.toml").open(
+            "rb"
+        ) as f:
             __version__ = tomllib.load(f)["project"]["version"]
     except (OSError, KeyError, ValueError):  # pragma: no cover
         __version__ = "0+unknown"
@@ -45,4 +47,3 @@ __all__ = [
     "create_nfr",
     "NodeState",
 ]
-

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -140,13 +140,17 @@ def register_callback(
 
 
 def invoke_callbacks(
-    G: "nx.Graph", event: CallbackEvent | str, ctx: dict[str, Any] | None = None
+    G: "nx.Graph",
+    event: CallbackEvent | str,
+    ctx: dict[str, Any] | None = None,
 ) -> None:
     """Invoke all callbacks registered for ``event`` with context ``ctx``."""
     if isinstance(event, CallbackEvent):
         event = event.value
     cbs = _ensure_callbacks(G).get(event, [])
-    strict = bool(G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"]))
+    strict = bool(
+        G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"])
+    )
     ctx = ctx or {}
     for spec in list(cbs):
         name, fn = spec.name, spec.func

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -136,7 +136,9 @@ TOKEN_MAP: Dict[str, Callable[[Any], Any]] = {
 def _default(obj: Any) -> Any:
     if isinstance(obj, deque):
         return list(obj)
-    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+    raise TypeError(
+        f"Object of type {obj.__class__.__name__} is not JSON serializable"
+    )
 
 
 def _save_json(path: str, data: Any) -> None:
@@ -200,7 +202,9 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
 
     Examples
     --------
-    >>> ns = argparse.Namespace(grammar_enabled=True, grammar_thol_min_len=2, other=1)
+    >>> ns = argparse.Namespace(
+    ...     grammar_enabled=True, grammar_thol_min_len=2, other=1
+    ... )
     >>> _args_to_dict(ns, "grammar_")
     {'enabled': True, 'thol_min_len': 2}
     """
@@ -238,7 +242,9 @@ def _persist_history(G: "nx.Graph", args: argparse.Namespace) -> None:
 
 def build_basic_graph(args: argparse.Namespace) -> "nx.Graph":
     """Construye el grafo base a partir de los argumentos del CLI."""
-    return build_graph(n=args.nodes, topology=args.topology, seed=args.seed, p=args.p)
+    return build_graph(
+        n=args.nodes, topology=args.topology, seed=args.seed, p=args.p
+    )
 
 
 def apply_cli_config(G: "nx.Graph", args: argparse.Namespace) -> None:
@@ -278,7 +284,9 @@ def apply_cli_config(G: "nx.Graph", args: argparse.Namespace) -> None:
         }
 
 
-def register_callbacks_and_observer(G: "nx.Graph", args: argparse.Namespace) -> None:
+def register_callbacks_and_observer(
+    G: "nx.Graph", args: argparse.Namespace
+) -> None:
     """Registra callbacks y observadores estándar."""
     _attach_callbacks(G)
     if args.observer:
@@ -313,7 +321,10 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--seed", type=int, default=1)
     parser.add_argument(
-        "--p", type=float, default=None, help="Probabilidad de arista si topology=erdos"
+        "--p",
+        type=float,
+        default=None,
+        help="Probabilidad de arista si topology=erdos",
     )
     parser.add_argument(
         "--observer", action="store_true", help="Adjunta observador estándar"
@@ -342,7 +353,9 @@ def add_grammar_args(parser: argparse.ArgumentParser) -> None:
 def add_grammar_selector_args(parser: argparse.ArgumentParser) -> None:
     """Agrega las opciones de gramática y el selector de glyph."""
     add_grammar_args(parser)
-    parser.add_argument("--selector", choices=["basic", "param"], default="basic")
+    parser.add_argument(
+        "--selector", choices=["basic", "param"], default="basic"
+    )
 
 
 def add_history_export_args(parser: argparse.ArgumentParser) -> None:
@@ -365,7 +378,10 @@ def add_canon_toggle(parser: argparse.ArgumentParser) -> None:
 def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     """Configura el subcomando ``run``."""
     p_run = sub.add_parser(
-        "run", help="Correr escenario libre o preset y opcionalmente exportar history"
+        "run",
+        help=(
+            "Correr escenario libre o preset y opcionalmente exportar history"
+        ),
     )
     add_common_args(p_run)
     p_run.add_argument("--steps", type=int, default=200)
@@ -402,7 +418,9 @@ def _add_sequence_parser(sub: argparse._SubParsersAction) -> None:
 
 def _add_metrics_parser(sub: argparse._SubParsersAction) -> None:
     """Configura el subcomando ``metrics``."""
-    p_met = sub.add_parser("metrics", help="Correr breve y volcar métricas clave")
+    p_met = sub.add_parser(
+        "metrics", help="Correr breve y volcar métricas clave"
+    )
     add_common_args(p_met)
     p_met.add_argument("--steps", type=int, default=300)
     add_canon_toggle(p_met)
@@ -414,7 +432,8 @@ def _add_metrics_parser(sub: argparse._SubParsersAction) -> None:
 def run_program(
     G: Optional["nx.Graph"], program: Optional[Any], args: argparse.Namespace
 ) -> "nx.Graph":
-    """Construir el grafo si es necesario, ejecutar un programa y guardar historial."""
+    """Construir el grafo si es necesario, ejecutar un programa y
+    guardar historial."""
     if G is None:
         G = _build_graph_from_args(args)
 
@@ -432,7 +451,9 @@ def run_program(
 def _log_run_summaries(G: "nx.Graph", args: argparse.Namespace) -> None:
     """Registrar resúmenes rápidos y métricas opcionales."""
 
-    if G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get("enabled", True):
+    if G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get(
+        "enabled", True
+    ):
         Wstats = G.graph.get("history", {}).get(
             G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"]).get(
                 "stats_history_key", "W_stats"
@@ -442,7 +463,9 @@ def _log_run_summaries(G: "nx.Graph", args: argparse.Namespace) -> None:
         if Wstats:
             logger.info("[COHERENCE] último paso: %s", Wstats[-1])
 
-    if G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get("enabled", True):
+    if G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get(
+        "enabled", True
+    ):
         last_diag = G.graph.get("history", {}).get(
             G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"]).get(
                 "history_key", "nodal_diag"
@@ -474,7 +497,9 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 def cmd_sequence(args: argparse.Namespace) -> int:
     if args.preset and args.sequence_file:
-        logger.error("No se puede usar --preset y --sequence-file al mismo tiempo")
+        logger.error(
+            "No se puede usar --preset y --sequence-file al mismo tiempo"
+        )
         return 1
     program = resolve_program(
         args,
@@ -529,7 +554,9 @@ def main(argv: Optional[List[str]] = None) -> int:
             '[\n  {"WAIT": 1},\n  {"TARGET": "A"}\n]'
         ),
     )
-    p.add_argument("--version", action="store_true", help="muestra versión y sale")
+    p.add_argument(
+        "--version", action="store_true", help="muestra versión y sale"
+    )
     sub = p.add_subparsers(dest="cmd")
 
     _add_run_parser(sub)

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -30,7 +30,9 @@ __all__ = [
     "mix_groups",
 ]
 
-MAX_MATERIALIZE_DEFAULT = 1000  # default materialization limit in ensure_collection
+MAX_MATERIALIZE_DEFAULT = (
+    1000  # default materialization limit in ensure_collection
+)
 
 
 def ensure_collection(
@@ -42,7 +44,9 @@ def ensure_collection(
     ``max_materialize`` es ``None``, se materializa el iterable completo sin
     límite. Si ``it`` no es iterable, se lanza :class:`TypeError`.
     """
-    if isinstance(it, Collection) and not isinstance(it, (str, bytes, bytearray)):
+    if isinstance(it, Collection) and not isinstance(
+        it, (str, bytes, bytearray)
+    ):
         return it
     if isinstance(it, (str, bytes, bytearray)):
         return cast(Collection[T], (it,))
@@ -72,7 +76,9 @@ def normalize_weights(
     keys = list(keys)
     default_float = float(default)
 
-    weights = _convert_weights(dict_like, keys, default_float, error_on_negative)
+    weights = _convert_weights(
+        dict_like, keys, default_float, error_on_negative
+    )
     _validate_weights(weights, error_on_negative)
     return _normalize_distribution(weights, keys)
 
@@ -97,7 +103,9 @@ def _convert_weights(
     return {k: _to_float(k) for k in keys}
 
 
-def _validate_weights(weights: Mapping[str, float], error_on_negative: bool) -> None:
+def _validate_weights(
+    weights: Mapping[str, float], error_on_negative: bool
+) -> None:
     negatives = {k: v for k, v in weights.items() if v < 0}
     if not negatives:
         return
@@ -119,7 +127,9 @@ def _normalize_distribution(
     return {k: v / total for k, v in weights.items()}
 
 
-def normalize_counter(counts: Mapping[str, int]) -> tuple[Dict[str, float], int]:
+def normalize_counter(
+    counts: Mapping[str, int],
+) -> tuple[Dict[str, float], int]:
     """Normalize a ``Counter`` returning proportions and total."""
     total = sum(counts.values())
     if total <= 0:

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -34,7 +34,8 @@ IMMUTABLE_TYPES = (
 
 # Diccionario combinado exportado
 # Unimos los diccionarios en orden de menor a mayor prioridad para que los
-# valores de ``METRIC_DEFAULTS`` sobrescriban al resto, como hacía ``ChainMap``.
+# valores de ``METRIC_DEFAULTS`` sobrescriban al resto,
+# como hacía ``ChainMap``.
 _DEFAULTS_COMBINED: Dict[str, Any] = (
     CORE_DEFAULTS | INIT_DEFAULTS | REMESH_DEFAULTS | METRIC_DEFAULTS
 )
@@ -79,7 +80,9 @@ def inject_defaults(
     G.graph.setdefault("_tnfr_defaults_attached", False)
     for k, v in defaults.items():
         if override or k not in G.graph:
-            G.graph[k] = v if isinstance(v, IMMUTABLE_TYPES) else copy.deepcopy(v)
+            G.graph[k] = (
+                v if isinstance(v, IMMUTABLE_TYPES) else copy.deepcopy(v)
+            )
     G.graph["_tnfr_defaults_attached"] = True
     try:  # local import para evitar dependencia circular
         from ..operators import _ensure_node_offset_map

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -29,7 +29,12 @@ class CoreDefaults:
     VF_MAX: float = 1.0
     THETA_WRAP: bool = True
     DNFR_WEIGHTS: Dict[str, float] = field(
-        default_factory=lambda: {"phase": 0.34, "epi": 0.33, "vf": 0.33, "topo": 0.0}
+        default_factory=lambda: {
+            "phase": 0.34,
+            "epi": 0.33,
+            "vf": 0.33,
+            "topo": 0.0,
+        }
     )
     SI_WEIGHTS: Dict[str, float] = field(
         default_factory=lambda: {"alpha": 0.34, "beta": 0.33, "gamma": 0.33}

--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -11,7 +11,11 @@ from types import MappingProxyType
 class MetricDefaults:
     PHASE_HISTORY_MAXLEN: int = 50
     STOP_EARLY: Dict[str, Any] = field(
-        default_factory=lambda: {"enabled": False, "window": 25, "fraction": 0.90}
+        default_factory=lambda: {
+            "enabled": False,
+            "window": 25,
+            "fraction": 0.90,
+        }
     )
     SIGMA: Dict[str, Any] = field(
         default_factory=lambda: {

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -24,7 +24,11 @@ def _ensure_kuramoto_cache(G, t) -> None:
     edge_version = int(G.graph.get("_edge_version", 0))
     nodes_sig = (len(G), checksum, edge_version)
     cache = G.graph.get("_kuramoto_cache")
-    if cache is None or cache.get("t") != t or cache.get("nodes_sig") != nodes_sig:
+    if (
+        cache is None
+        or cache.get("t") != t
+        or cache.get("nodes_sig") != nodes_sig
+    ):
         R, psi = kuramoto_R_psi(G)
         G.graph["_kuramoto_cache"] = {
             "t": t,
@@ -67,7 +71,9 @@ def _kuramoto_common(G, node, _cfg):
 # -----------------
 
 
-def _gamma_params(cfg: Mapping[str, Any], **defaults: float) -> tuple[float, ...]:
+def _gamma_params(
+    cfg: Mapping[str, Any], **defaults: float
+) -> tuple[float, ...]:
     """Return normalized Γ parameters from ``cfg``.
 
     Parameters are retrieved from ``cfg`` using the keys in ``defaults`` and
@@ -79,7 +85,9 @@ def _gamma_params(cfg: Mapping[str, Any], **defaults: float) -> tuple[float, ...
     >>> beta, R0 = _gamma_params(cfg, beta=0.0, R0=0.0)
     """
 
-    return tuple(float(cfg.get(name, default)) for name, default in defaults.items())
+    return tuple(
+        float(cfg.get(name, default)) for name, default in defaults.items()
+    )
 
 
 # -----------------
@@ -99,7 +107,8 @@ def gamma_kuramoto_linear(G, node, t, cfg: Dict[str, Any]) -> float:
       - ψ is the mean phase (coordination direction).
       - β, R0 are parameters (gain/threshold).
 
-    Use: reinforces integration when the network already shows phase coherence (R>R0).
+    Use: reinforces integration when the network already shows phase
+    coherence (R>R0).
     """
     beta, R0 = _gamma_params(cfg, beta=0.0, R0=0.0)
     th_i, R, psi = _kuramoto_common(G, node, cfg)
@@ -160,12 +169,13 @@ def eval_gamma(
     strict: bool = False,
     log_level: int | None = None,
 ) -> float:
-    """Evaluate Γi for ``node`` according to ``G.graph['GAMMA']`` specification.
+    """Evaluate Γi for ``node`` according to ``G.graph['GAMMA']``
+    specification.
 
     If ``strict`` is ``True`` exceptions raised during evaluation are
     propagated instead of returning ``0.0``. Likewise, if the specified
-    Γ type is not registered a warning is emitted (or ``ValueError`` in
-    strict mode) and ``gamma_none`` is used.
+    Γ type is not registered a warning is emitted (o ``ValueError`` en
+    modo estricto) y se usa ``gamma_none``.
 
     ``log_level`` controls the logging level for captured errors when
     ``strict`` is ``False``. If omitted, ``logging.ERROR`` is used in

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -86,7 +86,10 @@ class HistoryDict(dict):
 
     def _maybe_compact(self) -> None:
         self._ops += 1
-        if self._ops >= self._compact_every and len(self._heap) > len(self) * 2:
+        if (
+            self._ops >= self._compact_every
+            and len(self._heap) > len(self) * 2
+        ):
             self._compact_heap()
             self._ops = 0
 
@@ -96,7 +99,9 @@ class HistoryDict(dict):
         heapq.heappush(self._heap, (cnt, key))
         self._maybe_compact()
 
-    def _get_and_increment(self, key: str, default: Any = None, *, missing: bool = False):
+    def _get_and_increment(
+        self, key: str, default: Any = None, *, missing: bool = False
+    ):
         if not missing:
             val = super().__getitem__(key)
         else:
@@ -185,7 +190,9 @@ def last_glyph(nd: Dict[str, Any]) -> str | None:
     return hist[-1] if hist else None
 
 
-def count_glyphs(G, window: int | None = None, *, last_only: bool = False) -> Counter:
+def count_glyphs(
+    G, window: int | None = None, *, last_only: bool = False
+) -> Counter:
     """Count recent glyphs in the network.
 
     If ``window`` is ``None``, the full history for each node is used. When

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -226,8 +226,12 @@ def enforce_canonical_grammar(G, n, cand: str) -> str:
 
     original = cand
     cand = _check_repeats(G, n, cand, cfg_soft)
-    cand = _check_force(G, n, cand, original, cfg_soft, _dnfr_norm, "force_dnfr")
-    cand = _check_force(G, n, cand, original, cfg_soft, _accel_norm, "force_accel")
+    cand = _check_force(
+        G, n, cand, original, cfg_soft, _dnfr_norm, "force_dnfr"
+    )
+    cand = _check_force(
+        G, n, cand, original, cfg_soft, _accel_norm, "force_accel"
+    )
     cand = _check_oz_to_zhir(G, n, cand, cfg_canon)
     cand = _check_thol_closure(G, n, cand, cfg_canon, st)
     cand = _check_compatibility(G, n, cand)
@@ -257,7 +261,10 @@ def on_applied_glyph(G, n, applied: str) -> None:
 
 
 def apply_glyph_with_grammar(
-    G, nodes: Optional[Iterable[Any]], glyph: Glyph | str, window: Optional[int] = None
+    G,
+    nodes: Optional[Iterable[Any]],
+    glyph: Glyph | str,
+    window: Optional[int] = None,
 ) -> None:
     """Apply ``glyph`` to ``nodes`` enforcing the canonical grammar.
 
@@ -277,4 +284,3 @@ def apply_glyph_with_grammar(
         g_eff = enforce_canonical_grammar(G, n, g_str)
         apply_glyph(G, n, g_eff, window=window)
         on_applied_glyph(G, n, g_eff)
-

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -179,10 +179,10 @@ def ensure_parent(path: str | Path) -> None:
 def _stable_json(obj: Any) -> Any:
     """Helper to obtain a JSON-serialisable structure for ``obj``.
 
-    The default :func:`json.dumps` behaviour falls back to ``obj.__dict__`` when
-    available and otherwise uses ``repr(obj)`` which may include memory
-    addresses.  This function walks basic containers and objects to build a
-    representation that avoids such non-deterministic data.
+    The default :func:`json.dumps` behaviour falls back to ``obj.__dict__``
+    when available and otherwise uses ``repr(obj)`` which may include
+    memory addresses. This function walks basic containers and objects to
+    build a representation that avoids such non-deterministic data.
     """
 
     if isinstance(obj, (str, int, float, bool)) or obj is None:
@@ -196,7 +196,9 @@ def _stable_json(obj: Any) -> Any:
     return f"{obj.__module__}.{obj.__class__.__qualname__}"
 
 
-def node_set_checksum(G: "nx.Graph", nodes: Iterable[Any] | None = None) -> str:
+def node_set_checksum(
+    G: "nx.Graph", nodes: Iterable[Any] | None = None
+) -> str:
     """Devuelve el SHA1 del conjunto de nodos de ``G`` ordenado.
 
     ``nodes`` permite reutilizar una colección ya obtenida para evitar recorrer
@@ -211,7 +213,10 @@ def node_set_checksum(G: "nx.Graph", nodes: Iterable[Any] | None = None) -> str:
 
     def serialise(n: Any) -> str:
         return json.dumps(
-            _stable_json(n), sort_keys=True, ensure_ascii=False, separators=(",", ":")
+            _stable_json(n),
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
         )
 
     node_iter = nodes if nodes is not None else G.nodes()
@@ -342,15 +347,17 @@ def alias_get(
     strict: bool = False,
     log_level: int | None = None,
 ) -> Optional[T]:
-    """Busca en ``d`` la primera clave de ``aliases`` y retorna el valor convertido.
+    """Busca en ``d`` la primera clave de ``aliases`` y retorna el valor
+    convertido.
 
-    ``aliases`` puede ser cualquier secuencia de strings. Si no es una tupla
-    inmutable, se validará internamente mediante :func:`_validate_aliases`.
-    ``_validate_aliases`` garantiza que la secuencia no esté vacía y que todos
-    sus elementos sean strings.
+    ``aliases`` puede ser cualquier secuencia de strings. Si no es una
+    tupla inmutable, se validará internamente mediante
+    :func:`_validate_aliases`. ``_validate_aliases`` garantiza que la
+    secuencia no esté vacía y que todos sus elementos sean strings.
 
-    Si ninguna de las claves está presente o la conversión falla, devuelve
-    ``default`` convertido (o ``None`` si ``default`` es ``None``).
+    Si ninguna de las claves está presente o la conversión falla,
+    devuelve ``default`` convertido (o ``None`` si ``default`` es
+    ``None``).
 
     ``log_level`` permite ajustar el nivel de logging cuando la conversión
     falla en modo laxo.
@@ -373,10 +380,11 @@ def alias_set(
     conv: Callable[[Any], T],
     value: Any,
 ) -> T:
-    """Asigna ``value`` convertido a la primera clave disponible de ``aliases``.
+    """Asigna ``value`` convertido a la primera clave disponible de
+    ``aliases``.
 
-    ``aliases`` puede ser cualquier secuencia de strings. Si no es una tupla,
-    se validará internamente mediante :func:`_validate_aliases`.
+    ``aliases`` puede ser cualquier secuencia de strings. Si no es una
+    tupla, se validará internamente mediante :func:`_validate_aliases`.
     """
     if not isinstance(aliases, tuple):
         aliases = _validate_aliases(aliases)
@@ -398,8 +406,7 @@ class _Getter(Protocol[T]):
         *,
         strict: bool = False,
         log_level: int | None = None,
-    ) -> T:
-        ...
+    ) -> T: ...
 
     @overload
     def __call__(
@@ -410,8 +417,7 @@ class _Getter(Protocol[T]):
         *,
         strict: bool = False,
         log_level: int | None = None,
-    ) -> Optional[T]:
-        ...
+    ) -> Optional[T]: ...
 
 
 @overload
@@ -516,11 +522,15 @@ def _recompute_abs_max(G, aliases: tuple[str, ...]):
         key=lambda m: abs(get_attr(G.nodes[m], aliases, 0.0)),
         default=None,
     )
-    max_val = abs(get_attr(G.nodes[node], aliases, 0.0)) if node is not None else 0.0
+    max_val = (
+        abs(get_attr(G.nodes[node], aliases, 0.0)) if node is not None else 0.0
+    )
     return max_val, node
 
 
-def _update_cached_abs_max(G, aliases: tuple[str, ...], n, value, *, key: str) -> None:
+def _update_cached_abs_max(
+    G, aliases: tuple[str, ...], n, value, *, key: str
+) -> None:
     """Actualiza ``G.graph[key]`` y ``G.graph[f"{key}_node"]``."""
     node_key = f"{key}_node"
     val = abs(value)
@@ -604,7 +614,9 @@ def compute_coherence(G) -> float:
 # -------------------------
 
 
-def neighbor_mean(G, n, aliases: tuple[str, ...], default: float = 0.0) -> float:
+def neighbor_mean(
+    G, n, aliases: tuple[str, ...], default: float = 0.0
+) -> float:
     """Mean of ``aliases`` attribute among neighbours of ``n``."""
     vals = (get_attr(G.nodes[v], aliases, default) for v in G.neighbors(n))
     return list_mean(vals, default)
@@ -614,7 +626,8 @@ def neighbor_phase_mean(obj, n=None) -> float:
     """Promedio circular de las fases vecinales.
 
     Acepta un :class:`NodoProtocol` o un par ``(G, n)`` de ``networkx``. En el
-    segundo caso se envuelve en :class:`NodoNX` para reutilizar la misma lógica.
+    segundo caso se envuelve en :class:`NodoNX` para reutilizar la misma
+    lógica.
     """
 
     from .node import NodoNX  # importación local para evitar ciclo
@@ -630,7 +643,9 @@ def neighbor_phase_mean(obj, n=None) -> float:
         if hasattr(v, "theta"):
             th = getattr(v, "theta", 0.0)
         else:
-            th = NodoNX.from_graph(node.G, v).theta  # type: ignore[attr-defined]
+            th = NodoNX.from_graph(
+                node.G, v
+            ).theta  # type: ignore[attr-defined]
         x += math.cos(th)
         y += math.sin(th)
         count += 1

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -102,15 +102,25 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
         G.graph.get("INIT_RANDOM_PHASE", INIT_DEFAULTS["INIT_RANDOM_PHASE"])
     )
 
-    th_min = float(G.graph.get("INIT_THETA_MIN", INIT_DEFAULTS["INIT_THETA_MIN"]))
-    th_max = float(G.graph.get("INIT_THETA_MAX", INIT_DEFAULTS["INIT_THETA_MAX"]))
+    th_min = float(
+        G.graph.get("INIT_THETA_MIN", INIT_DEFAULTS["INIT_THETA_MIN"])
+    )
+    th_max = float(
+        G.graph.get("INIT_THETA_MAX", INIT_DEFAULTS["INIT_THETA_MAX"])
+    )
 
-    vf_mode = str(G.graph.get("INIT_VF_MODE", INIT_DEFAULTS["INIT_VF_MODE"])).lower()
+    vf_mode = str(
+        G.graph.get("INIT_VF_MODE", INIT_DEFAULTS["INIT_VF_MODE"])
+    ).lower()
     vf_min_lim = float(G.graph.get("VF_MIN", DEFAULTS["VF_MIN"]))
     vf_max_lim = float(G.graph.get("VF_MAX", DEFAULTS["VF_MAX"]))
 
-    vf_uniform_min = G.graph.get("INIT_VF_MIN", INIT_DEFAULTS.get("INIT_VF_MIN"))
-    vf_uniform_max = G.graph.get("INIT_VF_MAX", INIT_DEFAULTS.get("INIT_VF_MAX"))
+    vf_uniform_min = G.graph.get(
+        "INIT_VF_MIN", INIT_DEFAULTS.get("INIT_VF_MIN")
+    )
+    vf_uniform_max = G.graph.get(
+        "INIT_VF_MAX", INIT_DEFAULTS.get("INIT_VF_MAX")
+    )
     if vf_uniform_min is None:
         vf_uniform_min = vf_min_lim
     if vf_uniform_max is None:
@@ -123,7 +133,9 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
     vf_mean = float(G.graph.get("INIT_VF_MEAN", INIT_DEFAULTS["INIT_VF_MEAN"]))
     vf_std = float(G.graph.get("INIT_VF_STD", INIT_DEFAULTS["INIT_VF_STD"]))
     clamp_to_limits = bool(
-        G.graph.get("INIT_VF_CLAMP_TO_LIMITS", INIT_DEFAULTS["INIT_VF_CLAMP_TO_LIMITS"])
+        G.graph.get(
+            "INIT_VF_CLAMP_TO_LIMITS", INIT_DEFAULTS["INIT_VF_CLAMP_TO_LIMITS"]
+        )
     )
 
     si_min = float(G.graph.get("INIT_SI_MIN", 0.4))

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -152,7 +152,9 @@ def coherence_matrix(G):
             if key in seen:
                 continue
             seen.add(key)
-            wij = _combine_components(wnorm, G, u, v, epi_min, epi_max, vf_min, vf_max)
+            wij = _combine_components(
+                wnorm, G, u, v, epi_min, epi_max, vf_min, vf_max
+            )
             add_entry(i, j, wij)
             add_entry(j, i, wij)
     else:
@@ -184,7 +186,9 @@ def coherence_matrix(G):
     return nodes, W
 
 
-def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=None):
+def local_phase_sync_weighted(
+    G, n, nodes_order=None, W_row=None, node_to_index=None
+):
     cfg = G.graph.get("COHERENCE", COHERENCE)
     scope = str(cfg.get("scope", "neighbors")).lower()
     neighbors_only = scope != "all"
@@ -193,7 +197,9 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
     if W_row is None or nodes_order is None:
         vec = [
             cmath.exp(1j * get_attr(G.nodes[v], ALIAS_THETA, 0.0))
-            for v in (G.neighbors(n) if neighbors_only else (set(G.nodes()) - {n}))
+            for v in (
+                G.neighbors(n) if neighbors_only else (set(G.nodes()) - {n})
+            )
         ]
         if not vec:
             return 0.0
@@ -220,7 +226,11 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
     if i is None:
         i = nodes_order.index(n)
 
-    if isinstance(W_row, list) and W_row and isinstance(W_row[0], (int, float)):
+    if (
+        isinstance(W_row, list)
+        and W_row
+        and isinstance(W_row[0], (int, float))
+    ):
         weights = W_row
     else:
         weights = [0.0] * len(nodes_order)

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -74,7 +74,9 @@ def _update_coherence(G, hist) -> None:
     C = compute_coherence(G)
     hist.setdefault("C_steps", []).append(C)
 
-    wbar_w = int(G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25)))
+    wbar_w = int(
+        G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25))
+    )
     cs = hist["C_steps"]
     if cs:
         w = min(len(cs), max(1, wbar_w))
@@ -94,9 +96,13 @@ def _update_phase_sync(G, hist) -> None:
 def _update_sigma(G, hist) -> None:
     """Registrar carga glífica y vector Σ⃗ asociado."""
 
-    win = int(G.graph.get("GLYPH_LOAD_WINDOW", METRIC_DEFAULTS["GLYPH_LOAD_WINDOW"]))
+    win = int(
+        G.graph.get("GLYPH_LOAD_WINDOW", METRIC_DEFAULTS["GLYPH_LOAD_WINDOW"])
+    )
     gl = glyph_load(G, window=win)
-    hist.setdefault("glyph_load_estab", []).append(gl.get("_estabilizadores", 0.0))
+    hist.setdefault("glyph_load_estab", []).append(
+        gl.get("_estabilizadores", 0.0)
+    )
     hist.setdefault("glyph_load_disr", []).append(gl.get("_disruptivos", 0.0))
 
     dist = {k: v for k, v in gl.items() if not k.startswith("_")}
@@ -170,9 +176,11 @@ def _update_glyphogram(G, hist, counts, t, n_total):
     )
     row = {"t": t}
     total = max(1, n_total)
+
     def add_row(g):
         c = counts.get(g, 0)
         row[g] = (c / total) if normalize_series else c
+
     for_each_glyph(add_row)
     hist.setdefault("glyphogram", []).append(row)
 
@@ -235,7 +243,9 @@ def _metrics_step(G, *args, **kwargs):
     dt = float(G.graph.get("DT", 1.0))
     t = float(G.graph.get("_t", 0.0))
     thr = float(
-        G.graph.get("EPI_SUPPORT_THR", METRIC_DEFAULTS.get("EPI_SUPPORT_THR", 0.0))
+        G.graph.get(
+            "EPI_SUPPORT_THR", METRIC_DEFAULTS.get("EPI_SUPPORT_THR", 0.0)
+        )
     )
 
     # -- Métricas básicas heredadas de ``dynamics`` --
@@ -311,7 +321,8 @@ def _metrics_step(G, *args, **kwargs):
 
     try:
         sis = [
-            get_attr(nd, ALIAS_SI, float("nan")) for _, nd in G.nodes(data=True)
+            get_attr(nd, ALIAS_SI, float("nan"))
+            for _, nd in G.nodes(data=True)
         ]
         sis = [s for s in sis if not math.isnan(s)]
         if sis:
@@ -351,7 +362,9 @@ def _metrics_step(G, *args, **kwargs):
 
 
 def register_metrics_callbacks(G) -> None:
-    register_callback(G, event="after_step", func=_metrics_step, name="metrics_step")
+    register_callback(
+        G, event="after_step", func=_metrics_step, name="metrics_step"
+    )
     # Nuevas funcionalidades canónicas
     register_coherence_callbacks(G)
     register_diagnosis_callbacks(G)
@@ -369,14 +382,18 @@ def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
     tg_total: Dict[str, float] = hist.tracked_get("Tg_total", {})
     total = sum(tg_total.values()) or 1.0
     out: Dict[str, float] = {}
+
     def add(g):
         val = float(tg_total.get(g, 0.0))
         out[g] = val / total if normalize else val
+
     for_each_glyph(add)
     return out
 
 
-def Tg_by_node(G, n, normalize: bool = False) -> Dict[str, float | List[float]]:
+def Tg_by_node(
+    G, n, normalize: bool = False
+) -> Dict[str, float | List[float]]:
     """Per-node summary: if ``normalize`` return mean run per glyph;
     otherwise list runs."""
     hist = ensure_history(G)
@@ -384,14 +401,18 @@ def Tg_by_node(G, n, normalize: bool = False) -> Dict[str, float | List[float]]:
     if not normalize:
         # convertir default dict → list para serializar
         out: Dict[str, List[float]] = {}
+
         def copy_runs(g):
             out[g] = list(rec.get(g, []))
+
         for_each_glyph(copy_runs)
         return out
     out: Dict[str, float] = {}
+
     def add(g):
         runs = rec.get(g, [])
         out[g] = float(mean(runs)) if runs else 0.0
+
     for_each_glyph(add)
     return out
 
@@ -411,8 +432,10 @@ def glyphogram_series(G) -> Dict[str, List[float]]:
     if not xs:
         return {"t": []}
     out = {"t": [float(x.get("t", i)) for i, x in enumerate(xs)]}
+
     def add(g):
         out[g] = [float(x.get(g, 0.0)) for x in xs]
+
     for_each_glyph(add)
     return out
 
@@ -428,6 +451,7 @@ def glyph_dwell_stats(G, n) -> Dict[str, Dict[str, float]]:
     hist = ensure_history(G)
     rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
     out: Dict[str, Dict[str, float]] = {}
+
     def add(g):
         runs = list(rec.get(g, []))
         if not runs:
@@ -439,5 +463,6 @@ def glyph_dwell_stats(G, n) -> Dict[str, Dict[str, float]]:
                 "max": float(max(runs)),
                 "count": int(len(runs)),
             }
+
     for_each_glyph(add)
     return out

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -31,7 +31,9 @@ def _dnfr_norm(nd, dnfr_max):
     return 1.0 if x > 1 else x
 
 
-def _symmetry_index(G, n, epi_min: float | None = None, epi_max: float | None = None):
+def _symmetry_index(
+    G, n, epi_min: float | None = None, epi_max: float | None = None
+):
     """Compute the symmetry index for node ``n`` based on EPI values."""
     nd = G.nodes[n]
     epi_i = get_attr(nd, ALIAS_EPI, 0.0)
@@ -57,9 +59,11 @@ def _state_from_thresholds(Rloc, dnfr_n, cfg):
 
 def _recommendation(state, cfg):
     adv = cfg.get("advice", {})
-    key = {"estable": "stable", "transicion": "transition", "disonante": "dissonant"}[
-        state
-    ]
+    key = {
+        "estable": "stable",
+        "transicion": "transition",
+        "disonante": "dissonant",
+    }[state]
     return list(adv.get(key, []))
 
 

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -72,7 +72,11 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
         raise ValueError(f"Formato de exportación no soportado: {fmt}")
     if fmt == "csv":
         specs = [
-            ("_glyphogram.csv", ["t", *GLYPHS_CANONICAL], _iter_glif_rows(glyph)),
+            (
+                "_glyphogram.csv",
+                ["t", *GLYPHS_CANONICAL],
+                _iter_glif_rows(glyph),
+            ),
             (
                 "_sigma.csv",
                 ["t", "x", "y", "mag", "angle"],

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -196,7 +196,9 @@ class NodoTNFR:
     graph: Dict[str, object] = field(default_factory=dict)
     _neighbors: Dict["NodoTNFR", float] = field(default_factory=dict)
     _glyph_history: Deque[str] = field(
-        default_factory=lambda: deque(maxlen=DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 7))
+        default_factory=lambda: deque(
+            maxlen=DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 7)
+        )
     )
 
     def neighbors(self) -> Iterable["NodoTNFR"]:
@@ -210,7 +212,11 @@ class NodoTNFR:
         return self._neighbors.get(other, 0.0)
 
     def add_edge(
-        self, other: "NodoTNFR", weight: float = 1.0, *, overwrite: bool = False
+        self,
+        other: "NodoTNFR",
+        weight: float = 1.0,
+        *,
+        overwrite: bool = False,
     ) -> None:
         """Connect this node with ``other``."""
 
@@ -251,7 +257,9 @@ class NodoNX(NodoProtocol):
         to_python=str,
         to_storage=str,
     )
-    dnfr = _nx_attr_property(ALIAS_DNFR, setter=set_dnfr, use_graph_setter=True)
+    dnfr = _nx_attr_property(
+        ALIAS_DNFR, setter=set_dnfr, use_graph_setter=True
+    )
     d2EPI = _nx_attr_property(ALIAS_D2EPI)
 
     @classmethod

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -106,7 +106,9 @@ def wbar(G, window: int | None = None) -> float:
         # fallback: coherencia instantánea
         return compute_coherence(G)
     if window is None:
-        window = int(G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25)))
+        window = int(
+            G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25))
+        )
     w = min(len(cs), max(1, int(window)))
     if isinstance(cs, list):
         tail = cs[-w:]

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -41,7 +41,9 @@ def preparar_red(
         merge_overrides(G, **overrides)
     # Inicializaciones blandas
     ph_len = int(
-        G.graph.get("PHASE_HISTORY_MAXLEN", METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"])
+        G.graph.get(
+            "PHASE_HISTORY_MAXLEN", METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"]
+        )
     )
     G.graph.setdefault(
         "history",

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -26,10 +26,12 @@ _PRESETS = {
     "ejemplo_canonico": basic_canonical_example(),
     # Topologías fractales: expansión/contracción modular
     "fractal_expand": seq(
-        block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL), Glyph.RA
+        block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL),
+        Glyph.RA,
     ),
     "fractal_contract": seq(
-        block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA), Glyph.RA
+        block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA),
+        Glyph.RA,
     ),
 }
 

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -1,7 +1,17 @@
 """TNFR programming language."""
 
 from __future__ import annotations
-from typing import Any, Callable, Deque, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 from dataclasses import dataclass
 from contextlib import contextmanager
 from collections import deque
@@ -56,7 +66,9 @@ class THOL:
 
     body: Sequence[Any]
     repeat: int = 1  # number of times to repeat the body
-    force_close: Optional[Glyph] = None  # None → automatic closure; SHA or NUL to force
+    force_close: Optional[Glyph] = (
+        None  # None → automatic closure; SHA or NUL to force
+    )
 
 
 Token = Union[Glyph, WAIT, TARGET, THOL]
@@ -67,7 +79,6 @@ THOL_SENTINEL = object()
 # ---------------------
 # Internal utilities
 # ---------------------
-
 
 
 def _window(G) -> int:
@@ -88,7 +99,9 @@ def _all_nodes(G):
 # ---------------------
 
 
-def _apply_glyph_to_targets(G, g: Glyph | str, nodes: Optional[Iterable[Node]] = None):
+def _apply_glyph_to_targets(
+    G, g: Glyph | str, nodes: Optional[Iterable[Node]] = None
+):
     """Apply ``g`` to ``nodes`` (or all nodes) respecting the grammar.
 
     ``nodes`` may be any iterable of nodes, including a ``NodeView`` or other
@@ -134,7 +147,9 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
             continue
         if isinstance(item, THOL):
             repeats = max(1, int(item.repeat))
-            if item.force_close is not None and not isinstance(item.force_close, Glyph):
+            if item.force_close is not None and not isinstance(
+                item.force_close, Glyph
+            ):
                 raise ValueError("force_close must be a Glyph")
             closing = (
                 item.force_close
@@ -211,12 +226,15 @@ def _handle_glyph(
 # ---------------------
 
 
-def play(G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None) -> None:
+def play(
+    G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None
+) -> None:
     """Execute a canonical sequence on graph ``G``.
 
     Rules:
       - Use ``TARGET(nodes=...)`` to change the subset of application.
-      - ``WAIT(k)`` advances ``k`` steps with the current selector (no forced glyph).
+      - ``WAIT(k)`` advances ``k`` steps with the current selector
+        (no forced glyph).
       - ``THOL([...], repeat=r, force_close=…)`` opens a self-organising block,
         repeats the body and optionally forces closure with SHA/NUL.
       - Glyphs are applied via ``enforce_canonical_grammar``.
@@ -262,7 +280,9 @@ def seq(*tokens: Token) -> List[Token]:
     return list(tokens)
 
 
-def block(*tokens: Token, repeat: int = 1, close: Optional[Glyph] = None) -> THOL:
+def block(
+    *tokens: Token, repeat: int = 1, close: Optional[Glyph] = None
+) -> THOL:
     return THOL(body=list(tokens), repeat=repeat, force_close=close)
 
 
@@ -279,4 +299,6 @@ def basic_canonical_example() -> List[Token]:
 
     SHA → AL → RA → ZHIR → NUL → THOL
     """
-    return seq(Glyph.SHA, Glyph.AL, Glyph.RA, Glyph.ZHIR, Glyph.NUL, Glyph.THOL)
+    return seq(
+        Glyph.SHA, Glyph.AL, Glyph.RA, Glyph.ZHIR, Glyph.NUL, Glyph.THOL
+    )

--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -33,7 +33,8 @@ def build_graph(
     else:
         valid = ["ring", "complete", "erdos"]
         raise ValueError(
-            f"Invalid topology '{topology}'. Valid options are: {', '.join(valid)}"
+            f"Invalid topology '{topology}'. "
+            f"Valid options are: {', '.join(valid)}"
         )
 
     # Valores canónicos para inicialización

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -34,7 +34,9 @@ def _selector_thresholds(G: "nx.Graph") -> dict:
     glyph_defaults = DEFAULTS.get("GLYPH_THRESHOLDS", {})
     thr_def = {**glyph_defaults, **G.graph.get("GLYPH_THRESHOLDS", {})}
 
-    def _get_threshold(key: str, default: float, legacy: str | None = None) -> float:
+    def _get_threshold(
+        key: str, default: float, legacy: str | None = None
+    ) -> float:
         """Obtiene ``key`` de ``thr_sel`` respetando claves de legado.
 
         Si ``legacy`` se proporciona se usa ``thr_def`` como respaldo,
@@ -52,40 +54,53 @@ def _selector_thresholds(G: "nx.Graph") -> dict:
         (
             "si_hi",
             thr_def.get(
-                "hi", glyph_defaults.get("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"])
+                "hi",
+                glyph_defaults.get("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"]),
             ),
             "hi",
         ),
         (
             "si_lo",
             thr_def.get(
-                "lo", glyph_defaults.get("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"])
+                "lo",
+                glyph_defaults.get("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"]),
             ),
             "lo",
         ),
         (
             "dnfr_hi",
-            sel_defaults.get("dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]),
+            sel_defaults.get(
+                "dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]
+            ),
             None,
         ),
         (
             "dnfr_lo",
-            sel_defaults.get("dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]),
+            sel_defaults.get(
+                "dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]
+            ),
             None,
         ),
         (
             "accel_hi",
-            sel_defaults.get("accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]),
+            sel_defaults.get(
+                "accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]
+            ),
             None,
         ),
         (
             "accel_lo",
-            sel_defaults.get("accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]),
+            sel_defaults.get(
+                "accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]
+            ),
             None,
         ),
     ]
 
-    return {key: _get_threshold(key, default, legacy) for key, default, legacy in specs}
+    return {
+        key: _get_threshold(key, default, legacy)
+        for key, default, legacy in specs
+    }
 
 
 def _norms_para_selector(G: "nx.Graph") -> dict:
@@ -115,7 +130,8 @@ def _apply_selector_hysteresis(
     thr: Dict[str, float],
     margin: float,
 ) -> str | None:
-    """Aplica histéresis devolviendo el glyph previo si se está cerca de umbrales."""
+    """Aplica histéresis devolviendo el glyph previo si se está cerca de
+    umbrales."""
     d_si = min(abs(Si - thr["si_hi"]), abs(Si - thr["si_lo"]))
     d_dn = min(abs(dnfr - thr["dnfr_hi"]), abs(dnfr - thr["dnfr_lo"]))
     d_ac = min(abs(accel - thr["accel_hi"]), abs(accel - thr["accel_lo"]))

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -79,7 +79,9 @@ def _sigma_from_vectors(
     ``vectors`` may be a single complex number or an iterable of them.
     """
 
-    iterator = iter(vectors) if isinstance(vectors, Iterable) else iter([vectors])
+    iterator = (
+        iter(vectors) if isinstance(vectors, Iterable) else iter([vectors])
+    )
 
     cnt = 0
     acc = complex(0.0, 0.0)
@@ -94,7 +96,12 @@ def _sigma_from_vectors(
     x, y = acc.real / cnt, acc.imag / cnt
     mag = math.hypot(x, y)
     ang = math.atan2(y, x) if mag > 0 else float(fallback_angle)
-    vec = {"x": float(x), "y": float(y), "mag": float(mag), "angle": float(ang)}
+    vec = {
+        "x": float(x),
+        "y": float(y),
+        "mag": float(mag),
+        "angle": float(ang),
+    }
     return vec, cnt
 
 
@@ -107,7 +114,9 @@ def _sigma_from_pairs(
     return _sigma_from_vectors(vectors, fallback_angle)
 
 
-def sigma_vector_node(G, n, weight_mode: str | None = None) -> Dict[str, float] | None:
+def sigma_vector_node(
+    G, n, weight_mode: str | None = None
+) -> Dict[str, float] | None:
     cfg = _sigma_cfg(G)
     nd = G.nodes[n]
     nw = _node_weight(nd, weight_mode or cfg.get("weight", "Si"))

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -20,7 +20,9 @@ class _KuramotoFn(Protocol):
 
 
 class _SigmaVectorFn(Protocol):
-    def __call__(self, G: Any, weight_mode: str | None = None) -> Dict[str, float]: ...
+    def __call__(
+        self, G: Any, weight_mode: str | None = None
+    ) -> Dict[str, float]: ...
 
 
 class CallbackSpec(NamedTuple):
@@ -68,7 +70,9 @@ __all__ = [
 
 def _trace_setup(
     G,
-) -> tuple[Optional[Dict[str, Any]], set[str], Optional[Dict[str, Any]], Optional[str]]:
+) -> tuple[
+    Optional[Dict[str, Any]], set[str], Optional[Dict[str, Any]], Optional[str]
+]:
     """Common configuration for trace snapshots.
 
     Returns the active configuration, capture set, history and key under
@@ -131,7 +135,9 @@ def mapping_field(G, graph_key: str, out_key: str) -> Dict[str, Any]:
 
 def _new_trace_meta(
     G, phase: str
-) -> Optional[tuple[Dict[str, Any], set[str], Optional[Dict[str, Any]], Optional[str]]]:
+) -> Optional[
+    tuple[Dict[str, Any], set[str], Optional[Dict[str, Any]], Optional[str]]
+]:
     """Initialise trace metadata for a ``phase``.
 
     Wraps :func:`_trace_setup` and creates the base structure with timestamp
@@ -200,7 +206,9 @@ def si_weights_field(G):
     """Return sense-plane weights and sensitivity."""
 
     return {
-        **(mapping_field(G, "_Si_weights", "si_weights") or {"si_weights": {}}),
+        **(
+            mapping_field(G, "_Si_weights", "si_weights") or {"si_weights": {}}
+        ),
         **(
             mapping_field(G, "_Si_sensitivity", "si_sensitivity")
             or {"si_sensitivity": {}}
@@ -284,16 +292,18 @@ def _trace_after(G, *args, **kwargs):
 
 
 def register_trace(G) -> None:
-    """Enable before/after-step snapshots and dump operational metadata to history.
+    """Enable before/after-step snapshots and dump operational metadata
+    to history.
 
-    Stores in ``G.graph['history'][TRACE.history_key]`` a list of entries
-    ``{'phase': 'before'|'after', ...}`` with:
+    Stores in ``G.graph['history'][TRACE.history_key]`` a list of
+    entries ``{'phase': 'before'|'after', ...}`` with:
       - gamma: active Γi(R) specification
       - grammar: canonical grammar configuration
       - selector: glyph selector name
       - dnfr_weights: ΔNFR mix declared in the engine
       - si_weights: α/β/γ weights and Si sensitivity
-      - callbacks: callbacks registered per phase (if in ``G.graph['callbacks']``)
+      - callbacks: callbacks registered per phase (if in
+        ``G.graph['callbacks']``)
       - thol_open_nodes: how many nodes have an open THOL block
       - kuramoto: network ``(R, ψ)``
       - sigma: global sense-plane vector
@@ -307,7 +317,11 @@ def register_trace(G) -> None:
 
     from .callback_utils import register_callback
 
-    register_callback(G, event="before_step", func=_trace_before, name="trace_before")
-    register_callback(G, event="after_step", func=_trace_after, name="trace_after")
+    register_callback(
+        G, event="before_step", func=_trace_before, name="trace_before"
+    )
+    register_callback(
+        G, event="after_step", func=_trace_after, name="trace_after"
+    )
 
     G.graph["_trace_registered"] = True

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -13,7 +13,8 @@ EPS = 1e-9
 
 def _validate_epi_vf(G) -> None:
     cfg = {
-        k: float(get_param(G, k)) for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
+        k: float(get_param(G, k))
+        for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
     }
     get = get_attr
     epi_min, epi_max = cfg["EPI_MIN"], cfg["EPI_MAX"]

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -35,7 +35,9 @@ def _convert_value(
             else (logging.ERROR if strict else logging.DEBUG)
         )
         if key is not None:
-            logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)
+            logger.log(
+                level, "No se pudo convertir el valor para %r: %s", key, exc
+            )
         else:
             logger.log(level, "No se pudo convertir el valor: %s", exc)
         if strict:

--- a/tests/test_cli_flatten_tokens.py
+++ b/tests/test_cli_flatten_tokens.py
@@ -2,5 +2,5 @@ from tnfr.cli import _flatten_tokens
 
 
 def test_flatten_tokens_accepts_tuples():
-    data = ('a', ('b', ['c', ('d',)]))
-    assert list(_flatten_tokens(data)) == ['a', 'b', 'c', 'd']
+    data = ("a", ("b", ["c", ("d",)]))
+    assert list(_flatten_tokens(data)) == ["a", "b", "c", "d"]

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -7,7 +7,9 @@ import json
 def test_cli_run_save_history(tmp_path):
     path = tmp_path / "non" / "existing" / "hist.json"
     assert not path.parent.exists()
-    rc = main(["run", "--nodes", "5", "--steps", "0", "--save-history", str(path)])
+    rc = main(
+        ["run", "--nodes", "5", "--steps", "0", "--save-history", str(path)]
+    )
     assert rc == 0
     data = json.loads(path.read_text())
     assert isinstance(data, dict)
@@ -17,7 +19,15 @@ def test_cli_run_export_history(tmp_path):
     base = tmp_path / "other" / "history"
     assert not base.parent.exists()
     rc = main(
-        ["run", "--nodes", "5", "--steps", "0", "--export-history-base", str(base)]
+        [
+            "run",
+            "--nodes",
+            "5",
+            "--steps",
+            "0",
+            "--export-history-base",
+            str(base),
+        ]
     )
     assert rc == 0
     data = json.loads((base.with_suffix(".json")).read_text())

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -16,7 +16,9 @@ from tnfr import __version__
 
 def test_cli_metrics_runs(tmp_path):
     out = tmp_path / "m.json"
-    rc = main(["metrics", "--nodes", "10", "--steps", "50", "--save", str(out)])
+    rc = main(
+        ["metrics", "--nodes", "10", "--steps", "50", "--save", str(out)]
+    )
     assert rc == 0
     data = read_structured_file(out)
     assert "Tg_global" in data
@@ -39,7 +41,17 @@ def test_cli_version(capsys):
 
 def test_cli_run_erdos_p():
     rc = main(
-        ["run", "--topology", "erdos", "--p", "0.9", "--nodes", "5", "--steps", "1"]
+        [
+            "run",
+            "--topology",
+            "erdos",
+            "--p",
+            "0.9",
+            "--nodes",
+            "5",
+            "--steps",
+            "1",
+        ]
     )
     assert rc == 0
 

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -33,5 +33,7 @@ def test_local_phase_sync_independent_graphs():
     assert G2.graph[key]["nodes"] == tuple(nodes2)
     assert G1.graph[key] is not G2.graph[key]
 
-    r1_again = local_phase_sync_weighted(G1, nodes1[0], nodes_order=nodes1, W_row=W1)
+    r1_again = local_phase_sync_weighted(
+        G1, nodes1[0], nodes_order=nodes1, W_row=W1
+    )
     assert r1_again == pytest.approx(r1)

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -18,7 +18,9 @@ except ImportError:  # pragma: no cover - skip if not installed
         pytest.param(
             ".yaml",
             lambda data: yaml.safe_dump(data),
-            marks=pytest.mark.skipif(yaml is None, reason="pyyaml no está instalado"),
+            marks=pytest.mark.skipif(
+                yaml is None, reason="pyyaml no está instalado"
+            ),
         ),
     ],
 )

--- a/tests/test_defaults_integrity.py
+++ b/tests/test_defaults_integrity.py
@@ -15,7 +15,9 @@ from tnfr.constants import core, init, metric
 
 def test_defaults_is_union_of_parts():
     expected = dict(
-        ChainMap(METRIC_DEFAULTS, REMESH_DEFAULTS, INIT_DEFAULTS, CORE_DEFAULTS)
+        ChainMap(
+            METRIC_DEFAULTS, REMESH_DEFAULTS, INIT_DEFAULTS, CORE_DEFAULTS
+        )
     )
     assert DEFAULTS == expected
 

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -14,7 +14,12 @@ def _setup_graph():
         G.nodes[n][ALIAS_THETA[0]] = 0.1 * (n + 1)
         G.nodes[n][ALIAS_EPI[0]] = 0.2 * (n + 1)
         G.nodes[n][ALIAS_VF[0]] = 0.3 * (n + 1)
-    G.graph["DNFR_WEIGHTS"] = {"phase": 1.0, "epi": 0.0, "vf": 0.0, "topo": 0.0}
+    G.graph["DNFR_WEIGHTS"] = {
+        "phase": 1.0,
+        "epi": 0.0,
+        "vf": 0.0,
+        "topo": 0.0,
+    }
     return G
 
 

--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -3,7 +3,11 @@
 import pytest
 import networkx as nx
 
-from tnfr.dynamics import _prepare_dnfr_data, _compute_dnfr_numpy, _compute_dnfr_loops
+from tnfr.dynamics import (
+    _prepare_dnfr_data,
+    _compute_dnfr_numpy,
+    _compute_dnfr_loops,
+)
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
 from tnfr.helpers import get_attr
 
@@ -14,7 +18,12 @@ def _setup_graph():
         G.nodes[n][ALIAS_THETA] = 0.1 * (n + 1)
         G.nodes[n][ALIAS_EPI] = 0.2 * (n + 1)
         G.nodes[n][ALIAS_VF] = 0.3 * (n + 1)
-    G.graph["DNFR_WEIGHTS"] = {"phase": 0.4, "epi": 0.3, "vf": 0.2, "topo": 0.1}
+    G.graph["DNFR_WEIGHTS"] = {
+        "phase": 0.4,
+        "epi": 0.3,
+        "vf": 0.2,
+        "topo": 0.1,
+    }
     return G
 
 

--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -14,7 +14,12 @@ def _setup_graph():
         G.nodes[n][ALIAS_THETA] = 0.1 * (n + 1)
         G.nodes[n][ALIAS_EPI] = 0.2 * (n + 1)
         G.nodes[n][ALIAS_VF] = 0.3 * (n + 1)
-    G.graph["DNFR_WEIGHTS"] = {"phase": 0.4, "epi": 0.3, "vf": 0.2, "topo": 0.1}
+    G.graph["DNFR_WEIGHTS"] = {
+        "phase": 0.4,
+        "epi": 0.3,
+        "vf": 0.2,
+        "topo": 0.1,
+    }
     return G
 
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -4,7 +4,10 @@ import pytest
 from tnfr.node import NodoTNFR
 from tnfr.types import Glyph
 
-from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
+from tnfr.dynamics import (
+    default_compute_delta_nfr,
+    update_epi_via_nodal_equation,
+)
 
 
 def test_empty_graph_handling(graph_canon):

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -91,4 +91,3 @@ def test_export_history_invalid_format(tmp_path, graph_canon):
     G = graph_canon()
     with pytest.raises(ValueError):
         export_history(G, str(tmp_path / "base"), fmt="xml")
-

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -14,7 +14,9 @@ def test_gamma_linear_integration(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
     attach_defaults(G)
-    merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0})
+    merge_overrides(
+        G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0}
+    )
     for n in G.nodes():
         G.nodes[n]["νf"] = 1.0
         G.nodes[n]["ΔNFR"] = 0.0
@@ -43,7 +45,9 @@ def test_gamma_linear_string_params(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
     attach_defaults(G)
-    merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": "1.0", "R0": "0.0"})
+    merge_overrides(
+        G, GAMMA={"type": "kuramoto_linear", "beta": "1.0", "R0": "0.0"}
+    )
     for n in G.nodes():
         G.nodes[n]["θ"] = 0.0
     g0 = eval_gamma(G, 0, t=0.0)
@@ -105,7 +109,12 @@ def test_gamma_tanh_string_params(graph_canon):
     attach_defaults(G)
     merge_overrides(
         G,
-        GAMMA={"type": "kuramoto_tanh", "beta": "1.0", "k": "1.0", "R0": "0.0"},
+        GAMMA={
+            "type": "kuramoto_tanh",
+            "beta": "1.0",
+            "k": "1.0",
+            "R0": "0.0",
+        },
     )
     for n in [0, 1, 2]:
         G.nodes[n]["θ"] = 0.0
@@ -121,7 +130,9 @@ def test_kuramoto_cache_invalidation_on_version(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
     attach_defaults(G)
-    merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0})
+    merge_overrides(
+        G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0}
+    )
     for n in G.nodes():
         G.nodes[n]["θ"] = 0.0
     g_before = eval_gamma(G, 0, t=0.0)
@@ -140,7 +151,12 @@ def test_gamma_harmonic_string_params(graph_canon):
     attach_defaults(G)
     merge_overrides(
         G,
-        GAMMA={"type": "harmonic", "beta": "1.0", "omega": "1.0", "phi": "0.0"},
+        GAMMA={
+            "type": "harmonic",
+            "beta": "1.0",
+            "omega": "1.0",
+            "phi": "0.0",
+        },
     )
     for n in G.nodes():
         G.nodes[n]["θ"] = 0.0
@@ -191,7 +207,9 @@ def test_eval_gamma_unknown_type_warning_and_strict(graph_canon, caplog):
     with caplog.at_level(logging.WARNING):
         g = eval_gamma(G, 0, t=0.0)
     assert g == 0.0
-    assert any("Tipo GAMMA desconocido" in rec.message for rec in caplog.records)
+    assert any(
+        "Tipo GAMMA desconocido" in rec.message for rec in caplog.records
+    )
 
     with pytest.raises(ValueError):
         eval_gamma(G, 0, t=0.0, strict=True)

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -52,5 +52,7 @@ def test_heap_compaction_after_deletions():
 
 def test_pop_least_used_empty_message():
     hist = HistoryDict()
-    with pytest.raises(KeyError, match="HistoryDict is empty; cannot pop least used"):
+    with pytest.raises(
+        KeyError, match="HistoryDict is empty; cannot pop least used"
+    ):
         hist.pop_least_used()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -3,7 +3,13 @@
 import networkx as nx
 
 from tnfr.initialization import init_node_attrs
-from tnfr.constants import attach_defaults, VF_KEY, THETA_KEY, ALIAS_VF, ALIAS_THETA
+from tnfr.constants import (
+    attach_defaults,
+    VF_KEY,
+    THETA_KEY,
+    ALIAS_VF,
+    ALIAS_THETA,
+)
 from tnfr.helpers import get_attr
 
 
@@ -14,7 +20,8 @@ def test_init_node_attrs_reproducible():
     G1.graph["RANDOM_SEED"] = seed
     init_node_attrs(G1)
     attrs1 = {
-        n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G1.nodes(data=True)
+        n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"])
+        for n, d in G1.nodes(data=True)
     }
 
     G2 = nx.path_graph(5)
@@ -22,7 +29,8 @@ def test_init_node_attrs_reproducible():
     G2.graph["RANDOM_SEED"] = seed
     init_node_attrs(G2)
     attrs2 = {
-        n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"]) for n, d in G2.nodes(data=True)
+        n: (d["EPI"], d[THETA_KEY], d[VF_KEY], d["Si"])
+        for n, d in G2.nodes(data=True)
     }
 
     assert attrs1 == attrs2

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -44,17 +44,23 @@ def test_conservation_under_IL_SHA(G_small):
         nd["νf"] = 1.0
     G_small.graph["GAMMA"] = {"type": "none"}
 
-    epi0 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
+    epi0 = {
+        n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()
+    }
 
     for _ in range(5):
         for n in G_small.nodes():
             apply_glyph(G_small, n, Glyph.IL, window=1)
-    epi1 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
+    epi1 = {
+        n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()
+    }
 
     for _ in range(5):
         for n in G_small.nodes():
             apply_glyph(G_small, n, Glyph.SHA, window=1)
-    epi2 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
+    epi2 = {
+        n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()
+    }
 
     for n in G_small.nodes():
         assert abs(epi1[n] - epi0[n]) < 5e-3

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,11 @@ import networkx as nx
 
 from tnfr.constants import attach_defaults, ALIAS_EPI
 from tnfr.helpers import get_attr
-from tnfr.metrics import _metrics_step, _update_latency_index, _update_epi_support
+from tnfr.metrics import (
+    _metrics_step,
+    _update_latency_index,
+    _update_epi_support,
+)
 from tnfr.metrics.core import LATENT_GLYPH
 
 
@@ -97,7 +101,9 @@ def test_update_epi_support_matches_manual(graph_canon):
         if abs(get_attr(G.nodes[n], ALIAS_EPI, 0.0)) >= thr
     ]
     expected_size = len(expected_vals)
-    expected_norm = sum(expected_vals) / expected_size if expected_size else 0.0
+    expected_norm = (
+        sum(expected_vals) / expected_size if expected_size else 0.0
+    )
 
     rec = hist["EPI_support"][0]
     assert rec["size"] == expected_size

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -9,6 +9,7 @@ def build_graph():
     class Foo:
         def __init__(self, value):
             self.value = value
+
     G = nx.Graph()
     G.add_node(Foo(1))
     G.add_node(Foo(2))

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -65,7 +65,8 @@ def test_glyph_load_uses_module_constants(monkeypatch, graph_canon):
 
     # Patch constants to custom categories
     monkeypatch.setattr(
-        "tnfr.observers.GLYPH_GROUPS", {"estabilizadores": ["A"], "disruptivos": ["B"]}
+        "tnfr.observers.GLYPH_GROUPS",
+        {"estabilizadores": ["A"], "disruptivos": ["B"]},
     )
 
     dist = glyph_load(G)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,7 +1,12 @@
 """Pruebas de operators."""
 
 from tnfr.node import NodoNX
-from tnfr.operators import random_jitter, clear_rng_cache, apply_glyph, _select_dominant_glyph
+from tnfr.operators import (
+    random_jitter,
+    clear_rng_cache,
+    apply_glyph,
+    _select_dominant_glyph,
+)
 from types import SimpleNamespace
 import tnfr.operators as operators
 from tnfr.constants import attach_defaults

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -3,19 +3,26 @@ from tnfr.metrics import register_metrics_callbacks
 
 
 def test_public_exports():
-    expected = {'__version__', 'step', 'run', 'preparar_red', 'create_nfr', 'NodeState'}
+    expected = {
+        "__version__",
+        "step",
+        "run",
+        "preparar_red",
+        "create_nfr",
+        "NodeState",
+    }
     assert set(tnfr.__all__) == expected
 
 
 def test_basic_flow():
-    G, n = tnfr.create_nfr('n1')
+    G, n = tnfr.create_nfr("n1")
     tnfr.preparar_red(G)
     register_metrics_callbacks(G)
     tnfr.step(G)
     tnfr.run(G, steps=2)
-    assert len(G.graph['history']['C_steps']) == 3
+    assert len(G.graph["history"]["C_steps"]) == 3
     assert isinstance(tnfr.NodeState(), tnfr.NodeState)
 
 
 def test_removed_name():
-    assert not hasattr(tnfr, 'apply_topological_remesh')
+    assert not hasattr(tnfr, "apply_topological_remesh")

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -20,7 +20,9 @@ def test_read_structured_file_permission_error(
     path = tmp_path / "forbidden.json"
     original_open = Path.open
 
-    def fake_open(self, *args, **kwargs):  # pragma: no cover - monkeypatch helper
+    def fake_open(
+        self, *args, **kwargs
+    ):  # pragma: no cover - monkeypatch helper
         if self == path:
             raise PermissionError("denied")
         return original_open(self, *args, **kwargs)

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from tnfr.callback_utils import register_callback, invoke_callbacks, CallbackEvent
+from tnfr.callback_utils import (
+    register_callback,
+    invoke_callbacks,
+    CallbackEvent,
+)
 
 
 def test_register_callback_replaces_existing(graph_canon):
@@ -16,15 +20,23 @@ def test_register_callback_replaces_existing(graph_canon):
 
     # initial registration
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb1, name="cb")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [("cb", cb1)]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [
+        ("cb", cb1)
+    ]
 
     # same name should replace existing
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="cb")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [("cb", cb2)]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [
+        ("cb", cb2)
+    ]
 
     # same function with different name should also replace existing
-    register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="other")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [("other", cb2)]
+    register_callback(
+        G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="other"
+    )
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [
+        ("other", cb2)
+    ]
 
 
 def test_register_callback_rejects_tuple(graph_canon):

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -19,7 +19,9 @@ def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
     # Historial de EPI necesario para apply_network_remesh
     tau = G.graph["REMESH_TAU_GLOBAL"]
     maxlen = max(2 * tau + 5, 64)
-    G.graph["_epi_hist"] = deque([{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen)
+    G.graph["_epi_hist"] = deque(
+        [{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen
+    )
 
     # Sin parámetro personalizado no se debería activar
     apply_remesh_if_globally_stable(G)
@@ -39,7 +41,9 @@ def test_remesh_alpha_hard_ignores_glyph_factor(graph_canon):
     hist["stable_frac"] = [1.0, 1.0, 1.0]
     tau = G.graph["REMESH_TAU_GLOBAL"]
     maxlen = max(2 * tau + 5, 64)
-    G.graph["_epi_hist"] = deque([{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen)
+    G.graph["_epi_hist"] = deque(
+        [{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen
+    )
     G.graph["REMESH_ALPHA"] = 0.7
     G.graph["REMESH_ALPHA_HARD"] = True
     G.graph["GLYPH_FACTORS"]["REMESH_alpha"] = 0.1

--- a/tests/test_remesh_community.py
+++ b/tests/test_remesh_community.py
@@ -9,15 +9,17 @@ def test_remesh_community_reduces_nodes_and_preserves_connectivity(
     graph_canon,
 ):
     G = graph_canon()
-    G.add_edges_from([
-        (0, 1),
-        (1, 2),
-        (2, 0),
-        (3, 4),
-        (4, 5),
-        (5, 3),
-        (2, 3),
-    ])
+    G.add_edges_from(
+        [
+            (0, 1),
+            (1, 2),
+            (2, 0),
+            (3, 4),
+            (4, 5),
+            (5, 3),
+            (2, 3),
+        ]
+    )
     attach_defaults(G)
     for n in G.nodes():
         G.nodes[n]["EPI"] = float(n)

--- a/tests/test_selector_norms.py
+++ b/tests/test_selector_norms.py
@@ -1,6 +1,10 @@
 """Pruebas de selector norms."""
 
-from tnfr.dynamics import step, default_glyph_selector, parametric_glyph_selector
+from tnfr.dynamics import (
+    step,
+    default_glyph_selector,
+    parametric_glyph_selector,
+)
 from tnfr.constants.core import SELECTOR_THRESHOLD_DEFAULTS
 
 

--- a/tests/test_selector_utils.py
+++ b/tests/test_selector_utils.py
@@ -27,7 +27,10 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
             thr_sel.get(
                 "si_hi",
                 thr_def.get(
-                    "hi", glyph_defaults.get("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"])
+                    "hi",
+                    glyph_defaults.get(
+                        "hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"]
+                    ),
                 ),
             )
         )
@@ -37,7 +40,10 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
             thr_sel.get(
                 "si_lo",
                 thr_def.get(
-                    "lo", glyph_defaults.get("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"])
+                    "lo",
+                    glyph_defaults.get(
+                        "lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"]
+                    ),
                 ),
             )
         )
@@ -46,7 +52,9 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
         float(
             thr_sel.get(
                 "dnfr_hi",
-                sel_defaults.get("dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]),
+                sel_defaults.get(
+                    "dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]
+                ),
             )
         )
     )
@@ -54,7 +62,9 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
         float(
             thr_sel.get(
                 "dnfr_lo",
-                sel_defaults.get("dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]),
+                sel_defaults.get(
+                    "dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]
+                ),
             )
         )
     )
@@ -62,7 +72,9 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
         float(
             thr_sel.get(
                 "accel_hi",
-                sel_defaults.get("accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]),
+                sel_defaults.get(
+                    "accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]
+                ),
             )
         )
     )
@@ -70,7 +82,9 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
         float(
             thr_sel.get(
                 "accel_lo",
-                sel_defaults.get("accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]),
+                sel_defaults.get(
+                    "accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]
+                ),
             )
         )
     )
@@ -142,7 +156,9 @@ def test_configure_selector_weights_normalizes():
     G = nx.Graph()
     G.graph["SELECTOR_WEIGHTS"] = {"w_si": 2.0, "w_dnfr": 1.0, "w_accel": 1.0}
     weights = _configure_selector_weights(G)
-    assert weights == pytest.approx({"w_si": 0.5, "w_dnfr": 0.25, "w_accel": 0.25})
+    assert weights == pytest.approx(
+        {"w_si": 0.5, "w_dnfr": 0.25, "w_accel": 0.25}
+    )
     assert G.graph["_selector_weights"] == weights
 
 
@@ -150,7 +166,9 @@ def test_apply_selector_hysteresis_returns_prev():
     thr = DEFAULTS["SELECTOR_THRESHOLDS"]
     nd = {"glyph_history": ["RA"]}
     # near si_hi threshold
-    prev = _apply_selector_hysteresis(nd, thr["si_hi"] - 0.01, 0.2, 0.2, thr, 0.05)
+    prev = _apply_selector_hysteresis(
+        nd, thr["si_hi"] - 0.01, 0.2, 0.2, thr, 0.05
+    )
     assert prev == "RA"
     # far from thresholds
     none = _apply_selector_hysteresis(nd, 0.5, 0.2, 0.2, thr, 0.05)

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -57,7 +57,8 @@ def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
 
 
 def test_sigma_vector_from_graph_matches_naive():
-    """La versión optimizada coincide con el cálculo ingenuo y no es más lenta."""
+    """La versión optimizada coincide con el cálculo ingenuo y no es
+    más lenta."""
     G_opt = nx.Graph()
     glyphs = list(Glyph)
     for i in range(1000):
@@ -87,9 +88,11 @@ def test_sigma_from_vectors_accepts_single_complex():
 
 def test_unknown_glyph_does_not_shift_average():
     base, _ = _sigma_from_vectors([glyph_unit(Glyph.AL.value)])
-    with_unknown, _ = _sigma_from_vectors([
-        glyph_unit(Glyph.AL.value),
-        glyph_unit("ZZ"),
-    ])
+    with_unknown, _ = _sigma_from_vectors(
+        [
+            glyph_unit(Glyph.AL.value),
+            glyph_unit("ZZ"),
+        ]
+    )
     assert glyph_unit("ZZ") == 0 + 0j
     assert with_unknown["angle"] == pytest.approx(base["angle"])

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -18,7 +18,11 @@ def test_get_si_weights_normalization():
     G.graph["SI_WEIGHTS"] = {"alpha": 2, "beta": 1, "gamma": 1}
     alpha, beta, gamma = get_Si_weights(G)
     assert (alpha, beta, gamma) == pytest.approx((0.5, 0.25, 0.25))
-    assert G.graph["_Si_weights"] == {"alpha": alpha, "beta": beta, "gamma": gamma}
+    assert G.graph["_Si_weights"] == {
+        "alpha": alpha,
+        "beta": beta,
+        "gamma": gamma,
+    }
     assert G.graph["_Si_sensitivity"] == {
         "dSi_dvf_norm": alpha,
         "dSi_ddisp_fase": -beta,
@@ -64,4 +68,3 @@ def test_compute_Si_node():
     )
     assert Si == pytest.approx(0.7)
     assert get_attr(G.nodes[1], ALIAS_SI, 0.0) == pytest.approx(0.7)
-

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -2,6 +2,6 @@ from tnfr.helpers import _stable_json
 
 
 def test_stable_json_includes_module():
-    Foo1 = type('Foo', (), {'__module__': 'mod1', '__slots__': ()})
-    Foo2 = type('Foo', (), {'__module__': 'mod2', '__slots__': ()})
+    Foo1 = type("Foo", (), {"__module__": "mod1", "__slots__": ()})
+    Foo2 = type("Foo", (), {"__module__": "mod2", "__slots__": ()})
     assert _stable_json(Foo1()) != _stable_json(Foo2())

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -67,7 +67,9 @@ def test_callback_names_spec():
     def foo():
         pass
 
-    names = _callback_names([CallbackSpec("bar", foo), CallbackSpec(None, foo)])
+    names = _callback_names(
+        [CallbackSpec("bar", foo), CallbackSpec(None, foo)]
+    )
     assert names == ["bar", "foo"]
 
 

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -70,11 +70,15 @@ def test_update_tg_matches_naive(graph_canon):
     dt = 1.0
 
     start = time.perf_counter()
-    counts_opt, n_total_opt, n_latent_opt = _update_tg(G_opt, hist_opt, dt, True)
+    counts_opt, n_total_opt, n_latent_opt = _update_tg(
+        G_opt, hist_opt, dt, True
+    )
     t_opt = time.perf_counter() - start
 
     start = time.perf_counter()
-    counts_ref, n_total_ref, n_latent_ref = _update_tg_naive(G_ref, hist_ref, dt, True)
+    counts_ref, n_total_ref, n_latent_ref = _update_tg_naive(
+        G_ref, hist_ref, dt, True
+    )
     t_ref = time.perf_counter() - start
 
     assert counts_opt == counts_ref

--- a/tests/test_vf_coherencia.py
+++ b/tests/test_vf_coherencia.py
@@ -11,7 +11,12 @@ def test_vf_converge_to_neighbor_average_when_stable(graph_canon):
     G.add_edge(0, 1)
     attach_defaults(G)
     # configuraciones para estabilidad
-    G.graph["DNFR_WEIGHTS"] = {"phase": 1.0, "epi": 0.0, "vf": 0.0, "topo": 0.0}
+    G.graph["DNFR_WEIGHTS"] = {
+        "phase": 1.0,
+        "epi": 0.0,
+        "vf": 0.0,
+        "topo": 0.0,
+    }
     G.graph["VF_ADAPT_TAU"] = 2
     G.graph["VF_ADAPT_MU"] = 0.5
     for n in G.nodes():


### PR DESCRIPTION
## Summary
- format source and tests with `black -l 79` to keep lines within 79 characters
- wrap long docstrings, comments, and strings to eliminate flake8 E501 warnings

## Testing
- `python -m flake8 src tests`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbef5b92d4832186565c76d2b647cb