### PR TITLE
refactor: factor out attribute check helper

### DIFF
--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -11,29 +11,26 @@ from .constants_glyphs import GLYPHS_CANONICAL_SET
 EPS = 1e-9
 
 
+def _require_attr(data, alias, node, name):
+    """Return attribute value or raise if missing."""
+    val = get_attr(data, alias, None)
+    if val is None:
+        raise ValueError(f"Missing {name} attribute in node {node}")
+    return val
+
+
 def _validate_epi_vf(G) -> None:
     cfg = {
         k: float(get_param(G, k))
         for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
     }
-    get = get_attr
     epi_min, epi_max = cfg["EPI_MIN"], cfg["EPI_MAX"]
     vf_min, vf_max = cfg["VF_MIN"], cfg["VF_MAX"]
     for n, data in G.nodes(data=True):
-        try:
-            epi = get(data, ALIAS_EPI, None)
-            if epi is None:
-                raise KeyError
-        except KeyError:
-            raise ValueError(f"Missing EPI attribute in node {n}")
+        epi = _require_attr(data, ALIAS_EPI, n, "EPI")
         if not (epi_min - EPS <= epi <= epi_max + EPS):
             raise ValueError(f"EPI out of range in node {n}: {epi}")
-        try:
-            vf = get(data, ALIAS_VF, None)
-            if vf is None:
-                raise KeyError
-        except KeyError:
-            raise ValueError(f"Missing VF attribute in node {n}")
+        vf = _require_attr(data, ALIAS_VF, n, "VF")
         if not (vf_min - EPS <= vf <= vf_max + EPS):
             raise ValueError(f"VF out of range in node {n}: {vf}")
 


### PR DESCRIPTION
## Summary
- add `_require_attr` helper to load aliased node attributes or raise
- use helper to simplify repeated validator logic

## Testing
- `python -m pytest tests/test_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc320b8f008321bfd913145b642413