### PR TITLE
Clarify value conversion logging and add tests

### DIFF
--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -23,8 +23,8 @@ def _convert_value(
     """Attempt to convert ``value`` using ``conv`` with error handling.
 
     ``log_level`` controls the logging level when conversion fails in lax
-    mode. Defaults to ``logging.ERROR`` if ``strict`` is ``True`` and
-    ``logging.DEBUG`` otherwise.
+    mode. Defaults to ``logging.DEBUG``. If ``strict`` is ``True`` the
+    exception is raised and no log is emitted.
     """
     try:
         return True, conv(value)

--- a/tests/test_value_utils.py
+++ b/tests/test_value_utils.py
@@ -1,0 +1,30 @@
+"""Tests for ``value_utils`` module."""
+
+import logging
+
+from tnfr.value_utils import _convert_value
+
+
+def test_convert_value_logs_debug_by_default(caplog):
+    def conv(_):
+        raise ValueError("bad")
+
+    with caplog.at_level(logging.DEBUG, logger="tnfr.value_utils"):
+        ok, result = _convert_value("x", conv, key="foo")
+
+    assert not ok and result is None
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.DEBUG
+
+
+def test_convert_value_logs_custom_level(caplog):
+    def conv(_):
+        raise ValueError("bad")
+
+    with caplog.at_level(logging.INFO, logger="tnfr.value_utils"):
+        ok, result = _convert_value("x", conv, key="foo", log_level=logging.INFO)
+
+    assert not ok and result is None
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.INFO
+


### PR DESCRIPTION
## Summary
- Clarify `_convert_value` docstring: no log is emitted when `strict=True`
- Test `_convert_value` emits DEBUG logs by default and respects custom log level

## Testing
- `PYTHONPATH=src pytest tests/test_value_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd36591048832193645377d6c98e3d