### PR TITLE
Use set for callback events

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -26,7 +26,7 @@ class CallbackEvent(str, Enum):
     ON_REMESH = "on_remesh"
 
 
-_CALLBACK_EVENTS: tuple[str, ...] = tuple(e.value for e in CallbackEvent)
+_CALLBACK_EVENTS: set[str] = set(e.value for e in CallbackEvent)
 
 
 Callback = Callable[["nx.Graph", dict[str, Any]], None]


### PR DESCRIPTION
## Summary
- replace _CALLBACK_EVENTS tuple with set

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbfe65e4e08321b38d3615b3c132ce