### PR TITLE
Validate window parameter in observers

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -102,6 +102,8 @@ def glyph_load(G, window: int | None = None) -> dict:
       otherwise use the deque's maxlen.
     Returns a dict with proportions per glyph and useful aggregates.
     """
+    if window is not None and window <= 0:
+        raise ValueError("window must be positive")
     total = count_glyphs(G, window=window, last_only=(window == 1))
     dist, count = normalize_counter(total)
     if count == 0:
@@ -113,6 +115,8 @@ def glyph_load(G, window: int | None = None) -> dict:
 
 def wbar(G, window: int | None = None) -> float:
     """Return W̄ = mean of C(t) over a recent window."""
+    if window is not None and window <= 0:
+        raise ValueError("window must be positive")
     hist = G.graph.get("history", {})
     cs = hist.get("C_steps", [])
     if not cs:

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -132,6 +132,12 @@ def test_wbar_rejects_non_positive_window(graph_canon):
         wbar(G, window=0)
 
 
+def test_glyph_load_rejects_non_positive_window(graph_canon):
+    G = graph_canon()
+    with pytest.raises(ValueError):
+        glyph_load(G, window=0)
+
+
 def test_wbar_uses_default_window(graph_canon):
     G = graph_canon()
     hist = G.graph.setdefault("history", {})


### PR DESCRIPTION
## Summary
- validate positive `window` parameter before reading glyph or coherence history
- test for rejecting non-positive window values

## Testing
- `PYTHONPATH=src pytest tests/test_observers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9f84b9b883219781d6a9a841e658