### PR TITLE
Streamline validation and improve determinism

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -56,7 +56,11 @@ def _alias_resolve(
     strict: bool = False,
     log_level: int | None = None,
 ) -> Optional[T]:
-    aliases = _validate_aliases(aliases)
+    """Resolve the first matching key in ``aliases`` from ``d``.
+
+    ``aliases`` must already be validated with :func:`_validate_aliases`.
+    """
+
     ok_def = False
     def_val = None
     if default is not None:
@@ -113,12 +117,7 @@ def alias_get(
     log_level: int | None = None,
 ) -> Optional[T]:
     """Return the value for the first existing key in ``aliases``."""
-    if isinstance(aliases, str) or not isinstance(aliases, Sequence):
-        raise TypeError("'aliases' must be a non-string sequence")
-    try:
-        hash(aliases)
-    except TypeError as exc:  # pragma: no cover - defensive programming
-        raise TypeError("'aliases' must be a hashable sequence") from exc
+    aliases = _validate_aliases(aliases)
     return _alias_resolve(
         d,
         aliases,
@@ -136,12 +135,6 @@ def alias_set(
     value: Any,
 ) -> T:
     """Assign ``value`` converted to the first available key in ``aliases``."""
-    if isinstance(aliases, str) or not isinstance(aliases, Sequence):
-        raise TypeError("'aliases' must be a non-string sequence")
-    try:
-        hash(aliases)
-    except TypeError as exc:  # pragma: no cover - defensive programming
-        raise TypeError("'aliases' must be a hashable sequence") from exc
     aliases = _validate_aliases(aliases)
     _, val = _convert_value(value, conv, strict=True)
     key = next((k for k in aliases if k in d), aliases[0])
@@ -197,6 +190,7 @@ def _alias_get_set(
         log_level: int | None = None,
     ) -> Optional[T]:
         """Obtain an attribute using :func:`alias_get`."""
+        aliases = _validate_aliases(aliases)
         return _base_get(
             d,
             aliases,

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -208,23 +208,16 @@ def node_set_checksum(
 ) -> str:
     """Return a BLAKE2b checksum of ``G``'s node set.
 
-    Hashable nodes are hashed directly. Nodes lacking a ``__hash__`` fall back
-    to a stable ``repr``-based scheme. To benefit from caching and avoid sorting
-    the same collection repeatedly, the serialised values are stored as a
-    ``frozenset`` under ``"_node_set_checksum_cache"`` when ``store`` is ``True``.
-    Note that objects whose hash changes between runs will yield different
-    checksums each time.
+    Nodes are serialised using :func:`_node_repr` for determinism. To benefit
+    from caching and avoid sorting the same collection repeatedly, the
+    serialised values are stored as a ``frozenset`` under
+    ``"_node_set_checksum_cache"`` when ``store`` is ``True``.
     """
 
     graph = G.graph if hasattr(G, "graph") else G
     node_iterable = G.nodes() if nodes is None else nodes
 
-    serialised_list = []
-    for n in node_iterable:
-        try:
-            serialised_list.append(str(hash(n)))
-        except TypeError:
-            serialised_list.append(_node_repr(n))
+    serialised_list = [_node_repr(n) for n in node_iterable]
 
     marker = frozenset(serialised_list)
     if store:

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -52,14 +52,14 @@ def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
     count = G.number_of_nodes()
     if count:
-        dnfr_sum = math.fsum(
-            abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)
-        )
-        depi_sum = math.fsum(
-            abs(get_attr(nd, ALIAS_dEPI, 0.0)) for _, nd in G.nodes(data=True)
-        )
-        dnfr_mean = dnfr_sum / count
-        depi_mean = depi_sum / count
+        dnfr_vals: list[float] = []
+        depi_vals: list[float] = []
+        for _, nd in G.nodes(data=True):
+            # single pass over nodes to gather both metrics
+            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
+            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
+        dnfr_mean = math.fsum(dnfr_vals) / count
+        depi_mean = math.fsum(depi_vals) / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -51,9 +51,11 @@ std_on_remesh = _STD_CALLBACKS["on_remesh"]
 
 def attach_standard_observer(G):
     """Register standard callbacks: before_step, after_step, on_remesh."""
+    if G.graph.get("_STD_OBSERVER"):
+        return G
     for event, fn in _STD_CALLBACKS.items():
         register_callback(G, event, fn)
-    G.graph.setdefault("_STD_OBSERVER", "attached")
+    G.graph["_STD_OBSERVER"] = "attached"
     return G
 
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -82,11 +82,13 @@ def _sigma_cfg(G):
 
 
 def _sigma_from_iterable(
-    values: Iterable[complex] | complex, fallback_angle: float = 0.0
+    values: Iterable[complex | float | int] | complex | float | int,
+    fallback_angle: float = 0.0,
 ) -> tuple[Dict[str, float], int]:
-    """Normalise complex vectors in el plano σ.
+    """Normalise vectors in the σ-plane.
 
-    ``values`` puede ser un complejo individual o un iterable de ellos.
+    ``values`` may contain complex or real numbers; real inputs are promoted to
+    complex with zero imaginary part.
     """
 
     try:
@@ -94,22 +96,26 @@ def _sigma_from_iterable(
     except TypeError:
         iterator = iter([values])
 
+    def _to_complex(val: complex | float | int) -> complex:
+        if isinstance(val, complex):
+            return val
+        if isinstance(val, (int, float)):
+            return complex(val, 0.0)
+        raise TypeError("values must be an iterable of real or complex numbers")
+
     try:
-        first = next(iterator)
+        first = _to_complex(next(iterator))
     except StopIteration:
         vec = {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": float(fallback_angle)}
         return vec, 0
-    if not isinstance(first, complex):
-        raise TypeError("values must be an iterable of complex numbers")
 
     sum_x = first.real
     sum_y = first.imag
     cnt = 1
     for z in iterator:
-        if not isinstance(z, complex):
-            raise TypeError("values must be an iterable of complex numbers")
-        sum_x += z.real
-        sum_y += z.imag
+        zc = _to_complex(z)
+        sum_x += zc.real
+        sum_y += zc.imag
         cnt += 1
 
     x = sum_x / cnt

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -257,26 +257,30 @@ def glyph_counts_field(G):
     return {"glyphs": cnt}
 
 
+TRACE_FIELDS_BEFORE = {
+    "gamma": gamma_field,
+    "grammar": grammar_field,
+    "selector": selector_field,
+    "dnfr_weights": dnfr_weights_field,
+    "si_weights": si_weights_field,
+    "callbacks": callbacks_field,
+    "thol_state": thol_state_field,
+}
+
+
+TRACE_FIELDS_AFTER = {
+    "kuramoto": kuramoto_field,
+    "sigma": sigma_field,
+    "glyph_counts": glyph_counts_field,
+}
+
+
 def _trace_before(G, *args, **kwargs):
-    fields = {
-        "gamma": gamma_field,
-        "grammar": grammar_field,
-        "selector": selector_field,
-        "dnfr_weights": dnfr_weights_field,
-        "si_weights": si_weights_field,
-        "callbacks": callbacks_field,
-        "thol_state": thol_state_field,
-    }
-    _trace_capture(G, "before", fields)
+    _trace_capture(G, "before", TRACE_FIELDS_BEFORE)
 
 
 def _trace_after(G, *args, **kwargs):
-    fields = {
-        "kuramoto": kuramoto_field,
-        "sigma": sigma_field,
-        "glyph_counts": glyph_counts_field,
-    }
-    _trace_capture(G, "after", fields)
+    _trace_capture(G, "after", TRACE_FIELDS_AFTER)
 
 
 # -------------------------

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -132,3 +132,11 @@ def test_attach_standard_observer_registers_callbacks(graph_canon):
     attach_standard_observer(G)
     for ev in CallbackEvent:
         assert ev in G.graph["callbacks"]
+
+
+def test_attach_standard_observer_idempotent(graph_canon):
+    G = graph_canon()
+    attach_standard_observer(G)
+    callbacks = {ev: list(cbs) for ev, cbs in G.graph["callbacks"].items()}
+    attach_standard_observer(G)
+    assert {ev: list(cbs) for ev, cbs in G.graph["callbacks"].items()} == callbacks

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -89,8 +89,15 @@ def test_sigma_from_vectors_accepts_single_complex():
 
 
 def test_sigma_from_vectors_rejects_invalid_iterable():
-    with pytest.raises(TypeError, match="iterable of complex"):
+    with pytest.raises(TypeError, match="real or complex"):
         _sigma_from_vectors("abc")
+
+
+def test_sigma_from_iterable_accepts_reals():
+    vec, n = _sigma_from_iterable([1.0, 3.0])
+    assert n == 2
+    assert vec["x"] == pytest.approx(2.0)
+    assert vec["y"] == pytest.approx(0.0)
 
 
 def test_unknown_glyph_raises():


### PR DESCRIPTION
## Summary
- centralize alias validation via `_validate_aliases`
- make node set checksums and tracing more efficient and reproducible
- extend sigma helpers and observer registration behavior

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd374b71588321bd662ac8236f6f70