### PR TITLE
refactor: incremental node checksum

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -219,29 +219,31 @@ def node_set_checksum(
 ) -> str:
     """Return a BLAKE2b checksum of ``G``'s node set.
 
-    Nodes are serialised using :func:`_node_repr` for determinism. To benefit
-    from caching and avoid sorting the same collection repeatedly, the
-    serialised values are stored as a ``frozenset`` under
-    ``"_node_set_checksum_cache"`` when ``store`` is ``True``.
+    Nodes are serialised using :func:`_node_repr`. The checksum is computed
+    incrementally by hashing each node and combining the intermediate digests
+    in an order-independent manner. When ``store`` is ``True`` the accumulated
+    hash value is cached under ``"_node_set_checksum_cache"`` to avoid
+    recalculating it for unchanged graphs.
     """
 
     graph = get_graph(G)
     node_iterable = G.nodes() if nodes is None else nodes
 
-    serialised_list = [_node_repr(n) for n in node_iterable]
+    acc = 0
+    for n in node_iterable:
+        digest = hashlib.blake2b(
+            _node_repr(n).encode("utf-8"), digest_size=16
+        ).digest()
+        acc ^= int.from_bytes(digest, "big")
 
     if store:
-        marker = frozenset(serialised_list)
         cached = graph.get("_node_set_checksum_cache")
-        if cached and cached[0] == marker:
+        if cached and cached[0] == acc:
             return cached[1]
 
-    ordered = serialised_list if presorted else sorted(serialised_list)
-    hasher = hashlib.blake2b(digest_size=16)
-    hasher.update("|".join(ordered).encode("utf-8"))
-    checksum = hasher.hexdigest()
+    checksum = hashlib.blake2b(acc.to_bytes(16, "big"), digest_size=16).hexdigest()
     if store:
-        graph["_node_set_checksum_cache"] = (marker, checksum)
+        graph["_node_set_checksum_cache"] = (acc, checksum)
     return checksum
 
 

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -359,7 +359,10 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
 
 def local_phase_sync(G, n):
     """Compute unweighted local phase synchronization for node ``n``."""
-    return local_phase_sync_weighted(G, n)
+    nodes, W = coherence_matrix(G)
+    if nodes is None:
+        return 0.0
+    return local_phase_sync_weighted(G, n, nodes_order=nodes, W_row=W)
 
 
 def _coherence_step(G, ctx=None):

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -30,18 +30,15 @@ def test_node_set_checksum_object_stable():
 
 
 def _reference_checksum(G):
-    hasher = hashlib.blake2b(digest_size=16)
+    acc = 0
 
-    def serialise(n):
-        return _stable_json(n)
+    for n in G.nodes():
+        digest = hashlib.blake2b(
+            _stable_json(n).encode("utf-8"), digest_size=16
+        ).digest()
+        acc ^= int.from_bytes(digest, "big")
 
-    serialised = [serialise(n) for n in G.nodes()]
-    serialised.sort()
-    for i, node_repr in enumerate(serialised):
-        if i:
-            hasher.update(b"|")
-        hasher.update(node_repr.encode("utf-8"))
-    return hasher.hexdigest()
+    return hashlib.blake2b(acc.to_bytes(16, "big"), digest_size=16).hexdigest()
 
 
 def test_node_set_checksum_compatibility():


### PR DESCRIPTION
## Summary
- compute node_set_checksum incrementally and cache accumulator
- adjust coherence local_phase_sync wrapper
- update checksum tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd613a1a1c8321bd7a6c4b77481699