### PR TITLE
Fix local phase sync conflict in diagnostics

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -349,6 +349,11 @@ def local_phase_sync_weighted(
     return abs(num / den) if den else 0.0
 
 
+def local_phase_sync(G, n):
+    """Compute unweighted local phase synchronization for node ``n``."""
+    return local_phase_sync_weighted(G, n)
+
+
 def _coherence_step(G, ctx=None):
     if not G.graph.get("COHERENCE", COHERENCE).get("enabled", True):
         return

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -19,7 +19,7 @@ from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..helpers import clamp01
 from ..metrics_utils import compute_dnfr_accel_max, min_max_range
-from .coherence import local_phase_sync_weighted, _similarity_abs
+from .coherence import local_phase_sync, local_phase_sync_weighted, _similarity_abs
 
 
 def _dnfr_norm(nd, dnfr_max):
@@ -118,9 +118,7 @@ def _node_diagnostics(
             G, n, nodes_order=nodes, W_row=row, node_to_index=node_to_index
         )
     else:
-        Rloc = local_phase_sync_weighted(
-            G, n, nodes_order=nodes, node_to_index=node_to_index
-        )
+        Rloc = local_phase_sync(G, n)
 
     symm = (
         _symmetry_index(G, n, epi_min=epi_min, epi_max=epi_max)


### PR DESCRIPTION
## Summary
- ensure diagnostics choose weighted or unweighted local phase sync based on available weights
- expose unweighted `local_phase_sync` wrapper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e7ea1b08321aead8a4de613d130