### PR TITLE
refactor: streamline helpers and IO parser mapping

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -56,13 +56,13 @@ def coherence_matrix(G):
     if not cfg.get("enabled", True):
         return None, None
 
-    nodes = list(G.nodes())
+    node_to_index = ensure_node_index_map(G)
+    nodes = list(node_to_index.keys())
     n = len(nodes)
     if n == 0:
         return nodes, []
 
     # Precompute indices to avoid repeated list.index calls within loops
-    node_to_index = ensure_node_index_map(G)
 
     th_vals = [get_attr(G.nodes[v], ALIAS_THETA, 0.0) for v in nodes]
     epi_vals = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in nodes]

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -136,7 +136,7 @@ def _update_tg(G, hist, dt, save_by_node: bool):
 
     n_total = 0
     n_latent = 0
-    for n, nd in G._node.items():
+    for n, nd in G.nodes(data=True):
         g = last(nd)
         if not g:
             continue


### PR DESCRIPTION
## Summary
- use public NetworkX API in `_update_tg`
- clarify trig variable names and simplify node checksum
- build parser lookup map for structured files and harden caches

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc6bbbc824832184efad01a5954082