### PR TITLE
Add slots to WAIT, TARGET, and THOL dataclasses

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -31,7 +31,7 @@ AdvanceFn = Callable[[Any], None]  # normalmente dynamics.step
 # ---------------------
 
 
-@dataclass
+@dataclass(slots=True)
 class WAIT:
     """Wait a number of steps without applying glyphs.
 
@@ -42,7 +42,7 @@ class WAIT:
     steps: int = 1
 
 
-@dataclass
+@dataclass(slots=True)
 class TARGET:
     """Select the subset of nodes for subsequent glyphs.
 
@@ -53,7 +53,7 @@ class TARGET:
     nodes: Optional[Iterable[Node]] = None  # None = all nodes
 
 
-@dataclass
+@dataclass(slots=True)
 class THOL:
     """THOL block that opens self-organisation.
 


### PR DESCRIPTION
## Summary
- enable `slots=True` in `WAIT`, `TARGET`, and `THOL` dataclasses for reduced memory footprint and faster attribute access

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2138458c8321a86fc99f671921ee