### PR TITLE
Unify node cache helpers across dynamics and operators

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -96,9 +96,9 @@ def inject_defaults(
             G.graph[k] = v if _is_immutable(v) else copy.deepcopy(v)
     G.graph["_tnfr_defaults_attached"] = True
     try:  # local import para evitar dependencia circular
-        from ..operators import _ensure_node_offset_map
+        from ..helpers import ensure_node_offset_map
 
-        _ensure_node_offset_map(G)
+        ensure_node_offset_map(G)
     except ImportError:
         pass
 

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -19,7 +19,7 @@ from .helpers import (
     set_attr,
     neighbor_phase_mean,
     increment_edge_version,
-    node_set_checksum,
+    ensure_node_offset_map,
     get_rng,
 )
 from .callback_utils import invoke_callbacks
@@ -43,33 +43,9 @@ Note on REMESH α (alpha) precedence:
 2) ``G.graph["REMESH_ALPHA"]``
 3) ``REMESH_DEFAULTS["REMESH_ALPHA"]``
 """
-
-
-def _ensure_node_offset_map(G) -> Dict[Any, int]:
-    """Return cached node→index mapping for ``G``.
-
-    The mapping follows the natural insertion order of ``G.nodes`` for speed.
-    When ``G.graph['SORT_NODES']`` is true a deterministic sort is applied.
-    A checksum of the node set is stored so the mapping is recomputed only
-    when the nodes change.
-    """
-
-    nodes = list(G.nodes())
-    # Use order-independent deterministic checksum based on node set
-    checksum = node_set_checksum(G, nodes)
-    mapping = G.graph.get("_node_offset_map")
-    if mapping is None or G.graph.get("_node_offset_checksum") != checksum:
-        if bool(G.graph.get("SORT_NODES", False)):
-            nodes.sort(key=lambda x: str(x))
-        mapping = {node: idx for idx, node in enumerate(nodes)}
-        G.graph["_node_offset_map"] = mapping
-        G.graph["_node_offset_checksum"] = checksum
-    return mapping
-
-
 def _node_offset(G, n) -> int:
     """Deterministic node index used for jitter seeds."""
-    mapping = _ensure_node_offset_map(G)
+    mapping = ensure_node_offset_map(G)
     return int(mapping.get(n, 0))
 
 

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,0 +1,33 @@
+import networkx as nx
+
+from tnfr import dynamics, operators
+from tnfr.helpers import increment_edge_version
+
+
+def test_cached_nodes_and_A_reuse_and_invalidate():
+    G = nx.Graph()
+    G.add_edges_from([(0, 1), (1, 2)])
+    data1 = dynamics._prepare_dnfr_data(G)
+    nodes1 = data1["nodes"]
+    data2 = dynamics._prepare_dnfr_data(G)
+    assert nodes1 is data2["nodes"]
+    G.add_edge(0, 2)
+    increment_edge_version(G)
+    data3 = dynamics._prepare_dnfr_data(G)
+    assert data3["nodes"] is not nodes1
+
+
+def test_node_offset_map_updates_on_node_addition():
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    offset0 = operators._node_offset(G, 0)
+    mapping1 = G.graph["_node_offset_map"]
+    assert offset0 == 0
+    offset0_again = operators._node_offset(G, 0)
+    assert offset0_again == 0
+    assert mapping1 is G.graph["_node_offset_map"]
+    G.add_node(2)
+    offset2 = operators._node_offset(G, 2)
+    mapping2 = G.graph["_node_offset_map"]
+    assert mapping2 is not mapping1
+    assert offset2 == 2


### PR DESCRIPTION
## Summary
- add `ensure_node_offset_map` and `cached_nodes_and_A` helpers for shared graph caching
- refactor dynamics and operators to rely on new helpers
- cover node/adjacency caching flows in new tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc05e024b88321be5da28a5e5ba2fd