### PR TITLE
chore: tidy imports and simplify helpers

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -13,6 +13,11 @@ example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or
 
 from __future__ import annotations
 
+from .dynamics import step, run
+from .ontosim import preparar_red
+from .structural import create_nfr
+from .types import NodeState
+from .trace import CallbackSpec  # re-exported for tests  # noqa: F401
 from .import_utils import optional_import
 
 _metadata = optional_import("importlib.metadata")
@@ -31,20 +36,13 @@ except PackageNotFoundError:  # pragma: no cover
 
         try:
             with (Path(__file__).resolve().parents[2] / "pyproject.toml").open(
-                "rb"
+                "rb",
             ) as f:
                 __version__ = tomllib.load(f)["project"]["version"]
         except (OSError, KeyError, ValueError):  # pragma: no cover
             __version__ = "0+unknown"
     else:  # pragma: no cover
         __version__ = "0+unknown"
-
-# Minimal public API re-exports
-from .dynamics import step, run
-from .ontosim import preparar_red
-from .structural import create_nfr
-from .types import NodeState
-from .trace import CallbackSpec  # re-exported for tests  # noqa: F401
 
 __all__ = [
     "__version__",
@@ -54,3 +52,4 @@ __all__ = [
     "create_nfr",
     "NodeState",
 ]
+

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -8,7 +8,6 @@ import sys
 from typing import Any, Optional, Callable, TYPE_CHECKING
 from collections.abc import Sequence, Iterable
 from pathlib import Path
-from collections import deque
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import (
     Iterable,
-    Sequence,
     Any,
     TypeVar,
     Mapping,
@@ -13,7 +12,7 @@ from typing import (
 )
 import logging
 import math
-from itertools import islice
+import itertools
 
 from .value_utils import _convert_value
 
@@ -57,14 +56,12 @@ def ensure_collection(
         if max_materialize is None:
             return tuple(it)
         limit = max_materialize
-        out = []
-        for i, item in enumerate(it):
-            if i >= limit:
-                raise ValueError(
-                    f"Iterable produced {i + 1} items, exceeds limit {limit}"
-                )
-            out.append(item)
-        return tuple(out)
+        out = tuple(itertools.islice(it, limit + 1))
+        if len(out) > limit:
+            raise ValueError(
+                f"Iterable produced {len(out)} items, exceeds limit {limit}"
+            )
+        return out[:limit]
     except TypeError as exc:
         raise TypeError(f"{it!r} is not iterable") from exc
 

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Mapping
 import copy
 import warnings
 from types import MappingProxyType
+from weakref import ref
 
 from .core import CORE_DEFAULTS, REMESH_DEFAULTS
 from .init import INIT_DEFAULTS
@@ -34,8 +35,6 @@ IMMUTABLE_SIMPLE = (
     bytes,
     type(None),
 )
-
-from weakref import ref
 
 _IMMUTABLE_CACHE: dict[int, tuple[ref, bool]] = {}
 

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import math
-import random
 from collections import deque
 from typing import Dict, Any, Literal, TYPE_CHECKING
 
@@ -61,7 +60,7 @@ from .collections_utils import normalize_weights
 from .import_utils import get_numpy
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    import networkx as nx
+    import networkx as nx  # noqa: F401
 from .selector import (
     _selector_thresholds,
     _norms_para_selector,

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 from typing import (
     Iterable,
-    Sequence,
     Dict,
     Any,
-    Optional,
     TYPE_CHECKING,
     Callable,
     TypeVar,
@@ -18,8 +16,6 @@ from collections import OrderedDict
 from functools import lru_cache
 import threading
 
-_EDGE_CACHE_LOCK = threading.Lock()
-
 from .import_utils import get_numpy
 from .collections_utils import (
     MAX_MATERIALIZE_DEFAULT,
@@ -30,6 +26,8 @@ from .collections_utils import (
 )
 from .alias import get_attr
 from .constants import ALIAS_THETA
+
+_EDGE_CACHE_LOCK = threading.Lock()
 
 
 @lru_cache(maxsize=1)

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -17,7 +17,6 @@ Note on REMESH α (alpha) precedence:
 from __future__ import annotations
 from typing import Dict, Any, Optional, Iterable, TYPE_CHECKING
 import math
-import random
 import hashlib
 import heapq
 from functools import cache
@@ -37,6 +36,7 @@ from .glyph_history import append_metric
 
 if TYPE_CHECKING:
     from .node import NodoProtocol
+    import random  # noqa: F401
 from .types import Glyph
 from collections import deque
 def _node_offset(G, n) -> int:
@@ -280,12 +280,12 @@ def _op_UM(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # UM — Coupling
                     key=lambda j: abs(angle_diff(j.theta, th)),
                 )
             else:
-                rng = _jitter_base(
+                rng = get_rng(
                     int(node.graph.get("RANDOM_SEED", 0)), node.offset()
                 )
                 candidates = rng.sample(candidates, limit)
         elif mode == "sample" and limit > 0:
-            rng = _jitter_base(
+            rng = get_rng(
                 int(node.graph.get("RANDOM_SEED", 0)), node.offset()
             )
             rng.shuffle(candidates)

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -13,8 +13,6 @@ from .callback_utils import register_callback
 from .glyph_history import ensure_history, last_glyph, count_glyphs, append_metric
 from .constants_glyphs import (
     ANGLE_MAP,
-    ESTABILIZADORES,
-    DISRUPTIVOS,
     GLYPHS_CANONICAL,
 )
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -9,7 +9,7 @@ from tnfr.constants import ALIAS_THETA
 from tnfr.observers import phase_sync, kuramoto_order, glyph_load, wbar
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
-from tnfr.constants_glyphs import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
+from tnfr.constants_glyphs import ANGLE_MAP
 from tnfr.helpers import angle_diff
 from tnfr.alias import set_attr
 from tnfr.callback_utils import CallbackEvent

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -8,7 +8,6 @@ from tnfr.operators import (
     _select_dominant_glyph,
 )
 from types import SimpleNamespace
-import tnfr.operators as operators
 from tnfr.constants import attach_defaults
 import networkx as nx
 import pytest

--- a/tests/test_push_glyph.py
+++ b/tests/test_push_glyph.py
@@ -1,7 +1,5 @@
 """Tests for push_glyph window handling."""
 
-import pytest
-
 from tnfr.glyph_history import push_glyph
 
 

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -1,6 +1,7 @@
 """Pruebas de read structured file errors."""
 
 import pytest
+import importlib.util
 from pathlib import Path
 from json import JSONDecodeError
 import tnfr.io as io_mod
@@ -60,9 +61,7 @@ def test_read_structured_file_corrupt_yaml(tmp_path: Path):
 
 
 def test_read_structured_file_corrupt_toml(tmp_path: Path):
-    try:
-        import tomllib  # type: ignore[attr-defined]
-    except ModuleNotFoundError:
+    if importlib.util.find_spec("tomllib") is None:
         pytest.importorskip("tomli")
     path = tmp_path / "bad.toml"
     path.write_text("a = [1, 2", encoding="utf-8")

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -1,6 +1,4 @@
 import math
-
-import math
 import networkx as nx
 import pytest
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -11,7 +11,6 @@ from tnfr.trace import (
     CallbackSpec,
 )
 from tnfr.callback_utils import register_callback, invoke_callbacks
-import pytest
 from types import MappingProxyType
 
 


### PR DESCRIPTION
## Summary
- move public imports to top-level in `__init__`
- clean unused imports across modules and tests
- streamline `ensure_collection` using `itertools.islice`

## Testing
- `ruff check`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc527e0a5c8321bf582cdd2b3bf584