### PR TITLE
Limit RNG cache size for deterministic generators

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -120,7 +120,7 @@ __all__ = [
 # -------------------------
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=DEFAULTS["JITTER_CACHE_SIZE"])
 def get_rng(seed: int, key: int) -> random.Random:
     """Devuelve un ``random.Random`` cacheado por ``(seed, key)``.
 


### PR DESCRIPTION
## Summary
- restrict `get_rng` cache size using `DEFAULTS["JITTER_CACHE_SIZE"]`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc2538005883218bf1e9cdd8ae00fe