### PR TITLE
Refactor helpers, tighten validation and caching

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -35,16 +35,17 @@ __all__ = [
 ]
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=128)
 def _validate_aliases(aliases: Sequence[str]) -> tuple[str, ...]:
     """Return ``aliases`` as a validated tuple of strings."""
     if isinstance(aliases, str) or not isinstance(aliases, Sequence):
         raise TypeError("'aliases' must be a non-string sequence")
     seq = tuple(aliases)
-    if not seq or any(not isinstance(a, str) for a in seq):
-        if not seq:
-            raise ValueError("'aliases' must contain at least one key")
-        raise TypeError("'aliases' elements must be strings")
+    if not seq:
+        raise ValueError("'aliases' must contain at least one key")
+    for a in seq:
+        if not isinstance(a, str):
+            raise TypeError("'aliases' elements must be strings")
     return seq
 
 
@@ -134,7 +135,7 @@ def alias_set(
 ) -> T:
     """Assign ``value`` converted to the first available key in ``aliases``."""
     aliases = _validate_aliases(aliases)
-    _, val = _convert_value(value, conv, strict=True)
+    val = conv(value)
     key = next((k for k in aliases if k in d), aliases[0])
     d[key] = val
     return val

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -176,7 +176,7 @@ def invoke_callbacks(
         try:
             fn(G, ctx)
         except Exception as e:  # catch all callback errors
-            logger.warning("callback %r failed for %s: %s", name, event, e)
+            logger.exception("callback %r failed for %s: %s", name, event, e)
             if strict:
                 raise
             err_list.append(

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -12,6 +12,7 @@ from typing import (
 )
 import logging
 import math
+from itertools import islice
 
 from .value_utils import _convert_value
 
@@ -59,14 +60,12 @@ def ensure_collection(
         limit = max_materialize
         if limit == 0:
             return ()
-        items: list[T] = []
-        for idx, item in enumerate(iterable):
-            if idx >= limit:
-                raise ValueError(
-                    f"Iterable produced {idx + 1} items, exceeds limit {limit}"
-                )
-            items.append(item)
-        return tuple(items)
+        items = tuple(islice(iterable, limit + 1))
+        if len(items) > limit:
+            raise ValueError(
+                f"Iterable produced {len(items)} items, exceeds limit {limit}"
+            )
+        return items
 
     try:
         return _materialise(it)

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -135,7 +135,10 @@ def inject_defaults(
 
 def merge_overrides(G, **overrides) -> None:
     """Apply specific changes to ``G.graph``."""
-    G.graph.update(overrides)
+    for key, value in overrides.items():
+        if key not in DEFAULTS:
+            raise KeyError(f"Parámetro desconocido: '{key}'")
+        G.graph[key] = value
 
 
 def get_param(G, key: str):

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -139,12 +139,16 @@ class HistoryDict(dict):
 
     def pop_least_used_batch(self, k: int) -> None:
         if k > 0 and self._counts:
-            existing = [key for key in self._counts if key in self]
-            for key in heapq.nsmallest(k, existing, key=self._counts.get):
+            removed = 0
+            for key, _ in heapq.nsmallest(
+                len(self._counts), self._counts.items(), key=lambda item: item[1]
+            ):
                 self._counts.pop(key, None)
-                super().pop(key, None)
-            for key in [key for key in self._counts if key not in self]:
-                self._counts.pop(key, None)
+                if key in self:
+                    super().pop(key, None)
+                    removed += 1
+                    if removed >= k:
+                        break
 
 
 def ensure_history(G) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- limit cached alias validation and streamline value assignment
- raise KeyError on unknown overrides and improve callback error logging
- refactor node updates into helpers and optimize glyph history and collections utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd4f1d0d7c8321aaa0e8ea4e923b53