### PR TITLE
Refactor caching and algorithmic utilities

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -269,9 +269,12 @@ def set_attr_with_max(
     _update_cached_abs_max(G, aliases, n, val, key=cache)
 
 
-def set_vf(G, n, value: float) -> None:
-    """Set ``νf`` and update the global maximum."""
-    set_attr_with_max(G, n, ALIAS_VF, value, cache="_vfmax")
+def set_vf(G, n, value: float, *, update_max: bool = True) -> None:
+    """Set ``νf`` and optionally update the global maximum."""
+    val = float(value)
+    set_attr(G.nodes[n], ALIAS_VF, val)
+    if update_max:
+        _update_cached_abs_max(G, ALIAS_VF, n, val, key="_vfmax")
 
 
 def set_dnfr(G, n, value: float) -> None:

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -45,8 +45,11 @@ def _is_immutable(value: Any) -> bool:
     entry = _IMMUTABLE_CACHE.get(oid)
     if entry is not None:
         obj_ref, cached = entry
-        if obj_ref() is value:
+        obj = obj_ref()
+        if obj is value:
             return cached
+        if obj is None:
+            del _IMMUTABLE_CACHE[oid]
     if isinstance(value, IMMUTABLE_SIMPLE):
         res = True
     elif isinstance(value, (tuple, frozenset)):
@@ -57,6 +60,10 @@ def _is_immutable(value: Any) -> bool:
         res = False
     try:
         _IMMUTABLE_CACHE[oid] = (ref(value), res)
+        if len(_IMMUTABLE_CACHE) > 1024:
+            dead = [k for k, (r, _) in _IMMUTABLE_CACHE.items() if r() is None]
+            for k in dead:
+                _IMMUTABLE_CACHE.pop(k, None)
     except TypeError:
         pass
     return res
@@ -155,6 +162,18 @@ ALIAS_dVF = ("dνf_dt", "dvf_dt", "dnu_dt", "dvf")
 ALIAS_D2VF = ("d2νf_dt2", "d2vf_dt2", "d2nu_dt2", "B")
 ALIAS_dSI = ("δSi", "delta_Si", "dSi")
 
+VF_PRIMARY = ALIAS_VF[0]
+THETA_PRIMARY = ALIAS_THETA[0]
+DNFR_PRIMARY = ALIAS_DNFR[0]
+EPI_PRIMARY = ALIAS_EPI[0]
+EPI_KIND_PRIMARY = ALIAS_EPI_KIND[0]
+SI_PRIMARY = ALIAS_SI[0]
+dEPI_PRIMARY = ALIAS_dEPI[0]
+D2EPI_PRIMARY = ALIAS_D2EPI[0]
+dVF_PRIMARY = ALIAS_dVF[0]
+D2VF_PRIMARY = ALIAS_D2VF[0]
+dSI_PRIMARY = ALIAS_dSI[0]
+
 __all__ = [
     "CORE_DEFAULTS",
     "INIT_DEFAULTS",
@@ -185,4 +204,15 @@ __all__ = [
     "ALIAS_dVF",
     "ALIAS_D2VF",
     "ALIAS_dSI",
+    "VF_PRIMARY",
+    "THETA_PRIMARY",
+    "DNFR_PRIMARY",
+    "EPI_PRIMARY",
+    "EPI_KIND_PRIMARY",
+    "SI_PRIMARY",
+    "dEPI_PRIMARY",
+    "D2EPI_PRIMARY",
+    "dVF_PRIMARY",
+    "D2VF_PRIMARY",
+    "dSI_PRIMARY",
 ]

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -7,6 +7,7 @@ import cmath
 import logging
 import warnings
 import json
+import hashlib
 from collections.abc import Mapping
 
 from .constants import ALIAS_THETA
@@ -69,7 +70,8 @@ def _get_gamma_spec(G) -> Mapping[str, Any]:
     prev_hash = G.graph.get("_gamma_spec_hash")
     # ``json.dumps(..., default=str)`` provides a stable representation for
     # hash calculation even when values are not natively serialisable.
-    cur_hash = hash(json.dumps(raw, sort_keys=True, default=str))
+    dumped = json.dumps(raw, sort_keys=True, default=str).encode("utf-8")
+    cur_hash = hashlib.blake2b(dumped, digest_size=16).hexdigest()
     if cached is not None and prev_hash == cur_hash:
         return cached
     if raw is None:

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -55,6 +55,13 @@ def set_cache_maxsize(size: int) -> None:
     """Update RNG cache maximum size."""
 
     global _CACHE_MAXSIZE
-    _CACHE_MAXSIZE = int(size)
+    new_size = int(size)
+    with _RNG_LOCK:
+        _CACHE_MAXSIZE = new_size
+        if new_size <= 0:
+            _RNG_CACHE.clear()
+        else:
+            while len(_RNG_CACHE) > new_size:
+                _RNG_CACHE.popitem(last=False)
 
 __all__ = ["get_rng", "make_rng", "set_cache_maxsize"]

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -125,15 +125,6 @@ def _sigma_from_iterable(
     return vec, cnt
 
 
-def _sigma_from_pairs(
-    pairs: Iterable[tuple[str, float]], fallback_angle: float = 0.0
-) -> tuple[Dict[str, float], int]:
-    """Backward-compatible wrapper to compute σ from ``(glyph, weight)`` pairs."""
-
-    vectors = (glyph_unit(g) * float(w) for g, w in pairs)
-    return _sigma_from_iterable(vectors, fallback_angle)
-
-
 # Retro-compatibilidad
 _sigma_from_vectors = _sigma_from_iterable
 
@@ -165,8 +156,9 @@ def sigma_vector(dist: Dict[str, float]) -> tuple[Dict[str, float], int]:
     """Compute Σ⃗ from a glyph distribution.
 
     ``dist`` may contain raw counts or proportions. All ``(glyph, weight)``
-    pairs are forwarded to :func:`_sigma_from_pairs` and the resulting vector
-    together with the number of processed pairs are returned.
+    pairs are converted to vectors and passed to :func:`_sigma_from_iterable`.
+    The resulting vector together with the number of processed pairs are
+    returned.
     """
 
     vectors = (glyph_unit(g) * float(w) for g, w in dist.items())

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -10,7 +10,7 @@ from .dynamics import (
 )
 from .grammar import apply_glyph_with_grammar
 from .types import Glyph
-from .constants import ALIAS_EPI, ALIAS_VF, ALIAS_THETA
+from .constants import EPI_PRIMARY, VF_PRIMARY, THETA_PRIMARY
 
 
 # ---------------------------------------------------------------------------
@@ -35,9 +35,9 @@ def create_nfr(
     G.add_node(
         name,
         **{
-            ALIAS_EPI[0]: float(epi),
-            ALIAS_VF[0]: float(vf),
-            ALIAS_THETA[0]: float(theta),
+            EPI_PRIMARY: float(epi),
+            VF_PRIMARY: float(vf),
+            THETA_PRIMARY: float(theta),
         },
     )
     set_delta_nfr_hook(G, dnfr_hook)

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -1,7 +1,7 @@
 import pytest
 import networkx as nx
 
-from tnfr.constants import ALIAS_THETA
+from tnfr.constants import THETA_PRIMARY
 from tnfr.metrics import coherence_matrix, local_phase_sync_weighted
 
 
@@ -10,8 +10,8 @@ def make_graph(offset=0):
     G.add_node(offset)
     G.add_node(offset + 1)
     G.add_edge(offset, offset + 1)
-    G.nodes[offset][ALIAS_THETA[0]] = 0.0
-    G.nodes[offset + 1][ALIAS_THETA[0]] = 0.0
+    G.nodes[offset][THETA_PRIMARY] = 0.0
+    G.nodes[offset + 1][THETA_PRIMARY] = 0.0
     return G
 
 

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -4,16 +4,16 @@ import pytest
 import networkx as nx
 
 from tnfr.dynamics import default_compute_delta_nfr
-from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF
+from tnfr.constants import THETA_PRIMARY, EPI_PRIMARY, VF_PRIMARY
 from tnfr.helpers import increment_edge_version, cached_nodes_and_A
 
 
 def _setup_graph():
     G = nx.path_graph(3)
     for n in G.nodes:
-        G.nodes[n][ALIAS_THETA[0]] = 0.1 * (n + 1)
-        G.nodes[n][ALIAS_EPI[0]] = 0.2 * (n + 1)
-        G.nodes[n][ALIAS_VF[0]] = 0.3 * (n + 1)
+        G.nodes[n][THETA_PRIMARY] = 0.1 * (n + 1)
+        G.nodes[n][EPI_PRIMARY] = 0.2 * (n + 1)
+        G.nodes[n][VF_PRIMARY] = 0.3 * (n + 1)
     G.graph["DNFR_WEIGHTS"] = {
         "phase": 1.0,
         "epi": 0.0,

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -8,8 +8,8 @@ from tnfr.sense import (
     sigma_vector_node,
     sigma_vector_from_graph,
     _node_weight,
-    _sigma_from_pairs,
     _sigma_from_vectors,
+    _sigma_from_iterable,
     glyph_unit,
     glyph_angle,
 )
@@ -52,7 +52,8 @@ def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
             continue
         g, w, _ = nw
         pairs.append((g, w))
-    vec, n = _sigma_from_pairs(pairs)
+    vectors = (glyph_unit(g) * float(w) for g, w in pairs)
+    vec, n = _sigma_from_iterable(vectors)
     vec["n"] = n
     return vec
 

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -13,7 +13,7 @@ from tnfr.structural import (
     validate_sequence,
     run_sequence,
 )
-from tnfr.constants import ALIAS_EPI
+from tnfr.constants import EPI_PRIMARY
 
 
 def test_create_nfr_basic():
@@ -21,7 +21,7 @@ def test_create_nfr_basic():
     assert isinstance(G, nx.Graph)
     assert n in G
     nd = G.nodes[n]
-    assert nd[ALIAS_EPI[0]] == 0.1
+    assert nd[EPI_PRIMARY] == 0.1
 
 
 def test_sequence_validation_and_run():
@@ -32,7 +32,7 @@ def test_sequence_validation_and_run():
     assert ok, msg
     run_sequence(G, n, ops)
     # después de la secuencia la EPI se actualiza (no necesariamente cero)
-    assert ALIAS_EPI[0] in G.nodes[n]
+    assert EPI_PRIMARY in G.nodes[n]
 
 
 def test_invalid_sequence():


### PR DESCRIPTION
## Summary
- Clean `_IMMUTABLE_CACHE` and expose primary alias constants
- Use stable blake2b digest for Γ spec hashing
- Optimize node sampling and reuse neighbour-sum core
- Simplify candidate selection for UM operator and coherence matrix logic
- Drop `_sigma_from_pairs`, enforce RNG cache size and batch VF clamp updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd5e9e51483219fcc46f6919be405