### PR TITLE
Refactor helpers and streamline operations

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -56,4 +56,5 @@ __all__ = [
     "preparar_red",
     "create_nfr",
     "NodeState",
+    "CallbackSpec",
 ]

--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -55,6 +55,16 @@ def _alias_lookup(
     log_level: int | None = None,
 ) -> Optional[T]:
     aliases = _validate_aliases(aliases)
+    ok_def = False
+    def_val = None
+    if default is not None:
+        ok_def, def_val = _convert_value(
+            default,
+            conv,
+            strict=strict,
+            key="default",
+            log_level=logging.WARNING if not strict else log_level,
+        )
     for key in aliases:
         if key in d:
             ok, val = _convert_value(
@@ -64,14 +74,7 @@ def _alias_lookup(
                 return val
     if default is None:
         return None
-    ok, val = _convert_value(
-        default,
-        conv,
-        strict=strict,
-        key="default",
-        log_level=logging.WARNING if not strict else log_level,
-    )
-    return val if ok else None
+    return def_val if ok_def else None
 
 
 @overload

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -208,13 +208,16 @@ def count_glyphs(
     def _iter_seq(nd: Dict[str, Any]) -> Iterable[str]:
         if last_only:
             g = last_glyph(nd)
-            return [g] if g else []
+            if g:
+                yield g
+            return
         hist = nd.get("glyph_history")
         if not hist:
-            return []
+            return
         if window_int is None:
-            return hist
-        return islice(reversed(hist), window_int)
+            yield from hist
+        else:
+            yield from islice(reversed(hist), window_int)
 
     counts: Counter[str] = Counter()
     for _, nd in G.nodes(data=True):

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -11,6 +11,7 @@ from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..collections_utils import normalize_weights
 from ..helpers import clamp01, ensure_node_index_map
+from ..metrics_utils import min_max_range
 from ..import_utils import get_numpy
 
 
@@ -67,8 +68,8 @@ def coherence_matrix(G):
     epi_vals = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in nodes]
     vf_vals = [get_attr(G.nodes[v], ALIAS_VF, 0.0) for v in nodes]
     si_vals = [clamp01(get_attr(G.nodes[v], ALIAS_SI, 0.0)) for v in nodes]
-    epi_min, epi_max = min(epi_vals), max(epi_vals)
-    vf_min, vf_max = min(vf_vals), max(vf_vals)
+    epi_min, epi_max = min_max_range(epi_vals)
+    vf_min, vf_max = min_max_range(vf_vals)
 
     wdict = dict(cfg.get("weights", {}))
     for k in ("phase", "epi", "vf", "si"):

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -17,7 +17,7 @@ from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..helpers import clamp01
-from ..metrics_utils import compute_dnfr_accel_max
+from ..metrics_utils import compute_dnfr_accel_max, min_max_range
 from .coherence import local_phase_sync_weighted, _similarity_abs
 
 
@@ -88,17 +88,7 @@ def _diagnosis_step(G, ctx=None):
     G.graph["_sel_norms"] = norms
     dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
     epi_iter = (get_attr(nd, ALIAS_EPI, 0.0) for _, nd in G.nodes(data=True))
-    try:
-        first_epi = next(epi_iter)
-    except StopIteration:
-        epi_min, epi_max = 0.0, 1.0
-    else:
-        epi_min = epi_max = first_epi
-        for val in epi_iter:
-            if val < epi_min:
-                epi_min = val
-            elif val > epi_max:
-                epi_max = val
+    epi_min, epi_max = min_max_range(epi_iter, default=(0.0, 1.0))
 
     CfgW = G.graph.get("COHERENCE", COHERENCE)
     Wkey = CfgW.get("Wi_history_key", "W_i")

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, Sequence, Iterable
 import math
 
 from .constants import (
@@ -27,6 +27,7 @@ __all__ = [
     "precompute_trigonometry",
     "compute_Si_node",
     "compute_Si",
+    "min_max_range",
 ]
 
 
@@ -185,3 +186,20 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
             inplace=inplace,
         )
     return out
+
+
+def min_max_range(
+    values: Iterable[float], *, default: tuple[float, float] = (0.0, 0.0)
+) -> tuple[float, float]:
+    iterator = iter(values)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return default
+    vmin = vmax = first
+    for val in iterator:
+        if val < vmin:
+            vmin = val
+        elif val > vmax:
+            vmax = val
+    return vmin, vmax

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Deque, Dict, Iterable, Optional, Protocol, TypeVar
 from collections import deque
-from functools import partial
 from collections.abc import Hashable
 
 from .constants import (

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -68,8 +68,12 @@ def _get_R_psi(G, R: float | None = None, psi: float | None = None) -> tuple[flo
     return R, psi
 
 
+def _has_nodes(G) -> bool:
+    return G.number_of_nodes() != 0
+
+
 def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
-    if G.number_of_nodes() == 0:
+    if not _has_nodes(G):
         return 1.0
     _, psi = _get_R_psi(G, R, psi)
     thetas = [angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi) for _, data in G.nodes(data=True)]
@@ -79,7 +83,7 @@ def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
 
 def kuramoto_order(G, R: float | None = None, psi: float | None = None) -> float:
     """R in [0,1], 1 means perfectly aligned phases."""
-    if G.number_of_nodes() == 0:
+    if not _has_nodes(G):
         return 1.0
     R, _ = _get_R_psi(G, R, psi)
     return float(R)
@@ -113,9 +117,6 @@ def wbar(G, window: int | None = None) -> float:
     if w <= 0:
         raise ValueError("window must be positive")
     w = min(len(cs), w)
-    if isinstance(cs, list):
-        tail = cs[-w:]
-    else:
-        start = len(cs) - w
-        tail = islice(cs, start, None)
+    start = len(cs) - w
+    tail = islice(cs, start, None)
     return float(statistics.fmean(tail))

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -99,8 +99,10 @@ def random_jitter(
         scope_id = id(node)
 
     seed = base_seed ^ scope_id
+    cache_size = int(
+        node.graph.get("JITTER_CACHE_SIZE", DEFAULTS["JITTER_CACHE_SIZE"])
+    )
     if cache is None:
-        cache_size = int(node.graph.get("JITTER_CACHE_SIZE", DEFAULTS["JITTER_CACHE_SIZE"]))
         if cache_size <= 0:
             rng = make_rng(seed, seed_key)  # fresh each call
         else:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -10,6 +10,7 @@ def test_public_exports():
         "preparar_red",
         "create_nfr",
         "NodeState",
+        "CallbackSpec",
     }
     assert set(tnfr.__all__) == expected
 


### PR DESCRIPTION
## Summary
- expose CallbackSpec in top-level exports
- streamline glyph history and program execution helpers
- add min-max range helper and reuse across metrics
- optimize observers and random jitter operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc624469948321adfff62632b27319