### PR TITLE
Refactor gamma cache and selector thresholds

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -168,7 +168,7 @@ def invoke_callbacks(
         name, fn = spec.name, spec.func
         try:
             fn(G, ctx)
-        except (KeyError, AttributeError, TypeError) as e:
+        except Exception as e:  # catch all callback errors
             logger.warning("callback %r failed for %s: %s", name, event, e)
             if strict:
                 raise

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -6,6 +6,7 @@ import math
 import cmath
 import logging
 import warnings
+import json
 from collections import OrderedDict
 from collections.abc import Mapping
 
@@ -72,7 +73,11 @@ def _kuramoto_common(G, node, _cfg):
 def _get_gamma_spec(G) -> Mapping[str, Any]:
     raw = G.graph.get("GAMMA")
     cached = G.graph.get("_gamma_spec")
-    if cached is not None and G.graph.get("_gamma_spec_raw") is raw:
+    prev_hash = G.graph.get("_gamma_spec_hash")
+    # ``json.dumps(..., default=str)`` provides a stable representation for
+    # hash calculation even when values are not natively serialisable.
+    cur_hash = hash(json.dumps(raw, sort_keys=True, default=str))
+    if cached is not None and prev_hash == cur_hash:
         return cached
     if raw is None:
         spec = {"type": "none"}
@@ -86,7 +91,7 @@ def _get_gamma_spec(G) -> Mapping[str, Any]:
     else:
         spec = raw
     G.graph["_gamma_spec"] = spec
-    G.graph["_gamma_spec_raw"] = raw
+    G.graph["_gamma_spec_hash"] = cur_hash
     return spec
 
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -14,6 +14,7 @@ from .alias import get_attr
 from .helpers import clamp01
 from .glyph_history import recent_glyph
 from .types import Glyph
+from .operators import apply_glyph  # avoid repeated import inside functions
 
 # Nominal glyphs (to avoid typos)
 AL = Glyph.AL
@@ -277,9 +278,6 @@ def apply_glyph_with_grammar(
     directly to avoid unnecessary materialisation; callers must materialise if
     they need indexing.
     """
-
-    from .operators import apply_glyph
-
     if window is None:
         window = get_param(G, "GLYPH_HYSTERESIS_WINDOW")
 

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -49,13 +49,14 @@ def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
     count = G.number_of_nodes()
     if count:
-        dnfr_vals: list[float] = []
-        depi_vals: list[float] = []
-        for _, nd in G.nodes(data=True):
-            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
-            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
-        dnfr_mean = math.fsum(dnfr_vals) / count
-        depi_mean = math.fsum(depi_vals) / count
+        dnfr_sum = math.fsum(
+            abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)
+        )
+        depi_sum = math.fsum(
+            abs(get_attr(nd, ALIAS_dEPI, 0.0)) for _, nd in G.nodes(data=True)
+        )
+        dnfr_mean = dnfr_sum / count
+        depi_mean = depi_sum / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -35,73 +35,23 @@ def _selector_thresholds(G: "nx.Graph") -> dict:
     glyph_defaults = DEFAULTS.get("GLYPH_THRESHOLDS", {})
     thr_def = {**glyph_defaults, **G.graph.get("GLYPH_THRESHOLDS", {})}
 
-    def _get_threshold(
-        key: str, default: float, legacy: str | None = None
-    ) -> float:
-        """Obtain ``key`` from ``thr_sel`` honouring legacy keys.
+    specs = {
+        "si_hi": ("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"]),
+        "si_lo": ("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"]),
+        "dnfr_hi": (None, SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]),
+        "dnfr_lo": (None, SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]),
+        "accel_hi": (None, SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]),
+        "accel_lo": (None, SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]),
+    }
 
-        When ``legacy`` is provided ``thr_def`` is used as fallback,
-        allowing compatibility with ``GLYPH_THRESHOLDS`` from older
-        versions.
-        """
-
+    out: Dict[str, float] = {}
+    for key, (legacy, default) in specs.items():
         if legacy is not None:
             val = thr_sel.get(key, thr_def.get(legacy, default))
         else:
             val = thr_sel.get(key, default)
-        return clamp01(float(val))
-
-    specs = [
-        (
-            "si_hi",
-            thr_def.get(
-                "hi",
-                glyph_defaults.get("hi", SELECTOR_THRESHOLD_DEFAULTS["si_hi"]),
-            ),
-            "hi",
-        ),
-        (
-            "si_lo",
-            thr_def.get(
-                "lo",
-                glyph_defaults.get("lo", SELECTOR_THRESHOLD_DEFAULTS["si_lo"]),
-            ),
-            "lo",
-        ),
-        (
-            "dnfr_hi",
-            sel_defaults.get(
-                "dnfr_hi", SELECTOR_THRESHOLD_DEFAULTS["dnfr_hi"]
-            ),
-            None,
-        ),
-        (
-            "dnfr_lo",
-            sel_defaults.get(
-                "dnfr_lo", SELECTOR_THRESHOLD_DEFAULTS["dnfr_lo"]
-            ),
-            None,
-        ),
-        (
-            "accel_hi",
-            sel_defaults.get(
-                "accel_hi", SELECTOR_THRESHOLD_DEFAULTS["accel_hi"]
-            ),
-            None,
-        ),
-        (
-            "accel_lo",
-            sel_defaults.get(
-                "accel_lo", SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]
-            ),
-            None,
-        ),
-    ]
-
-    return {
-        key: _get_threshold(key, default, legacy)
-        for key, default, legacy in specs
-    }
+        out[key] = clamp01(float(val))
+    return out
 
 
 def _norms_para_selector(G: "nx.Graph") -> dict:


### PR DESCRIPTION
## Summary
- Refresh gamma spec cache to detect in-place mutations
- Simplify sigma utilities with Counter-based rose, EMA helper and cleanup
- Streamline coherence metric, broaden callback error handling and cache optional imports
- Move `apply_glyph` import to module level and refactor selector thresholds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5cbb85708321a8d05359149db99e