### PR TITLE
Allow list alias sequences in _validate_aliases

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -41,18 +41,26 @@ __all__ = [
 ]
 
 
-@lru_cache(maxsize=128)
 def _validate_aliases(aliases: Sequence[str]) -> tuple[str, ...]:
     """Return ``aliases`` as a validated tuple of strings."""
     if isinstance(aliases, str) or not isinstance(aliases, Sequence):
         raise TypeError("'aliases' must be a non-string sequence")
-    seq = tuple(aliases)
-    if not seq:
+    return _cached_validate_aliases(tuple(aliases))
+
+
+@lru_cache(maxsize=128)
+def _cached_validate_aliases(aliases: tuple[str, ...]) -> tuple[str, ...]:
+    if not aliases:
         raise ValueError("'aliases' must contain at least one key")
-    for a in seq:
+    for a in aliases:
         if not isinstance(a, str):
             raise TypeError("'aliases' elements must be strings")
-    return seq
+    return aliases
+
+
+# expose cache management helpers on the public function
+_validate_aliases.cache_clear = _cached_validate_aliases.cache_clear  # type: ignore[attr-defined]
+_validate_aliases.cache_info = _cached_validate_aliases.cache_info  # type: ignore[attr-defined]
 
 
 def _alias_resolve(

--- a/tests/test_alias_sequence.py
+++ b/tests/test_alias_sequence.py
@@ -15,12 +15,16 @@ def test_alias_set_accepts_hashable_sequence():
     assert d["x"] == 5
 
 
-def test_alias_rejects_str_and_unhashable():
+def test_alias_rejects_str():
     with pytest.raises(TypeError):
         alias_get({}, "x", int)
     with pytest.raises(TypeError):
         alias_set({}, "x", int, 1)
-    with pytest.raises(TypeError):
-        alias_get({}, ["x"], int)
-    with pytest.raises(TypeError):
-        alias_set({}, ["x"], int, 1)
+
+
+def test_alias_accepts_list_sequence():
+    d = {"b": "1"}
+    assert alias_get(d, ["a", "b"], int) == 1
+    d2 = {}
+    alias_set(d2, ["x", "y"], int, "5")
+    assert d2["x"] == 5

--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -18,6 +18,5 @@ def test_rejects_non_string_elements():
         _validate_aliases(("a", 1))
 
 
-def test_rejects_unhashable_sequence():
-    with pytest.raises(TypeError):
-        _validate_aliases(["a"])
+def test_accepts_list_sequence():
+    assert _validate_aliases(["a"]) == ("a",)


### PR DESCRIPTION
## Summary
- accept list inputs for alias helpers by converting to tuple before caching
- expose cache helpers on `_validate_aliases`
- expand tests for list alias sequences

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd6ffb3b6483219afdf08c5ade0e81