### PR TITLE
refactor: modularize utility functions

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -1,0 +1,265 @@
+"""Attribute helpers supporting alias keys."""
+
+from __future__ import annotations
+from typing import Sequence, Dict, Any, Callable, TypeVar, Optional, overload, Protocol
+import logging
+from functools import partial
+
+from .value_utils import _convert_value
+from .constants import ALIAS_VF, ALIAS_DNFR
+
+T = TypeVar("T")
+
+__all__ = [
+    "alias_get",
+    "alias_set",
+    "get_attr",
+    "set_attr",
+    "get_attr_str",
+    "set_attr_str",
+    "set_attr_with_max",
+    "set_vf",
+    "set_dnfr",
+]
+
+
+def _validate_aliases(aliases: Sequence[str]) -> tuple[str, ...]:
+    """Validate ``aliases`` and return them as a tuple of strings."""
+    if isinstance(aliases, str) or not isinstance(aliases, Sequence):
+        raise TypeError("'aliases' must be a non-string sequence")
+    seq = aliases if isinstance(aliases, tuple) else tuple(aliases)
+    if not seq or any(not isinstance(a, str) for a in seq):
+        if not seq:
+            raise ValueError("'aliases' must contain at least one key")
+        raise TypeError("'aliases' elements must be strings")
+    return seq
+
+
+def _alias_lookup(
+    d: Dict[str, Any],
+    aliases: tuple[str, ...],
+    conv: Callable[[Any], T],
+    *,
+    default: Optional[Any] = None,
+    strict: bool = False,
+    log_level: int | None = None,
+) -> Optional[T]:
+    for key in aliases:
+        if key in d:
+            ok, val = _convert_value(
+                d[key], conv, strict=strict, key=key, log_level=log_level
+            )
+            if ok:
+                return val
+    if default is None:
+        return None
+    ok, val = _convert_value(
+        default,
+        conv,
+        strict=strict,
+        key="default",
+        log_level=logging.WARNING if not strict else log_level,
+    )
+    return val if ok else None
+
+
+@overload
+def alias_get(
+    d: Dict[str, Any],
+    aliases: Sequence[str],
+    conv: Callable[[Any], T],
+    *,
+    default: T,
+    strict: bool = False,
+    log_level: int | None = None,
+) -> T: ...
+
+
+@overload
+def alias_get(
+    d: Dict[str, Any],
+    aliases: Sequence[str],
+    conv: Callable[[Any], T],
+    *,
+    default: None = ...,
+    strict: bool = False,
+    log_level: int | None = None,
+) -> Optional[T]: ...
+
+
+def alias_get(
+    d: Dict[str, Any],
+    aliases: Sequence[str],
+    conv: Callable[[Any], T],
+    *,
+    default: Optional[Any] = None,
+    strict: bool = False,
+    log_level: int | None = None,
+) -> Optional[T]:
+    """Return the value for the first existing key in ``aliases``."""
+    return _alias_get(
+        d,
+        aliases,
+        conv=conv,
+        default=default,
+        strict=strict,
+        log_level=log_level,
+    )
+
+
+def alias_set(
+    d: Dict[str, Any],
+    aliases: Sequence[str],
+    conv: Callable[[Any], T],
+    value: Any,
+) -> T:
+    """Assign ``value`` converted to the first available key in ``aliases``."""
+    if not isinstance(aliases, tuple):
+        aliases = _validate_aliases(aliases)
+    _, val = _convert_value(value, conv, strict=True)
+    if val is None:
+        raise ValueError("conversion yielded None")
+    key = next((k for k in aliases if k in d), aliases[0])
+    d[key] = val
+    return val
+
+
+class _Getter(Protocol[T]):
+    @overload
+    def __call__(
+        self,
+        d: Dict[str, Any],
+        aliases: Sequence[str],
+        default: T = ...,  # noqa: D401 - documented in alias_get
+        *,
+        strict: bool = False,
+        log_level: int | None = None,
+    ) -> T: ...
+
+    @overload
+    def __call__(
+        self,
+        d: Dict[str, Any],
+        aliases: Sequence[str],
+        default: None = ...,  # noqa: D401 - documented in alias_get
+        *,
+        strict: bool = False,
+        log_level: int | None = None,
+    ) -> Optional[T]: ...
+
+
+class _Setter(Protocol[T]):
+    def __call__(self, d: Dict[str, Any], aliases: Sequence[str], value: T) -> T:
+        ...
+
+
+def _alias_get(
+    d: Dict[str, Any],
+    aliases: Sequence[str],
+    *,
+    conv: Callable[[Any], T],
+    default: Optional[Any] = None,
+    strict: bool = False,
+    log_level: int | None = None,
+) -> Optional[T]:
+    if not isinstance(aliases, tuple):
+        aliases = _validate_aliases(aliases)
+    return _alias_lookup(
+        d,
+        aliases,
+        conv=conv,
+        default=default,
+        strict=strict,
+        log_level=log_level,
+    )
+
+
+def _alias_get_set(
+    conv: Callable[[Any], T],
+    *,
+    default: T | None = None,
+) -> tuple[_Getter[T], _Setter[T]]:
+    """Create alias ``get``/``set`` functions using ``conv``."""
+    _base_get = partial(_alias_get, conv=conv)
+
+    def _get(
+        d: Dict[str, Any],
+        aliases: Sequence[str],
+        default: Optional[T] = default,
+        *,
+        strict: bool = False,
+        log_level: int | None = None,
+    ) -> Optional[T]:
+        """Obtain an attribute using :func:`alias_get`."""
+        return _base_get(
+            d,
+            aliases,
+            default=default,
+            strict=strict,
+            log_level=log_level,
+        )
+
+    def _set(d: Dict[str, Any], aliases: Sequence[str], value: T) -> T:
+        """Set an attribute using :func:`alias_set`."""
+        return alias_set(d, aliases, conv, value)
+
+    return _get, _set
+
+
+get_attr, set_attr = _alias_get_set(float, default=0.0)
+get_attr_str, set_attr_str = _alias_get_set(str, default="")
+
+
+# -------------------------
+# Máximos globales con caché
+# -------------------------
+
+
+def _recompute_abs_max(G, aliases: tuple[str, ...]):
+    """Recalculate and return ``(max_val, node)`` for ``aliases``."""
+    node = max(
+        G.nodes(),
+        key=lambda m: abs(get_attr(G.nodes[m], aliases, 0.0)),
+        default=None,
+    )
+    max_val = (
+        abs(get_attr(G.nodes[node], aliases, 0.0)) if node is not None else 0.0
+    )
+    return max_val, node
+
+
+def _update_cached_abs_max(
+    G, aliases: tuple[str, ...], n, value, *, key: str
+) -> None:
+    """Update ``G.graph[key]`` and ``G.graph[f"{key}_node"]``."""
+    node_key = f"{key}_node"
+    val = abs(value)
+    cur = float(G.graph.get(key, 0.0))
+    cur_node = G.graph.get(node_key)
+    if val >= cur:
+        G.graph[key] = val
+        G.graph[node_key] = n
+    elif cur_node == n and val < cur:
+        max_val, max_node = _recompute_abs_max(G, aliases)
+        G.graph[key] = max_val
+        G.graph[node_key] = max_node
+
+
+def set_attr_with_max(
+    G, n, aliases: tuple[str, ...], value: float, *, cache: str
+) -> None:
+    """Assign ``value`` and update the global maximum."""
+    val = float(value)
+    set_attr(G.nodes[n], aliases, val)
+    _update_cached_abs_max(G, aliases, n, val, key=cache)
+
+
+def set_vf(G, n, value: float) -> None:
+    """Set ``νf`` and update the global maximum."""
+    set_attr_with_max(G, n, ALIAS_VF, value, cache="_vfmax")
+
+
+def set_dnfr(G, n, value: float) -> None:
+    """Set ``ΔNFR`` and update the global maximum."""
+    set_attr_with_max(G, n, ALIAS_DNFR, value, cache="_dnfrmax")
+

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -37,7 +37,8 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
-from .helpers import read_structured_file, list_mean, safe_write
+from .io import read_structured_file, safe_write
+from .helpers import list_mean
 from .observers import attach_standard_observer
 from . import __version__
 

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 from pathlib import Path
-from .helpers import read_structured_file
+from .io import read_structured_file
 
 from .constants import inject_defaults
 

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -42,19 +42,20 @@ from .helpers import (
     clamp,
     clamp01,
     angle_diff,
+    neighbor_mean,
+    neighbor_phase_mean,
+    cached_nodes_and_A,
+)
+from .alias import (
     get_attr,
     set_attr,
     get_attr_str,
     set_attr_str,
-    neighbor_mean,
-    neighbor_phase_mean,
     set_vf,
     set_dnfr,
-    compute_Si,
-    compute_dnfr_accel_max,
-    cached_nodes_and_A,
-    get_rng,
 )
+from .metrics_utils import compute_Si, compute_dnfr_accel_max
+from .rng import get_rng
 from .callback_utils import invoke_callbacks
 from .glyph_history import recent_glyph, ensure_history, append_metric
 from .collections_utils import normalize_weights

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -9,7 +9,8 @@ import warnings
 from collections.abc import Mapping
 
 from .constants import ALIAS_THETA
-from .helpers import get_attr, node_set_checksum
+from .alias import get_attr
+from .helpers import node_set_checksum
 
 
 logger = logging.getLogger(__name__)

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -10,7 +10,8 @@ from .constants import (
     ALIAS_D2EPI,
     get_param,
 )
-from .helpers import get_attr, clamp01
+from .alias import get_attr
+from .helpers import clamp01
 from .glyph_history import recent_glyph
 from .types import Glyph
 

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -1,64 +1,14 @@
 """Helper functions."""
 
 from __future__ import annotations
-from typing import (
-    Iterable,
-    Sequence,
-    Dict,
-    Any,
-    Callable,
-    TypeVar,
-    Optional,
-    overload,
-    Protocol,
-    TYPE_CHECKING,
-)
-import logging
+from typing import Iterable, Sequence, Dict, Any, Optional, TYPE_CHECKING
 import math
 import json
 import hashlib
-import random
-import struct
-from functools import lru_cache, partial
 from statistics import fmean, StatisticsError
-from json import JSONDecodeError
-from pathlib import Path
 from collections import OrderedDict
 
-from .import_utils import optional_import, get_numpy
-
-if TYPE_CHECKING:  # pragma: no cover - solo para type checkers
-    import networkx as nx
-
-
-tomllib = optional_import("tomllib") or optional_import("tomli")
-if tomllib is not None:
-    TOMLDecodeError = getattr(tomllib, "TOMLDecodeError", Exception)
-    has_toml = True
-else:  # pragma: no cover - depende de tomllib/tomli
-    has_toml = False
-
-    class TOMLDecodeError(Exception):
-        pass
-
-yaml = optional_import("yaml")
-if yaml is not None:
-    YAMLError = getattr(yaml, "YAMLError", Exception)
-else:  # pragma: no cover - depende de pyyaml
-
-    class YAMLError(Exception):
-        pass
-
-
-from .constants import (
-    DEFAULTS,
-    ALIAS_VF,
-    ALIAS_THETA,
-    ALIAS_DNFR,
-    ALIAS_dEPI,
-    ALIAS_SI,
-    ALIAS_D2EPI,
-)
+from .import_utils import get_numpy
 from .collections_utils import (
     MAX_MATERIALIZE_DEFAULT,
     ensure_collection,
@@ -66,33 +16,23 @@ from .collections_utils import (
     normalize_counter,
     mix_groups,
 )
-from .value_utils import _convert_value
+from .alias import get_attr
+from .constants import ALIAS_THETA
+
+if TYPE_CHECKING:  # pragma: no cover - solo para type checkers
+    import networkx as nx
 
 PI = math.pi
 TWO_PI = 2 * PI
 
-T = TypeVar("T")
-
 __all__ = [
     "MAX_MATERIALIZE_DEFAULT",
-    "read_structured_file",
-    "safe_write",
-    "StructuredFileError",
     "ensure_collection",
     "clamp",
     "clamp01",
     "list_mean",
     "angle_diff",
     "normalize_weights",
-    "alias_get",
-    "alias_set",
-    "get_attr",
-    "set_attr",
-    "get_attr_str",
-    "set_attr_str",
-    "set_attr_with_max",
-    "set_vf",
-    "set_dnfr",
     "neighbor_mean",
     "neighbor_phase_mean",
     "push_glyph",
@@ -102,151 +42,92 @@ __all__ = [
     "count_glyphs",
     "normalize_counter",
     "mix_groups",
-    "compute_dnfr_accel_max",
-    "compute_coherence",
-    "get_Si_weights",
-    "precompute_trigonometry",
-    "compute_Si_node",
-    "compute_Si",
     "ensure_node_offset_map",
     "cached_nodes_and_A",
     "increment_edge_version",
     "node_set_checksum",
-    "get_rng",
 ]
 
+
 # -------------------------
-# Generadores pseudoaleatorios
+# Utilidades numéricas básicas
 # -------------------------
 
 
-@lru_cache(maxsize=DEFAULTS["JITTER_CACHE_SIZE"])
-def get_rng(seed: int, key: int) -> random.Random:
-    """Return a cached ``random.Random`` for ``(seed, key)``.
+def clamp(x: float, a: float, b: float) -> float:
+    """Return ``x`` clamped to the ``[a, b]`` interval."""
+    return max(a, min(b, x))
 
-    A stable hash combines both values to guarantee reproducibility across
-    runs and avoid ``PYTHONHASHSEED`` collisions.
+
+def clamp01(x: float) -> float:
+    """Clamp ``x`` to the ``[0,1]`` interval."""
+    return clamp(float(x), 0.0, 1.0)
+
+
+def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
+    """Return the arithmetic mean of ``xs`` or ``default`` if empty."""
+    try:
+        return float(fmean(xs))
+    except (StatisticsError, ValueError):
+        return float(default)
+
+
+def angle_diff(a: float, b: float) -> float:
+    """Return the minimal difference between two angles in radians."""
+    return (float(a) - float(b) + PI) % TWO_PI - PI
+
+
+# -------------------------
+# Estadísticos vecinales
+# -------------------------
+
+
+def neighbor_mean(G, n, aliases: tuple[str, ...], default: float = 0.0) -> float:
+    """Mean of ``aliases`` attribute among neighbours of ``n``."""
+    vals = (get_attr(G.nodes[v], aliases, default) for v in G.neighbors(n))
+    return list_mean(vals, default)
+
+
+def neighbor_phase_mean(obj, n=None) -> float:
+    """Circular mean of neighbour phases.
+
+    Accepts a :class:`NodoProtocol` or a ``(G, n)`` pair from ``networkx``. The
+    latter is wrapped in :class:`NodoNX` to reuse the same logic.
     """
+    from .node import NodoNX  # importación local para evitar ciclo
 
-    seed_bytes = struct.pack(
-        ">QQ",
-        int(seed) & 0xFFFFFFFFFFFFFFFF,
-        int(key) & 0xFFFFFFFFFFFFFFFF,
-    )
-    seed_int = int.from_bytes(
-        hashlib.blake2b(seed_bytes, digest_size=8).digest(), "big"
-    )
-    return random.Random(seed_int)
-
-# -------------------------
-# Entrada/salida estructurada
-# -------------------------
-
-
-def _missing_dependency(name: str) -> Callable[[str], Any]:
-    def _raise(_: str) -> Any:
-        raise ImportError(f"{name} no está instalado")
-
-    return _raise
-
-
-PARSERS: Dict[str, Callable[[str], Any]] = {".json": json.loads}
-
-
-def _get_parser(suffix: str) -> Callable[[str], Any]:
-    parser = PARSERS.get(suffix)
-    if parser is not None:
-        return parser
-    if suffix in (".yaml", ".yml"):
-        parser = getattr(yaml, "safe_load", _missing_dependency("pyyaml"))
-    elif suffix == ".toml":
-        parser = getattr(tomllib, "loads", _missing_dependency("tomllib/tomli"))
+    if n is not None:
+        node = NodoNX(obj, n)
     else:
-        raise KeyError(suffix)
-    PARSERS[suffix] = parser
-    return parser
+        node = obj  # se asume NodoProtocol
+
+    x = y = 0.0
+    count = 0
+    for v in node.neighbors():
+        if hasattr(v, "theta"):
+            th = getattr(v, "theta", 0.0)
+        else:
+            th = NodoNX.from_graph(node.G, v).theta  # type: ignore[attr-defined]
+        x += math.cos(th)
+        y += math.sin(th)
+        count += 1
+    if count == 0:
+        return getattr(node, "theta", 0.0)
+    return math.atan2(y, x)
 
 
-def _format_structured_file_error(path: Path, e: Exception) -> str:
-    """Return a formatted error message for ``path``.
+# -------------------------
+# Historial de glyphs por nodo
+# -------------------------
 
-    Centralises message generation when handling different exceptions raised
-    while reading or parsing structured files.
-    """
-
-    if isinstance(e, OSError):
-        return f"No se pudo leer {path}: {e}"
-    if isinstance(e, UnicodeDecodeError):
-        return f"Error de codificación al leer {path}: {e}"
-    if isinstance(e, JSONDecodeError):
-        return f"Error al parsear archivo JSON en {path}: {e}"
-    if isinstance(e, YAMLError):
-        return f"Error al parsear archivo YAML en {path}: {e}"
-    if has_toml and isinstance(e, TOMLDecodeError):
-        return f"Error al parsear archivo TOML en {path}: {e}"
-    if isinstance(e, ImportError):
-        return f"Dependencia faltante al parsear {path}: {e}"
-    return f"Error al parsear {path}: {e}"
-
-
-class StructuredFileError(Exception):
-    """Error while reading or parsing a structured file.
-
-    The original exception is available via ``__cause__``.
-    """
-
-    def __init__(self, path: Path, original: Exception):
-        super().__init__(_format_structured_file_error(path, original))
-        self.path = path
-
-
-def read_structured_file(path: Path) -> Any:
-    """Read a JSON, YAML or TOML file and return parsed data.
-
-    Raises
-    ------
-    StructuredFileError
-        If a read or parse error occurs. The original exception is exposed as
-        ``__cause__``.
-    ValueError
-        If the file extension is not supported.
-    """
-
-    suffix = path.suffix.lower()
-    try:
-        parser = _get_parser(suffix)
-    except KeyError as e:
-        raise ValueError(f"Extensión de archivo no soportada: {suffix}") from e
-    try:
-        text = path.read_text(encoding="utf-8")
-        return parser(text)
-    except Exception as e:
-        raise StructuredFileError(path, e) from e
-
-
-def safe_write(
-    path: str | Path,
-    write: Callable[[Any], Any],
-    *,
-    mode: str = "w",
-    encoding: str | None = "utf-8",
-    **open_kwargs: Any,
-) -> None:
-    """Write to ``path`` ensuring parent directory exists and handle errors.
-
-    ``write`` receives a file object opened at ``path``. Any :class:`OSError`
-    is re-raised with a descriptive message.
-    """
-
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    open_params = dict(mode=mode, **open_kwargs)
-    if encoding is not None:
-        open_params["encoding"] = encoding
-    try:
-        with open(path, **open_params) as f:
-            write(f)
-    except OSError as e:
-        raise OSError(f"Failed to write file {path}: {e}") from e
+# Importaciones diferidas para evitar ciclos con ``alias``
+from .glyph_history import (  # noqa: E402
+    push_glyph,
+    recent_glyph,
+    ensure_history,
+    last_glyph,
+    count_glyphs,
+)
 
 
 # -------------------------
@@ -255,14 +136,7 @@ def safe_write(
 
 
 def _stable_json(obj: Any, visited: set[int] | None = None) -> Any:
-    """Helper to obtain a JSON-serialisable structure for ``obj``.
-
-    The default :func:`json.dumps` behaviour falls back to ``obj.__dict__``
-    when available and otherwise uses ``repr(obj)`` which may include
-    memory addresses. This function walks basic containers and objects to
-    build a representation that avoids such non-deterministic data.
-    """
-
+    """Helper to obtain a JSON-serialisable structure for ``obj``."""
     if isinstance(obj, (str, int, float, bool)) or obj is None:
         return obj
 
@@ -286,15 +160,7 @@ def _stable_json(obj: Any, visited: set[int] | None = None) -> Any:
 def node_set_checksum(
     G: "nx.Graph", nodes: Iterable[Any] | None = None
 ) -> str:
-    """Return the SHA1 of ``G``'s node set in sorted order.
-
-    ``nodes`` allows reusing a previously materialised collection to avoid
-    iterating over ``G`` twice.
-
-    Each node is serialised to JSON with sorted keys and without memory
-    addresses, ensuring a stable representation of the set.
-    """
-
+    """Return the SHA1 of ``G``'s node set in sorted order."""
     hasher = hashlib.blake2b(digest_size=16)
 
     def serialise(n: Any) -> str:
@@ -315,14 +181,7 @@ def node_set_checksum(
 
 
 def ensure_node_offset_map(G) -> Dict[Any, int]:
-    """Return cached node→index mapping for ``G``.
-
-    The mapping follows the natural insertion order of ``G.nodes`` for speed.
-    When ``G.graph['SORT_NODES']`` is true a deterministic sort is applied.
-    A checksum of the node set is stored so the mapping is recomputed only
-    when the nodes change.
-    """
-
+    """Return cached node→index mapping for ``G``."""
     nodes = list(G.nodes())
     checksum = node_set_checksum(G, nodes)
     mapping = G.graph.get("_node_offset_map")
@@ -338,14 +197,7 @@ def ensure_node_offset_map(G) -> Dict[Any, int]:
 def cached_nodes_and_A(
     G: "nx.Graph", *, cache_size: int | None = 1
 ) -> tuple[list[int], Any]:
-    """Return list of nodes and adjacency matrix for ``G`` with caching.
-
-    Information is stored in ``G.graph['_dnfr_cache']`` and reused while the
-    graph structure remains unchanged. ``cache_size`` limits the number of
-    entries per graph (``None`` or values <= 0 imply no limit). The node set
-    is signed deterministically to ensure stable cache keys across runs.
-    """
-
+    """Return list of nodes and adjacency matrix for ``G`` with caching."""
     cache: OrderedDict = G.graph.setdefault("_dnfr_cache", OrderedDict())
     nodes_list = list(G.nodes())
     checksum = node_set_checksum(G, nodes_list)
@@ -376,607 +228,10 @@ def cached_nodes_and_A(
     return nodes_and_A
 
 
-# -------------------------
-# Iterables y colecciones
-# -------------------------
-# -------------------------
-# Utilidades numéricas
-# -------------------------
-
-
-def clamp(x: float, a: float, b: float) -> float:
-    """Clamp ``x`` to the closed interval [a, b]."""
-    return min(max(x, a), b)
-
-
-def clamp01(x: float) -> float:
-    """Clamp ``x`` to the [0, 1] range."""
-    return clamp(x, 0.0, 1.0)
-
-
-def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
-    """Arithmetic mean or ``default`` if ``xs`` is empty."""
-    try:
-        return fmean(xs)
-    except StatisticsError:
-        return default
-
-
-def _wrap_angle(a: float) -> float:
-    """Wrap angle to (-π, π]."""
-    return (a + PI) % TWO_PI - PI
-
-
-def angle_diff(a: float, b: float) -> float:
-    """Minimum difference between ``a`` and ``b`` in (-π, π]."""
-    return _wrap_angle(a - b)
-
-
-# -------------------------
-# Acceso a atributos con alias
-# -------------------------
-def _validate_aliases(aliases: Sequence[str]) -> tuple[str, ...]:
-    """Validate ``aliases`` and return them as a tuple of strings.
-
-    This helper is intended to be used when building alias collections for
-    :func:`alias_get`, :func:`alias_set` and demás utilidades públicas. A
-    pre-existing tuple is returned unchanged; other sequences are converted to
-    tuples. The result is guaranteed to be a non-empty tuple of strings.
-    """
-
-    if isinstance(aliases, str) or not isinstance(aliases, Sequence):
-        raise TypeError("'aliases' must be a non-string sequence")
-
-    seq = aliases if isinstance(aliases, tuple) else tuple(aliases)
-    if not seq or any(not isinstance(a, str) for a in seq):
-        if not seq:
-            raise ValueError("'aliases' must contain at least one key")
-        raise TypeError("'aliases' elements must be strings")
-    return seq
-
-
-def _alias_lookup(
-    d: Dict[str, Any],
-    aliases: tuple[str, ...],
-    conv: Callable[[Any], T],
-    *,
-    default: Optional[Any] = None,
-    strict: bool = False,
-    log_level: int | None = None,
-) -> Optional[T]:
-    for key in aliases:
-        if key in d:
-            ok, val = _convert_value(
-                d[key], conv, strict=strict, key=key, log_level=log_level
-            )
-            if ok:
-                return val
-    if default is None:
-        return None
-    ok, val = _convert_value(
-        default,
-        conv,
-        strict=strict,
-        key="default",
-        log_level=logging.WARNING if not strict else log_level,
-    )
-    return val if ok else None
-
-
-@overload
-def alias_get(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    conv: Callable[[Any], T],
-    *,
-    default: T,
-    strict: bool = False,
-    log_level: int | None = None,
-) -> T: ...
-
-
-@overload
-def alias_get(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    conv: Callable[[Any], T],
-    *,
-    default: None = ...,
-    strict: bool = False,
-    log_level: int | None = None,
-) -> Optional[T]: ...
-
-
-def alias_get(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    conv: Callable[[Any], T],
-    *,
-    default: Optional[Any] = None,
-    strict: bool = False,
-    log_level: int | None = None,
-) -> Optional[T]:
-    """Return the value for the first existing key in ``aliases``.
-
-    ``aliases`` may be any sequence of strings. Non-tuple sequences are
-    validated internally via :func:`_validate_aliases`, which guarantees a
-    non-empty sequence of strings.
-
-    If none of the keys are present or conversion fails, ``default`` is
-    returned (converted or ``None`` if ``default`` is ``None``).
-
-    ``log_level`` controls the logging level when conversion fails in lax
-    mode.
-    """
-    return _alias_get(
-        d,
-        aliases,
-        conv=conv,
-        default=default,
-        strict=strict,
-        log_level=log_level,
-    )
-
-
-def alias_set(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    conv: Callable[[Any], T],
-    value: Any,
-) -> T:
-    """Assign ``value`` converted to the first available key in ``aliases``.
-
-    ``aliases`` may be any sequence of strings. Non-tuples are validated via
-    :func:`_validate_aliases`.
-    """
-    if not isinstance(aliases, tuple):
-        aliases = _validate_aliases(aliases)
-    _, val = _convert_value(value, conv, strict=True)
-    if val is None:
-        raise ValueError("conversion yielded None")
-    key = next((k for k in aliases if k in d), aliases[0])
-    d[key] = val
-    return val
-
-
-class _Getter(Protocol[T]):
-    @overload
-    def __call__(
-        self,
-        d: Dict[str, Any],
-        aliases: Sequence[str],
-        default: T = ...,  # noqa: D401 - documented in alias_get
-        *,
-        strict: bool = False,
-        log_level: int | None = None,
-    ) -> T: ...
-
-    @overload
-    def __call__(
-        self,
-        d: Dict[str, Any],
-        aliases: Sequence[str],
-        default: None,
-        *,
-        strict: bool = False,
-        log_level: int | None = None,
-    ) -> Optional[T]: ...
-
-
-@overload
-def _alias_get(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    *,
-    conv: Callable[[Any], T],
-    default: T,
-    strict: bool = False,
-    log_level: int | None = None,
-) -> T: ...
-
-
-@overload
-def _alias_get(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    *,
-    conv: Callable[[Any], T],
-    default: None = ...,  # noqa: D401 - documented in alias_get
-    strict: bool = False,
-    log_level: int | None = None,
-) -> Optional[T]: ...
-
-
-def _alias_get(
-    d: Dict[str, Any],
-    aliases: Sequence[str],
-    *,
-    conv: Callable[[Any], T],
-    default: Optional[T] = None,
-    strict: bool = False,
-    log_level: int | None = None,
-) -> Optional[T]:
-    if not isinstance(aliases, tuple):
-        aliases = _validate_aliases(aliases)
-    return _alias_lookup(
-        d,
-        aliases,
-        conv,
-        default=default,
-        strict=strict,
-        log_level=log_level,
-    )
-
-
-def _alias_get_set(
-    conv: Callable[[Any], T],
-    *,
-    default: T,
-) -> tuple[_Getter[T], Callable[..., T]]:
-    """Create alias ``get``/``set`` functions using ``conv``.
-
-    Parameters
-    ----------
-    conv:
-        Conversion function applied to retrieved values.
-    default:
-        Default value used when the key is missing.
-    """
-
-    _base_get = partial(_alias_get, conv=conv)
-
-    def _get(
-        d: Dict[str, Any],
-        aliases: Sequence[str],
-        default: Optional[T] = default,
-        *,
-        strict: bool = False,
-        log_level: int | None = None,
-    ) -> Optional[T]:
-        """Obtain an attribute using :func:`alias_get`."""
-        return _base_get(
-            d,
-            aliases,
-            default=default,
-            strict=strict,
-            log_level=log_level,
-        )
-
-    def _set(d: Dict[str, Any], aliases: Sequence[str], value: T) -> T:
-        """Set an attribute using :func:`alias_set`."""
-        return alias_set(d, aliases, conv, value)
-
-    return _get, _set
-
-
-get_attr, set_attr = _alias_get_set(float, default=0.0)
-get_attr_str, set_attr_str = _alias_get_set(str, default="")
-
-
-# -------------------------
-# Máximos globales con caché
-# -------------------------
-
-
-def _recompute_abs_max(G, aliases: tuple[str, ...]):
-    """Recalcula y retorna ``(max_val, node)`` para ``aliases``."""
-    node = max(
-        G.nodes(),
-        key=lambda m: abs(get_attr(G.nodes[m], aliases, 0.0)),
-        default=None,
-    )
-    max_val = (
-        abs(get_attr(G.nodes[node], aliases, 0.0)) if node is not None else 0.0
-    )
-    return max_val, node
-
-
-def _update_cached_abs_max(
-    G, aliases: tuple[str, ...], n, value, *, key: str
-) -> None:
-    """Update ``G.graph[key]`` and ``G.graph[f"{key}_node"]``."""
-    node_key = f"{key}_node"
-    val = abs(value)
-    cur = float(G.graph.get(key, 0.0))
-    cur_node = G.graph.get(node_key)
-    if val >= cur:
-        G.graph[key] = val
-        G.graph[node_key] = n
-    elif cur_node == n and val < cur:
-        max_val, max_node = _recompute_abs_max(G, aliases)
-        G.graph[key] = max_val
-        G.graph[node_key] = max_node
-
-
-def set_attr_with_max(
-    G, n, aliases: tuple[str, ...], value: float, *, cache: str
-) -> None:
-    """Assign ``value`` to the given attribute and update the global maximum.
-
-    ``aliases`` must be an immutable tuple of valid keys.
-    """
-    val = float(value)
-    set_attr(G.nodes[n], aliases, val)
-    _update_cached_abs_max(G, aliases, n, val, key=cache)
-
-
-def set_vf(G, n, value: float) -> None:
-    """Set ``νf`` and update the global maximum."""
-    set_attr_with_max(G, n, ALIAS_VF, value, cache="_vfmax")
-
-
-def set_dnfr(G, n, value: float) -> None:
-    """Set ``ΔNFR`` and update the global maximum."""
-    set_attr_with_max(G, n, ALIAS_DNFR, value, cache="_dnfrmax")
-
-
-# -------------------------
-# Normalizadores de ΔNFR y aceleración
-# -------------------------
-
-
-def compute_dnfr_accel_max(G) -> dict:
-    """Compute absolute maxima of |ΔNFR| and |d²EPI/dt²|.
-
-    Returns a dictionary with keys ``dnfr_max`` and ``accel_max``. If the graph
-    has no nodes both values are ``0.0``.
-    """
-
-    dnfr_max = 0.0
-    accel_max = 0.0
-    for _, nd in G.nodes(data=True):
-        dnfr_max = max(dnfr_max, abs(get_attr(nd, ALIAS_DNFR, 0.0)))
-        accel_max = max(accel_max, abs(get_attr(nd, ALIAS_D2EPI, 0.0)))
-    return {"dnfr_max": float(dnfr_max), "accel_max": float(accel_max)}
-
-
-# -------------------------
-# Coherencia global
-# -------------------------
-
-
-def compute_coherence(G) -> float:
-    """Compute global coherence C(t) from ΔNFR and dEPI."""
-    dnfr_sum = 0.0
-    depi_sum = 0.0
-    count = 0
-    for _, nd in G.nodes(data=True):
-        dnfr_sum += abs(get_attr(nd, ALIAS_DNFR, 0.0))
-        depi_sum += abs(get_attr(nd, ALIAS_dEPI, 0.0))
-        count += 1
-    if count:
-        dnfr_mean = dnfr_sum / count
-        depi_mean = depi_sum / count
-    else:
-        dnfr_mean = depi_mean = 0.0
-    return 1.0 / (1.0 + dnfr_mean + depi_mean)
-
-
-# -------------------------
-# Estadísticos vecinales
-# -------------------------
-
-
-def neighbor_mean(
-    G, n, aliases: tuple[str, ...], default: float = 0.0
-) -> float:
-    """Mean of ``aliases`` attribute among neighbours of ``n``."""
-    vals = (get_attr(G.nodes[v], aliases, default) for v in G.neighbors(n))
-    return list_mean(vals, default)
-
-
-def neighbor_phase_mean(obj, n=None) -> float:
-    """Circular mean of neighbour phases.
-
-    Accepts a :class:`NodoProtocol` or a ``(G, n)`` pair from ``networkx``. The
-    latter is wrapped in :class:`NodoNX` to reuse the same logic.
-    """
-
-    from .node import NodoNX  # importación local para evitar ciclo
-
-    if n is not None:
-        node = NodoNX(obj, n)
-    else:
-        node = obj  # se asume NodoProtocol
-
-    x = y = 0.0
-    count = 0
-    for v in node.neighbors():
-        if hasattr(v, "theta"):
-            th = getattr(v, "theta", 0.0)
-        else:
-            th = NodoNX.from_graph(
-                node.G, v
-            ).theta  # type: ignore[attr-defined]
-        x += math.cos(th)
-        y += math.sin(th)
-        count += 1
-    if count == 0:
-        return getattr(node, "theta", 0.0)
-    return math.atan2(y, x)
-
-
-# -------------------------
-# Historial de glyphs por nodo
-# -------------------------
-
-# Importaciones diferidas para evitar ciclos al definir ``get_attr_str`` arriba
-from .glyph_history import (  # noqa: E402
-    push_glyph,
-    recent_glyph,
-    ensure_history,
-    last_glyph,
-    count_glyphs,
-)
-
-# -------------------------
-# Índice de sentido (Si)
-# -------------------------
-
-
-def get_Si_weights(G: Any) -> tuple[float, float, float]:
-    """Obtain and normalise weights for the sense index."""
-    w = {**DEFAULTS["SI_WEIGHTS"], **G.graph.get("SI_WEIGHTS", {})}
-    weights = normalize_weights(w, ("alpha", "beta", "gamma"), default=0.0)
-    alpha = weights["alpha"]
-    beta = weights["beta"]
-    gamma = weights["gamma"]
-    G.graph["_Si_weights"] = weights
-    G.graph["_Si_sensitivity"] = {
-        "dSi_dvf_norm": alpha,
-        "dSi_ddisp_fase": -beta,
-        "dSi_ddnfr_norm": -gamma,
-    }
-    return alpha, beta, gamma
-
-
-def precompute_trigonometry(
-    G: Any,
-) -> tuple[Dict[Any, float], Dict[Any, float], Dict[Any, float]]:
-    """Precompute cosines and sines of ``θ`` per node.
-
-    Values are stored in ``G.graph`` and reused while the graph structure
-    (versioned via ``"_edge_version"``) remains unchanged.
-    """
-
-    graph = G.graph
-    edge_version = int(graph.get("_edge_version", 0))
-    cached_version = graph.get("_trig_version")
-
-    cos_th = graph.get("_cos_th")
-    sin_th = graph.get("_sin_th")
-    thetas = graph.get("_thetas")
-
-    if (
-        cached_version == edge_version
-        and cos_th is not None
-        and sin_th is not None
-        and thetas is not None
-    ):
-        return cos_th, sin_th, thetas
-
-    cos_th = {}
-    sin_th = {}
-    thetas = {}
-    for n, nd in G.nodes(data=True):
-        th = get_attr(nd, ALIAS_THETA, 0.0)
-        thetas[n] = th
-        cos_th[n] = math.cos(th)
-        sin_th[n] = math.sin(th)
-
-    graph["_cos_th"] = cos_th
-    graph["_sin_th"] = sin_th
-    graph["_thetas"] = thetas
-    graph["_trig_version"] = edge_version
-    return cos_th, sin_th, thetas
-
-
-def compute_Si_node(
-    n: Any,
-    nd: Dict[str, Any],
-    *,
-    alpha: float,
-    beta: float,
-    gamma: float,
-    vfmax: float,
-    dnfrmax: float,
-    cos_th: Dict[Any, float],
-    sin_th: Dict[Any, float],
-    thetas: Dict[Any, float],
-    neighbors: Dict[Any, Sequence[Any]],
-    inplace: bool,
-) -> float:
-    """Compute ``Si`` for a single node."""
-    vf = get_attr(nd, ALIAS_VF, 0.0)
-    vf_norm = clamp01(abs(vf) / vfmax)
-
-    th_i = thetas[n]
-    neigh = neighbors[n]
-    deg = len(neigh)
-    if deg:
-        sum_cos = sum(cos_th[v] for v in neigh)
-        sum_sin = sum(sin_th[v] for v in neigh)
-        mean_cos = sum_cos / deg
-        mean_sin = sum_sin / deg
-        th_bar = math.atan2(mean_sin, mean_cos)
-    else:
-        th_bar = th_i
-    disp_fase = abs(angle_diff(th_i, th_bar)) / math.pi
-
-    dnfr = get_attr(nd, ALIAS_DNFR, 0.0)
-    dnfr_norm = clamp01(abs(dnfr) / dnfrmax)
-
-    Si = alpha * vf_norm + beta * (1.0 - disp_fase) + gamma * (1.0 - dnfr_norm)
-    Si = clamp01(Si)
-    if inplace:
-        set_attr(nd, ALIAS_SI, Si)
-    return Si
-
-
-def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
-    """Compute ``Si`` per node and write it to ``G.nodes[n]["Si"]``.
-
-    Formula:
-        Si = α·νf_norm + β·(1 - disp_fase_local) + γ·(1 - |ΔNFR|/max|ΔNFR|)
-    Also stores normalised weights and partial sensitivity (∂Si/∂component)
-    in ``G.graph``.
-    """
-    graph = G.graph
-    edge_version = int(graph.get("_edge_version", 0))
-
-    neighbors = graph.get("_neighbors")
-    if graph.get("_neighbors_version") != edge_version or neighbors is None:
-        neighbors = {n: list(G.neighbors(n)) for n in G}
-        graph["_neighbors"] = neighbors
-        graph["_neighbors_version"] = edge_version
-
-    alpha, beta, gamma = get_Si_weights(G)
-
-    # Normalización de νf y ΔNFR en red usando máximos cacheados
-    vfmax = G.graph.get("_vfmax")
-    if vfmax is None:
-        vfmax, vf_node = _recompute_abs_max(G, ALIAS_VF)
-        G.graph.setdefault("_vfmax", vfmax)
-        G.graph.setdefault("_vfmax_node", vf_node)
-    dnfrmax = G.graph.get("_dnfrmax")
-    if dnfrmax is None:
-        dnfrmax, dnfr_node = _recompute_abs_max(G, ALIAS_DNFR)
-        G.graph.setdefault("_dnfrmax", dnfrmax)
-        G.graph.setdefault("_dnfrmax_node", dnfr_node)
-    vfmax = 1.0 if vfmax == 0 else vfmax
-    dnfrmax = 1.0 if dnfrmax == 0 else dnfrmax
-
-    # precálculo de cosenos y senos de cada nodo
-    cos_th, sin_th, thetas = precompute_trigonometry(G)
-
-    out: Dict[Any, float] = {}
-    for n, nd in G.nodes(data=True):
-        out[n] = compute_Si_node(
-            n,
-            nd,
-            alpha=alpha,
-            beta=beta,
-            gamma=gamma,
-            vfmax=vfmax,
-            dnfrmax=dnfrmax,
-            cos_th=cos_th,
-            sin_th=sin_th,
-            thetas=thetas,
-            neighbors=neighbors,
-            inplace=inplace,
-        )
-    return out
-
-
 def increment_edge_version(G: Any) -> None:
-    """Increment the edge version counter in ``G.graph``.
-
-    Accepts an ``nx.Graph`` or a dictionary acting as ``G.graph`` and updates
-    ``"_edge_version"`` to invalidate edge-dependent caches.
-    """
+    """Increment the edge version counter in ``G.graph``."""
     graph = G.graph if hasattr(G, "graph") else G
     graph["_edge_version"] = int(graph.get("_edge_version", 0)) + 1
-    # eliminar caches dependientes de la estructura
     for key in (
         "_neighbors",
         "_neighbors_version",
@@ -986,3 +241,4 @@ def increment_edge_version(G: Any) -> None:
         "_trig_version",
     ):
         graph.pop(key, None)
+

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -5,7 +5,8 @@ import random
 from typing import TYPE_CHECKING
 
 from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
-from .helpers import clamp, get_rng
+from .helpers import clamp
+from .rng import get_rng
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -1,0 +1,112 @@
+"""Structured file I/O utilities."""
+
+from __future__ import annotations
+from typing import Any, Callable, Dict
+import json
+from pathlib import Path
+
+from .import_utils import optional_import
+
+
+tomllib = optional_import("tomllib") or optional_import("tomli")
+if tomllib is not None:
+    TOMLDecodeError = getattr(tomllib, "TOMLDecodeError", Exception)
+    has_toml = True
+else:  # pragma: no cover - depende de tomllib/tomli
+    has_toml = False
+
+    class TOMLDecodeError(Exception):
+        pass
+
+yaml = optional_import("yaml")
+if yaml is not None:
+    YAMLError = getattr(yaml, "YAMLError", Exception)
+else:  # pragma: no cover - depende de pyyaml
+
+    class YAMLError(Exception):
+        pass
+
+PARSERS: Dict[str, Callable[[str], Any]] = {".json": json.loads}
+
+
+def _missing_dependency(name: str) -> Callable[[str], Any]:
+    def _raise(_: str) -> Any:
+        raise ImportError(f"{name} no está instalado")
+
+    return _raise
+
+
+def _get_parser(suffix: str) -> Callable[[str], Any]:
+    parser = PARSERS.get(suffix)
+    if parser is not None:
+        return parser
+    if suffix in (".yaml", ".yml"):
+        parser = getattr(yaml, "safe_load", _missing_dependency("pyyaml"))
+    elif suffix == ".toml":
+        parser = getattr(tomllib, "loads", _missing_dependency("tomllib/tomli"))
+    else:
+        raise KeyError(suffix)
+    PARSERS[suffix] = parser
+    return parser
+
+
+def _format_structured_file_error(path: Path, e: Exception) -> str:
+    if isinstance(e, OSError):
+        return f"No se pudo leer {path}: {e}"
+    if isinstance(e, UnicodeDecodeError):
+        return f"Error de codificación al leer {path}: {e}"
+    if isinstance(e, json.JSONDecodeError):
+        return f"Error al parsear archivo JSON en {path}: {e}"
+    if isinstance(e, YAMLError):
+        return f"Error al parsear archivo YAML en {path}: {e}"
+    if has_toml and isinstance(e, TOMLDecodeError):
+        return f"Error al parsear archivo TOML en {path}: {e}"
+    if isinstance(e, ImportError):
+        return f"Dependencia faltante al parsear {path}: {e}"
+    return f"Error al parsear {path}: {e}"
+
+
+class StructuredFileError(Exception):
+    """Error while reading or parsing a structured file."""
+
+    def __init__(self, path: Path, original: Exception):
+        super().__init__(_format_structured_file_error(path, original))
+        self.path = path
+
+
+def read_structured_file(path: Path) -> Any:
+    """Read a JSON, YAML or TOML file and return parsed data."""
+    suffix = path.suffix.lower()
+    try:
+        parser = _get_parser(suffix)
+    except KeyError as e:
+        raise ValueError(f"Extensión de archivo no soportada: {suffix}") from e
+    try:
+        text = path.read_text(encoding="utf-8")
+        return parser(text)
+    except Exception as e:
+        raise StructuredFileError(path, e) from e
+
+
+def safe_write(
+    path: str | Path,
+    write: Callable[[Any], Any],
+    *,
+    mode: str = "w",
+    encoding: str | None = "utf-8",
+    **open_kwargs: Any,
+) -> None:
+    """Write to ``path`` ensuring parent directory exists and handle errors."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    open_params = dict(mode=mode, **open_kwargs)
+    if encoding is not None:
+        open_params["encoding"] = encoding
+    try:
+        with open(path, **open_params) as f:
+            write(f)
+    except OSError as e:
+        raise OSError(f"Failed to write file {path}: {e}") from e
+
+
+__all__ = ["read_structured_file", "safe_write", "StructuredFileError"]
+

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -9,7 +9,8 @@ from typing import Dict
 from ..constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_SI, COHERENCE
 from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
-from ..helpers import get_attr, clamp01
+from ..alias import get_attr
+from ..helpers import clamp01
 
 
 def _norm01(x, lo, hi):

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -25,7 +25,9 @@ from ..constants import (
 )
 from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, last_glyph, append_metric
-from ..helpers import get_attr, set_attr, list_mean, compute_coherence
+from ..alias import get_attr, set_attr
+from ..helpers import list_mean
+from ..metrics_utils import compute_coherence
 from ..constants_glyphs import GLYPHS_CANONICAL, GLYPH_GROUPS
 from ..types import Glyph
 from .coherence import register_coherence_callbacks
@@ -142,7 +144,9 @@ def _update_tg(G, hist, dt, save_by_node: bool):
     curr_key = TgCurr
     run_key = TgRun
 
-    for n, nd in G.nodes(data=True):
+    nodes = G.nodes
+    for n in nodes():
+        nd = nodes[n]
         g = last(nd)
         if not g:
             continue

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -15,11 +15,9 @@ from ..constants import (
 )
 from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
-from ..helpers import (
-    get_attr,
-    clamp01,
-    compute_dnfr_accel_max,
-)
+from ..alias import get_attr
+from ..helpers import clamp01
+from ..metrics_utils import compute_dnfr_accel_max
 from .coherence import local_phase_sync_weighted, _similarity_abs
 
 

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -7,7 +7,7 @@ import json
 from itertools import zip_longest
 
 from ..glyph_history import ensure_history
-from ..helpers import safe_write
+from ..io import safe_write
 from ..constants_glyphs import GLYPHS_CANONICAL
 from .core import glyphogram_series
 

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -1,0 +1,197 @@
+"""Miscellaneous metrics helpers."""
+
+from __future__ import annotations
+from typing import Any, Dict, Sequence
+import math
+
+from .constants import (
+    DEFAULTS,
+    ALIAS_DNFR,
+    ALIAS_D2EPI,
+    ALIAS_dEPI,
+    ALIAS_VF,
+    ALIAS_THETA,
+    ALIAS_SI,
+)
+from .alias import get_attr, set_attr, _recompute_abs_max
+from .collections_utils import normalize_weights
+from .helpers import clamp01, angle_diff
+
+
+__all__ = [
+    "compute_dnfr_accel_max",
+    "compute_coherence",
+    "get_Si_weights",
+    "precompute_trigonometry",
+    "compute_Si_node",
+    "compute_Si",
+]
+
+
+def compute_dnfr_accel_max(G) -> dict:
+    """Compute absolute maxima of |ΔNFR| and |d²EPI/dt²|."""
+    dnfr_max = 0.0
+    accel_max = 0.0
+    for _, nd in G.nodes(data=True):
+        dnfr_max = max(dnfr_max, abs(get_attr(nd, ALIAS_DNFR, 0.0)))
+        accel_max = max(accel_max, abs(get_attr(nd, ALIAS_D2EPI, 0.0)))
+    return {"dnfr_max": float(dnfr_max), "accel_max": float(accel_max)}
+
+
+def compute_coherence(G) -> float:
+    """Compute global coherence C(t) from ΔNFR and dEPI."""
+    dnfr_sum = 0.0
+    depi_sum = 0.0
+    count = 0
+    for _, nd in G.nodes(data=True):
+        dnfr_sum += abs(get_attr(nd, ALIAS_DNFR, 0.0))
+        depi_sum += abs(get_attr(nd, ALIAS_dEPI, 0.0))
+        count += 1
+    if count:
+        dnfr_mean = dnfr_sum / count
+        depi_mean = depi_sum / count
+    else:
+        dnfr_mean = depi_mean = 0.0
+    return 1.0 / (1.0 + dnfr_mean + depi_mean)
+
+
+def get_Si_weights(G: Any) -> tuple[float, float, float]:
+    """Obtain and normalise weights for the sense index."""
+    w = {**DEFAULTS["SI_WEIGHTS"], **G.graph.get("SI_WEIGHTS", {})}
+    weights = normalize_weights(w, ("alpha", "beta", "gamma"), default=0.0)
+    alpha = weights["alpha"]
+    beta = weights["beta"]
+    gamma = weights["gamma"]
+    G.graph["_Si_weights"] = weights
+    G.graph["_Si_sensitivity"] = {
+        "dSi_dvf_norm": alpha,
+        "dSi_ddisp_fase": -beta,
+        "dSi_ddnfr_norm": -gamma,
+    }
+    return alpha, beta, gamma
+
+
+def precompute_trigonometry(
+    G: Any,
+) -> tuple[Dict[Any, float], Dict[Any, float], Dict[Any, float]]:
+    """Precompute cosines and sines of ``θ`` per node."""
+    graph = G.graph
+    edge_version = int(graph.get("_edge_version", 0))
+    cached_version = graph.get("_trig_version")
+
+    cos_th = graph.get("_cos_th")
+    sin_th = graph.get("_sin_th")
+    thetas = graph.get("_thetas")
+
+    if (
+        cached_version == edge_version
+        and cos_th is not None
+        and sin_th is not None
+        and thetas is not None
+    ):
+        return cos_th, sin_th, thetas
+
+    cos_th = {}
+    sin_th = {}
+    thetas = {}
+    for n, nd in G.nodes(data=True):
+        th = get_attr(nd, ALIAS_THETA, 0.0)
+        thetas[n] = th
+        cos_th[n] = math.cos(th)
+        sin_th[n] = math.sin(th)
+
+    graph["_cos_th"] = cos_th
+    graph["_sin_th"] = sin_th
+    graph["_thetas"] = thetas
+    graph["_trig_version"] = edge_version
+    return cos_th, sin_th, thetas
+
+
+def compute_Si_node(
+    n: Any,
+    nd: Dict[str, Any],
+    *,
+    alpha: float,
+    beta: float,
+    gamma: float,
+    vfmax: float,
+    dnfrmax: float,
+    cos_th: Dict[Any, float],
+    sin_th: Dict[Any, float],
+    thetas: Dict[Any, float],
+    neighbors: Dict[Any, Sequence[Any]],
+    inplace: bool,
+) -> float:
+    """Compute ``Si`` for a single node."""
+    vf = get_attr(nd, ALIAS_VF, 0.0)
+    vf_norm = clamp01(abs(vf) / vfmax)
+
+    th_i = thetas[n]
+    neigh = neighbors[n]
+    deg = len(neigh)
+    if deg:
+        sum_cos = sum(cos_th[v] for v in neigh)
+        sum_sin = sum(sin_th[v] for v in neigh)
+        mean_cos = sum_cos / deg
+        mean_sin = sum_sin / deg
+        th_bar = math.atan2(mean_sin, mean_cos)
+    else:
+        th_bar = th_i
+    disp_fase = abs(angle_diff(th_i, th_bar)) / math.pi
+
+    dnfr = get_attr(nd, ALIAS_DNFR, 0.0)
+    dnfr_norm = clamp01(abs(dnfr) / dnfrmax)
+
+    Si = alpha * vf_norm + beta * (1.0 - disp_fase) + gamma * (1.0 - dnfr_norm)
+    Si = clamp01(Si)
+    if inplace:
+        set_attr(nd, ALIAS_SI, Si)
+    return Si
+
+
+def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
+    """Compute ``Si`` per node and write it to ``G.nodes[n]['Si']``."""
+    graph = G.graph
+    edge_version = int(graph.get("_edge_version", 0))
+
+    neighbors = graph.get("_neighbors")
+    if graph.get("_neighbors_version") != edge_version or neighbors is None:
+        neighbors = {n: list(G.neighbors(n)) for n in G}
+        graph["_neighbors"] = neighbors
+        graph["_neighbors_version"] = edge_version
+
+    alpha, beta, gamma = get_Si_weights(G)
+
+    vfmax = G.graph.get("_vfmax")
+    if vfmax is None:
+        vfmax, vf_node = _recompute_abs_max(G, ALIAS_VF)
+        G.graph.setdefault("_vfmax", vfmax)
+        G.graph.setdefault("_vfmax_node", vf_node)
+    dnfrmax = G.graph.get("_dnfrmax")
+    if dnfrmax is None:
+        dnfrmax, dnfr_node = _recompute_abs_max(G, ALIAS_DNFR)
+        G.graph.setdefault("_dnfrmax", dnfrmax)
+        G.graph.setdefault("_dnfrmax_node", dnfr_node)
+    vfmax = 1.0 if vfmax == 0 else vfmax
+    dnfrmax = 1.0 if dnfrmax == 0 else dnfrmax
+
+    cos_th, sin_th, thetas = precompute_trigonometry(G)
+
+    out: Dict[Any, float] = {}
+    for n, nd in G.nodes(data=True):
+        out[n] = compute_Si_node(
+            n,
+            nd,
+            alpha=alpha,
+            beta=beta,
+            gamma=gamma,
+            vfmax=vfmax,
+            dnfrmax=dnfrmax,
+            cos_th=cos_th,
+            sin_th=sin_th,
+            thetas=thetas,
+            neighbors=neighbors,
+            inplace=inplace,
+        )
+    return out
+

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -18,15 +18,15 @@ from .constants import (
     ALIAS_D2EPI,
 )
 from .glyph_history import push_glyph
-from .helpers import (
+from .alias import (
     get_attr,
     get_attr_str,
     set_attr,
     set_attr_str,
     set_vf,
     set_dnfr,
-    increment_edge_version,
 )
+from .helpers import increment_edge_version
 
 from .operators import apply_glyph_obj
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -6,11 +6,9 @@ from itertools import islice
 from functools import partial
 
 from .constants import ALIAS_THETA, METRIC_DEFAULTS
-from .helpers import (
-    get_attr,
-    angle_diff,
-    compute_coherence,
-)
+from .alias import get_attr
+from .helpers import angle_diff
+from .metrics_utils import compute_coherence
 from .callback_utils import register_callback
 from .glyph_history import ensure_history, count_glyphs, append_metric
 from .collections_utils import normalize_counter, mix_groups

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -28,13 +28,12 @@ from .constants import DEFAULTS, REMESH_DEFAULTS, ALIAS_EPI, get_param
 from .helpers import (
     list_mean,
     angle_diff,
-    get_attr,
-    set_attr,
     neighbor_phase_mean,
     increment_edge_version,
     ensure_node_offset_map,
-    get_rng,
 )
+from .alias import get_attr, set_attr
+from .rng import get_rng
 from .callback_utils import invoke_callbacks
 from .glyph_history import append_metric
 

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -1,0 +1,26 @@
+"""Deterministic RNG helpers."""
+from __future__ import annotations
+
+import hashlib
+import random
+import struct
+from functools import lru_cache
+
+from .constants import DEFAULTS
+
+
+@lru_cache(maxsize=DEFAULTS["JITTER_CACHE_SIZE"])
+def get_rng(seed: int, key: int) -> random.Random:
+    """Return a cached ``random.Random`` for ``(seed, key)``."""
+    seed_bytes = struct.pack(
+        ">QQ",
+        int(seed) & 0xFFFFFFFFFFFFFFFF,
+        int(key) & 0xFFFFFFFFFFFFFFFF,
+    )
+    seed_int = int.from_bytes(
+        hashlib.blake2b(seed_bytes, digest_size=8).digest(), "big"
+    )
+    return random.Random(seed_int)
+
+
+__all__ = ["get_rng"]

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
 from .constants import DEFAULTS
 from .constants.core import SELECTOR_THRESHOLD_DEFAULTS
-from .helpers import clamp01, compute_dnfr_accel_max
+from .helpers import clamp01
+from .metrics_utils import compute_dnfr_accel_max
 
 
 HYSTERESIS_GLYPHS = ("IL", "OZ", "ZHIR", "THOL", "NAV", "RA")

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -7,10 +7,8 @@ import math
 import networkx as nx
 
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
-from .helpers import (
-    get_attr,
-    clamp01,
-)
+from .alias import get_attr
+from .helpers import clamp01
 from .callback_utils import register_callback
 from .glyph_history import ensure_history, last_glyph, count_glyphs, append_metric
 from .constants_glyphs import (

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .constants import ALIAS_EPI, ALIAS_VF, get_param
-from .helpers import get_attr
+from .alias import get_attr
 from .glyph_history import last_glyph
 from .sense import sigma_vector_from_graph
 from .constants_glyphs import GLYPHS_CANONICAL_SET

--- a/tests/test_alias_get_default.py
+++ b/tests/test_alias_get_default.py
@@ -1,6 +1,6 @@
 """Pruebas de alias get default."""
 
-from tnfr.helpers import alias_get
+from tnfr.alias import alias_get
 
 
 def test_alias_get_default_none_returns_none():

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -2,7 +2,7 @@
 
 import logging
 import pytest
-from tnfr.helpers import alias_get
+from tnfr.alias import alias_get
 
 
 def test_alias_get_logs_on_error(caplog):

--- a/tests/test_alias_helpers_threadsafe.py
+++ b/tests/test_alias_helpers_threadsafe.py
@@ -2,7 +2,7 @@
 
 from concurrent.futures import ThreadPoolExecutor
 
-from tnfr.helpers import alias_get, alias_set, _validate_aliases
+from tnfr.alias import alias_get, alias_set, _validate_aliases
 
 
 def _worker(i):

--- a/tests/test_alias_sequence.py
+++ b/tests/test_alias_sequence.py
@@ -1,7 +1,7 @@
 """Pruebas de helpers de alias con secuencias genéricas."""
 
 import pytest
-from tnfr.helpers import alias_get, alias_set
+from tnfr.alias import alias_get, alias_set
 
 
 def test_alias_get_accepts_sequence():

--- a/tests/test_alias_set_error.py
+++ b/tests/test_alias_set_error.py
@@ -1,7 +1,7 @@
 """Pruebas de alias_set para conversiones nulas."""
 
 import pytest
-from tnfr.helpers import alias_set
+from tnfr.alias import alias_set
 
 
 def test_alias_set_raises_value_error_on_none():

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -10,7 +10,7 @@ from tnfr.cli import (
     _args_to_dict,
 )
 from tnfr.constants import METRIC_DEFAULTS
-from tnfr.helpers import read_structured_file
+from tnfr.io import read_structured_file
 from tnfr import __version__
 
 

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -5,7 +5,8 @@ import networkx as nx
 
 from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
-from tnfr.helpers import get_attr, increment_edge_version
+from tnfr.alias import get_attr
+from tnfr.helpers import increment_edge_version
 
 
 def _setup_graph():

--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -9,7 +9,7 @@ from tnfr.dynamics import (
     _compute_dnfr_loops,
 )
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
-from tnfr.helpers import get_attr
+from tnfr.alias import get_attr
 
 
 def _setup_graph():

--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
-from tnfr.helpers import get_attr
+from tnfr.alias import get_attr
 
 
 def _setup_graph():

--- a/tests/test_get_rng.py
+++ b/tests/test_get_rng.py
@@ -1,7 +1,7 @@
 import random
 import hashlib
 import struct
-from tnfr.helpers import get_rng
+from tnfr.rng import get_rng
 
 def _derive_seed(seed: int, key: int) -> int:
     seed_bytes = struct.pack(

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -10,7 +10,7 @@ from tnfr.constants import (
     ALIAS_VF,
     ALIAS_THETA,
 )
-from tnfr.helpers import get_attr
+from tnfr.alias import get_attr
 
 
 def test_init_node_attrs_reproducible():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,7 +4,7 @@ import pytest
 import networkx as nx
 
 from tnfr.constants import attach_defaults, ALIAS_EPI
-from tnfr.helpers import get_attr
+from tnfr.alias import get_attr
 from tnfr.metrics import (
     _metrics_step,
     _update_latency_index,

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -10,7 +10,8 @@ from tnfr.observers import phase_sync, kuramoto_order, glyph_load, wbar
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
 from tnfr.constants_glyphs import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
-from tnfr.helpers import angle_diff, set_attr
+from tnfr.helpers import angle_diff
+from tnfr.alias import set_attr
 from tnfr.callback_utils import CallbackEvent
 from tnfr.observers import attach_standard_observer
 

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -4,9 +4,9 @@ import pytest
 from pathlib import Path
 from json import JSONDecodeError
 import json
-import tnfr.helpers as helpers
+import tnfr.io as io_mod
 
-from tnfr.helpers import read_structured_file, StructuredFileError
+from tnfr.io import read_structured_file, StructuredFileError
 
 
 def test_read_structured_file_missing_file(tmp_path: Path):
@@ -83,7 +83,7 @@ def test_read_structured_file_missing_dependency(
     def fake_parser(_: str) -> None:
         raise ImportError("pyyaml no está instalado")
 
-    monkeypatch.setitem(helpers.PARSERS, ".yaml", fake_parser)
+    monkeypatch.setitem(io_mod.PARSERS, ".yaml", fake_parser)
 
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
@@ -102,7 +102,7 @@ def test_read_structured_file_missing_dependency_toml(
     def fake_parser(_: str) -> None:
         raise ImportError("toml no está instalado")
 
-    monkeypatch.setitem(helpers.PARSERS, ".toml", fake_parser)
+    monkeypatch.setitem(io_mod.PARSERS, ".toml", fake_parser)
 
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
@@ -126,11 +126,11 @@ def test_json_error_not_reported_as_toml(monkeypatch: pytest.MonkeyPatch) -> Non
     class DummyTOMLDecodeError(Exception):
         pass
 
-    monkeypatch.setattr(helpers, "has_toml", False)
-    monkeypatch.setattr(helpers, "TOMLDecodeError", DummyTOMLDecodeError)
+    monkeypatch.setattr(io_mod, "has_toml", False)
+    monkeypatch.setattr(io_mod, "TOMLDecodeError", DummyTOMLDecodeError)
 
     err = JSONDecodeError("msg", "", 0)
-    msg = helpers._format_structured_file_error(Path("data.json"), err)
+    msg = io_mod._format_structured_file_error(Path("data.json"), err)
     assert msg.startswith("Error al parsear archivo JSON en")
     assert not msg.startswith("Error al parsear archivo TOML")
 
@@ -139,11 +139,11 @@ def test_import_error_not_reported_as_toml(monkeypatch: pytest.MonkeyPatch) -> N
     class DummyTOMLDecodeError(Exception):
         pass
 
-    monkeypatch.setattr(helpers, "has_toml", False)
-    monkeypatch.setattr(helpers, "TOMLDecodeError", DummyTOMLDecodeError)
+    monkeypatch.setattr(io_mod, "has_toml", False)
+    monkeypatch.setattr(io_mod, "TOMLDecodeError", DummyTOMLDecodeError)
 
     err = ImportError("dep missing")
-    msg = helpers._format_structured_file_error(Path("data.toml"), err)
+    msg = io_mod._format_structured_file_error(Path("data.toml"), err)
     assert msg.startswith("Dependencia faltante al parsear")
     assert not msg.startswith("Error al parsear archivo TOML")
 
@@ -153,7 +153,7 @@ def test_read_structured_file_ignores_missing_yaml_when_parsing_json(
 ):
     path = tmp_path / "data.json"
     path.write_text("{\"a\": 1}", encoding="utf-8")
-    monkeypatch.setattr(helpers, "yaml", None)
-    monkeypatch.setattr(helpers, "tomllib", None)
-    monkeypatch.setattr(helpers, "PARSERS", {".json": json.loads})
+    monkeypatch.setattr(io_mod, "yaml", None)
+    monkeypatch.setattr(io_mod, "tomllib", None)
+    monkeypatch.setattr(io_mod, "PARSERS", {".json": json.loads})
     assert read_structured_file(path) == {"a": 1}

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -4,13 +4,12 @@ import networkx as nx
 import pytest
 
 from tnfr.constants import ALIAS_DNFR, ALIAS_SI, ALIAS_THETA, ALIAS_VF
-from tnfr.helpers import (
+from tnfr.metrics_utils import (
     compute_Si_node,
-    get_attr,
     get_Si_weights,
     precompute_trigonometry,
-    set_attr,
 )
+from tnfr.alias import get_attr, set_attr
 
 
 def test_get_si_weights_normalization():

--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tnfr.helpers import _validate_aliases
+from tnfr.alias import _validate_aliases
 
 
 def test_rejects_string():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,7 +9,8 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.helpers import set_attr_str, set_attr, read_structured_file
+from tnfr.alias import set_attr_str, set_attr
+from tnfr.io import read_structured_file
 from tnfr.config import load_config
 
 try:  # pragma: no cover - compatibilidad Python


### PR DESCRIPTION
## Summary
- extract alias helpers into dedicated module
- add structured file I/O utilities module
- centralize RNG and metrics helpers
- update imports and tests to new module layout

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2a37588883219c3d1db3249f3ad9