### PR TITLE
Optimize HistoryDict eviction with efficient min and heapq

### DIFF
--- a/tests/test_history_methods.py
+++ b/tests/test_history_methods.py
@@ -29,3 +29,25 @@ def test_setdefault_inserts_and_converts_without_usage():
     val2 = hist.setdefault("a", [2])
     assert val2 is val
     assert hist._counts.get("a", 0) == 0
+
+
+def test_pop_least_used_removes_least_frequent_key():
+    hist = HistoryDict({"a": 1, "b": 2})
+    hist.get_increment("a")
+    hist.get_increment("b")
+    hist.get_increment("b")
+    val = hist.pop_least_used()
+    assert val == 1
+    assert "a" not in hist
+    assert "a" not in hist._counts
+
+
+def test_pop_least_used_batch_removes_k_keys():
+    hist = HistoryDict()
+    for i in range(5):
+        hist[f"k{i}"] = i
+        for _ in range(i):
+            hist.get_increment(f"k{i}")
+    hist.pop_least_used_batch(2)
+    assert set(hist) == {"k2", "k3", "k4"}
+    assert set(hist._counts) == {"k2", "k3", "k4"}

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -4,6 +4,7 @@ from tnfr.constants import attach_defaults
 from tnfr.dynamics import step
 from tnfr.metrics import register_metrics_callbacks
 from tnfr.gamma import GAMMA_REGISTRY
+from tnfr.glyph_history import HistoryDict
 
 
 def test_history_delta_si_and_B(graph_canon):
@@ -28,3 +29,14 @@ def test_gamma_kuramoto_tanh_registry(graph_canon):
     gamma_fn, _ = GAMMA_REGISTRY["kuramoto_tanh"]
     val = gamma_fn(G, 0, 0.0, cfg)
     assert abs(val) <= cfg["beta"]
+
+
+def test_pop_least_used_batch_skips_stale_entries():
+    hist = HistoryDict({"a": 1, "b": 2})
+    hist.get_increment("a")
+    hist.get_increment("b")
+    hist.get_increment("b")
+    hist._counts["stale"] = 0
+    hist.pop_least_used_batch(2)
+    assert not hist
+    assert not hist._counts


### PR DESCRIPTION
## Summary
- Use `min(self._counts, key=self._counts.get)` to find the least-used key
- Apply `heapq.nsmallest` for batched eviction
- Add tests for single and batched eviction and handle stale entries

## Testing
- `PYTHONPATH=src pytest tests/test_history* tests/test_ensure_history_trim_performance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd3c610718832181df0f5345918658