### PR TITLE
Introduce append_metric helper for metric history

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -57,7 +57,7 @@ from .helpers import (
     get_rng,
 )
 from .callback_utils import invoke_callbacks
-from .glyph_history import recent_glyph, ensure_history
+from .glyph_history import recent_glyph, ensure_history, append_metric
 from .collections_utils import normalize_weights
 from .selector import (
     _selector_thresholds,
@@ -832,8 +832,8 @@ def coordinate_global_local_phase(
 
     g["PHASE_K_GLOBAL"] = kG
     g["PHASE_K_LOCAL"] = kL
-    hist.setdefault("phase_kG", []).append(float(kG))
-    hist.setdefault("phase_kL", []).append(float(kL))
+    append_metric(hist, "phase_kG", float(kG))
+    append_metric(hist, "phase_kL", float(kL))
 
     # 6) Fase GLOBAL (centroide) para empuje
     x_sum = y_sum = 0.0

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -14,6 +14,7 @@ __all__ = [
     "push_glyph",
     "recent_glyph",
     "ensure_history",
+    "append_metric",
     "last_glyph",
     "count_glyphs",
 ]
@@ -183,6 +184,11 @@ def ensure_history(G) -> Dict[str, Any]:
             hist.pop_least_used()
         # Note: trimming is O(n) only when history exceeds ``maxlen``
     return hist
+
+
+def append_metric(hist: Dict[str, Any], key: str, value: Any) -> None:
+    """Append ``value`` to ``hist[key]`` list, creating it if missing."""
+    hist.setdefault(key, []).append(value)
 
 
 def last_glyph(nd: Dict[str, Any]) -> str | None:

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 from ..constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_SI, COHERENCE
 from ..callback_utils import register_callback
-from ..glyph_history import ensure_history
+from ..glyph_history import ensure_history, append_metric
 from ..helpers import get_attr, clamp01
 
 
@@ -179,9 +179,9 @@ def coherence_matrix(G):
     }
 
     hist = ensure_history(G)
-    hist.setdefault(cfg.get("history_key", "W_sparse"), []).append(W)
-    hist.setdefault(cfg.get("Wi_history_key", "W_i"), []).append(Wi)
-    hist.setdefault(cfg.get("stats_history_key", "W_stats"), []).append(stats)
+    append_metric(hist, cfg.get("history_key", "W_sparse"), W)
+    append_metric(hist, cfg.get("Wi_history_key", "W_i"), Wi)
+    append_metric(hist, cfg.get("stats_history_key", "W_stats"), stats)
 
     return nodes, W
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -13,7 +13,7 @@ from .helpers import (
     compute_coherence,
 )
 from .callback_utils import register_callback
-from .glyph_history import ensure_history, count_glyphs
+from .glyph_history import ensure_history, count_glyphs, append_metric
 from .collections_utils import normalize_counter, mix_groups
 from .constants_glyphs import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
@@ -37,7 +37,7 @@ __all__ = [
 def _std_log(kind: str, G, ctx: dict):
     """Store compact events in ``history['events']``."""
     h = ensure_history(G)
-    h.setdefault("events", []).append((kind, dict(ctx)))
+    append_metric(h, "events", (kind, dict(ctx)))
 
 
 _STD_CALLBACKS = {

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -8,6 +8,7 @@ from .constants import METRIC_DEFAULTS, attach_defaults, get_param
 from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
+from .glyph_history import append_metric
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
@@ -81,8 +82,10 @@ def preparar_red(
 
             attach_standard_observer(G)
         except ImportError as e:
-            G.graph.setdefault("_callback_errors", []).append(
-                {"event": "attach_std_observer", "error": repr(e)}
+            append_metric(
+                G.graph,
+                "_callback_errors",
+                {"event": "attach_std_observer", "error": repr(e)},
             )
     # Hook explícito para ΔNFR (se puede sustituir luego con
     # dynamics.set_delta_nfr_hook)

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -12,7 +12,7 @@ from .helpers import (
     clamp01,
 )
 from .callback_utils import register_callback
-from .glyph_history import ensure_history, last_glyph, count_glyphs
+from .glyph_history import ensure_history, last_glyph, count_glyphs, append_metric
 from .constants_glyphs import (
     ANGLE_MAP,
     ESTABILIZADORES,
@@ -199,11 +199,11 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
 
     sv["t"] = float(G.graph.get("_t", 0.0) if t is None else t)
 
-    hist.setdefault(key, []).append(sv)
+    append_metric(hist, key, sv)
 
     # Conteo de glyphs por paso (útil para rosa glífica)
     counts = count_glyphs(G, last_only=True)
-    hist.setdefault("sigma_counts", []).append({"t": sv["t"], **counts})
+    append_metric(hist, "sigma_counts", {"t": sv["t"], **counts})
 
     # Trayectoria por nodo (opcional)
     if cfg.get("per_node", False):

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple
 from collections.abc import Mapping
 
 from .constants import TRACE
-from .glyph_history import ensure_history, count_glyphs
+from .glyph_history import ensure_history, count_glyphs, append_metric
 
 
 class _KuramotoFn(Protocol):
@@ -176,7 +176,7 @@ def _trace_capture(
             meta.update(getter(G))
     if hist is None or key is None:
         return
-    hist.setdefault(key, []).append(meta)
+    append_metric(hist, key, meta)
 
 
 def gamma_field(G):


### PR DESCRIPTION
## Summary
- add `append_metric` helper to centralize history list updates
- refactor metrics and observers to use the helper and reduce repetition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0727b358832181a5b2f55112b70f