### PR TITLE
Refactor helpers and optimize utilities

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -21,28 +21,27 @@ from .metric import (
 from ..import_utils import optional_import
 
 # Valores que pueden asignarse directamente sin copiar
-IMMUTABLE_TYPES = (
+IMMUTABLE_SIMPLE = (
     int,
     float,
     complex,
     str,
     bool,
-    tuple,
-    frozenset,
     bytes,
     type(None),
 )
 
 
 def _is_immutable(value: Any) -> bool:
-    """Check recursively if ``value`` is immutable.
-
-    Tuples are traversed to ensure they don't contain mutable elements.
-    """
-    if isinstance(value, IMMUTABLE_TYPES):
-        if isinstance(value, tuple):
-            return all(_is_immutable(item) for item in value)
+    """Check recursively if ``value`` is immutable."""
+    if isinstance(value, IMMUTABLE_SIMPLE):
         return True
+    if isinstance(value, tuple):
+        return all(_is_immutable(item) for item in value)
+    if isinstance(value, frozenset):
+        return all(_is_immutable(item) for item in value)
+    if isinstance(value, MappingProxyType):
+        return all(_is_immutable(v) for v in value.values())
     return False
 
 # Diccionario combinado exportado

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -111,28 +111,26 @@ def coherence_matrix(G):
     sum_val = 0.0
     count_val = 0
 
+    def _accumulate(i: int, j: int, w: float) -> None:
+        nonlocal min_val, max_val, sum_val, count_val
+        if i == j:
+            return
+        if w < min_val:
+            min_val = w
+        if w > max_val:
+            max_val = w
+        sum_val += w
+        count_val += 1
+
     def add_entry(i: int, j: int, w: float) -> None:
         """Add a value to the matrix and accumulate sums/counters."""
-        nonlocal min_val, max_val, sum_val, count_val
         if mode == "dense":
             W[i][j] = w
-            if i != j:
-                if w < min_val:
-                    min_val = w
-                if w > max_val:
-                    max_val = w
-                sum_val += w
-                count_val += 1
+            _accumulate(i, j, w)
         else:
             if w >= thr:
                 W.append((i, j, w))
-                if i != j:
-                    if w < min_val:
-                        min_val = w
-                    if w > max_val:
-                        max_val = w
-                    sum_val += w
-                    count_val += 1
+                _accumulate(i, j, w)
         row_sum[i] += w
         row_count[i] += 1
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -79,18 +79,19 @@ def _sigma_from_vectors(
     ``vectors`` may be a single complex number or an iterable of them.
     """
 
-    if isinstance(vectors, (str, bytes, bytearray)):
-        raise TypeError("vectors must be an iterable of complex numbers")
-
-    iterator = (
-        iter(vectors) if isinstance(vectors, Iterable) else iter([vectors])
-    )
+    try:
+        iterator = iter(vectors)
+    except TypeError:
+        iterator = iter([vectors])
 
     cnt = 0
     acc = complex(0.0, 0.0)
     for z in iterator:
         cnt += 1
-        acc += z
+        try:
+            acc += z
+        except TypeError:
+            raise TypeError("vectors must be an iterable of complex numbers") from None
 
     if cnt <= 0:
         vec = {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": float(fallback_angle)}

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -90,14 +90,7 @@ def _trace_setup(
 
 def _callback_names(callbacks: list[CallbackSpec]) -> list[str]:
     """Return callback names from ``callbacks``."""
-
-    names: list[str] = []
-    for cb in callbacks:
-        if cb.name is not None:
-            names.append(cb.name)
-        else:
-            names.append(getattr(cb.func, "__name__", "fn"))
-    return names
+    return [cb.name or getattr(cb.func, "__name__", "fn") for cb in callbacks]
 
 
 def _safe_graph_mapping(G, key: str) -> Optional[Dict[str, Any]]:

--- a/tests/test_is_immutable.py
+++ b/tests/test_is_immutable.py
@@ -1,0 +1,19 @@
+"""Tests for _is_immutable helper."""
+
+from types import MappingProxyType
+
+from tnfr.constants import _is_immutable
+
+
+def test_is_immutable_nested_structures():
+    nested = (
+        1,
+        frozenset({2, (3, 4)}),
+        MappingProxyType({"a": (5, 6), "b": frozenset({7})}),
+    )
+    assert _is_immutable(nested)
+
+
+def test_is_immutable_detects_mutable():
+    data = MappingProxyType({"a": [1, 2]})
+    assert not _is_immutable(data)

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -111,6 +111,16 @@ def test_read_structured_file_missing_dependency_toml(
     assert "toml" in msg.lower()
 
 
+def test_read_structured_file_unicode_error(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_bytes(b"\xff\xfe\xfa")
+    with pytest.raises(ValueError) as excinfo:
+        read_structured_file(path)
+    msg = str(excinfo.value)
+    assert msg.startswith("Error de codificación al leer")
+    assert str(path) in msg
+
+
 def test_json_error_not_reported_as_toml(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyTOMLDecodeError(Exception):
         pass

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -86,6 +86,11 @@ def test_sigma_from_vectors_accepts_single_complex():
     assert vec["y"] == pytest.approx(1.0)
 
 
+def test_sigma_from_vectors_rejects_invalid_iterable():
+    with pytest.raises(TypeError, match="iterable of complex"):
+        _sigma_from_vectors("abc")
+
+
 def test_unknown_glyph_does_not_shift_average():
     base, _ = _sigma_from_vectors([glyph_unit(Glyph.AL.value)])
     with_unknown, _ = _sigma_from_vectors(


### PR DESCRIPTION
## Summary
- Consolidate optional module imports and simplify structured-file parsing
- Improve heap management and glyph counting utilities
- Factor out coherence statistics and streamline callbacks
- Broaden immutability checks and simplify token parsing and sigma vectors

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1623f1448321b76afa89b8a6bf1b