### PR TITLE
Optimize coherence computation

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -53,14 +53,13 @@ def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
     count = G.number_of_nodes()
     if count:
-        dnfr_sum = math.fsum(
-            abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)
-        )
-        depi_sum = math.fsum(
-            abs(get_attr(nd, ALIAS_dEPI, 0.0)) for _, nd in G.nodes(data=True)
-        )
-        dnfr_mean = dnfr_sum / count
-        depi_mean = depi_sum / count
+        dnfr_vals = []
+        depi_vals = []
+        for _, nd in G.nodes(data=True):
+            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
+            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
+        dnfr_mean = math.fsum(dnfr_vals) / count
+        depi_mean = math.fsum(depi_vals) / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)


### PR DESCRIPTION
## Summary
- aggregate DNFR and dEPI values in one pass to compute coherence more efficiently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd73edff048321aedb8736151b7d24