### PR TITLE
Run builder outside edge cache lock

### DIFF
--- a/tests/test_edge_version_cache_threadsafe.py
+++ b/tests/test_edge_version_cache_threadsafe.py
@@ -17,7 +17,9 @@ def test_edge_version_cache_thread_safety():
         results = list(ex.map(lambda _: edge_version_cache(G, "k", builder), range(32)))
     first = results[0]
     assert all(r is first for r in results)
-    assert calls == 1
+    assert calls >= 1
+
+    calls_after_first = calls
 
     increment_edge_version(G)
     with ThreadPoolExecutor(max_workers=16) as ex:
@@ -25,4 +27,4 @@ def test_edge_version_cache_thread_safety():
     second = results2[0]
     assert all(r is second for r in results2)
     assert second is not first
-    assert calls == 2
+    assert calls > calls_after_first


### PR DESCRIPTION
## Summary
- run `edge_version_cache` builders outside the cache lock and re-check before caching
- document that builders must be pure across concurrent calls
- adjust thread-safety test to ensure consistent results under concurrency

## Testing
- `PYTHONPATH=src pytest tests/test_edge_version_cache_threadsafe.py tests/test_edge_version_cache_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd613bfb04832190e6ccc8b583de95