### PR TITLE
Cache reversed sequence in THOL flattening

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -128,10 +128,11 @@ def _flatten_thol(item: THOL, stack: deque[Any]) -> None:
         else None
     )
     seq = ensure_collection(item.body)
+    rev_seq = tuple(reversed(seq))
     for _ in range(repeats):
         if closing is not None:
             stack.append(closing)
-        stack.extend(reversed(seq))
+        stack.extend(rev_seq)
     stack.append(THOL_SENTINEL)
 
 


### PR DESCRIPTION
## Summary
- Cache reversed THOL body sequence once and reuse it across repeats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd64afae108321b7728de43b7e3d6a