### PR TITLE
Refactor caching and helper utilities

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -184,21 +184,9 @@ def ensure_history(G) -> Dict[str, Any]:
         hist = HistoryDict(hist, maxlen=maxlen, compact_every=compact_every)
         G.graph["history"] = hist
     if maxlen > 0:
-        excess = len(hist) - maxlen
-        if excess > 0:
-            # Remove least used keys in bulk using heapq.nsmallest
-            candidates = []
-            for cnt, key in heapq.nsmallest(excess * 2, hist._heap):
-                if key in hist and hist._counts.get(key) == cnt and key not in candidates:
-                    candidates.append(key)
-                if len(candidates) >= excess:
-                    break
-            for key in candidates:
-                hist._counts.pop(key, None)
-                dict.__delitem__(hist, key)
-            hist._dirty += len(candidates)
-            hist._maybe_compact()
-        # Note: trimming is O(n) only when history exceeds ``maxlen``
+        while len(hist) > maxlen:
+            hist.pop_least_used()
+        # Note: trimming is O(n log n) when history exceeds ``maxlen``
     return hist
 
 

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -54,22 +54,12 @@ def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
     count = G.number_of_nodes()
     if count:
-        dnfr_sum = depi_sum = 0.0
-        dnfr_c = depi_c = 0.0
-        for _, nd in G.nodes(data=True):
-            dnfr_val = abs(get_attr(nd, ALIAS_DNFR, 0.0))
-            y = dnfr_val - dnfr_c
-            t = dnfr_sum + y
-            dnfr_c = (t - dnfr_sum) - y
-            dnfr_sum = t
-
-            depi_val = abs(get_attr(nd, ALIAS_dEPI, 0.0))
-            y = depi_val - depi_c
-            t = depi_sum + y
-            depi_c = (t - depi_sum) - y
-            depi_sum = t
-        dnfr_mean = dnfr_sum / count
-        depi_mean = depi_sum / count
+        dnfr_mean = math.fsum(
+            abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)
+        ) / count
+        depi_mean = math.fsum(
+            abs(get_attr(nd, ALIAS_dEPI, 0.0)) for _, nd in G.nodes(data=True)
+        ) / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -133,7 +133,8 @@ def _flatten(seq: Sequence[Token]) -> list[tuple[str, Any]]:
             ops.append(("TARGET", item))
             continue
         if isinstance(item, WAIT):
-            ops.append(("WAIT", item.steps))
+            steps = max(1, int(getattr(item, "steps", 1)))
+            ops.append(("WAIT", steps))
             continue
         if isinstance(item, THOL):
             repeats = max(1, int(item.repeat))
@@ -190,7 +191,6 @@ def _handle_target(G, payload: TARGET, _curr_target, trace: deque, _step_fn):
 def _handle_wait(
     G, steps: int, curr_target, trace: deque, step_fn: Optional[AdvanceFn]
 ):
-    steps = max(1, int(steps))
     for _ in range(steps):
         _advance(G, step_fn)
     _record_trace(trace, G, "WAIT", k=steps)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -160,6 +160,36 @@ def test_kuramoto_cache_reuses_checksum(graph_canon, monkeypatch):
     assert calls == [1]
 
 
+def test_kuramoto_cache_updates_on_time_change(graph_canon):
+    from tnfr import gamma as gamma_mod
+
+    G = graph_canon()
+    G.add_nodes_from([0])
+    attach_defaults(G)
+    G.nodes[0]["θ"] = 0.0
+    gamma_mod._ensure_kuramoto_cache(G, t=0)
+    cache0 = G.graph["_kuramoto_cache"]
+    gamma_mod._ensure_kuramoto_cache(G, t=1)
+    cache1 = G.graph["_kuramoto_cache"]
+    assert cache0 is not cache1
+
+
+def test_kuramoto_cache_updates_on_nodes_change(graph_canon):
+    from tnfr import gamma as gamma_mod
+
+    G = graph_canon()
+    G.add_nodes_from([0])
+    attach_defaults(G)
+    G.nodes[0]["θ"] = 0.0
+    gamma_mod._ensure_kuramoto_cache(G, t=0)
+    cache0 = G.graph["_kuramoto_cache"]
+    G.add_node(1)
+    G.nodes[1]["θ"] = 0.0
+    gamma_mod._ensure_kuramoto_cache(G, t=0)
+    cache1 = G.graph["_kuramoto_cache"]
+    assert cache0 is not cache1
+
+
 def test_kuramoto_cache_invalidation_on_version(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -50,6 +50,23 @@ def test_history_least_used_removed(graph_canon):
     assert "a" in hist
 
 
+def test_history_trim_uses_pop_least_used(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    G.graph["HISTORY_MAXLEN"] = 2
+
+    hist = ensure_history(G)
+    for key in ["a", "b", "c", "d"]:
+        hist.setdefault(key, []).append(1)
+    _ = hist["a"]
+    _ = hist["a"]
+    _ = hist["b"]
+
+    ensure_history(G)
+    assert set(hist.keys()) == {"a", "b"}
+
+
 def test_history_maxlen_override_respected(graph_canon):
     G = graph_canon()
     G.add_node(0)

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -46,6 +46,12 @@ def test_wait_logs_sanitized_steps(graph_canon):
     assert trace[0]["k"] == 1
 
 
+def test_flatten_wait_sanitizes_steps():
+    program = seq(WAIT(-2.5), WAIT(2.4))
+    ops = _flatten(program)
+    assert ops == [("WAIT", 1), ("WAIT", 2)]
+
+
 def test_play_handles_deeply_nested_blocks(graph_canon):
     G = graph_canon()
     G.add_node(1)


### PR DESCRIPTION
## Summary
- Clarify node_set_checksum docstring to mention BLAKE2b hash
- Centralize Kuramoto cache on edge_version_cache and add invalidation tests
- Simplify coherence and helper utilities, sanitize WAIT steps, and streamline history trimming

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc4705697083219a7ebdc491117af3