### PR TITLE
Cache validated alias tuples and enforce hashable sequences

### DIFF
--- a/tests/test_alias_cache.py
+++ b/tests/test_alias_cache.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tnfr.alias import alias_get, alias_set, _validate_aliases
+
+
+def test_alias_get_uses_cache():
+    d = {"b": "1"}
+    _validate_aliases.cache_clear()
+    alias_get(d, ("a", "b"), int)
+    info1 = _validate_aliases.cache_info()
+    alias_get(d, ("a", "b"), int)
+    info2 = _validate_aliases.cache_info()
+    assert info2.hits == info1.hits + 1
+    assert info2.misses == info1.misses
+
+
+def test_alias_set_uses_cache():
+    d = {}
+    _validate_aliases.cache_clear()
+    alias_set(d, ("x", "y"), int, "5")
+    info1 = _validate_aliases.cache_info()
+    alias_set(d, ("x", "y"), int, "6")
+    info2 = _validate_aliases.cache_info()
+    assert info2.hits == info1.hits + 1
+    assert info2.misses == info1.misses

--- a/tests/test_alias_get_default.py
+++ b/tests/test_alias_get_default.py
@@ -5,6 +5,6 @@ from tnfr.alias import alias_get
 
 def test_alias_get_default_none_returns_none():
     d = {}
-    result = alias_get(d, ["x"], int, default=None)
+    result = alias_get(d, ("x",), int, default=None)
     assert result is None
     assert d == {}

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -8,7 +8,7 @@ from tnfr.alias import alias_get
 def test_alias_get_logs_on_error(caplog):
     d = {"x": "abc"}
     with caplog.at_level(logging.DEBUG):
-        result = alias_get(d, ["x"], int)
+        result = alias_get(d, ("x",), int)
     assert result is None
     assert any("No se pudo convertir" in m for m in caplog.messages)
 
@@ -16,11 +16,11 @@ def test_alias_get_logs_on_error(caplog):
 def test_alias_get_custom_log_level(caplog):
     d = {"x": "abc"}
     with caplog.at_level(logging.WARNING):
-        alias_get(d, ["x"], int, log_level=logging.WARNING)
+        alias_get(d, ("x",), int, log_level=logging.WARNING)
     assert any("No se pudo convertir" in m for m in caplog.messages)
 
 
 def test_alias_get_strict_raises():
     d = {"x": "abc"}
     with pytest.raises(ValueError):
-        alias_get(d, ["x"], int, strict=True)
+        alias_get(d, ("x",), int, strict=True)

--- a/tests/test_alias_sequence.py
+++ b/tests/test_alias_sequence.py
@@ -4,19 +4,23 @@ import pytest
 from tnfr.alias import alias_get, alias_set
 
 
-def test_alias_get_accepts_sequence():
+def test_alias_get_accepts_hashable_sequence():
     d = {"b": "1"}
-    assert alias_get(d, ["a", "b"], int) == 1
+    assert alias_get(d, ("a", "b"), int) == 1
 
 
-def test_alias_set_accepts_sequence():
+def test_alias_set_accepts_hashable_sequence():
     d = {}
-    alias_set(d, ["x", "y"], int, "5")
+    alias_set(d, ("x", "y"), int, "5")
     assert d["x"] == 5
 
 
-def test_alias_rejects_str():
+def test_alias_rejects_str_and_unhashable():
     with pytest.raises(TypeError):
         alias_get({}, "x", int)
     with pytest.raises(TypeError):
         alias_set({}, "x", int, 1)
+    with pytest.raises(TypeError):
+        alias_get({}, ["x"], int)
+    with pytest.raises(TypeError):
+        alias_set({}, ["x"], int, 1)

--- a/tests/test_alias_set_error.py
+++ b/tests/test_alias_set_error.py
@@ -6,5 +6,5 @@ from tnfr.alias import alias_set
 def test_alias_set_allows_none_conversion():
     """alias_set debe permitir valores ``None``."""
     d = {}
-    alias_set(d, ["x"], lambda v: None, 123)
+    alias_set(d, ("x",), lambda v: None, 123)
     assert "x" in d and d["x"] is None

--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -10,9 +10,14 @@ def test_rejects_string():
 
 def test_rejects_empty_iterable():
     with pytest.raises(ValueError):
-        _validate_aliases([])
+        _validate_aliases(())
 
 
 def test_rejects_non_string_elements():
     with pytest.raises(TypeError):
-        _validate_aliases(["a", 1])
+        _validate_aliases(("a", 1))
+
+
+def test_rejects_unhashable_sequence():
+    with pytest.raises(TypeError):
+        _validate_aliases(["a"])


### PR DESCRIPTION
## Summary
- cache `_validate_aliases` results to avoid redundant tuple validations
- require `alias_get` and `alias_set` aliases to be hashable sequences
- test cached validation is reused on repeated alias operations

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bce71f1ab48321af81a223d16567d0