### PR TITLE
Refactor core utilities and improve performance

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -59,6 +59,11 @@ def _ensure_callbacks(G: "nx.Graph") -> CallbackRegistry:
     return cbs
 
 
+def _normalize_event(event: CallbackEvent | str) -> str:
+    """Return ``event`` as a string."""
+    return event.value if isinstance(event, CallbackEvent) else str(event)
+
+
 def _normalize_callback_entry(entry: Any) -> "CallbackSpec | None":
     """Normalize a callback specification.
 
@@ -127,8 +132,7 @@ def register_callback(
     >>> ctx["called"]
     1
     """
-    if isinstance(event, CallbackEvent):
-        event = event.value
+    event = _normalize_event(event)
     if event not in _CALLBACK_EVENTS:
         raise ValueError(f"Unknown event: {event}")
     if not callable(func):
@@ -155,8 +159,7 @@ def invoke_callbacks(
     ctx: dict[str, Any] | None = None,
 ) -> None:
     """Invoke all callbacks registered for ``event`` with context ``ctx``."""
-    if isinstance(event, CallbackEvent):
-        event = event.value
+    event = _normalize_event(event)
     cbs = _ensure_callbacks(G).get(event, [])
     strict = bool(
         G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"])

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -82,6 +82,8 @@ def normalize_weights(
     """Normalize ``keys`` in ``dict_like`` so their sum is 1."""
     keys = list(keys)
     default_float = float(default)
+    if not keys:
+        return {}
     weights: dict[str, float] = {}
     negatives: dict[str, float] = {}
     for k in keys:
@@ -101,16 +103,12 @@ def normalize_weights(
     if negatives:
         if error_on_negative:
             raise ValueError(f"Pesos negativos detectados: {negatives}")
-    if negatives and not error_on_negative:
         logger.warning("Pesos negativos detectados: %s", negatives)
     total = math.fsum(weights.values())
-    n = len(keys)
     if total <= 0:
-        if n == 0:
-            return {}
-        uniform = 1.0 / n
+        uniform = 1.0 / len(keys)
         return {k: uniform for k in keys}
-    return {k: weights[k] / total for k in keys}
+    return {k: w / total for k, w in weights.items()}
 
 
 def normalize_counter(

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -129,11 +129,8 @@ def safe_write(
     except Exception as e:  # noqa: BLE001 - rewrap after cleanup
         raise OSError(f"Failed to write file {path}: {e}") from e
     finally:
-        if tmp_path is not None and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
 
 
 __all__ = ["read_structured_file", "safe_write", "StructuredFileError"]

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -116,7 +116,9 @@ def _advance(G, step_fn: Optional[AdvanceFn] = None):
 
 def _flatten_thol(item: THOL, stack: deque[Any]) -> None:
     """Expand a ``THOL`` block onto ``stack`` for processing."""
-    repeats = max(1, int(item.repeat))
+    repeats = int(item.repeat)
+    if repeats < 1:
+        raise ValueError("repeat must be ≥1")
     if item.force_close is not None and not isinstance(item.force_close, Glyph):
         raise ValueError("force_close must be a Glyph")
     closing = (

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -34,7 +34,7 @@ def _reference_checksum(G):
     hasher = hashlib.blake2b(digest_size=16)
 
     def serialise(n):
-        return repr(_stable_json(n))
+        return _stable_json(n)
 
     serialised = [serialise(n) for n in G.nodes()]
     serialised.sort()

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -12,11 +12,13 @@ from tnfr.program import (
     TARGET,
     _handle_target,
     _flatten,
+    _flatten_thol,
     block,
     play,
     seq,
     target,
     wait,
+    THOL,
 )
 from tnfr.constants import get_param
 from tnfr.types import Glyph
@@ -206,3 +208,8 @@ def test_flatten_accepts_sequence_without_reversed():
     program = NoReverseSeq([Glyph.AL, Glyph.OZ])
     ops = _flatten(program)
     assert ops == [("GLYPH", Glyph.AL.value), ("GLYPH", Glyph.OZ.value)]
+
+
+def test_thol_repeat_lt_one_raises():
+    with pytest.raises(ValueError, match="repeat must be ≥1"):
+        _flatten_thol(THOL(body=[], repeat=0), deque())

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -53,8 +53,7 @@ def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
         g, w, _ = nw
         pairs.append((g, w))
     vectors = (glyph_unit(g) * float(w) for g, w in pairs)
-    vec, n = _sigma_from_iterable(vectors)
-    vec["n"] = n
+    vec = _sigma_from_iterable(vectors)
     return vec
 
 
@@ -82,8 +81,8 @@ def test_sigma_vector_from_graph_matches_naive():
 
 
 def test_sigma_from_vectors_accepts_single_complex():
-    vec, n = _sigma_from_vectors(1 + 1j)
-    assert n == 1
+    vec = _sigma_from_vectors(1 + 1j)
+    assert vec["n"] == 1
     assert vec["x"] == pytest.approx(1.0)
     assert vec["y"] == pytest.approx(1.0)
 
@@ -94,8 +93,8 @@ def test_sigma_from_vectors_rejects_invalid_iterable():
 
 
 def test_sigma_from_iterable_accepts_reals():
-    vec, n = _sigma_from_iterable([1.0, 3.0])
-    assert n == 2
+    vec = _sigma_from_iterable([1.0, 3.0])
+    assert vec["n"] == 2
     assert vec["x"] == pytest.approx(2.0)
     assert vec["y"] == pytest.approx(0.0)
 

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -1,3 +1,5 @@
+import json
+
 from tnfr.helpers import _stable_json
 
 
@@ -9,14 +11,15 @@ def test_stable_json_set_order_deterministic():
     res1 = _stable_json(s)
     res2 = _stable_json(s)
     assert res1 == res2
-    assert res1 == sorted(res1, key=str)
+    parsed = json.loads(res1)
+    assert parsed == sorted(parsed, key=str)
 
 
 def test_stable_json_respects_max_depth_dict():
     obj = {"a": {"b": {"c": 1}}}
-    assert _stable_json(obj, max_depth=1) == {"a": "<max-depth>"}
+    assert json.loads(_stable_json(obj, max_depth=1)) == {"a": "<max-depth>"}
 
 
 def test_stable_json_respects_max_depth_list():
     obj = [1, [2, [3]]]
-    assert _stable_json(obj, max_depth=1) == [1, "<max-depth>"]
+    assert json.loads(_stable_json(obj, max_depth=1)) == [1, "<max-depth>"]


### PR DESCRIPTION
## Summary
- Optimise optional imports by tracking failures in a set for O(1) lookups
- Introduce shared callback event normalisation and simplify event handling
- Refactor sigma helpers to include sample counts and fast path single nodes
- Replace custom stable JSON serializer with deterministic `json.dumps`
- Streamline weight normalisation, safe file writes, and THOL repeat handling

## Testing
- `PYTHONPATH=src pytest tests/test_stable_json.py tests/test_normalize_weights.py`
- `PYTHONPATH=src pytest tests/test_alias_*.py tests/test_history_methods.py tests/test_history_series.py tests/test_optional_import.py tests/test_register_callback.py tests/test_sense.py tests/test_node_set_checksum.py tests/test_safe_write.py tests/test_program.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd3a86583c8321804578e9e028f68c