### PR TITLE
Refactor helpers and consolidate optional dependencies

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -37,7 +37,7 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
-from .helpers import read_structured_file, ensure_parent, list_mean
+from .helpers import read_structured_file, list_mean, safe_write
 from .observers import attach_standard_observer
 from . import __version__
 
@@ -147,12 +147,10 @@ def _default(obj: Any) -> Any:
 
 
 def _save_json(path: str, data: Any) -> None:
-    ensure_parent(path)
-    try:
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
-    except OSError as e:
-        raise OSError(f"Failed to write JSON file {path}: {e}") from e
+    def _write(f):
+        json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
+
+    safe_write(path, _write)
 
 
 # Metadatos para las opciones de gramática y del glyph

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import importlib
 import warnings
+import logging
+from functools import lru_cache
 from typing import Any
 
-__all__ = ["optional_import"]
+__all__ = ["optional_import", "get_numpy"]
+
+
+logger = logging.getLogger(__name__)
 
 
 def optional_import(name: str, fallback: Any | None = None) -> Any | None:
@@ -50,3 +55,23 @@ def optional_import(name: str, fallback: Any | None = None) -> Any | None:
             stacklevel=2,
         )
         return fallback
+
+
+@lru_cache(maxsize=1)
+def get_numpy(*, warn: bool = False) -> Any | None:
+    """Devuelve el módulo :mod:`numpy` o ``None`` si no está disponible.
+
+    Parameters
+    ----------
+    warn:
+        Si es ``True`` se registra una advertencia cuando la importación
+        falla. En caso contrario se registra a nivel ``DEBUG``.
+    """
+
+    module = optional_import("numpy")
+    if module is None:
+        log = logger.warning if warn else logger.debug
+        log(
+            "Fallo al importar numpy, se continuará con el modo no vectorizado"
+        )
+    return module

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -22,20 +22,20 @@ def test_node_set_checksum_object_stable():
     assert checksum1 == checksum2
 
 
-def _old_checksum(G):
-    sha1 = hashlib.sha1()
+def _reference_checksum(G):
+    hasher = hashlib.blake2b(digest_size=16)
 
     def serialise(n):
         return json.dumps(_stable_json(n), sort_keys=True, ensure_ascii=False)
 
     for i, node_repr in enumerate(sorted(serialise(n) for n in G.nodes())):
         if i:
-            sha1.update(b"|")
-        sha1.update(node_repr.encode("utf-8"))
-    return sha1.hexdigest()
+            hasher.update(b"|")
+        hasher.update(node_repr.encode("utf-8"))
+    return hasher.hexdigest()
 
 
 def test_node_set_checksum_compatibility():
     G = nx.Graph()
     G.add_nodes_from([1, 2, 3])
-    assert node_set_checksum(G) == _old_checksum(G)
+    assert node_set_checksum(G) == _reference_checksum(G)


### PR DESCRIPTION
## Summary
- centralize optional imports and networkx type usage in `helpers`
- add `safe_write` and `StructuredFileError` for robust I/O
- replace SHA1 checksum with faster BLAKE2b and unify NumPy access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc1bf8e28c832196aceaf8672f7b6d