### PR TITLE
refactor: simplify numpy optional import

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -71,20 +71,13 @@ logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
-def _optional_numpy() -> Any | None:
-    """Intenta importar ``numpy`` de forma perezosa.
-
-    Si el paquete no está disponible, devuelve ``None``. El resultado se
-    almacena en caché para evitar búsquedas repetidas.
-    """
-
-    return optional_import("numpy")
-
-
 def _np(*, warn: bool = False) -> Any | None:
-    """Devuelve el módulo ``numpy`` o ``None`` si no está disponible."""
+    """Devuelve el módulo ``numpy`` o ``None`` si no está disponible.
 
-    module = _optional_numpy()
+    Realiza la importación de forma perezosa y cachea el resultado para
+    evitar búsquedas repetidas."""
+
+    module = optional_import("numpy")
     if module is None:
         log = logger.warning if warn else logger.debug
         log(


### PR DESCRIPTION
## Summary
- cache the optional NumPy import behind a single `_np` function
- remove redundant `_optional_numpy` helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ec9b3448321ab3c162c0d669b56