### PR TITLE
Introduce TrigCache dataclass for trigonometric caching

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -113,7 +113,8 @@ def neighbor_phase_mean(obj, n=None) -> float:
     if G is not None:
         from .metrics_utils import precompute_trigonometry
 
-        cos_th, sin_th, thetas = precompute_trigonometry(G)
+        trig = precompute_trigonometry(G)
+        cos_th, sin_th = trig.cos, trig.sin
         for v in node.neighbors():
             x += cos_th[v]
             y += sin_th[v]
@@ -280,6 +281,7 @@ def increment_edge_version(G: Any) -> None:
         "_cos_th",
         "_sin_th",
         "_thetas",
+        "_trig_cache",
         "_trig_version",
     ):
         graph.pop(key, None)

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -1,5 +1,6 @@
 import math
 
+import math
 import networkx as nx
 import pytest
 
@@ -34,7 +35,8 @@ def test_precompute_trigonometry():
     G.add_nodes_from([1, 2])
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, math.pi / 2)
-    cos_th, sin_th, thetas = precompute_trigonometry(G)
+    trig = precompute_trigonometry(G)
+    cos_th, sin_th, thetas = trig.cos, trig.sin, trig.theta
     assert cos_th[1] == pytest.approx(1.0)
     assert sin_th[1] == pytest.approx(0.0)
     assert cos_th[2] == pytest.approx(0.0, abs=1e-8)
@@ -49,7 +51,8 @@ def test_compute_Si_node():
     set_attr(G.nodes[1], ALIAS_DNFR, 0.2)
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, 0.0)
-    cos_th, sin_th, thetas = precompute_trigonometry(G)
+    trig = precompute_trigonometry(G)
+    cos_th, sin_th, thetas = trig.cos, trig.sin, trig.theta
     neighbors = {n: list(G.neighbors(n)) for n in G}
     Si = compute_Si_node(
         1,


### PR DESCRIPTION
## Summary
- Add `TrigCache` dataclass to store cosine, sine and theta per node
- Cache trigonometric values using `TrigCache` and update usages in metrics and helpers
- Adjust tests for new trigonometry cache API

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc3946515883218fe7c93ccda25fe2