### PR TITLE
Remove unused logger from helpers module

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -66,8 +66,6 @@ from .collections_utils import (
 )
 from .value_utils import _convert_value
 
-logger = logging.getLogger(__name__)
-
 PI = math.pi
 TWO_PI = 2 * PI
 


### PR DESCRIPTION
## Summary
- remove unused logger initialization in `helpers.py`
- keep `logging` import for `logging.WARNING` use

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbfd6845b883219321f8ebde135d58