### PR TITLE
Handle set and bytearray immutability checks

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -52,8 +52,12 @@ def _freeze(value: Any):
         return tuple(_freeze(v) for v in value)
     if isinstance(value, list):
         return ("list", tuple(_freeze(v) for v in value))
+    if isinstance(value, set):
+        return ("set", tuple(_freeze(v) for v in value))
     if isinstance(value, frozenset):
         return frozenset(_freeze(v) for v in value)
+    if isinstance(value, bytearray):
+        return ("bytearray", bytes(value))
     if isinstance(value, Mapping):
         tag = "dict" if hasattr(value, "__setitem__") else "mapping"
         return (tag, tuple((k, _freeze(v)) for k, v in value.items()))
@@ -67,7 +71,7 @@ def _is_immutable_inner(value: Any) -> bool:
     if isinstance(value, tuple):
         if value and isinstance(value[0], str):
             tag = value[0]
-            if tag in {"list", "dict"}:
+            if tag in {"list", "dict", "set", "bytearray"}:
                 return False
             if tag == "mapping":
                 return all(_is_immutable_inner(v) for v in value[1])

--- a/tests/test_is_immutable.py
+++ b/tests/test_is_immutable.py
@@ -20,6 +20,11 @@ def test_is_immutable_detects_mutable():
     assert not _is_immutable(data)
 
 
+def test_is_immutable_detects_set_and_bytearray():
+    assert not _is_immutable({1, 2})
+    assert not _is_immutable(bytearray(b"abc"))
+
+
 def test_is_immutable_lists_dicts_nested():
     data = (1, [2, {"a": (3, 4)}])
     assert not _is_immutable(data)
@@ -34,6 +39,16 @@ def test_is_immutable_inner_handles_mapping_tag():
 
 def test_is_immutable_inner_handles_dict_tag():
     frozen = ("dict", (("a", 1),))
+    assert not _is_immutable_inner(frozen)
+
+
+def test_is_immutable_inner_handles_set_tag():
+    frozen = ("set", (1, 2))
+    assert not _is_immutable_inner(frozen)
+
+
+def test_is_immutable_inner_handles_bytearray_tag():
+    frozen = ("bytearray", b"abc")
     assert not _is_immutable_inner(frozen)
 
 


### PR DESCRIPTION
## Summary
- handle `set` and `bytearray` in the immutability helpers
- test immutability detection for new types

## Testing
- `pytest tests/test_is_immutable.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8cbe404c83219aaf1ef0e8574a54