### PR TITLE
Limit failed import registry for optional imports

### DIFF
--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -1,7 +1,11 @@
 import types
 import importlib
 
-from tnfr.import_utils import optional_import, _FAILED_IMPORTS
+from tnfr.import_utils import (
+    optional_import,
+    _FAILED_IMPORTS,
+    _optional_import_cache_clear,
+)
 
 
 def test_optional_import_clears_failures(monkeypatch):
@@ -18,6 +22,25 @@ def test_optional_import_clears_failures(monkeypatch):
     assert optional_import("fake_mod") is None
     assert "fake_mod" in _FAILED_IMPORTS
     optional_import.cache_clear()
+    result = optional_import("fake_mod")
+    assert result is not None
+    assert "fake_mod" not in _FAILED_IMPORTS
+
+
+def test_optional_import_removes_entry_on_success(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_import(name):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ImportError("boom")
+        return types.SimpleNamespace(value=1)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    _optional_import_cache_clear()
+    assert optional_import("fake_mod") is None
+    assert "fake_mod" in _FAILED_IMPORTS
+    _optional_import_cache_clear()  # retry without clearing failure registry
     result = optional_import("fake_mod")
     assert result is not None
     assert "fake_mod" not in _FAILED_IMPORTS


### PR DESCRIPTION
## Summary
- limit failed import tracking to a bounded deque
- drop failed entries after a successful import
- add regression test ensuring failed records are removed after retry

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd33426cec83218ce0cb69ae3e6c61