### PR TITLE
refactor: sample candidates deterministically

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -246,18 +246,16 @@ def _um_select_candidates(
     th: float,
 ):
     cand_list = list(candidates)
+    rng = get_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset())
     if limit > 0 and len(cand_list) > limit:
         if mode == "proximity":
             cand_list = heapq.nsmallest(
                 limit, cand_list, key=lambda j: abs(angle_diff(j.theta, th))
             )
         else:
-            rng = get_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset())
             cand_list = rng.sample(cand_list, limit)
     elif mode == "sample" and limit > 0:
-        rng = get_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset())
-        rng.shuffle(cand_list)
-        cand_list = cand_list[:limit]
+        cand_list = rng.sample(cand_list, min(limit, len(cand_list)))
     return cand_list
 
 


### PR DESCRIPTION
## Summary
- initialize RNG once in `_um_select_candidates`
- use deterministic `rng.sample` for "sample" mode

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd673f7ebc832181afc5b4d1c7b881