### PR TITLE
Rename export history function

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -21,7 +21,7 @@ from .metrics import (
     latency_series,
     glyphogram_series,
     glyph_top,
-    export_history,
+    export_metrics,
     _metrics_step,
 )
 from .trace import register_trace
@@ -240,7 +240,7 @@ def _persist_history(G: "nx.Graph", args: argparse.Namespace) -> None:
         if args.save_history:
             _save_json(args.save_history, history)
         if args.export_history_base:
-            export_history(G, args.export_history_base, fmt=args.export_format)
+            export_metrics(G, args.export_history_base, fmt=args.export_format)
 
 
 def build_basic_graph(args: argparse.Namespace) -> "nx.Graph":

--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -26,7 +26,7 @@ from .diagnosis import (
     register_diagnosis_callbacks,
     dissonance_events,
 )
-from .export import export_history
+from .export import export_metrics
 
 __all__ = [
     "register_metrics_callbacks",
@@ -46,5 +46,5 @@ __all__ = [
     "register_coherence_callbacks",
     "register_diagnosis_callbacks",
     "dissonance_events",
-    "export_history",
+    "export_metrics",
 ]

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -33,7 +33,7 @@ def _iter_sigma_rows(sigma_rows):
     return ([t, x, y, m, a] for t, x, y, m, a in sigma_rows)
 
 
-def export_history(G, base_path: str, fmt: str = "csv") -> None:
+def export_metrics(G, base_path: str, fmt: str = "csv") -> None:
     """Dump glyphogram and σ(t) trace to compact CSV or JSON files."""
     hist = ensure_history(G)
     glyph = glyphogram_series(G)

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -15,7 +15,7 @@ def test_cli_run_save_history(tmp_path):
     assert isinstance(data, dict)
 
 
-def test_cli_run_export_history(tmp_path):
+def test_cli_run_export_metrics(tmp_path):
     base = tmp_path / "other" / "history"
     assert not base.parent.exists()
     rc = main(
@@ -34,7 +34,7 @@ def test_cli_run_export_history(tmp_path):
     assert isinstance(data, dict)
 
 
-def test_cli_run_save_and_export_history(tmp_path):
+def test_cli_run_save_and_export_metrics(tmp_path):
     save_path = tmp_path / "hist.json"
     export_base = tmp_path / "history"
     rc = main(
@@ -66,7 +66,7 @@ def test_cli_sequence_save_history(tmp_path):
     assert isinstance(data, dict)
 
 
-def test_cli_sequence_export_history(tmp_path):
+def test_cli_sequence_export_metrics(tmp_path):
     base = tmp_path / "other" / "history"
     assert not base.parent.exists()
     rc = main(["sequence", "--nodes", "5", "--export-history-base", str(base)])

--- a/tests/test_export_metrics.py
+++ b/tests/test_export_metrics.py
@@ -1,58 +1,58 @@
-"""Pruebas de export history."""
+"""Pruebas de export metrics."""
 
 import json
 import csv
 import pytest
 
-from tnfr.metrics import export_history
+from tnfr.metrics import export_metrics
 
 
-def test_export_history_creates_directory_csv(tmp_path, graph_canon):
+def test_export_metrics_creates_directory_csv(tmp_path, graph_canon):
     base = tmp_path / "non" / "existing" / "run"
     dir_path = base.parent
     assert not dir_path.exists()
     G = graph_canon()
-    export_history(G, str(base), fmt="csv")
+    export_metrics(G, str(base), fmt="csv")
     assert dir_path.exists()
     assert (dir_path / (base.name + "_glyphogram.csv")).is_file()
     assert (dir_path / (base.name + "_sigma.csv")).is_file()
 
 
-def test_export_history_creates_directory_json(tmp_path, graph_canon):
+def test_export_metrics_creates_directory_json(tmp_path, graph_canon):
     base = tmp_path / "other" / "path" / "history"
     dir_path = base.parent
     assert not dir_path.exists()
     G = graph_canon()
-    export_history(G, str(base), fmt="json")
+    export_metrics(G, str(base), fmt="json")
     assert dir_path.exists()
     assert (base.with_suffix(".json")).is_file()
 
 
-def test_export_history_writes_optional_files(tmp_path, graph_canon):
+def test_export_metrics_writes_optional_files(tmp_path, graph_canon):
     base = tmp_path / "extras" / "run"
     G = graph_canon()
     hist = G.graph.setdefault("history", {})
     hist["morph"] = [{"t": 0, "ID": 1, "CM": 2, "NE": 3, "PP": 4}]
     hist["EPI_support"] = [{"t": 0, "size": 1, "epi_norm": 0.5}]
-    export_history(G, str(base), fmt="csv")
+    export_metrics(G, str(base), fmt="csv")
     dir_path = base.parent
     assert (dir_path / (base.name + "_morph.csv")).is_file()
     assert (dir_path / (base.name + "_epi_support.csv")).is_file()
 
 
-def test_export_history_json_contains_optional(tmp_path, graph_canon):
+def test_export_metrics_json_contains_optional(tmp_path, graph_canon):
     base = tmp_path / "extras" / "jsonrun"
     G = graph_canon()
     hist = G.graph.setdefault("history", {})
     hist["morph"] = [{"t": 0, "ID": 1, "CM": 2, "NE": 3, "PP": 4}]
     hist["EPI_support"] = [{"t": 0, "size": 1, "epi_norm": 0.5}]
-    export_history(G, str(base), fmt="json")
+    export_metrics(G, str(base), fmt="json")
     data = json.loads((base.with_suffix(".json")).read_text())
     assert data["morph"]
     assert data["epi_support"]
 
 
-def test_export_history_extends_sigma(tmp_path, graph_canon):
+def test_export_metrics_extends_sigma(tmp_path, graph_canon):
     base = tmp_path / "short" / "run"
     G = graph_canon()
     hist = G.graph.setdefault("history", {})
@@ -60,7 +60,7 @@ def test_export_history_extends_sigma(tmp_path, graph_canon):
     hist["sense_sigma_y"] = [3]
     hist["sense_sigma_mag"] = [4, 5, 6]
     hist["sense_sigma_angle"] = [7, 8]
-    export_history(G, str(base), fmt="csv")
+    export_metrics(G, str(base), fmt="csv")
     sigma_path = base.parent / (base.name + "_sigma.csv")
     with open(sigma_path, newline="") as f:
         rows = list(csv.reader(f))
@@ -70,7 +70,7 @@ def test_export_history_extends_sigma(tmp_path, graph_canon):
     assert len(rows) == 4
 
 
-def test_export_history_preserves_timestamps(tmp_path, graph_canon):
+def test_export_metrics_preserves_timestamps(tmp_path, graph_canon):
     base = tmp_path / "ts" / "run"
     G = graph_canon()
     hist = G.graph.setdefault("history", {})
@@ -79,7 +79,7 @@ def test_export_history_preserves_timestamps(tmp_path, graph_canon):
     hist["sense_sigma_y"] = []
     hist["sense_sigma_mag"] = []
     hist["sense_sigma_angle"] = []
-    export_history(G, str(base), fmt="csv")
+    export_metrics(G, str(base), fmt="csv")
     sigma_path = base.parent / (base.name + "_sigma.csv")
     with open(sigma_path, newline="") as f:
         rows = list(csv.reader(f))
@@ -87,7 +87,7 @@ def test_export_history_preserves_timestamps(tmp_path, graph_canon):
     assert rows[2][0] == "20"
 
 
-def test_export_history_invalid_format(tmp_path, graph_canon):
+def test_export_metrics_invalid_format(tmp_path, graph_canon):
     G = graph_canon()
     with pytest.raises(ValueError):
-        export_history(G, str(tmp_path / "base"), fmt="xml")
+        export_metrics(G, str(tmp_path / "base"), fmt="xml")


### PR DESCRIPTION
## Summary
- rename `export_history` function to `export_metrics`
- update CLI and tests to use the new name

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc293a4ae48321a84303ec4db14462