### PR TITLE
feat: support sequences in normalize_weights

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -8,6 +8,7 @@ from typing import (
     TypeVar,
     Mapping,
     Collection,
+    Sequence,
     cast,
 )
 import logging
@@ -75,13 +76,18 @@ def ensure_collection(
 
 def normalize_weights(
     dict_like: dict[str, Any],
-    keys: Iterable[str],
+    keys: Iterable[str] | Sequence[str],
     default: float = 0.0,
     *,
     error_on_negative: bool = False,
 ) -> dict[str, float]:
-    """Normalize ``keys`` in ``dict_like`` so their sum is 1."""
-    keys = list(keys)
+    """Normalize ``keys`` in ``dict_like`` so their sum is 1.
+
+    ``keys`` may be any iterable of strings. Sequences and other collections
+    are used directly while non-collection iterables are materialized.
+    """
+    if not isinstance(keys, Collection):
+        keys = list(keys)
     default_float = float(default)
     if not keys:
         return {}


### PR DESCRIPTION
## Summary
- allow `normalize_weights` to take sequences directly
- document and avoid materializing `keys` when already a collection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9993b5f88321b34de9534cedd76c