### PR TITLE
chore: remove unused contextmanager import

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -13,7 +13,6 @@ from typing import (
     Union,
 )
 from dataclasses import dataclass
-from contextlib import contextmanager
 from collections import deque
 
 from .constants import get_param


### PR DESCRIPTION
## Summary
- remove unused contextmanager import from program module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc20c168048321addc5fe4d76f3ba7