### PR TITLE
feat: add optional numpy path for coherence

### DIFF
--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -51,3 +51,13 @@ def test_node_index_map_invalidation():
 
     assert mapping1 is not mapping2
     assert set(mapping2.keys()) == set(G.nodes())
+
+
+def test_use_numpy_parameter_matches_loops():
+    G = nx.cycle_graph(3)
+    for n in G.nodes:
+        G.nodes[n][THETA_PRIMARY] = 0.0
+    nodes_l, W_l = coherence_matrix(G, use_numpy=False)
+    nodes_v, W_v = coherence_matrix(G, use_numpy=True)
+    assert nodes_l == nodes_v
+    assert W_l == W_v


### PR DESCRIPTION
## Summary
- expand coherence_matrix with a `use_numpy` option and automatically prefer numpy when available
- precompute reusable trigonometric and range components in the loop-based weight builder
- add regression test to ensure numpy and loop paths yield identical results

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5762de888321a4f0f9ffdd907d26