### PR TITLE
Refactor diagnosis threshold evaluation

### DIFF
--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from statistics import fmean, StatisticsError
+from operator import ge, le
 
 from ..constants import (
     ALIAS_EPI,
@@ -49,10 +50,21 @@ def _symmetry_index(
 def _state_from_thresholds(Rloc, dnfr_n, cfg):
     stb = cfg.get("stable", {"Rloc_hi": 0.8, "dnfr_lo": 0.2, "persist": 3})
     dsr = cfg.get("dissonance", {"Rloc_lo": 0.4, "dnfr_hi": 0.5, "persist": 3})
-    if (Rloc >= float(stb["Rloc_hi"])) and (dnfr_n <= float(stb["dnfr_lo"])):
+
+    stable_checks = {
+        "Rloc": (Rloc, float(stb["Rloc_hi"]), ge),
+        "dnfr": (dnfr_n, float(stb["dnfr_lo"]), le),
+    }
+    if all(comp(val, thr) for val, thr, comp in stable_checks.values()):
         return "estable"
-    if (Rloc <= float(dsr["Rloc_lo"])) and (dnfr_n >= float(dsr["dnfr_hi"])):
+
+    dissonant_checks = {
+        "Rloc": (Rloc, float(dsr["Rloc_lo"]), le),
+        "dnfr": (dnfr_n, float(dsr["dnfr_hi"]), ge),
+    }
+    if all(comp(val, thr) for val, thr, comp in dissonant_checks.values()):
         return "disonante"
+
     return "transicion"
 
 

--- a/tests/test_diagnosis_state.py
+++ b/tests/test_diagnosis_state.py
@@ -1,0 +1,13 @@
+"""Tests for _state_from_thresholds."""
+
+from tnfr.metrics.diagnosis import _state_from_thresholds
+
+
+def test_state_from_thresholds_checks_all_conditions():
+    cfg = {
+        "stable": {"Rloc_hi": 0.8, "dnfr_lo": 0.2},
+        "dissonance": {"Rloc_lo": 0.4, "dnfr_hi": 0.5},
+    }
+    assert _state_from_thresholds(0.9, 0.1, cfg) == "estable"
+    assert _state_from_thresholds(0.3, 0.6, cfg) == "disonante"
+    assert _state_from_thresholds(0.5, 0.3, cfg) == "transicion"


### PR DESCRIPTION
## Summary
- Refactor `_state_from_thresholds` to evaluate metrics via iterable threshold mappings
- Add regression tests for diagnostic threshold evaluation

## Testing
- `pytest tests/test_diagnosis_state.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd575cbde48321aeac76617fbdef6f