### PR TITLE
Refactor alias_get overloads

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -419,10 +419,10 @@ def alias_get(
     aliases: Sequence[str],
     conv: Callable[[Any], T],
     *,
-    default: None = ...,
+    default: T,
     strict: bool = False,
     log_level: int | None = None,
-) -> Optional[T]: ...
+) -> T: ...
 
 
 @overload
@@ -431,10 +431,10 @@ def alias_get(
     aliases: Sequence[str],
     conv: Callable[[Any], T],
     *,
-    default: T,
+    default: None = ...,
     strict: bool = False,
     log_level: int | None = None,
-) -> T: ...
+) -> Optional[T]: ...
 
 
 def alias_get(


### PR DESCRIPTION
## Summary
- group alias_get type hints into two overloads and remove redundant stub
- keep single implementation with optional default
- verify _alias_get and _alias_get_set signatures remain unique

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0fa3537083218c7c00c59d4b5bde