### PR TITLE
Optimize compute_coherence to single-pass summation

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -51,15 +51,29 @@ def compute_dnfr_accel_max(G) -> dict:
 
 def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
-    count = G.number_of_nodes()
+    dnfr_sum = 0.0
+    dnfr_c = 0.0
+    depi_sum = 0.0
+    depi_c = 0.0
+    count = 0
+    for _, nd in G.nodes(data=True):
+        dnfr_val = abs(get_attr(nd, ALIAS_DNFR, 0.0))
+        y = dnfr_val - dnfr_c
+        t = dnfr_sum + y
+        dnfr_c = (t - dnfr_sum) - y
+        dnfr_sum = t
+
+        depi_val = abs(get_attr(nd, ALIAS_dEPI, 0.0))
+        y = depi_val - depi_c
+        t = depi_sum + y
+        depi_c = (t - depi_sum) - y
+        depi_sum = t
+
+        count += 1
+
     if count:
-        dnfr_vals = []
-        depi_vals = []
-        for _, nd in G.nodes(data=True):
-            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
-            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
-        dnfr_mean = math.fsum(dnfr_vals) / count
-        depi_mean = math.fsum(depi_vals) / count
+        dnfr_mean = dnfr_sum / count
+        depi_mean = depi_sum / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)


### PR DESCRIPTION
## Summary
- streamline compute_coherence to iterate nodes once and compute ΔNFR & dEPI means via compensated summation, removing intermediate lists

## Testing
- `PYTHONPATH=src pytest tests/test_compute_coherence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9d641fa48321a8c538a56c718c26