### PR TITLE
feat: share trigonometric cache across modules

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -129,9 +129,9 @@ def neighbor_phase_mean(obj, n=None) -> float:
     node = NodoNX(obj, n) if n is not None else obj
     if getattr(node, "G", None) is None:
         raise TypeError("neighbor_phase_mean requires nodes bound to a graph")
-    from .metrics_utils import precompute_trigonometry
+    from .metrics_utils import get_trig_cache
 
-    trig = precompute_trigonometry(node.G)
+    trig = get_trig_cache(node.G)
     return _neighbor_phase_mean(node, trig)
 
 

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -25,6 +25,7 @@ __all__ = [
     "compute_coherence",
     "ensure_neighbors_map",
     "get_Si_weights",
+    "get_trig_cache",
     "precompute_trigonometry",
     "compute_Si_node",
     "compute_Si",
@@ -105,11 +106,17 @@ def _build_trig_cache(G: Any) -> TrigCache:
     return TrigCache(cos=cos_th, sin=sin_th, theta=thetas)
 
 
-def precompute_trigonometry(
-    G: Any,
-) -> TrigCache:
-    """Precompute cosines and sines of ``θ`` per node."""
+def get_trig_cache(G: Any) -> TrigCache:
+    """Return cached cosines and sines of ``θ`` per node."""
     return edge_version_cache(G, "_trig", lambda: _build_trig_cache(G))
+
+
+def precompute_trigonometry(G: Any) -> TrigCache:
+    """Precompute cosines and sines of ``θ`` per node.
+
+    Alias for :func:`get_trig_cache` for backward compatibility.
+    """
+    return get_trig_cache(G)
 
 
 def compute_Si_node(

--- a/tests/test_trig_cache_reuse.py
+++ b/tests/test_trig_cache_reuse.py
@@ -1,0 +1,52 @@
+import math
+import networkx as nx
+import pytest
+
+from tnfr.constants import ALIAS_THETA, ALIAS_VF, ALIAS_DNFR
+from tnfr.metrics_utils import get_trig_cache, compute_Si
+from tnfr.helpers import neighbor_phase_mean
+from tnfr.alias import set_attr
+
+
+def test_trig_cache_reuse_between_modules(monkeypatch):
+    cos_calls = 0
+    sin_calls = 0
+    orig_cos = math.cos
+    orig_sin = math.sin
+
+    def cos_wrapper(x):
+        nonlocal cos_calls
+        cos_calls += 1
+        return orig_cos(x)
+
+    def sin_wrapper(x):
+        nonlocal sin_calls
+        sin_calls += 1
+        return orig_sin(x)
+
+    monkeypatch.setattr(math, "cos", cos_wrapper)
+    monkeypatch.setattr(math, "sin", sin_wrapper)
+
+    G = nx.Graph()
+    G.add_edge(1, 2)
+    set_attr(G.nodes[1], ALIAS_THETA, 0.0)
+    set_attr(G.nodes[2], ALIAS_THETA, math.pi / 2)
+    set_attr(G.nodes[1], ALIAS_VF, 0.0)
+    set_attr(G.nodes[2], ALIAS_VF, 0.0)
+    set_attr(G.nodes[1], ALIAS_DNFR, 0.0)
+    set_attr(G.nodes[2], ALIAS_DNFR, 0.0)
+
+    trig1 = get_trig_cache(G)
+    assert cos_calls == 2
+    assert sin_calls == 2
+
+    assert neighbor_phase_mean(G, 1) == pytest.approx(math.pi / 2)
+    assert cos_calls == 2
+    assert sin_calls == 2
+
+    compute_Si(G, inplace=False)
+    assert cos_calls == 2
+    assert sin_calls == 2
+
+    trig2 = get_trig_cache(G)
+    assert trig1 is trig2


### PR DESCRIPTION
## Summary
- expose reusable trigonometric cache via `get_trig_cache`
- reuse trig cache in `neighbor_phase_mean`
- ensure trig cache is reused across helpers and metrics utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd304dfb5c8321aa28315afec13f64