### PR TITLE
Avoid redundant deque wrapping in HistoryDict

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -125,7 +125,9 @@ class HistoryDict(dict):
             val = super().setdefault(key, default)
         else:
             val = super().__getitem__(key)
-        if self._maxlen > 0 and not isinstance(val, deque):
+        if self._maxlen > 0:
+            if isinstance(val, deque):
+                return val
             if isinstance(val, Iterable) and not isinstance(val, (str, bytes)):
                 val = deque(val, maxlen=self._maxlen)
             else:

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -27,7 +27,7 @@ def test_history_maxlen_and_cleanup(graph_canon):
     series.extend([1, 2, 3])
     assert isinstance(series, deque)
     assert series.maxlen == 2
-    assert list(series) == [2, 3]
+    assert series == deque([2, 3], maxlen=2)
 
 
 def test_history_least_used_removed(graph_canon):

--- a/tests/test_history_methods.py
+++ b/tests/test_history_methods.py
@@ -24,7 +24,7 @@ def test_setdefault_inserts_and_converts_without_usage():
     hist = HistoryDict(maxlen=2)
     val = hist.setdefault("a", [1])
     assert isinstance(val, deque)
-    assert list(val) == [1]
+    assert val == deque([1])
     assert hist._counts.get("a", 0) == 0
     val2 = hist.setdefault("a", [2])
     assert val2 is val


### PR DESCRIPTION
## Summary
- Return existing deque values in `HistoryDict._resolve_value` instead of rewrapping
- Update tests to compare deque contents directly without list conversion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd97e41b9483218fb7de6da759ec65