### PR TITLE
Optimize neighbor phase lookup and add benchmark

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -103,11 +103,19 @@ def neighbor_phase_mean(obj, n=None) -> float:
 
     x = y = 0.0
     count = 0
+    G = getattr(node, "G", None)
+    nodes = G.nodes if G is not None else None
+    theta_cache: Dict[Any, float] = {}
     for v in node.neighbors():
-        if hasattr(v, "theta"):
-            th = getattr(v, "theta", 0.0)
-        else:
-            th = NodoNX.from_graph(node.G, v).theta  # type: ignore[attr-defined]
+        th = theta_cache.get(v)
+        if th is None:
+            if hasattr(v, "theta"):
+                th = getattr(v, "theta", 0.0)
+            elif nodes is not None:
+                th = get_attr(nodes[v], ALIAS_THETA, 0.0)
+            else:
+                th = NodoNX.from_graph(node.G, v).theta  # type: ignore[attr-defined]
+            theta_cache[v] = th
         x += math.cos(th)
         y += math.sin(th)
         count += 1

--- a/tests/test_neighbor_phase_mean_performance.py
+++ b/tests/test_neighbor_phase_mean_performance.py
@@ -1,0 +1,47 @@
+"""Benchmark for neighbor_phase_mean performance."""
+
+import time
+import math
+import networkx as nx
+import pytest
+
+from tnfr.helpers import neighbor_phase_mean
+from tnfr.constants import ALIAS_THETA
+from tnfr.node import NodoNX
+
+
+def _naive_neighbor_phase_mean(G, n):
+    """Reference implementation using NodoNX wrappers for each neighbour."""
+    node = NodoNX(G, n)
+    x = y = 0.0
+    count = 0
+    for v in node.neighbors():
+        th = NodoNX.from_graph(node.G, v).theta
+        x += math.cos(th)
+        y += math.sin(th)
+        count += 1
+    if count == 0:
+        return node.theta
+    return math.atan2(y, x)
+
+
+@pytest.mark.slow
+def test_neighbor_phase_mean_performance():
+    """Optimised neighbour mean should be faster than naive version."""
+    G = nx.gnp_random_graph(200, 0.2, seed=1)
+    for n in G.nodes:
+        G.nodes[n][ALIAS_THETA] = 0.0
+
+    start = time.perf_counter()
+    for _ in range(5):
+        for n in G.nodes:
+            neighbor_phase_mean(G, n)
+    t_opt = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(5):
+        for n in G.nodes:
+            _naive_neighbor_phase_mean(G, n)
+    t_naive = time.perf_counter() - start
+
+    assert t_opt <= t_naive


### PR DESCRIPTION
## Summary
- optimize `neighbor_phase_mean` to read neighbor phase data straight from graph and cache node phases
- add benchmark showing faster `neighbor_phase_mean`

## Testing
- `PYTHONPATH=src pytest tests/test_neighbor_phase_mean_performance.py -m slow -vv`
- `PYTHONPATH=src pytest` *(fails: tests/test_update_tg_performance.py::test_update_tg_matches_naive)*
- `PYTHONPATH=src pytest -k 'not test_update_tg_performance'`


------
https://chatgpt.com/codex/tasks/task_e_68bc2f6a3b8c8321a145d539f2cbf5a6