### PR TITLE
feat: reuse precomputed kuramoto order values

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -59,10 +59,21 @@ def attach_standard_observer(G):
     return G
 
 
-def phase_sync(G) -> float:
+def _get_R_psi(G, R: float | None = None, psi: float | None = None) -> tuple[float, float]:
+    """Return ``(R, ψ)`` using cached values if provided."""
+    if R is None or psi is None:
+        R_calc, psi_calc = kuramoto_R_psi(G)
+        if R is None:
+            R = R_calc
+        if psi is None:
+            psi = psi_calc
+    return R, psi
+
+
+def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
     if G.number_of_nodes() == 0:
         return 1.0
-    _, psi = kuramoto_R_psi(G)
+    _, psi = _get_R_psi(G, R, psi)
     var = statistics.pvariance(
         angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
         for _, data in G.nodes(data=True)
@@ -70,11 +81,11 @@ def phase_sync(G) -> float:
     return 1.0 / (1.0 + var)
 
 
-def kuramoto_order(G) -> float:
+def kuramoto_order(G, R: float | None = None, psi: float | None = None) -> float:
     """R in [0,1], 1 means perfectly aligned phases."""
     if G.number_of_nodes() == 0:
         return 1.0
-    R, _ = kuramoto_R_psi(G)
+    R, _ = _get_R_psi(G, R, psi)
     return float(R)
 
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -34,6 +34,12 @@ def test_phase_observers_match_manual_calculation(graph_canon):
     R = ((sum(X) ** 2 + sum(Y) ** 2) ** 0.5) / len(angles)
     assert math.isclose(kuramoto_order(G), float(R))
 
+    R_calc, psi_calc = kuramoto_R_psi(G)
+    ps_again = phase_sync(G, R_calc, psi_calc)
+    R_again = kuramoto_order(G, R_calc, psi_calc)
+    assert math.isclose(ps_again, ps)
+    assert math.isclose(R_again, R)
+
 
 def test_phase_sync_bounds(graph_canon):
     G = graph_canon()
@@ -54,8 +60,10 @@ def test_kuramoto_order_matches_kuramoto_R_psi(graph_canon):
         set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     R_ok = kuramoto_order(G)
-    R, _ = kuramoto_R_psi(G)
+    R, psi = kuramoto_R_psi(G)
     assert math.isclose(R_ok, R)
+    assert math.isclose(kuramoto_order(G, R, psi), R)
+    assert math.isclose(phase_sync(G, R, psi), phase_sync(G))
 
 
 def test_glyph_load_uses_module_constants(monkeypatch, graph_canon):


### PR DESCRIPTION
## Summary
- add helper to reuse precomputed Kuramoto order and phase
- allow passing precomputed R and psi to `phase_sync` and `kuramoto_order`
- test new observer arguments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc23727c7c8321a74c36e0acbccc0d