### PR TITLE
Aggregate alias conversion errors in strict mode

### DIFF
--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tnfr.alias import _validate_aliases
+from tnfr.alias import _validate_aliases, alias_get
 
 
 def test_rejects_string():
@@ -20,3 +20,17 @@ def test_rejects_non_string_elements():
 
 def test_accepts_list_sequence():
     assert _validate_aliases(["a"]) == ("a",)
+
+
+def test_alias_get_reports_all_failures():
+    d = {"a": "x", "b": "y"}
+    with pytest.raises(ValueError) as exc:
+        alias_get(d, ("a", "b"), int, strict=True)
+    msg = str(exc.value)
+    assert "'a'" in msg and "'b'" in msg
+
+
+def test_alias_get_includes_default_failure():
+    with pytest.raises(ValueError) as exc:
+        alias_get({}, ("a",), int, default="x", strict=True)
+    assert "default" in str(exc.value)


### PR DESCRIPTION
## Summary
- raise a single informative ValueError listing all aliases that failed conversion in `_alias_resolve`
- add tests for aggregated alias error messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9af4dbac83219f57af888bb70c27