### PR TITLE
Simplify wbar calculation and test list/deque compatibility

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -1,7 +1,6 @@
 """Observer management."""
 
 from __future__ import annotations
-from itertools import islice
 from functools import partial
 import statistics
 
@@ -119,12 +118,12 @@ def wbar(G, window: int | None = None) -> float:
     if not cs:
         # fallback: coherencia instantánea
         return compute_coherence(G)
+    if not isinstance(cs, list):
+        cs = list(cs)
     if window is None:
         window = int(get_param(G, "WBAR_WINDOW"))
     w = int(window)
     if w <= 0:
         raise ValueError("window must be positive")
     w = min(len(cs), w)
-    start = len(cs) - w
-    tail = islice(cs, start, None)
-    return float(statistics.fmean(tail))
+    return float(statistics.fmean(cs[-w:]))

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -113,6 +113,18 @@ def test_wbar_accepts_deque(graph_canon):
     assert wbar(G, window=2) == pytest.approx((0.5 + 0.9) / 2)
 
 
+def test_wbar_list_and_deque_same_result(graph_canon):
+    G = graph_canon()
+    data = [0.1, 0.5, 0.9]
+    expected = (0.5 + 0.9) / 2
+
+    G.graph["history"] = {"C_steps": data}
+    assert wbar(G, window=2) == pytest.approx(expected)
+
+    G.graph["history"] = {"C_steps": deque(data, maxlen=10)}
+    assert wbar(G, window=2) == pytest.approx(expected)
+
+
 def test_wbar_rejects_non_positive_window(graph_canon):
     G = graph_canon()
     G.graph["history"] = {"C_steps": [0.1, 0.2]}


### PR DESCRIPTION
## Summary
- Simplify `wbar` by slicing the last `w` coherence values
- Remove unused `itertools.islice` import
- Add test ensuring `wbar` yields the same result for lists and `deque`

## Testing
- `pytest tests/test_observers.py::test_wbar_list_and_deque_same_result tests/test_observers.py::test_wbar_accepts_deque -q`
- `pytest -q` *(fails: ValueError: nodes_order and W_row are required for weighted phase synchrony)*

------
https://chatgpt.com/codex/tasks/task_e_68bd613b968083219c7255718cd3c505