### PR TITLE
Refactor history retrieval to use get

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -122,11 +122,6 @@ class HistoryDict(dict):
         except KeyError:
             return default
 
-    def tracked_get(self, key, default=None):
-        if key in self:
-            return self[key]
-        return default
-
     def __setitem__(self, key, value):  # type: ignore[override]
         super().__setitem__(key, value)
         self._counts.setdefault(key, 0)

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -387,7 +387,7 @@ def Tg_global(G, normalize: bool = True) -> dict[str, float]:
     """Total glyph time per class. If ``normalize=True``, return fractions
     of the total."""
     hist = ensure_history(G)
-    tg_total: dict[str, float] = hist.tracked_get("Tg_total", {})
+    tg_total: dict[str, float] = hist.get("Tg_total", {})
     total = sum(tg_total.values()) or 1.0
     out: dict[str, float] = {}
 
@@ -405,7 +405,7 @@ def Tg_by_node(
     """Per-node summary: if ``normalize`` return mean run per glyph;
     otherwise list runs."""
     hist = ensure_history(G)
-    rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
+    rec = hist.get("Tg_by_node", {}).get(n, {})
     if not normalize:
         # convertir default dict → list para serializar
         out: dict[str, list[float]] = {}
@@ -427,7 +427,7 @@ def Tg_by_node(
 
 def latency_series(G) -> dict[str, list[float]]:
     hist = ensure_history(G)
-    xs = hist.tracked_get("latency_index", [])
+    xs = hist.get("latency_index", [])
     return {
         "t": [float(x.get("t", i)) for i, x in enumerate(xs)],
         "value": [float(x.get("value", 0.0)) for x in xs],
@@ -436,7 +436,7 @@ def latency_series(G) -> dict[str, list[float]]:
 
 def glyphogram_series(G) -> dict[str, list[float]]:
     hist = ensure_history(G)
-    xs = hist.tracked_get("glyphogram", [])
+    xs = hist.get("glyphogram", [])
     if not xs:
         return {"t": []}
     out = {"t": [float(x.get("t", i)) for i, x in enumerate(xs)]}
@@ -457,7 +457,7 @@ def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
 def glyph_dwell_stats(G, n) -> dict[str, dict[str, float]]:
     """Per-node statistics: mean/median/max of runs per glyph."""
     hist = ensure_history(G)
-    rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
+    rec = hist.get("Tg_by_node", {}).get(n, {})
     out: dict[str, dict[str, float]] = {}
 
     def add(g):

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -86,9 +86,9 @@ def _diagnosis_step(G, ctx=None):
     CfgW = G.graph.get("COHERENCE", COHERENCE)
     Wkey = CfgW.get("Wi_history_key", "W_i")
     Wm_key = CfgW.get("history_key", "W_sparse")
-    Wi_series = hist.tracked_get(Wkey, [])
+    Wi_series = hist.get(Wkey, [])
     Wi_last = Wi_series[-1] if Wi_series else None
-    Wm_series = hist.tracked_get(Wm_key, [])
+    Wm_series = hist.get(Wm_key, [])
     Wm_last = Wm_series[-1] if Wm_series else None
 
     nodes = list(G.nodes())
@@ -157,7 +157,7 @@ def dissonance_events(G, ctx=None):
     # eventos de disonancia se registran en ``history['events']``
     norms = G.graph.get("_sel_norms", {})
     dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
-    step_idx = len(hist.tracked_get("C_steps", []))
+    step_idx = len(hist.get("C_steps", []))
     nodes = list(G.nodes())
     node_to_index = {v: i for i, v in enumerate(nodes)}
     for n in nodes:

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -37,11 +37,11 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     """Dump glyphogram and σ(t) trace to compact CSV or JSON files."""
     hist = ensure_history(G)
     glyph = glyphogram_series(G)
-    sigma_x = hist.tracked_get("sense_sigma_x", [])
-    sigma_y = hist.tracked_get("sense_sigma_y", [])
-    sigma_mag = hist.tracked_get("sense_sigma_mag", [])
-    sigma_angle = hist.tracked_get("sense_sigma_angle", [])
-    t_series = hist.tracked_get("sense_sigma_t", []) or glyph.get("t", [])
+    sigma_x = hist.get("sense_sigma_x", [])
+    sigma_y = hist.get("sense_sigma_y", [])
+    sigma_mag = hist.get("sense_sigma_mag", [])
+    sigma_angle = hist.get("sense_sigma_angle", [])
+    t_series = hist.get("sense_sigma_t", []) or glyph.get("t", [])
     rows_raw = zip_longest(
         t_series, sigma_x, sigma_y, sigma_mag, sigma_angle, fillvalue=None
     )
@@ -62,8 +62,8 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
         "mag": [m for _, _, _, m, _ in sigma_rows],
         "angle": [a for _, _, _, _, a in sigma_rows],
     }
-    morph = hist.tracked_get("morph", [])
-    epi_supp = hist.tracked_get("EPI_support", [])
+    morph = hist.get("morph", [])
+    epi_supp = hist.get("EPI_support", [])
     fmt = fmt.lower()
     if fmt not in {"csv", "json"}:
         raise ValueError(f"Formato de exportación no soportado: {fmt}")


### PR DESCRIPTION
## Summary
- Remove obsolete `tracked_get` method from `HistoryDict`
- Replace `tracked_get` calls with `get` across metrics modules

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc248b659c8321ae07e5c7f61cf970