### PR TITLE
Guard _stable_json against exceeding recursion limit

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -13,6 +13,7 @@ import hashlib
 from statistics import fmean, StatisticsError
 import threading
 import json
+import sys
 from functools import lru_cache
 from cachetools import LRUCache
 import networkx as nx
@@ -165,7 +166,19 @@ def get_graph(obj: Any) -> Any:
 def _stable_json(
     obj: Any, visited: set[int] | None = None, max_depth: int = 10
 ) -> str:
-    """Return a JSON string with deterministic ordering."""
+    """Return a JSON string with deterministic ordering.
+
+    Raises
+    ------
+    ValueError
+        If ``max_depth`` is greater than or equal to Python's recursion limit.
+    """
+
+    recursion_limit = sys.getrecursionlimit()
+    if max_depth >= recursion_limit:
+        raise ValueError(
+            f"max_depth={max_depth} exceeds recursion limit ({recursion_limit})"
+        )
 
     def _to_basic(o: Any, depth: int) -> Any:
         if isinstance(o, (str, int, float, bool)) or o is None:

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -1,4 +1,7 @@
 import json
+import sys
+
+import pytest
 
 from tnfr.helpers import _stable_json
 
@@ -26,3 +29,13 @@ def test_stable_json_respects_max_depth_dict():
 def test_stable_json_respects_max_depth_list():
     obj = [1, [2, [3]]]
     assert json.loads(_stable_json(obj, max_depth=1)) == [1, "<max-depth>"]
+
+
+def test_stable_json_recursion_limit_guard():
+    limit = sys.getrecursionlimit()
+    obj = current = {}
+    for _ in range(limit - 1):
+        current["a"] = {}
+        current = current["a"]
+    with pytest.raises(ValueError):
+        _stable_json(obj, max_depth=limit)


### PR DESCRIPTION
## Summary
- prevent `_stable_json` from exceeding Python's recursion limit by checking `sys.getrecursionlimit`
- document recursion guard and add test for limit handling

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd8b1c319c8321a4203eb95779873d