### PR TITLE
feat: accept string paths in config helpers

### DIFF
--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -1,25 +1,29 @@
 """Configuration utilities."""
 
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 from pathlib import Path
 from .helpers import read_structured_file
 
 from .constants import inject_defaults
 
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    import networkx as nx
 
-def load_config(path: Path) -> Dict[str, Any]:
+
+def load_config(path: str | Path) -> Dict[str, Any]:
     """Read a JSON/YAML file and return a ``dict`` with parameters."""
-    data = read_structured_file(path)
+    data = read_structured_file(Path(path))
     if not isinstance(data, dict):
         raise ValueError("Configuration file must contain an object")
     return data
 
 
-def apply_config(G, path: Path) -> None:
+def apply_config(G: nx.Graph, path: str | Path) -> None:
     """Inject parameters from ``path`` into ``G.graph``.
 
     Reuses :func:`inject_defaults` to keep canonical default semantics.
     """
+    path = Path(path)
     cfg = load_config(path)
     inject_defaults(G, cfg, override=True)


### PR DESCRIPTION
## Summary
- allow `load_config`/`apply_config` to accept `str` paths in addition to `Path`
- type `apply_config`'s graph argument as `nx.Graph` and import NetworkX for type checking

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbfdf3a73483218d4fa357ed2cb49b