### PR TITLE
Remove unknown events from callback registry

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -43,6 +43,9 @@ def _ensure_callbacks(G: "nx.Graph") -> CallbackRegistry:
         cbs = defaultdict(list, cbs or {})
         G.graph["callbacks"] = cbs
     for event in list(cbs):
+        if event not in _CALLBACK_EVENTS:
+            del cbs[event]
+            continue
         lst = cbs[event]
         cbs[event] = [
             spec

--- a/tests/test_ensure_callbacks.py
+++ b/tests/test_ensure_callbacks.py
@@ -1,0 +1,32 @@
+"""Tests for `_ensure_callbacks` behavior."""
+
+from tnfr.callback_utils import _ensure_callbacks, register_callback, CallbackEvent
+
+
+def test_ensure_callbacks_drops_unknown_events(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        pass
+
+    G.graph["callbacks"] = {
+        "nope": [("cb", cb)],
+        CallbackEvent.BEFORE_STEP.value: [("cb", cb)],
+    }
+
+    _ensure_callbacks(G)
+
+    assert list(G.graph["callbacks"]) == [CallbackEvent.BEFORE_STEP.value]
+
+
+def test_register_callback_cleans_unknown_events(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        pass
+
+    G.graph["callbacks"] = {"nope": [("cb", cb)]}
+
+    register_callback(G, CallbackEvent.AFTER_STEP, cb, name="cb")
+
+    assert list(G.graph["callbacks"]) == [CallbackEvent.AFTER_STEP.value]


### PR DESCRIPTION
## Summary
- drop unrecognized callback events in `_ensure_callbacks`
- test cleanup of unknown callback events

## Testing
- `PYTHONPATH=src python -m pytest tests/test_register_callback.py tests/test_ensure_callbacks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2e05a2cc83218bdc6aecd38ff392