### PR TITLE
Fix min_max_range generator handling

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -209,9 +209,7 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
 def min_max_range(
     values: Iterable[float], *, default: tuple[float, float] = (0.0, 0.0)
 ) -> tuple[float, float]:
-    try:
-        vmin = min(values)
-        vmax = max(values)
-    except ValueError:
+    vals = list(values)
+    if not vals:
         return default
-    return vmin, vmax
+    return min(vals), max(vals)

--- a/tests/test_min_max_range.py
+++ b/tests/test_min_max_range.py
@@ -1,0 +1,12 @@
+import pytest
+from tnfr.metrics_utils import min_max_range
+
+
+def test_min_max_range_generator():
+    vals = (x for x in [1.0, 2.0, -1.0])
+    assert min_max_range(vals) == pytest.approx((-1.0, 2.0))
+
+
+def test_min_max_range_empty_generator_returns_default():
+    vals = (x for x in [])
+    assert min_max_range(vals, default=(-2.0, 1.0)) == pytest.approx((-2.0, 1.0))


### PR DESCRIPTION
## Summary
- Materialize iterables in `min_max_range` to compute min and max safely
- Add tests ensuring `min_max_range` works with generators and handles empties

## Testing
- `PYTHONPATH=src pytest tests/test_min_max_range.py tests/test_si_helpers.py tests/test_compute_coherence.py tests/test_compute_Si_numpy_usage.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd613691e883218326d74772baf8be