### PR TITLE
Handle deque in HistoryDict _resolve_value

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -125,8 +125,11 @@ class HistoryDict(dict):
             val = super().setdefault(key, default)
         else:
             val = super().__getitem__(key)
-        if self._maxlen > 0 and isinstance(val, list):
-            val = deque(val, maxlen=self._maxlen)
+        if self._maxlen > 0 and not isinstance(val, deque):
+            if isinstance(val, Iterable) and not isinstance(val, (str, bytes)):
+                val = deque(val, maxlen=self._maxlen)
+            else:
+                val = deque([val], maxlen=self._maxlen)
             super().__setitem__(key, val)
         return val
 

--- a/tests/test_history_methods.py
+++ b/tests/test_history_methods.py
@@ -29,6 +29,10 @@ def test_setdefault_inserts_and_converts_without_usage():
     val2 = hist.setdefault("a", [2])
     assert val2 is val
     assert hist._counts.get("a", 0) == 0
+    existing = deque([3])
+    val3 = hist.setdefault("b", existing)
+    assert val3 is existing
+    assert hist._counts.get("b", 0) == 0
 
 
 def test_pop_least_used_removes_least_frequent_key():


### PR DESCRIPTION
## Summary
- Avoid re-wrapping existing deques in `HistoryDict._resolve_value`
- Cover `setdefault` with existing deque and ensure usage counts unchanged

## Testing
- `PYTHONPATH=src pytest tests/test_history_methods.py::test_setdefault_inserts_and_converts_without_usage -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd9702f58883219f7ab72f8d4c1f74