### PR TITLE
Recursively copy tuple defaults to avoid shared state

### DIFF
--- a/tests/test_inject_defaults_tuple.py
+++ b/tests/test_inject_defaults_tuple.py
@@ -1,0 +1,18 @@
+"""Pruebas para ``inject_defaults`` con tuplas mutables."""
+
+import networkx as nx
+
+from tnfr.constants import inject_defaults, DEFAULTS
+import tnfr.constants as const
+
+
+def test_mutating_graph_tuple_does_not_affect_defaults(monkeypatch):
+    tup = ([1], {"a": 1})
+    monkeypatch.setitem(const._DEFAULTS_COMBINED, "_test_tuple", tup)
+    G = nx.Graph()
+    inject_defaults(G)
+    assert G.graph["_test_tuple"] is not const._DEFAULTS_COMBINED["_test_tuple"]
+    G.graph["_test_tuple"][0].append(2)
+    G.graph["_test_tuple"][1]["a"] = 2
+    assert const._DEFAULTS_COMBINED["_test_tuple"] == tup
+    assert DEFAULTS["_test_tuple"] == tup


### PR DESCRIPTION
## Summary
- ensure `inject_defaults` deep-copies tuples containing mutable items
- add regression test guarding `DEFAULTS` from tuple mutations

## Testing
- `pytest tests/test_inject_defaults_tuple.py tests/test_defaults_integrity.py::test_defaults_is_immutable -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbf2c293cc8321acf8eb5da07fa0bd