### PR TITLE
Deprecate attach_defaults in favor of inject_defaults

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -119,9 +119,17 @@ _ALIAS_TARGET_TO_KEY: Dict[str, str] = {
 def attach_defaults(G, override: bool = False) -> None:
     """Write combined ``DEFAULTS`` into ``G.graph``.
 
+    .. deprecated:: 0.0.0
+       Use :func:`inject_defaults` instead.
+
     If ``override`` is ``True`` existing values are overwritten.
     """
-    inject_defaults(G, DEFAULTS, override=override)
+    warnings.warn(
+        "attach_defaults is deprecated; use inject_defaults instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    inject_defaults(G, override=override)
 
 
 def inject_defaults(

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections import deque
 from typing import TYPE_CHECKING
 
-from .constants import METRIC_DEFAULTS, attach_defaults, get_param
+from .constants import METRIC_DEFAULTS, inject_defaults, get_param
 from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
@@ -32,11 +32,11 @@ def preparar_red(
         Run ``init_node_attrs`` when ``True`` (default), leaving node
         attributes untouched when ``False``.
     override_defaults:
-        If ``True``, :func:`attach_defaults` overwrites existing entries.
+        If ``True``, :func:`inject_defaults` overwrites existing entries.
     **overrides:
         Parameters applied after the defaults phase.
     """
-    attach_defaults(G, override=override_defaults)
+    inject_defaults(G, override=override_defaults)
     if overrides:
         from .constants import merge_overrides
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 import networkx as nx
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 
 
 @pytest.fixture
@@ -12,7 +12,7 @@ def graph_canon():
 
     def _factory():
         G = nx.Graph()
-        attach_defaults(G)
+        inject_defaults(G)
         return G
 
     return _factory

--- a/tests/test_ensure_history_trim_performance.py
+++ b/tests/test_ensure_history_trim_performance.py
@@ -3,13 +3,13 @@ import pytest
 import networkx as nx
 
 from tnfr.glyph_history import HistoryDict, ensure_history
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 
 
 @pytest.mark.slow
 def test_ensure_history_trim_performance():
     G = nx.Graph()
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 1000
     G.graph["HISTORY_COMPACT_EVERY"] = 100
     hist = {f"k{i}": [] for i in range(2000)}

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -4,7 +4,7 @@ import math
 import logging
 import pytest
 
-from tnfr.constants import attach_defaults, merge_overrides
+from tnfr.constants import inject_defaults, merge_overrides
 from tnfr.dynamics import update_epi_via_nodal_equation
 from tnfr.gamma import eval_gamma, GAMMA_REGISTRY
 from tnfr.helpers import increment_edge_version
@@ -13,7 +13,7 @@ from tnfr.helpers import increment_edge_version
 def test_gamma_linear_integration(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0}
     )
@@ -30,7 +30,7 @@ def test_gamma_linear_integration(graph_canon):
 def test_gamma_bandpass_eval(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1, 2, 3])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "kuramoto_bandpass", "beta": 1.0})
     for n in [0, 1, 2]:
         G.nodes[n]["θ"] = 0.0
@@ -44,7 +44,7 @@ def test_gamma_bandpass_eval(graph_canon):
 def test_gamma_linear_string_params(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G, GAMMA={"type": "kuramoto_linear", "beta": "1.0", "R0": "0.0"}
     )
@@ -59,7 +59,7 @@ def test_gamma_linear_string_params(graph_canon):
 def test_gamma_tanh_eval(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1, 2, 3])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G,
         GAMMA={"type": "kuramoto_tanh", "beta": 1.0, "k": 1.0, "R0": 0.0},
@@ -77,7 +77,7 @@ def test_gamma_tanh_eval(graph_canon):
 def test_gamma_bandpass_string_params(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1, 2, 3])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "kuramoto_bandpass", "beta": "1.0"})
     for n in [0, 1, 2]:
         G.nodes[n]["θ"] = 0.0
@@ -91,7 +91,7 @@ def test_gamma_bandpass_string_params(graph_canon):
 def test_gamma_harmonic_eval(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G, GAMMA={"type": "harmonic", "beta": 1.0, "omega": 1.0, "phi": 0.0}
     )
@@ -106,7 +106,7 @@ def test_gamma_harmonic_eval(graph_canon):
 def test_gamma_tanh_string_params(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1, 2, 3])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G,
         GAMMA={
@@ -165,7 +165,7 @@ def test_kuramoto_cache_updates_on_time_change(graph_canon):
 
     G = graph_canon()
     G.add_nodes_from([0])
-    attach_defaults(G)
+    inject_defaults(G)
     G.nodes[0]["θ"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     cache0 = G.graph["_kuramoto_cache"]
@@ -179,7 +179,7 @@ def test_kuramoto_cache_updates_on_nodes_change(graph_canon):
 
     G = graph_canon()
     G.add_nodes_from([0])
-    attach_defaults(G)
+    inject_defaults(G)
     G.nodes[0]["θ"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     cache0 = G.graph["_kuramoto_cache"]
@@ -195,7 +195,7 @@ def test_kuramoto_cache_step_limit(graph_canon):
 
     G = graph_canon()
     G.add_nodes_from([0])
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["KURAMOTO_CACHE_STEPS"] = 2
     G.nodes[0]["θ"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
@@ -209,7 +209,7 @@ def test_kuramoto_cache_step_limit(graph_canon):
 def test_kuramoto_cache_invalidation_on_version(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0}
     )
@@ -228,7 +228,7 @@ def test_kuramoto_cache_invalidation_on_version(graph_canon):
 def test_gamma_harmonic_string_params(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(
         G,
         GAMMA={
@@ -249,7 +249,7 @@ def test_gamma_harmonic_string_params(graph_canon):
 def test_eval_gamma_logs_and_strict_mode(graph_canon, caplog):
     G = graph_canon()
     G.add_nodes_from([0])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": "bad"})
 
     caplog.clear()
@@ -270,7 +270,7 @@ def test_eval_gamma_logs_and_strict_mode(graph_canon, caplog):
 def test_eval_gamma_non_mapping_warns(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0])
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["GAMMA"] = "not a dict"
     with pytest.warns(UserWarning):
         g = eval_gamma(G, 0, t=0.0)
@@ -280,7 +280,7 @@ def test_eval_gamma_non_mapping_warns(graph_canon):
 def test_eval_gamma_unknown_type_warning_and_strict(graph_canon, caplog):
     G = graph_canon()
     G.add_nodes_from([0])
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "unknown_type"})
 
     caplog.clear()
@@ -298,7 +298,7 @@ def test_eval_gamma_unknown_type_warning_and_strict(graph_canon, caplog):
 def test_eval_gamma_unhandled_exception_propagates(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "bad"})
 
     def bad_gamma(G, node, t, cfg):

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -2,7 +2,7 @@
 
 from collections import deque
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.grammar import (
     enforce_canonical_grammar,
     on_applied_glyph,
@@ -22,7 +22,7 @@ from tnfr.grammar import (
 def test_compatibility_fallback(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["glyph_history"] = deque([AL])
     assert enforce_canonical_grammar(G, 0, IL) == EN
@@ -31,7 +31,7 @@ def test_compatibility_fallback(graph_canon):
 def test_precondition_oz_to_zhir(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["glyph_history"] = deque([NAV])
     nd["ΔNFR"] = 0.0
@@ -43,7 +43,7 @@ def test_precondition_oz_to_zhir(graph_canon):
 def test_thol_closure(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["glyph_history"] = deque([THOL])
     on_applied_glyph(G, 0, THOL)
@@ -60,7 +60,7 @@ def test_thol_closure(graph_canon):
 def test_repeat_window_and_force(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["glyph_history"] = deque([ZHIR.value, "OZ"])
     G.graph["GRAMMAR"] = {
@@ -87,7 +87,7 @@ def test_repeat_window_and_force(graph_canon):
 def test_repeat_invalid_fallback_string(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["glyph_history"] = deque([ZHIR.value])
     G.graph["GRAMMAR"] = {
@@ -101,7 +101,7 @@ def test_repeat_invalid_fallback_string(graph_canon):
 def test_repeat_invalid_fallback_type(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["glyph_history"] = deque([ZHIR.value])
     obj = object()
@@ -116,7 +116,7 @@ def test_repeat_invalid_fallback_type(graph_canon):
 def test_lag_counters_enforced(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["AL_MAX_LAG"] = 2
     G.graph["EN_MAX_LAG"] = 2
     from tnfr.dynamics import step
@@ -131,10 +131,10 @@ def test_lag_counters_enforced(graph_canon):
 def test_apply_glyph_with_grammar_equivalence(graph_canon):
     G_manual = graph_canon()
     G_manual.add_node(0)
-    attach_defaults(G_manual)
+    inject_defaults(G_manual)
     G_func = graph_canon()
     G_func.add_node(0)
-    attach_defaults(G_func)
+    inject_defaults(G_func)
 
     # Aplicación manual
     g_eff = enforce_canonical_grammar(G_manual, 0, ZHIR)
@@ -153,7 +153,7 @@ def test_apply_glyph_with_grammar_multiple_nodes(graph_canon):
     G = graph_canon()
     G.add_node(0, theta=0.0)
     G.add_node(1)
-    attach_defaults(G)
+    inject_defaults(G)
     G.nodes[0]["glyph_history"] = deque([OZ])
 
     apply_glyph_with_grammar(G, [0, 1], ZHIR, 1)
@@ -165,7 +165,7 @@ def test_apply_glyph_with_grammar_multiple_nodes(graph_canon):
 def test_apply_glyph_with_grammar_accepts_iterables(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     G.nodes[0]["glyph_history"] = deque([OZ])
     G.nodes[1]["glyph_history"] = deque([OZ])
     apply_glyph_with_grammar(G, G.nodes(), ZHIR, 1)
@@ -174,7 +174,7 @@ def test_apply_glyph_with_grammar_accepts_iterables(graph_canon):
 
     G2 = graph_canon()
     G2.add_nodes_from([0, 1])
-    attach_defaults(G2)
+    inject_defaults(G2)
     G2.nodes[0]["glyph_history"] = deque([OZ])
     G2.nodes[1]["glyph_history"] = deque([OZ])
     apply_glyph_with_grammar(G2, (n for n in G2.nodes()), ZHIR, 1)

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -4,14 +4,14 @@ from collections import deque
 
 import pytest
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.glyph_history import ensure_history, HistoryDict
 
 
 def test_history_maxlen_and_cleanup(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 2
 
     hist = ensure_history(G)
@@ -33,7 +33,7 @@ def test_history_maxlen_and_cleanup(graph_canon):
 def test_history_least_used_removed(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 2
 
     hist = ensure_history(G)
@@ -53,7 +53,7 @@ def test_history_least_used_removed(graph_canon):
 def test_history_trim_uses_pop_least_used(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 2
 
     hist = ensure_history(G)
@@ -70,7 +70,7 @@ def test_history_trim_uses_pop_least_used(graph_canon):
 def test_history_maxlen_override_respected(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
 
     hist = ensure_history(G)
     assert not isinstance(hist, HistoryDict)
@@ -84,7 +84,7 @@ def test_history_maxlen_override_respected(graph_canon):
 def test_history_not_trimmed_when_equal_maxlen(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 2
 
     hist = ensure_history(G)
@@ -99,7 +99,7 @@ def test_history_not_trimmed_when_equal_maxlen(graph_canon):
 def test_history_not_trimmed_when_below_maxlen(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 2
 
     hist = ensure_history(G)
@@ -113,7 +113,7 @@ def test_history_not_trimmed_when_below_maxlen(graph_canon):
 def test_history_negative_maxlen_raises(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = -1
     with pytest.raises(ValueError):
         ensure_history(G)

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -1,6 +1,6 @@
 """Pruebas de history series."""
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.dynamics import step
 from tnfr.metrics import register_metrics_callbacks
 from tnfr.gamma import GAMMA_REGISTRY
@@ -10,7 +10,7 @@ from tnfr.glyph_history import HistoryDict
 def test_history_delta_si_and_B(graph_canon):
     G = graph_canon()
     G.add_node(0, EPI=0.0, νf=0.5, θ=0.0)
-    attach_defaults(G)
+    inject_defaults(G)
     register_metrics_callbacks(G)
     step(G, apply_glyphs=False)
     step(G, apply_glyphs=False)
@@ -22,7 +22,7 @@ def test_history_delta_si_and_B(graph_canon):
 def test_gamma_kuramoto_tanh_registry(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    attach_defaults(G)
+    inject_defaults(G)
     G.nodes[0]["θ"] = 0.0
     G.nodes[1]["θ"] = 0.0
     cfg = {"type": "kuramoto_tanh", "beta": 0.5, "k": 2.0, "R0": 0.0}

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -4,7 +4,7 @@ import networkx as nx
 
 from tnfr.initialization import init_node_attrs
 from tnfr.constants import (
-    attach_defaults,
+    inject_defaults,
     VF_KEY,
     THETA_KEY,
     ALIAS_VF,
@@ -16,7 +16,7 @@ from tnfr.alias import get_attr
 def test_init_node_attrs_reproducible():
     seed = 123
     G1 = nx.path_graph(5)
-    attach_defaults(G1)
+    inject_defaults(G1)
     G1.graph["RANDOM_SEED"] = seed
     init_node_attrs(G1)
     attrs1 = {
@@ -25,7 +25,7 @@ def test_init_node_attrs_reproducible():
     }
 
     G2 = nx.path_graph(5)
-    attach_defaults(G2)
+    inject_defaults(G2)
     G2.graph["RANDOM_SEED"] = seed
     init_node_attrs(G2)
     attrs2 = {
@@ -39,7 +39,7 @@ def test_init_node_attrs_reproducible():
 def test_init_node_attrs_reversed_uniform_bounds():
     seed = 2024
     G1 = nx.path_graph(3)
-    attach_defaults(G1)
+    inject_defaults(G1)
     G1.graph.update(
         {
             "RANDOM_SEED": seed,
@@ -52,7 +52,7 @@ def test_init_node_attrs_reversed_uniform_bounds():
     vfs1 = [d[VF_KEY] for _, d in G1.nodes(data=True)]
 
     G2 = nx.path_graph(3)
-    attach_defaults(G2)
+    inject_defaults(G2)
     G2.graph.update(
         {
             "RANDOM_SEED": seed,
@@ -69,7 +69,7 @@ def test_init_node_attrs_reversed_uniform_bounds():
 
 def test_init_node_attrs_alias_access():
     G = nx.path_graph(2)
-    attach_defaults(G)
+    inject_defaults(G)
     init_node_attrs(G)
     for _, d in G.nodes(data=True):
         d_ascii = {"nu_f": d[VF_KEY], "theta": d[THETA_KEY]}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,7 @@ import networkx as nx
 from typing import Any
 
 from tnfr.constants import (
-    attach_defaults,
+    inject_defaults,
     ALIAS_EPI,
     ALIAS_DNFR,
     ALIAS_dEPI,
@@ -78,7 +78,7 @@ def test_aggregate_si_computes_stats():
     """_aggregate_si computes mean and fractions."""
 
     G = nx.Graph()
-    attach_defaults(G)
+    inject_defaults(G)
     hist = {"Si_mean": [], "Si_hi_frac": [], "Si_lo_frac": []}
     G.add_node(0)
     G.add_node(1)
@@ -98,7 +98,7 @@ def test_compute_advanced_metrics_populates_history():
     """_compute_advanced_metrics records glyph-based metrics."""
 
     G = nx.Graph()
-    attach_defaults(G)
+    inject_defaults(G)
     hist: dict[str, Any] = {}
     cfg = G.graph["METRICS"]
     thr = float(G.graph.get("EPI_SUPPORT_THR"))
@@ -127,7 +127,7 @@ def test_pp_val_zero_when_no_remesh(graph_canon):
     G = graph_canon()
     # Nodo en estado SHA, pero sin eventos REMESH
     G.add_node(0, EPI_kind=LATENT_GLYPH)
-    attach_defaults(G)
+    inject_defaults(G)
 
     _metrics_step(G)
 
@@ -140,7 +140,7 @@ def test_pp_val_handles_missing_sha(graph_canon):
     G = graph_canon()
     # Nodo en estado REMESH pero sin nodos SHA
     G.add_node(0, EPI_kind="REMESH")
-    attach_defaults(G)
+    inject_defaults(G)
 
     _metrics_step(G)
 
@@ -161,7 +161,7 @@ def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
     for G in (G_true, G_false):
         G.add_node(0, EPI_kind="OZ")
         G.add_node(1, EPI_kind=LATENT_GLYPH)
-        attach_defaults(G)
+        inject_defaults(G)
         for n in G.nodes():
             nd = G.nodes[n]
             nd["glyph_history"] = [nd.get("EPI_kind")]
@@ -199,7 +199,7 @@ def test_update_epi_support_matches_manual(graph_canon):
     G.add_node(1, EPI=-0.1)
     G.add_node(2, EPI=0.01)
     G.add_node(3, EPI=0.05)
-    attach_defaults(G)
+    inject_defaults(G)
     hist = {}
     thr = float(G.graph.get("EPI_SUPPORT_THR"))
     _update_epi_support(G, hist, t=0, thr=thr)

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.operators import apply_glyph
 
 
 def test_nav_converges_to_vf_without_jitter(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["ΔNFR"] = 0.2
     nd["νf"] = 1.0
@@ -23,7 +23,7 @@ def test_nav_converges_to_vf_without_jitter(graph_canon):
 def test_nav_strict_sets_dnfr_to_vf(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     nd = G.nodes[0]
     nd["ΔNFR"] = -0.5
     nd["νf"] = 0.8

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -8,7 +8,7 @@ from tnfr.operators import (
     _select_dominant_glyph,
 )
 from types import SimpleNamespace
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 import networkx as nx
 import pytest
 
@@ -71,7 +71,7 @@ def test_rng_cache_disabled_with_size_zero(graph_canon):
 
 def test_um_candidate_subset_proximity():
     G = nx.Graph()
-    attach_defaults(G)
+    inject_defaults(G)
     for i, th in enumerate([0.0, 0.1, 0.2, 1.0]):
         G.add_node(i, **{"θ": th, "EPI": 0.5, "Si": 0.5})
 

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -2,14 +2,14 @@
 
 from collections import deque
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.operators import apply_remesh_if_globally_stable
 
 
 def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["REMESH_REQUIRE_STABILITY"] = False
 
     # Historial suficiente para el parámetro personalizado
@@ -35,7 +35,7 @@ def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
 def test_remesh_alpha_hard_ignores_glyph_factor(graph_canon):
     G = graph_canon()
     G.add_node(0)
-    attach_defaults(G)
+    inject_defaults(G)
     G.graph["REMESH_REQUIRE_STABILITY"] = False
     hist = G.graph.setdefault("history", {})
     hist["stable_frac"] = [1.0, 1.0, 1.0]

--- a/tests/test_topological_remesh.py
+++ b/tests/test_topological_remesh.py
@@ -2,7 +2,7 @@
 
 import networkx as nx
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.operators import apply_topological_remesh
 
 
@@ -10,7 +10,7 @@ def _graph_with_epi(graph_canon, n=6):
     G = graph_canon()
     for i in range(n):
         G.add_node(i)
-    attach_defaults(G)
+    inject_defaults(G)
     for i in G.nodes():
         G.nodes[i]["EPI"] = float(i)
     return G
@@ -29,7 +29,7 @@ def test_remesh_community_reduces_nodes_and_preserves_connectivity(graph_canon):
             (2, 3),
         ]
     )
-    attach_defaults(G)
+    inject_defaults(G)
     apply_topological_remesh(G, mode="community")
     assert nx.is_connected(G)
     assert G.number_of_nodes() < 6

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -3,7 +3,7 @@
 import time
 from collections import Counter, defaultdict
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.glyph_history import last_glyph
 from tnfr.metrics import _update_tg, _tg_state
 from tnfr.metrics.core import LATENT_GLYPH, TgCurr, TgRun
@@ -63,7 +63,7 @@ def test_update_tg_matches_naive(graph_canon):
         G.add_node(2, EPI_kind="NAV")
         G.add_node(3, EPI_kind="OZ")
         G.add_node(4, EPI_kind=LATENT_GLYPH)
-        attach_defaults(G)
+        inject_defaults(G)
 
     hist_opt = {}
     hist_ref = {}

--- a/tests/test_vf_coherencia.py
+++ b/tests/test_vf_coherencia.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 from tnfr.dynamics import step
 
 
 def test_vf_converge_to_neighbor_average_when_stable(graph_canon):
     G = graph_canon()
     G.add_edge(0, 1)
-    attach_defaults(G)
+    inject_defaults(G)
     # configuraciones para estabilidad
     G.graph["DNFR_WEIGHTS"] = {
         "phase": 1.0,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,10 @@
 import networkx as nx
-from tnfr.constants import attach_defaults
+from tnfr.constants import inject_defaults
 
 
 def build_graph(n):
     G = nx.Graph()
-    attach_defaults(G)
+    inject_defaults(G)
     for i in range(n):
         G.add_node(i, **{"θ": 0.0, "EPI": 0.0})
     return G


### PR DESCRIPTION
## Summary
- deprecate `attach_defaults` and forward to `inject_defaults`
- call `inject_defaults` directly in internal simulation setup
- update tests to use `inject_defaults`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9bb9d7708321b18a40b4434a0130