### PR TITLE
Ensure HistoryDict heap remains bounded during churn

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -104,11 +104,13 @@ class HistoryDict(dict):
     def _prune_heap(self) -> None:
         """Remove stale heap entries incrementally."""
         target = len(self._counts) + self._compact_every
-        while len(self._heap) > target:
-            cnt, key = self._heap[0]
+        buffer: list[tuple[int, str]] = []
+        while len(self._heap) + len(buffer) > target:
+            cnt, key = heapq.heappop(self._heap)
             if self._counts.get(key) == cnt:
-                break
-            heapq.heappop(self._heap)
+                buffer.append((cnt, key))
+        for item in buffer:
+            heapq.heappush(self._heap, item)
 
     def _pop_heap_key(self) -> str:
         """Pop and return the key with the smallest count from the heap."""

--- a/tests/test_history_heap_bound.py
+++ b/tests/test_history_heap_bound.py
@@ -6,3 +6,11 @@ def test_heap_size_stays_bounded_under_churn():
     for i in range(1000):
         _ = hist.get_increment(f"k{i % 10}")
     assert len(hist._heap) <= len(hist._counts) + hist._compact_every
+
+
+def test_heap_size_skewed_churn():
+    hist = HistoryDict({f"k{i}": [] for i in range(10)}, compact_every=5)
+    for i in range(10_000):
+        key = "k0" if i % 2 == 0 else f"k{(i % 9) + 1}"
+        _ = hist.get_increment(key)
+    assert len(hist._heap) <= len(hist._counts) + hist._compact_every


### PR DESCRIPTION
## Summary
- revise `_prune_heap` to drop stale entries until heap size is within allowed slack
- add unit tests exercising bounded heap behavior under both uniform and skewed churn

## Testing
- `PYTHONPATH=src pytest tests/test_history_heap_bound.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd95a20a1c83218732cb6a9a05bb4f