### PR TITLE
Track warned modules for optional imports

### DIFF
--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -1,6 +1,7 @@
 import types
 import importlib
 
+import tnfr.import_utils as import_utils
 from tnfr.import_utils import (
     optional_import,
     _IMPORT_STATE,
@@ -25,6 +26,25 @@ def test_optional_import_clears_failures(monkeypatch):
     result = optional_import("fake_mod")
     assert result is not None
     assert "fake_mod" not in _IMPORT_STATE
+
+
+def test_warns_with_stacklevel_2_only_once(monkeypatch):
+    def fake_import(name):
+        raise ImportError("boom")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    stacklevels = []
+
+    def fake_warn(msg, category=None, stacklevel=1):
+        stacklevels.append(stacklevel)
+
+    monkeypatch.setattr(import_utils.warnings, "warn", fake_warn)
+    optional_import.cache_clear()
+    optional_import("fake_mod.attr1")
+    optional_import("fake_mod.attr2")
+    optional_import.cache_clear()
+    assert stacklevels == [2, 1]
 
 
 def test_optional_import_removes_entry_on_success(monkeypatch):


### PR DESCRIPTION
## Summary
- warn with `stacklevel=2` only on the first failed import per module
- clear warning state when an import succeeds
- add regression test covering warning stacklevel behaviour

## Testing
- `pytest tests/test_optional_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8cba8fc08321ab5663748fea2968