### PR TITLE
feat: add optional_import helper and refactor imports

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -13,23 +13,30 @@ example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or
 
 from __future__ import annotations
 
-try:  # pragma: no cover
-    from importlib.metadata import version, PackageNotFoundError
-except ImportError:  # pragma: no cover
-    from importlib_metadata import version, PackageNotFoundError
+from .import_utils import optional_import
+
+_metadata = optional_import("importlib.metadata")
+if _metadata is None:  # pragma: no cover
+    _metadata = optional_import("importlib_metadata")
+
+version = _metadata.version  # type: ignore[attr-defined]
+PackageNotFoundError = _metadata.PackageNotFoundError  # type: ignore[attr-defined]
 
 try:
     __version__ = version("tnfr")
 except PackageNotFoundError:  # pragma: no cover
-    try:
-        import tomllib
+    tomllib = optional_import("tomllib")
+    if tomllib is not None:
         from pathlib import Path
 
-        with (Path(__file__).resolve().parents[2] / "pyproject.toml").open(
-            "rb"
-        ) as f:
-            __version__ = tomllib.load(f)["project"]["version"]
-    except (OSError, KeyError, ValueError):  # pragma: no cover
+        try:
+            with (Path(__file__).resolve().parents[2] / "pyproject.toml").open(
+                "rb"
+            ) as f:
+                __version__ = tomllib.load(f)["project"]["version"]
+        except (OSError, KeyError, ValueError):  # pragma: no cover
+            __version__ = "0+unknown"
+    else:  # pragma: no cover
         __version__ = "0+unknown"
 
 # Minimal public API re-exports

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -18,6 +18,7 @@ from .metric import (
     COHERENCE,
     DIAGNOSIS,
 )
+from ..import_utils import optional_import
 
 # Valores que pueden asignarse directamente sin copiar
 IMMUTABLE_TYPES = (
@@ -95,12 +96,9 @@ def inject_defaults(
         if override or k not in G.graph:
             G.graph[k] = v if _is_immutable(v) else copy.deepcopy(v)
     G.graph["_tnfr_defaults_attached"] = True
-    try:  # local import para evitar dependencia circular
-        from ..helpers import ensure_node_offset_map
-
+    ensure_node_offset_map = optional_import("tnfr.helpers.ensure_node_offset_map")
+    if ensure_node_offset_map is not None:
         ensure_node_offset_map(G)
-    except ImportError:
-        pass
 
 
 def merge_overrides(G, **overrides) -> None:

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -59,6 +59,7 @@ from .helpers import (
 from .callback_utils import invoke_callbacks
 from .glyph_history import recent_glyph, ensure_history, append_metric
 from .collections_utils import normalize_weights
+from .import_utils import optional_import
 from .selector import (
     _selector_thresholds,
     _norms_para_selector,
@@ -77,12 +78,7 @@ def _optional_numpy() -> Any | None:
     almacena en caché para evitar búsquedas repetidas.
     """
 
-    try:  # pragma: no cover - dependency opcional
-        import numpy  # type: ignore
-    except ImportError:  # pragma: no cover - dependency opcional
-        return None
-    else:
-        return numpy
+    return optional_import("numpy")
 
 
 def _np(*, warn: bool = False) -> Any | None:

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -25,29 +25,19 @@ from collections import OrderedDict
 
 import networkx as nx
 
-try:  # pragma: no cover - dependencia opcional
-    import numpy as np  # type: ignore
-except ImportError:  # pragma: no cover
-    np = None  # type: ignore
+from .import_utils import optional_import
+np = optional_import("numpy")  # type: ignore
 
-try:  # pragma: no cover - dependencia opcional
-    import tomllib  # type: ignore[attr-defined]
-    from tomllib import TOMLDecodeError  # type: ignore[attr-defined]
-except ModuleNotFoundError:  # pragma: no cover
-    try:
-        import tomli as tomllib  # type: ignore
-        from tomli import TOMLDecodeError  # type: ignore
-    except ModuleNotFoundError:  # pragma: no cover
-        tomllib = None  # type: ignore
-        TOMLDecodeError = Exception  # type: ignore[assignment]
+tomllib = optional_import("tomllib") or optional_import("tomli")  # type: ignore
+if tomllib is not None:
+    TOMLDecodeError = getattr(tomllib, "TOMLDecodeError", Exception)  # type: ignore[attr-defined]
+else:
+    TOMLDecodeError = Exception  # type: ignore[assignment]
 
-
-try:  # pragma: no cover - dependencia opcional
-    import yaml  # type: ignore
-    from yaml import YAMLError  # type: ignore
-except ImportError:  # pragma: no cover
-    yaml = None
-
+yaml = optional_import("yaml")  # type: ignore
+if yaml is not None:
+    YAMLError = getattr(yaml, "YAMLError", Exception)  # type: ignore[attr-defined]
+else:
     class YAMLError(Exception):  # type: ignore
         pass
 

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -1,0 +1,52 @@
+"""Utilidades para importaciones opcionales."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+from typing import Any
+
+__all__ = ["optional_import"]
+
+
+def optional_import(name: str, fallback: Any | None = None) -> Any | None:
+    """Importa ``name`` devolviendo ``fallback`` si falla.
+
+    ``name`` puede apuntar a un módulo, submódulo o atributo. Si la
+    importación o el acceso al atributo fallan se emite una advertencia y se
+    devuelve ``fallback``.
+
+    Parameters
+    ----------
+    name:
+        Ruta completa del módulo, submódulo o atributo a importar.
+    fallback:
+        Valor a devolver cuando la importación falla. Por defecto ``None``.
+
+    Returns
+    -------
+    Any | None
+        Objeto importado o ``fallback`` si ocurre un error.
+
+    Notes
+    -----
+    Se devuelve ``fallback`` cuando el módulo no está disponible o el
+    atributo solicitado no existe. En ambos casos se emite una advertencia.
+    """
+
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        if "." in name:
+            module_name, attr = name.rsplit(".", 1)
+            try:
+                module = importlib.import_module(module_name)
+                return getattr(module, attr)
+            except (ImportError, AttributeError):
+                pass
+        warnings.warn(
+            f"No se pudo importar '{name}'; usando valor de fallback.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return fallback

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -9,6 +9,7 @@ from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
 from .glyph_history import append_metric
+from .import_utils import optional_import
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
@@ -77,15 +78,16 @@ def preparar_red(
     G.graph.setdefault("_epi_hist", deque(maxlen=maxlen))
     # Auto-attach del observador estándar si se pide
     if G.graph.get("ATTACH_STD_OBSERVER", False):
-        try:
-            from .observers import attach_standard_observer
-
+        attach_standard_observer = optional_import(
+            "tnfr.observers.attach_standard_observer"
+        )
+        if attach_standard_observer is not None:
             attach_standard_observer(G)
-        except ImportError as e:
+        else:
             append_metric(
                 G.graph,
                 "_callback_errors",
-                {"event": "attach_std_observer", "error": repr(e)},
+                {"event": "attach_std_observer", "error": "ImportError"},
             )
     # Hook explícito para ΔNFR (se puede sustituir luego con
     # dynamics.set_delta_nfr_hook)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping
 
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
+from .import_utils import optional_import
 
 
 class _KuramotoFn(Protocol):
@@ -32,27 +33,24 @@ class CallbackSpec(NamedTuple):
     func: Callable[..., Any]
 
 
-try:
-    from .gamma import kuramoto_R_psi as _kuramoto_R_psi
-except ImportError:  # pragma: no cover
-
-    def _kuramoto_R_psi(G: Any) -> tuple[float, float]:
-        return 0.0, 0.0
+def _kuramoto_fallback(G: Any) -> tuple[float, float]:
+    return 0.0, 0.0
 
 
-kuramoto_R_psi: _KuramotoFn = _kuramoto_R_psi
-
-try:
-    from .sense import sigma_vector_from_graph as _sigma_vector_from_graph
-except ImportError:  # pragma: no cover
-
-    def _sigma_vector_from_graph(
-        G: Any, weight_mode: str | None = None
-    ) -> Dict[str, float]:
-        return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0.0}
+kuramoto_R_psi: _KuramotoFn = optional_import(
+    "tnfr.gamma.kuramoto_R_psi", fallback=_kuramoto_fallback
+)
 
 
-sigma_vector_from_graph: _SigmaVectorFn = _sigma_vector_from_graph
+def _sigma_fallback(
+    G: Any, weight_mode: str | None = None
+) -> Dict[str, float]:
+    return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0.0}
+
+
+sigma_vector_from_graph: _SigmaVectorFn = optional_import(
+    "tnfr.sense.sigma_vector_from_graph", fallback=_sigma_fallback
+)
 
 # Public exports for this module
 __all__ = [


### PR DESCRIPTION
## Summary
- add optional_import function for safe optional module loading
- replace scattered try/except import blocks with optional_import
- warn and return fallbacks when optional dependencies are missing

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc081cd84c832198af6e37419f66bd