### PR TITLE
chore: apply code cleanups across utilities

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -130,6 +130,10 @@ def mix_groups(
 ) -> dict[str, float]:
     """Aggregate values of ``dist`` according to ``groups``."""
     out: dict[str, float] = dict(dist)
-    for label, keys in groups.items():
-        out[f"{prefix}{label}"] = sum(dist.get(k, 0.0) for k in keys)
+    out.update(
+        {
+            f"{prefix}{label}": sum(dist.get(k, 0.0) for k in keys)
+            for label, keys in groups.items()
+        }
+    )
     return out

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -81,31 +81,32 @@ def _update_node_sample(G, *, step: int) -> None:
     when the graph size changes. Sampling operates directly on this cached
     tuple.
     """
-    limit = int(G.graph.get("UM_CANDIDATE_COUNT", 0))
-    nodes = G.graph.get("_node_list")
-    stored_len = G.graph.get("_node_list_len")
+    graph = G.graph
+    limit = int(graph.get("UM_CANDIDATE_COUNT", 0))
+    nodes = graph.get("_node_list")
+    stored_len = graph.get("_node_list_len")
     current_n = G.number_of_nodes()
-    dirty = bool(G.graph.pop("_node_list_dirty", False))
+    dirty = bool(graph.pop("_node_list_dirty", False))
     if nodes is None or stored_len != current_n or dirty:
         nodes = tuple(G.nodes())
         checksum = node_set_checksum(G, nodes, store=False)
-        G.graph["_node_list"] = nodes
-        G.graph["_node_list_checksum"] = checksum
-        G.graph["_node_list_len"] = current_n
+        graph["_node_list"] = nodes
+        graph["_node_list_checksum"] = checksum
+        graph["_node_list_len"] = current_n
     else:
-        checksum = G.graph.get("_node_list_checksum")
+        checksum = graph.get("_node_list_checksum")
     n = len(nodes)
     if limit <= 0 or n < 50 or limit >= n:
         # Avoid exposing a mutable NodeView that may change later.
-        G.graph["_node_sample"] = nodes
+        graph["_node_sample"] = nodes
         return
 
-    seed = int(G.graph.get("RANDOM_SEED", 0))
+    seed = int(graph.get("RANDOM_SEED", 0))
     # Ensure deterministic seeding independent of ``PYTHONHASHSEED`` by
     # combining the user seed and step via bitwise XOR instead of a string
     # seed, which would rely on Python's randomized hashing of strings.
     rng = get_rng(seed, step)
-    G.graph["_node_sample"] = rng.sample(nodes, limit)
+    graph["_node_sample"] = rng.sample(nodes, limit)
 
 
 # -------------------------

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -246,7 +246,6 @@ def count_glyphs(
         else:
             yield from islice(reversed(hist), window_int)
 
-    counts: Counter[str] = Counter()
-    for _, nd in G.nodes(data=True):
-        counts.update(_iter_seq(nd))
-    return counts
+    return Counter(
+        g for _, nd in G.nodes(data=True) for g in _iter_seq(nd)
+    )

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -24,7 +24,6 @@ from .collections_utils import (
     mix_groups,
 )
 from .alias import get_attr
-from .constants import ALIAS_THETA
 
 _EDGE_CACHE_LOCK = threading.Lock()
 _EDGE_CACHE_COND = threading.Condition(_EDGE_CACHE_LOCK)

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -155,8 +155,6 @@ def compute_Si_node(
 
 def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
     """Compute ``Si`` per node and write it to ``G.nodes[n]['Si']``."""
-    graph = G.graph
-
     neighbors = ensure_neighbors_map(G)
     alpha, beta, gamma = get_Si_weights(G)
 


### PR DESCRIPTION
## Summary
- drop unused constant import in helpers
- simplify mix_groups with a dict comprehension
- streamline glyph counting with single Counter comprehension
- remove unused temp variables and reduce repeated graph lookups

## Testing
- `pyflakes src/tnfr/helpers.py`
- `pyflakes src/tnfr/metrics_utils.py`
- `pyflakes src/tnfr/collections_utils.py`
- `pyflakes src/tnfr/glyph_history.py`
- `pyflakes src/tnfr/dynamics.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcdcb2a568832195ac41641beaa805