### PR TITLE
Avoid infinite recursion in _stable_json

### DIFF
--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -1,3 +1,4 @@
+from typing import Any
 from tnfr.helpers import _stable_json
 
 
@@ -5,3 +6,9 @@ def test_stable_json_includes_module():
     Foo1 = type("Foo", (), {"__module__": "mod1", "__slots__": ()})
     Foo2 = type("Foo", (), {"__module__": "mod2", "__slots__": ()})
     assert _stable_json(Foo1()) != _stable_json(Foo2())
+
+
+def test_stable_json_handles_cycles():
+    obj: list[Any] = []
+    obj.append(obj)
+    assert _stable_json(obj) == ["<recursion>"]


### PR DESCRIPTION
## Summary
- Track visited object ids in `_stable_json` to avoid infinite recursion
- Represent cyclic references with a `<recursion>` placeholder
- Test serialization on self-referential list

## Testing
- `PYTHONPATH=src pytest tests/test_stable_json.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbf36b9b40832198e99ea9592489fa