### PR TITLE
Validate window size in push_glyph

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -22,6 +22,8 @@ __all__ = [
 
 def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
     """Add ``glyph`` to node history with maximum size ``window``."""
+    if window < 0:
+        raise ValueError("window must be >= 0")
     hist = nd.get("glyph_history")
     if hist is None or hist.maxlen != window:
         hist = deque(hist or [], maxlen=window)

--- a/tests/test_push_glyph.py
+++ b/tests/test_push_glyph.py
@@ -1,0 +1,28 @@
+"""Tests for push_glyph window handling."""
+
+import pytest
+
+from tnfr.glyph_history import push_glyph
+
+
+def test_push_glyph_negative_window():
+    nd = {}
+    with pytest.raises(ValueError, match="window must be >= 0"):
+        push_glyph(nd, "A", window=-1)
+
+
+def test_push_glyph_zero_window():
+    nd = {}
+    push_glyph(nd, "A", window=0)
+    assert list(nd["glyph_history"]) == []
+    push_glyph(nd, "B", window=0)
+    assert list(nd["glyph_history"]) == []
+
+
+def test_push_glyph_positive_window():
+    nd = {}
+    push_glyph(nd, "A", window=2)
+    push_glyph(nd, "B", window=2)
+    assert list(nd["glyph_history"]) == ["A", "B"]
+    push_glyph(nd, "C", window=2)
+    assert list(nd["glyph_history"]) == ["B", "C"]


### PR DESCRIPTION
## Summary
- ensure push_glyph rejects negative window sizes
- add tests for negative, zero, and positive window behavior

## Testing
- `PYTHONPATH=src pytest tests/test_push_glyph.py tests/test_recent_glyph.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc318134e08321b27e1369671b8f4c