### PR TITLE
Refactor graph utilities and improve immutability handling

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -44,11 +44,10 @@ def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
 
 def recent_glyph(nd: Dict[str, Any], glyph: str, window: int) -> bool:
     """Return ``True`` if ``glyph`` appeared in last ``window`` emissions."""
-    gl = str(glyph)
-    if window <= 0:
-        if window < 0:
-            _validate_window(window)
+    window = _validate_window(window)
+    if window == 0:
         return False
+    gl = str(glyph)
     hist = _ensure_glyph_history(nd, window)
     return gl in hist
 

--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 __all__ = ["mark_dnfr_prep_dirty"]
 
+
 def mark_dnfr_prep_dirty(G: Any) -> None:
     """Mark cached ΔNFR preparation data as stale for ``G``.
 
@@ -12,5 +13,8 @@ def mark_dnfr_prep_dirty(G: Any) -> None:
     :func:`_prepare_dnfr_data` know that node attributes or topology have
     changed and cached arrays need to be refreshed.
     """
-    graph = G.graph if hasattr(G, "graph") else G
+
+    from .helpers import get_graph
+
+    graph = get_graph(G)
     graph["_dnfr_prep_dirty"] = True

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -168,12 +168,9 @@ def _update_glyphogram(G, hist, counts, t, n_total):
     )
     row = {"t": t}
     total = max(1, n_total)
-
-    def add_row(g):
+    for g in GLYPHS_CANONICAL:
         c = counts.get(g, 0)
         row[g] = (c / total) if normalize_series else c
-
-    for_each_glyph(add_row)
     append_metric(hist, "glyphogram", row)
 
 

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -53,14 +53,14 @@ def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
     count = G.number_of_nodes()
     if count:
-        dnfr_vals: list[float] = []
-        depi_vals: list[float] = []
-        for _, nd in G.nodes(data=True):
-            # single pass over nodes to gather both metrics
-            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
-            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
-        dnfr_mean = math.fsum(dnfr_vals) / count
-        depi_mean = math.fsum(depi_vals) / count
+        dnfr_sum = math.fsum(
+            abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)
+        )
+        depi_sum = math.fsum(
+            abs(get_attr(nd, ALIAS_dEPI, 0.0)) for _, nd in G.nodes(data=True)
+        )
+        dnfr_mean = dnfr_sum / count
+        depi_mean = depi_sum / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)

--- a/tests/test_is_immutable.py
+++ b/tests/test_is_immutable.py
@@ -2,7 +2,7 @@
 
 from types import MappingProxyType
 
-from tnfr.constants import _is_immutable, _prune_cache
+from tnfr.constants import _is_immutable
 
 
 def test_is_immutable_nested_structures():
@@ -19,11 +19,8 @@ def test_is_immutable_detects_mutable():
     assert not _is_immutable(data)
 
 
-def test_prune_cache_allows_gc():
-    class Dummy:
-        pass
-
-    d = Dummy()
-    assert not _is_immutable(d)
-    _prune_cache()
-    assert not _is_immutable(d)
+def test_is_immutable_lists_dicts_nested():
+    data = (1, [2, {"a": (3, 4)}])
+    assert not _is_immutable(data)
+    # call twice to exercise cache behaviour
+    assert not _is_immutable(data)

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -1,10 +1,9 @@
 import hashlib
 import networkx as nx
-
 import timeit
 
 from tnfr import helpers as h
-from tnfr.helpers import node_set_checksum, _stable_json
+from tnfr.helpers import node_set_checksum, _stable_json, increment_edge_version
 
 
 def build_graph():
@@ -68,3 +67,18 @@ def test_node_set_checksum_presorted_performance():
         lambda: node_set_checksum(G, nodes, presorted=True), number=1
     )
     assert t_presorted <= t_unsorted * 3.0
+
+
+def test_node_set_checksum_no_store_does_not_cache():
+    G = nx.Graph()
+    G.add_nodes_from([1, 2])
+    node_set_checksum(G, store=False)
+    assert "_node_set_checksum_cache" not in G.graph
+
+
+def test_node_repr_cache_cleared_on_increment():
+    nxG = nx.Graph()
+    h._node_repr("foo")
+    assert h._node_repr.cache_info().currsize > 0
+    increment_edge_version(nxG)
+    assert h._node_repr.cache_info().currsize == 0


### PR DESCRIPTION
## Summary
- support lists and dicts in constants immutability checks
- centralize graph access via `get_graph` and cache `_node_repr`
- streamline glyph history, coherence calculation and metrics helpers

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c023df88321803f8560cbab052e