### PR TITLE
Refactor caching and concurrency in helpers

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -12,7 +12,6 @@ from typing import (
 )
 import logging
 import math
-import itertools
 
 from .value_utils import _convert_value
 
@@ -59,12 +58,14 @@ def ensure_collection(
         limit = max_materialize
         if limit == 0:
             return ()
-        out = tuple(itertools.islice(it, limit + 1))
-        if len(out) > limit:
-            raise ValueError(
-                f"Iterable produced {len(out)} items, exceeds limit {limit}"
-            )
-        return out[:limit]
+        out: list[T] = []
+        for idx, item in enumerate(it):
+            if idx >= limit:
+                raise ValueError(
+                    f"Iterable produced {idx + 1} items, exceeds limit {limit}"
+                )
+            out.append(item)
+        return tuple(out)
     except TypeError as exc:
         raise TypeError(f"{it!r} is not iterable") from exc
 

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -83,10 +83,12 @@ def _update_node_sample(G, *, step: int) -> None:
     limit = int(G.graph.get("UM_CANDIDATE_COUNT", 0))
     nodes = G.graph.get("_node_list")
     checksum = G.graph.get("_node_list_checksum")
-    current_checksum = node_set_checksum(G, nodes) if nodes is not None else None
+    current_checksum = (
+        node_set_checksum(G, nodes, store=False) if nodes is not None else None
+    )
     if nodes is None or checksum != current_checksum:
         nodes = tuple(G.nodes())
-        checksum = node_set_checksum(G, nodes)
+        checksum = node_set_checksum(G, nodes, store=False)
         G.graph["_node_list"] = nodes
         G.graph["_node_list_checksum"] = checksum
     n = len(nodes)
@@ -174,9 +176,11 @@ def _prepare_dnfr_data(G, *, cache_size: int | None = 1) -> dict:
 
     for i, n in enumerate(nodes):
         nd = G.nodes[n]
-        theta[i] = get_attr(nd, ALIAS_THETA, 0.0)
-        epi[i] = get_attr(nd, ALIAS_EPI, 0.0)
-        vf[i] = get_attr(nd, ALIAS_VF, 0.0)
+        theta[i], epi[i], vf[i] = (
+            get_attr(nd, ALIAS_THETA, 0.0),
+            get_attr(nd, ALIAS_EPI, 0.0),
+            get_attr(nd, ALIAS_VF, 0.0),
+        )
 
     w_phase = float(weights.get("phase", 0.0))
     w_epi = float(weights.get("epi", 0.0))

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -76,8 +76,16 @@ def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
     if not _has_nodes(G):
         return 1.0
     _, psi = _get_R_psi(G, R, psi)
-    thetas = [angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi) for _, data in G.nodes(data=True)]
-    var = statistics.pvariance(thetas)
+    mean = 0.0
+    m2 = 0.0
+    n = 0
+    for _, data in G.nodes(data=True):
+        th = angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
+        n += 1
+        delta = th - mean
+        mean += delta / n
+        m2 += delta * (th - mean)
+    var = m2 / n if n else 0.0
     return 1.0 / (1.0 + var)
 
 

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -63,15 +63,6 @@ def _check_glyph(g, n):
 
 def run_validators(G) -> None:
     """Run all invariant validators on ``G``."""
-    cfg = {
-        k: float(get_param(G, k))
-        for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
-    }
-    epi_min, epi_max = cfg["EPI_MIN"], cfg["EPI_MAX"]
-    vf_min, vf_max = cfg["VF_MIN"], cfg["VF_MAX"]
-    for n, data in G.nodes(data=True):
-        epi = _require_attr(data, ALIAS_EPI, n, "EPI")
-        vf = _require_attr(data, ALIAS_VF, n, "VF")
-        _check_epi_vf(epi, vf, epi_min, epi_max, vf_min, vf_max, n)
-        _check_glyph(last_glyph(data), n)
+    _validate_epi_vf(G)
+    _validate_glyphs(G)
     _validate_sigma(G)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -201,8 +201,9 @@ def test_kuramoto_cache_step_limit(graph_canon):
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     gamma_mod._ensure_kuramoto_cache(G, t=1)
     gamma_mod._ensure_kuramoto_cache(G, t=2)
-    cache_dict = G.graph["_edge_version_cache"]["_kuramoto"][1]
-    assert len(cache_dict) == 2
+    cache = G.graph["_edge_version_cache"]
+    entries = [k for k in cache if isinstance(k, tuple)]
+    assert len(entries) == 2
 
 
 def test_kuramoto_cache_invalidation_on_version(graph_canon):


### PR DESCRIPTION
## Summary
- Deduplicate neighbor phase mean logic with shared trigonometry iterator
- Harden edge and import caches against concurrency issues
- Streamline collection materialization and caching of node sets
- Simplify program flattening and validators
- Use streaming variance for phase sync and switch Kuramoto cache to edge cache

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc65d4797483218f79197d1cb20fcc