### PR TITLE
Usar genéricos integrados de Python en anotaciones

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import logging
 import sys
-from typing import Any, Dict, List, Optional, Callable, TYPE_CHECKING
+from typing import Any, Optional, Callable, TYPE_CHECKING
 from collections.abc import Sequence
 from pathlib import Path
 from collections import deque
@@ -72,8 +72,8 @@ def _flatten_tokens(obj: Any):
         yield obj
 
 
-def _parse_tokens(obj: Any) -> List[Any]:
-    out: List[Any] = []
+def _parse_tokens(obj: Any) -> list[Any]:
+    out: list[Any] = []
     for pos, tok in enumerate(_flatten_tokens(obj), start=1):
         try:
             if isinstance(tok, dict):
@@ -93,7 +93,7 @@ def _parse_tokens(obj: Any) -> List[Any]:
     return out
 
 
-def parse_thol(spec: Dict[str, Any]) -> Any:
+def parse_thol(spec: dict[str, Any]) -> Any:
     """Parsea la especificación de un bloque ``THOL``.
 
     Parameters
@@ -126,7 +126,7 @@ def parse_thol(spec: Dict[str, Any]) -> Any:
     )
 
 
-TOKEN_MAP: Dict[str, Callable[[Any], Any]] = {
+TOKEN_MAP: dict[str, Callable[[Any], Any]] = {
     "WAIT": lambda v: wait(int(v)),
     "TARGET": lambda v: target(v),
     "THOL": parse_thol,
@@ -182,7 +182,7 @@ HISTORY_ARG_SPECS = [
 ]
 
 
-def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
+def _args_to_dict(args: argparse.Namespace, prefix: str) -> dict[str, Any]:
     """Extract arguments matching a prefix.
 
     Parameters
@@ -216,7 +216,7 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
     }
 
 
-def _load_sequence(path: Path) -> List[Any]:
+def _load_sequence(path: Path) -> list[Any]:
     data = read_structured_file(path)
 
     return seq(*_parse_tokens(data))
@@ -540,7 +540,7 @@ def cmd_metrics(args: argparse.Namespace) -> int:
     return 0
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: Optional[list[str]] = None) -> int:
     logging.basicConfig(
         level=logging.INFO, format="%(message)s", stream=sys.stdout, force=True
     )

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import (
     Iterable,
     Sequence,
-    Dict,
     Any,
     TypeVar,
     Mapping,
@@ -66,12 +65,12 @@ def ensure_collection(
 
 
 def normalize_weights(
-    dict_like: Dict[str, Any],
+    dict_like: dict[str, Any],
     keys: Iterable[str],
     default: float = 0.0,
     *,
     error_on_negative: bool = False,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Normalize ``keys`` in ``dict_like`` so their sum is 1."""
     keys = list(keys)
     default_float = float(default)
@@ -88,7 +87,7 @@ def _convert_weights(
     keys: Iterable[str],
     default_float: float,
     error_on_negative: bool,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     def _to_float(k: str) -> float:
         val = dict_like.get(k, default_float)
         ok, converted = _convert_value(
@@ -116,7 +115,7 @@ def _validate_weights(
 
 def _normalize_distribution(
     weights: Mapping[str, float], keys: Sequence[str]
-) -> Dict[str, float]:
+) -> dict[str, float]:
     total = math.fsum(weights.values())
     n = len(keys)
     if total <= 0:
@@ -129,7 +128,7 @@ def _normalize_distribution(
 
 def normalize_counter(
     counts: Mapping[str, int],
-) -> tuple[Dict[str, float], int]:
+) -> tuple[dict[str, float], int]:
     """Normalize a ``Counter`` returning proportions and total."""
     total = sum(counts.values())
     if total <= 0:
@@ -143,9 +142,9 @@ def mix_groups(
     groups: Mapping[str, Iterable[str]],
     *,
     prefix: str = "_",
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Aggregate values of ``dist`` according to ``groups``."""
-    out: Dict[str, float] = dict(dist)
+    out: dict[str, float] = dict(dist)
     for label, keys in groups.items():
         out[f"{prefix}{label}"] = sum(dist.get(k, 0.0) for k in keys)
     return out

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -1,7 +1,7 @@
 """Configuration utilities."""
 
 from __future__ import annotations
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from pathlib import Path
 from .helpers import read_structured_file
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover - only for type checkers
     import networkx as nx
 
 
-def load_config(path: str | Path) -> Dict[str, Any]:
+def load_config(path: str | Path) -> dict[str, Any]:
     """Read a JSON/YAML file and return a ``dict`` with parameters."""
     data = read_structured_file(Path(path))
     if not isinstance(data, dict):

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from statistics import mean, median
-from typing import Any, Dict, List, Tuple
+from typing import Any
 import heapq
 import logging
 import math
@@ -47,7 +47,7 @@ TgRun = "run"
 # -------------
 
 
-def _tg_state(nd: Dict[str, Any]) -> Dict[str, Any]:
+def _tg_state(nd: dict[str, Any]) -> dict[str, Any]:
     """Internal per-node structure for accumulating run times per glyph.
     Fields: curr (current glyph), run (accumulated time in current glyph)
     """
@@ -375,13 +375,13 @@ def register_metrics_callbacks(G) -> None:
 # -------------
 
 
-def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
+def Tg_global(G, normalize: bool = True) -> dict[str, float]:
     """Total glyph time per class. If ``normalize=True``, return fractions
     of the total."""
     hist = ensure_history(G)
-    tg_total: Dict[str, float] = hist.tracked_get("Tg_total", {})
+    tg_total: dict[str, float] = hist.tracked_get("Tg_total", {})
     total = sum(tg_total.values()) or 1.0
-    out: Dict[str, float] = {}
+    out: dict[str, float] = {}
 
     def add(g):
         val = float(tg_total.get(g, 0.0))
@@ -393,21 +393,21 @@ def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
 
 def Tg_by_node(
     G, n, normalize: bool = False
-) -> Dict[str, float | List[float]]:
+) -> dict[str, float | list[float]]:
     """Per-node summary: if ``normalize`` return mean run per glyph;
     otherwise list runs."""
     hist = ensure_history(G)
     rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
     if not normalize:
         # convertir default dict → list para serializar
-        out: Dict[str, List[float]] = {}
+        out: dict[str, list[float]] = {}
 
         def copy_runs(g):
             out[g] = list(rec.get(g, []))
 
         for_each_glyph(copy_runs)
         return out
-    out: Dict[str, float] = {}
+    out: dict[str, float] = {}
 
     def add(g):
         runs = rec.get(g, [])
@@ -417,7 +417,7 @@ def Tg_by_node(
     return out
 
 
-def latency_series(G) -> Dict[str, List[float]]:
+def latency_series(G) -> dict[str, list[float]]:
     hist = ensure_history(G)
     xs = hist.tracked_get("latency_index", [])
     return {
@@ -426,7 +426,7 @@ def latency_series(G) -> Dict[str, List[float]]:
     }
 
 
-def glyphogram_series(G) -> Dict[str, List[float]]:
+def glyphogram_series(G) -> dict[str, list[float]]:
     hist = ensure_history(G)
     xs = hist.tracked_get("glyphogram", [])
     if not xs:
@@ -440,17 +440,17 @@ def glyphogram_series(G) -> Dict[str, List[float]]:
     return out
 
 
-def glyph_top(G, k: int = 3) -> List[Tuple[str, float]]:
+def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
     """Top-k structural operators by ``Tg_global`` (fraction)."""
     tg = Tg_global(G, normalize=True)
     return heapq.nlargest(max(1, int(k)), tg.items(), key=lambda kv: kv[1])
 
 
-def glyph_dwell_stats(G, n) -> Dict[str, Dict[str, float]]:
+def glyph_dwell_stats(G, n) -> dict[str, dict[str, float]]:
     """Per-node statistics: mean/median/max of runs per glyph."""
     hist = ensure_history(G)
     rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
-    out: Dict[str, Dict[str, float]] = {}
+    out: dict[str, dict[str, float]] = {}
 
     def add(g):
         runs = list(rec.get(g, []))


### PR DESCRIPTION
## Summary
- Reemplaza `Dict`, `List` y `Tuple` por `dict`, `list` y `tuple` en módulos de configuración, CLI, utilidades de colecciones y métricas
- Limpia importaciones de `typing` que quedaron redundantes tras el cambio

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc00b46fb48321ae4aecbac5a3a189