### PR TITLE
Refactor callback error handling for callbacks

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -153,6 +153,7 @@ def invoke_callbacks(
         G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"])
     )
     ctx = ctx or {}
+    err_list = G.graph.setdefault("_callback_errors", [])
     for spec in list(cbs):
         name, fn = spec.name, spec.func
         try:
@@ -161,7 +162,7 @@ def invoke_callbacks(
             logger.warning("callback %r failed for %s: %s", name, event, e)
             if strict:
                 raise
-            G.graph.setdefault("_callback_errors", []).append(
+            err_list.append(
                 {
                     "event": event,
                     "step": ctx.get("step"),


### PR DESCRIPTION
## Summary
- Capture `_callback_errors` list once before invoking callbacks
- Append callback failure info directly to `_callback_errors`

## Testing
- `pytest` *(fails: assert 2.21770001189725e-05 <= (9.357999715575716e-06 * 2))*

------
https://chatgpt.com/codex/tasks/task_e_68bbff62ff748321ba779b96f66c0ea6