### PR TITLE
Add max depth handling to _stable_json recursion

### DIFF
--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -10,3 +10,13 @@ def test_stable_json_set_order_deterministic():
     res2 = _stable_json(s)
     assert res1 == res2
     assert res1 == sorted(res1, key=str)
+
+
+def test_stable_json_respects_max_depth_dict():
+    obj = {"a": {"b": {"c": 1}}}
+    assert _stable_json(obj, max_depth=1) == {"a": "<max-depth>"}
+
+
+def test_stable_json_respects_max_depth_list():
+    obj = [1, [2, [3]]]
+    assert _stable_json(obj, max_depth=1) == [1, "<max-depth>"]


### PR DESCRIPTION
## Summary
- add `max_depth` parameter to `_stable_json` and return `<max-depth>` when depth exceeded
- test nested dicts and lists to ensure `max_depth` stopping behavior

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd31cdd98c832188c420863e4bef91