### PR TITLE
Use binary seed packing for RNG

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -17,6 +17,7 @@ import math
 import json
 import hashlib
 import random
+import struct
 from functools import partial, lru_cache
 from statistics import fmean, StatisticsError
 from json import JSONDecodeError
@@ -123,9 +124,13 @@ def get_rng(seed: int, key: int) -> random.Random:
     ``PYTHONHASHSEED``.
     """
 
-    seed_input = (int(seed), int(key))
+    seed_bytes = struct.pack(
+        ">QQ",
+        int(seed) & 0xFFFFFFFFFFFFFFFF,
+        int(key) & 0xFFFFFFFFFFFFFFFF,
+    )
     seed_int = int.from_bytes(
-        hashlib.blake2b(repr(seed_input).encode()).digest()[:8], "big"
+        hashlib.blake2b(seed_bytes, digest_size=8).digest(), "big"
     )
     return random.Random(seed_int)
 

--- a/tests/test_get_rng.py
+++ b/tests/test_get_rng.py
@@ -1,11 +1,16 @@
 import random
 import hashlib
+import struct
 from tnfr.helpers import get_rng
 
 def _derive_seed(seed: int, key: int) -> int:
-    seed_input = (int(seed), int(key))
+    seed_bytes = struct.pack(
+        ">QQ",
+        int(seed) & 0xFFFFFFFFFFFFFFFF,
+        int(key) & 0xFFFFFFFFFFFFFFFF,
+    )
     return int.from_bytes(
-        hashlib.blake2b(repr(seed_input).encode()).digest()[:8], "big"
+        hashlib.blake2b(seed_bytes, digest_size=8).digest(), "big"
     )
 
 def test_get_rng_reproducible_sequence():


### PR DESCRIPTION
## Summary
- derive RNG seeds via binary packing and blake2b digest
- adjust deterministic RNG tests for new seed hash

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc0e2a70e4832188e6f1b65642d4c5