### PR TITLE
Handle iterable serialization in CLI

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -6,7 +6,7 @@ import json
 import logging
 import sys
 from typing import Any, Optional, Callable, TYPE_CHECKING
-from collections.abc import Sequence
+from collections.abc import Sequence, Iterable
 from pathlib import Path
 from collections import deque
 
@@ -140,7 +140,9 @@ TOKEN_MAP: dict[str, Callable[[Any], Any]] = {
 
 
 def _default(obj: Any) -> Any:
-    if isinstance(obj, deque):
+    if isinstance(obj, (deque, set, tuple)):
+        return list(obj)
+    if isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
         return list(obj)
     raise TypeError(
         f"Object of type {obj.__class__.__name__} is not JSON serializable"

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -1,7 +1,8 @@
 """Pruebas de cli history."""
 
-from tnfr.cli import main
+from tnfr.cli import main, _save_json
 import json
+from collections import deque
 
 
 def test_cli_run_save_history(tmp_path):
@@ -87,3 +88,13 @@ def test_cli_sequence_no_history_args(tmp_path, monkeypatch):
     rc = main(["sequence", "--nodes", "5"])
     assert rc == 0
     assert not any(tmp_path.iterdir())
+
+
+def test_save_json_serializes_iterables(tmp_path):
+    path = tmp_path / "data.json"
+    data = {"set": {1, 2}, "tuple": (1, 2), "deque": deque([1, 2])}
+    _save_json(str(path), data)
+    loaded = json.loads(path.read_text())
+    assert sorted(loaded["set"]) == [1, 2]
+    assert loaded["tuple"] == [1, 2]
+    assert loaded["deque"] == [1, 2]


### PR DESCRIPTION
## Summary
- allow CLI JSON serialization of sets, tuples and other iterables by converting to lists
- test `_save_json` to ensure sets, tuples and deques serialize correctly

## Testing
- `PYTHONPATH=src pytest tests/test_cli_history.py tests/test_cli_sanity.py tests/test_cli_flatten_tokens.py tests/test_parse_tokens_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ebc09908321bf3111408c50ca2f