### PR TITLE
Improve error handling and caching

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -160,9 +160,14 @@ def _prepare_dnfr_data(G, *, cache_size: int | None = 1) -> dict:
         A = None
 
     idx = {n: i for i, n in enumerate(nodes)}
-    theta = [get_attr(G.nodes[n], ALIAS_THETA, 0.0) for n in nodes]
-    epi = [get_attr(G.nodes[n], ALIAS_EPI, 0.0) for n in nodes]
-    vf = [get_attr(G.nodes[n], ALIAS_VF, 0.0) for n in nodes]
+    theta = []
+    epi = []
+    vf = []
+    for n in nodes:
+        nd = G.nodes[n]
+        theta.append(get_attr(nd, ALIAS_THETA, 0.0))
+        epi.append(get_attr(nd, ALIAS_EPI, 0.0))
+        vf.append(get_attr(nd, ALIAS_VF, 0.0))
     w_phase = float(weights.get("phase", 0.0))
     w_epi = float(weights.get("epi", 0.0))
     w_vf = float(weights.get("vf", 0.0))

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -215,7 +215,7 @@ def eval_gamma(
         _ensure_kuramoto_cache(G, t)
     try:
         return float(fn(G, node, t, spec))
-    except Exception as exc:
+    except (ValueError, TypeError, ArithmeticError) as exc:
         level = (
             log_level
             if log_level is not None
@@ -223,10 +223,11 @@ def eval_gamma(
         )
         logger.log(
             level,
-            "Fallo al evaluar Γi para nodo %s en t=%s",
+            "Fallo al evaluar Γi para nodo %s en t=%s: %s: %s",
             node,
             t,
-            exc_info=exc,
+            exc.__class__.__name__,
+            exc,
         )
         if strict:
             raise

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -32,11 +32,25 @@ GLYPH_UNITS: Dict[str, complex] = {
 
 
 def glyph_angle(g: str) -> float:
-    return float(ANGLE_MAP.get(g, 0.0))
+    """Return angle for glyph ``g``.
+
+    Raises ``KeyError`` if ``g`` is not registered in :data:`ANGLE_MAP`.
+    """
+    try:
+        return float(ANGLE_MAP[g])
+    except KeyError as e:
+        raise KeyError(f"Glyph desconocido: {g}") from e
 
 
 def glyph_unit(g: str) -> complex:
-    return GLYPH_UNITS.get(g, 0 + 0j)
+    """Return unit vector for glyph ``g``.
+
+    Raises ``KeyError`` if ``g`` is not registered in :data:`ANGLE_MAP`.
+    """
+    try:
+        return GLYPH_UNITS[g]
+    except KeyError as e:
+        raise KeyError(f"Glyph desconocido: {g}") from e
 
 
 def _weight(nd, mode: str) -> float:

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -32,14 +32,16 @@ def test_cache_invalidated_on_graph_change(vectorized):
     G = _setup_graph()
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
-    assert len(G.graph.get("_dnfr_cache", {})) == 1
+    cache = G.graph["_edge_version_cache"]["_dnfr"][1]
+    assert len(cache) == 1
     before = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
 
     G.add_edge(2, 3)  # Cambia número de nodos y aristas
     increment_edge_version(G)
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
-    assert len(G.graph.get("_dnfr_cache", {})) == 1
+    cache = G.graph["_edge_version_cache"]["_dnfr"][1]
+    assert len(cache) == 1
     after = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
 
     assert len(after) == 4
@@ -49,7 +51,8 @@ def test_cache_invalidated_on_graph_change(vectorized):
     increment_edge_version(G)
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
-    assert len(G.graph.get("_dnfr_cache", {})) == 1
+    cache = G.graph["_edge_version_cache"]["_dnfr"][1]
+    assert len(cache) == 1
 
 
 def test_cache_is_per_graph():
@@ -57,9 +60,11 @@ def test_cache_is_per_graph():
     G2 = _setup_graph()
     default_compute_delta_nfr(G1)
     default_compute_delta_nfr(G2)
-    assert G1.graph["_dnfr_cache"] is not G2.graph["_dnfr_cache"]
-    assert len(G1.graph["_dnfr_cache"]) == 1
-    assert len(G2.graph["_dnfr_cache"]) == 1
+    cache1 = G1.graph["_edge_version_cache"]["_dnfr"][1]
+    cache2 = G2.graph["_edge_version_cache"]["_dnfr"][1]
+    assert cache1 is not cache2
+    assert len(cache1) == 1
+    assert len(cache2) == 1
 
 
 def test_cache_invalidated_on_node_rename():

--- a/tests/test_edge_version_cache_limit.py
+++ b/tests/test_edge_version_cache_limit.py
@@ -8,5 +8,6 @@ def test_edge_version_cache_limit():
     edge_version_cache(G, "a", lambda: 1, max_entries=2)
     edge_version_cache(G, "b", lambda: 2, max_entries=2)
     edge_version_cache(G, "c", lambda: 3, max_entries=2)
-    assert "a_cache" not in G.graph
-    assert "b_cache" in G.graph and "c_cache" in G.graph
+    cache = G.graph["_edge_version_cache"]
+    assert "a" not in cache
+    assert "b" in cache and "c" in cache

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -279,7 +279,7 @@ def test_eval_gamma_unknown_type_warning_and_strict(graph_canon, caplog):
         eval_gamma(G, 0, t=0.0, strict=True)
 
 
-def test_eval_gamma_handles_unexpected_exception(graph_canon, caplog):
+def test_eval_gamma_unhandled_exception_propagates(graph_canon):
     G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
@@ -290,10 +290,8 @@ def test_eval_gamma_handles_unexpected_exception(graph_canon, caplog):
 
     GAMMA_REGISTRY["bad"] = (bad_gamma, False)
     try:
-        caplog.clear()
-        with caplog.at_level(logging.DEBUG, logger="tnfr.gamma"):
-            assert eval_gamma(G, 0, t=0.0, strict=False) == 0.0
-        assert any("Fallo al evaluar" in r.message for r in caplog.records)
+        with pytest.raises(RuntimeError):
+            eval_gamma(G, 0, t=0.0, strict=False)
         with pytest.raises(RuntimeError):
             eval_gamma(G, 0, t=0.0, strict=True)
     finally:

--- a/tests/test_get_rng_threadsafe.py
+++ b/tests/test_get_rng_threadsafe.py
@@ -1,0 +1,27 @@
+import threading
+
+from tnfr import rng as rng_mod
+from tnfr.rng import get_rng
+from tnfr.constants import DEFAULTS
+
+
+def test_get_rng_thread_safety(monkeypatch):
+    monkeypatch.setattr(rng_mod, "DEFAULTS", dict(DEFAULTS))
+    monkeypatch.setitem(rng_mod.DEFAULTS, "JITTER_CACHE_SIZE", 4)
+    get_rng.cache_clear()
+    errors = []
+
+    def worker(idx):
+        try:
+            rng = get_rng(123, idx)
+            rng.random()
+        except Exception as e:  # pragma: no cover - should not happen
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -24,6 +24,7 @@ from tnfr.metrics import (
 from tnfr.metrics.core import LATENT_GLYPH
 from tnfr.metrics.core import _update_sigma
 from tnfr.constants import METRIC_DEFAULTS
+from tnfr.types import Glyph
 
 
 def test_track_stability_updates_hist():
@@ -63,7 +64,7 @@ def test_track_stability_updates_hist():
 def test_update_sigma_uses_default_window(graph_canon):
     G = graph_canon()
     for n in range(2):
-        G.add_node(n, glyph_history=["A", "B"])
+        G.add_node(n, glyph_history=[Glyph.AL.value, Glyph.EN.value])
     hist = {}
     G.graph.pop("GLYPH_LOAD_WINDOW", None)
     _update_sigma(G, hist)

--- a/tests/test_neighbor_phase_mean_no_graph.py
+++ b/tests/test_neighbor_phase_mean_no_graph.py
@@ -1,4 +1,6 @@
 import pytest
+import math
+import time
 
 from tnfr.helpers import neighbor_phase_mean
 
@@ -19,3 +21,36 @@ class DummyNode:
 def test_neighbor_phase_mean_handles_missing_G():
     node = DummyNode()
     assert neighbor_phase_mean(node) == pytest.approx(node.theta)
+
+
+@pytest.mark.slow
+def test_neighbor_phase_mean_no_graph_performance():
+    neigh = DummyNeighbor()
+    node = DummyNode()
+    node._neigh = [neigh] * 1000
+
+    def naive(n: DummyNode):
+        x = y = 0.0
+        count = 0
+        for v in n.neighbors():
+            th = getattr(v, "theta", None)
+            if th is None:
+                continue
+            x += math.cos(th)
+            y += math.sin(th)
+            count += 1
+        if count == 0:
+            return n.theta
+        return math.atan2(y, x)
+
+    start = time.perf_counter()
+    for _ in range(50):
+        neighbor_phase_mean(node)
+    t_opt = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(50):
+        naive(node)
+    t_naive = time.perf_counter() - start
+
+    assert t_opt <= t_naive

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -1,5 +1,5 @@
-import networkx as nx
 import hashlib
+import networkx as nx
 
 from tnfr.helpers import node_set_checksum, _stable_json
 
@@ -40,3 +40,10 @@ def test_node_set_checksum_compatibility():
     G = nx.Graph()
     G.add_nodes_from([1, 2, 3])
     assert node_set_checksum(G) == _reference_checksum(G)
+
+
+def test_node_set_checksum_iterable_equivalence():
+    G = nx.Graph()
+    G.add_nodes_from([3, 1, 2])
+    gen = (n for n in G.nodes())
+    assert node_set_checksum(G, gen) == node_set_checksum(G)

--- a/tests/test_prepare_dnfr_data_performance.py
+++ b/tests/test_prepare_dnfr_data_performance.py
@@ -1,0 +1,37 @@
+import time
+import networkx as nx
+import pytest
+
+from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF
+from tnfr.dynamics import _prepare_dnfr_data
+from tnfr.helpers import cached_nodes_and_A
+from tnfr.alias import get_attr
+
+
+def _naive_prepare(G):
+    nodes, _ = cached_nodes_and_A(G, cache_size=1)
+    theta = [get_attr(G.nodes[n], ALIAS_THETA, 0.0) for n in nodes]
+    epi = [get_attr(G.nodes[n], ALIAS_EPI, 0.0) for n in nodes]
+    vf = [get_attr(G.nodes[n], ALIAS_VF, 0.0) for n in nodes]
+    return theta, epi, vf
+
+
+@pytest.mark.slow
+def test_prepare_dnfr_data_performance():
+    G = nx.gnp_random_graph(300, 0.1, seed=1)
+    for n in G.nodes:
+        G.nodes[n][ALIAS_THETA] = 0.0
+        G.nodes[n][ALIAS_EPI] = 0.0
+        G.nodes[n][ALIAS_VF] = 0.0
+
+    start = time.perf_counter()
+    for _ in range(5):
+        _prepare_dnfr_data(G)
+    t_opt = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(5):
+        _naive_prepare(G)
+    t_naive = time.perf_counter() - start
+
+    assert t_opt <= t_naive

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -11,6 +11,7 @@ from tnfr.sense import (
     _sigma_from_pairs,
     _sigma_from_vectors,
     glyph_unit,
+    glyph_angle,
 )
 from tnfr.types import Glyph
 
@@ -91,13 +92,8 @@ def test_sigma_from_vectors_rejects_invalid_iterable():
         _sigma_from_vectors("abc")
 
 
-def test_unknown_glyph_does_not_shift_average():
-    base, _ = _sigma_from_vectors([glyph_unit(Glyph.AL.value)])
-    with_unknown, _ = _sigma_from_vectors(
-        [
-            glyph_unit(Glyph.AL.value),
-            glyph_unit("ZZ"),
-        ]
-    )
-    assert glyph_unit("ZZ") == 0 + 0j
-    assert with_unknown["angle"] == pytest.approx(base["angle"])
+def test_unknown_glyph_raises():
+    with pytest.raises(KeyError):
+        glyph_angle("ZZ")
+    with pytest.raises(KeyError):
+        glyph_unit("ZZ")

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -60,7 +60,7 @@ def test_validator_glyph_invalido():
     n0 = list(G.nodes())[0]
     set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
     G.nodes[n0]["glyph_history"] = ["INVALID"]
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         run_validators(G)
 
 


### PR DESCRIPTION
## Summary
- tighten structured-file parsing and cache parser resolution
- narrow gamma evaluation errors and improve logging
- optimize neighbor phase mean, node checksum, and edge cache
- ensure RNG cache and DNFR prep are thread-safe and efficient
- validate glyph lookups with explicit errors

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc4941a17c83219077fbcf136ac653