### PR TITLE
refactor: cache numpy lookup in Si metrics

### DIFF
--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -84,3 +84,31 @@ def test_compute_Si_node():
     )
     assert Si == pytest.approx(0.7)
     assert get_attr(G.nodes[1], ALIAS_SI, 0.0) == pytest.approx(0.7)
+
+    class DummyNP:
+        def fromiter(self, iterable, dtype, count):
+            vals = list(iterable)
+            class Arr(list):
+                def mean(self):
+                    return sum(self) / len(self)
+            return Arr(vals)
+
+        def arctan2(self, y, x):
+            return math.atan2(y, x)
+
+    Si_np = compute_Si_node(
+        1,
+        G.nodes[1],
+        alpha=0.5,
+        beta=0.25,
+        gamma=0.25,
+        vfmax=1.0,
+        dnfrmax=1.0,
+        cos_th=cos_th,
+        sin_th=sin_th,
+        thetas=thetas,
+        neighbors=neighbors,
+        inplace=False,
+        np=DummyNP(),
+    )
+    assert Si_np == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- test: ensure compute_Si retrieves numpy once and forwards it to compute_Si_node
- test: cover compute_Si_node using optional `np` backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd5760a52c83219c9877787fea5591