### PR TITLE
Refactor HistoryDict accessors and document compaction

### DIFF
--- a/tests/test_history_methods.py
+++ b/tests/test_history_methods.py
@@ -1,0 +1,31 @@
+from collections import deque
+
+from tnfr.glyph_history import HistoryDict
+
+
+def test_getitem_tracks_usage():
+    hist = HistoryDict({"a": 1})
+    val = hist["a"]
+    assert val == 1
+    assert hist._counts["a"] == 1
+
+
+def test_get_handles_present_and_missing_keys():
+    hist = HistoryDict({"a": 1})
+    val = hist.get("a")
+    assert val == 1
+    assert hist._counts["a"] == 1
+    assert hist.get("missing", 42) == 42
+    assert "missing" not in hist
+    assert "missing" not in hist._counts
+
+
+def test_setdefault_inserts_converts_and_tracks_usage():
+    hist = HistoryDict(maxlen=2)
+    val = hist.setdefault("a", [1])
+    assert isinstance(val, deque)
+    assert list(val) == [1]
+    assert hist._counts["a"] == 1
+    val2 = hist.setdefault("a", [2])
+    assert val2 is val
+    assert hist._counts["a"] == 2


### PR DESCRIPTION
## Summary
- extract value resolution helper in `HistoryDict` to centralize list-to-deque conversion and counter setup
- streamline `__getitem__`, `get` and `setdefault` to use the shared helper
- clarify heap compaction strategy in `HistoryDict` docstring and add tests for accessor methods

## Testing
- `PYTHONPATH=src pytest tests/test_history_methods.py tests/test_history_heap_cleanup.py tests/test_history_maxlen.py tests/test_history_series.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3b736b048321b83118748f998faf