### PR TITLE
refactor history param retrieval

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -19,6 +19,11 @@ __all__ = [
 ]
 
 
+def _param_with_default(G, key):
+    """Return ``G.graph[key]`` if present, else get default parameter."""
+    return G.graph[key] if key in G.graph else get_param(G, key)
+
+
 def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
     """Add ``glyph`` to node history with maximum size ``window``."""
     hist = nd.get("glyph_history")
@@ -156,16 +161,10 @@ def ensure_history(G) -> Dict[str, Any]:
     ``HISTORY_MAXLEN`` must be non-negative and ``HISTORY_COMPACT_EVERY``
     must be a positive integer; otherwise a :class:`ValueError` is raised.
     """
-    if "HISTORY_MAXLEN" in G.graph:
-        maxlen = int(G.graph["HISTORY_MAXLEN"])
-    else:
-        maxlen = int(get_param(G, "HISTORY_MAXLEN"))
+    maxlen = int(_param_with_default(G, "HISTORY_MAXLEN"))
     if maxlen < 0:
         raise ValueError("HISTORY_MAXLEN must be >= 0")
-    if "HISTORY_COMPACT_EVERY" in G.graph:
-        compact_every = int(G.graph["HISTORY_COMPACT_EVERY"])
-    else:
-        compact_every = int(get_param(G, "HISTORY_COMPACT_EVERY"))
+    compact_every = int(_param_with_default(G, "HISTORY_COMPACT_EVERY"))
     if compact_every <= 0:
         raise ValueError("HISTORY_COMPACT_EVERY must be > 0")
     hist = G.graph.get("history")


### PR DESCRIPTION
## Summary
- add `_param_with_default` helper for history parameters
- use helper in `ensure_history` to fetch `HISTORY_MAXLEN` and `HISTORY_COMPACT_EVERY`

## Testing
- `pytest tests/test_history.py tests/test_history_heap_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbf3f893f88321a42447fb666face9