### PR TITLE
Optimize node_set_checksum hashing

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -258,10 +258,8 @@ def node_set_checksum(
         )
 
     node_iter = nodes if nodes is not None else G.nodes()
-    for i, node_repr in enumerate(sorted(serialise(n) for n in node_iter)):
-        if i:
-            sha1.update(b"|")
-        sha1.update(node_repr.encode("utf-8"))
+    serialised = sorted(serialise(n) for n in node_iter)
+    sha1.update("|".join(serialised).encode("utf-8"))
     return sha1.hexdigest()
 
 


### PR DESCRIPTION
## Summary
- Avoid repeated hash updates in `node_set_checksum` by precomputing serialised nodes and hashing a single joined string

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0014a7408321b82fe77fcf9d0761