### PR TITLE
Refactor metrics step helpers

### DIFF
--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -14,6 +14,9 @@ from .core import (
     _update_tg,
     _update_latency_index,
     _update_epi_support,
+    _track_stability,
+    _aggregate_si,
+    _compute_advanced_metrics,
     _metrics_step,
 )
 
@@ -40,6 +43,9 @@ __all__ = [
     "_update_tg",
     "_update_latency_index",
     "_update_epi_support",
+    "_track_stability",
+    "_aggregate_si",
+    "_compute_advanced_metrics",
     "_metrics_step",
     "coherence_matrix",
     "local_phase_sync_weighted",


### PR DESCRIPTION
## Summary
- factor out stability, Si aggregation, and advanced metric calculations into dedicated helper functions
- simplify `_metrics_step` to orchestrate these helpers
- add targeted tests for each helper

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc33e000348321b49f068113f5379b