### PR TITLE
Cache node index map for coherence metrics

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -41,6 +41,7 @@ __all__ = [
     "count_glyphs",
     "normalize_counter",
     "mix_groups",
+    "ensure_node_index_map",
     "ensure_node_offset_map",
     "cached_nodes_and_A",
     "increment_edge_version",
@@ -189,6 +190,24 @@ def node_set_checksum(
             hasher.update(b"|")
         hasher.update(node_repr.encode("utf-8"))
     return hasher.hexdigest()
+
+
+def ensure_node_index_map(G) -> Dict[Any, int]:
+    """Return cached node→index mapping for ``G``.
+
+    The mapping is stored in ``G.graph['_node_index_map']`` and reused on
+    subsequent calls. It is recalculated whenever the set of nodes in ``G``
+    changes.
+    """
+
+    nodes = list(G.nodes())
+    checksum = node_set_checksum(G, nodes)
+    mapping = G.graph.get("_node_index_map")
+    if mapping is None or G.graph.get("_node_index_checksum") != checksum:
+        mapping = {node: idx for idx, node in enumerate(nodes)}
+        G.graph["_node_index_map"] = mapping
+        G.graph["_node_index_checksum"] = checksum
+    return mapping
 
 
 def ensure_node_offset_map(G) -> Dict[Any, int]:

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -11,7 +11,7 @@ from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..collections_utils import normalize_weights
-from ..helpers import clamp01
+from ..helpers import clamp01, ensure_node_index_map
 
 
 def _norm01(x, lo, hi):
@@ -78,7 +78,7 @@ def coherence_matrix(G):
         return nodes, []
 
     # Precompute indices to avoid repeated list.index calls within loops
-    node_to_index = {node: idx for idx, node in enumerate(nodes)}
+    node_to_index = ensure_node_index_map(G)
 
     epi_vals = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in nodes]
     vf_vals = [get_attr(G.nodes[v], ALIAS_VF, 0.0) for v in nodes]
@@ -207,19 +207,7 @@ def local_phase_sync_weighted(
 
     # --- Mapeo nodo → índice ---
     if node_to_index is None:
-        cache_key = "_lpsw_cache"
-        cache = G.graph.get(cache_key, {})
-        nodes_tuple = tuple(nodes_order)
-        nodes_set = frozenset(G.nodes())
-        if cache.get("nodes") != nodes_tuple or cache.get("set") != nodes_set:
-            node_to_index = {v: i for i, v in enumerate(nodes_order)}
-            G.graph[cache_key] = {
-                "nodes": nodes_tuple,
-                "set": nodes_set,
-                "map": node_to_index,
-            }
-        else:
-            node_to_index = cache.get("map", {})
+        node_to_index = ensure_node_index_map(G)
 
     i = node_to_index.get(n, None)
     if i is None:

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -28,12 +28,26 @@ def test_local_phase_sync_independent_graphs():
     assert r1 == pytest.approx(1.0)
     assert r2 == pytest.approx(1.0)
 
-    key = "_lpsw_cache"
-    assert G1.graph[key]["nodes"] == tuple(nodes1)
-    assert G2.graph[key]["nodes"] == tuple(nodes2)
-    assert G1.graph[key] is not G2.graph[key]
+    key = "_node_index_map"
+    map1 = G1.graph[key]
+    map2 = G2.graph[key]
+    assert map1 is not map2
+    assert set(map1.keys()) == set(nodes1)
+    assert set(map2.keys()) == set(nodes2)
 
-    r1_again = local_phase_sync_weighted(
-        G1, nodes1[0], nodes_order=nodes1, W_row=W1
-    )
+    r1_again = local_phase_sync_weighted(G1, nodes1[0], nodes_order=nodes1, W_row=W1)
     assert r1_again == pytest.approx(r1)
+    assert G1.graph[key] is map1
+
+
+def test_node_index_map_invalidation():
+    G = make_graph(0)
+    coherence_matrix(G)
+    mapping1 = G.graph["_node_index_map"]
+
+    G.add_node(2)
+    coherence_matrix(G)
+    mapping2 = G.graph["_node_index_map"]
+
+    assert mapping1 is not mapping2
+    assert set(mapping2.keys()) == set(G.nodes())


### PR DESCRIPTION
## Summary
- add `ensure_node_index_map` caching node-to-index mapping
- use cached mapping in `coherence_matrix` and `local_phase_sync_weighted`
- extend coherence cache tests to verify mapping reuse and invalidation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3760dda08321b61a628ef342b377