### PR TITLE
Optimize node checksum serialization

### DIFF
--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -1,5 +1,4 @@
 import networkx as nx
-import json
 import hashlib
 
 from tnfr.helpers import node_set_checksum, _stable_json
@@ -26,9 +25,11 @@ def _reference_checksum(G):
     hasher = hashlib.blake2b(digest_size=16)
 
     def serialise(n):
-        return json.dumps(_stable_json(n), sort_keys=True, ensure_ascii=False)
+        return repr(_stable_json(n))
 
-    for i, node_repr in enumerate(sorted(serialise(n) for n in G.nodes())):
+    serialised = [serialise(n) for n in G.nodes()]
+    serialised.sort()
+    for i, node_repr in enumerate(serialised):
         if i:
             hasher.update(b"|")
         hasher.update(node_repr.encode("utf-8"))

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -12,3 +12,10 @@ def test_stable_json_handles_cycles():
     obj: list[Any] = []
     obj.append(obj)
     assert _stable_json(obj) == ["<recursion>"]
+
+
+def test_stable_json_orders_structures():
+    obj = {"b": {2, 1}, "a": 1}
+    stable = _stable_json(obj)
+    assert list(stable.keys()) == ["a", "b"]
+    assert stable["b"] == [1, 2]


### PR DESCRIPTION
## Summary
- Use stable repr-based encoding for node checksums and cache serialized nodes
- Ensure `_stable_json` orders dicts, sets, and attributes for deterministic checksums
- Expand tests to cover new deterministic serialization

## Testing
- `python -m pytest`
- `python - <<'PY'
import time, json, hashlib
import networkx as nx
from tnfr.helpers import node_set_checksum, _stable_json

def old_checksum(G, nodes=None):
    hasher = hashlib.blake2b(digest_size=16)
    def serialise(n):
        return json.dumps(
            _stable_json(n),
            sort_keys=True,
            ensure_ascii=False,
            separators=(",", ":"),
        )
    node_iter = nodes if nodes is not None else G.nodes()
    sorted_nodes = sorted(node_iter, key=lambda n: serialise(n))
    for idx, n in enumerate(sorted_nodes):
        if idx:
            hasher.update(b"|")
        hasher.update(serialise(n).encode("utf-8"))
    return hasher.hexdigest()

N=10000
G=nx.Graph()
G.add_nodes_from(range(N))

start=time.time(); old_checksum(G); t_old=time.time()-start
start=time.time(); node_set_checksum(G); t_new=time.time()-start
print("old", t_old)
print("new", t_new)
print("speedup", t_old/t_new if t_new>0 else float('inf'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bc32f15edc8321b3408fec83cffaf4