### PR TITLE
Use LRU cache for edge helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: TNFR"
 ]
 dependencies = [
-  "networkx>=2.6"
+  "networkx>=2.6",
+  "cachetools>=5"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_edge_version_cache_threadsafe.py
+++ b/tests/test_edge_version_cache_threadsafe.py
@@ -1,0 +1,28 @@
+import networkx as nx
+from concurrent.futures import ThreadPoolExecutor
+
+from tnfr.helpers import edge_version_cache, increment_edge_version
+
+
+def test_edge_version_cache_thread_safety():
+    G = nx.Graph()
+    calls = 0
+
+    def builder():
+        nonlocal calls
+        calls += 1
+        return object()
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        results = list(ex.map(lambda _: edge_version_cache(G, "k", builder), range(32)))
+    first = results[0]
+    assert all(r is first for r in results)
+    assert calls == 1
+
+    increment_edge_version(G)
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        results2 = list(ex.map(lambda _: edge_version_cache(G, "k", builder), range(32)))
+    second = results2[0]
+    assert all(r is second for r in results2)
+    assert second is not first
+    assert calls == 2


### PR DESCRIPTION
## Summary
- replace manual edge version cache with `cachetools.LRUCache` guarded by a re-entrant lock
- expose `invalidate_edge_version_cache` and clear cache when edge version increments
- add concurrency test for edge cache

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bce86ee29c8321a3d8f5652d12bd57