### PR TITLE
feat: centralize logging with helper function

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -20,10 +20,11 @@ from typing import (
 )
 import logging
 from functools import lru_cache
+from .logging_utils import get_logger
 
 from .constants import ALIAS_VF, ALIAS_DNFR
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 T = TypeVar("T")
 

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, DefaultDict, TYPE_CHECKING
 from enum import Enum
 from collections import defaultdict, deque
 from collections.abc import Sequence
-import logging
+from .logging_utils import get_logger
 
 from .constants import DEFAULTS
 from .trace import CallbackSpec
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 __all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class CallbackEvent(str, Enum):

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -40,8 +40,9 @@ from .io import read_structured_file, safe_write
 from .helpers import list_mean
 from .observers import attach_standard_observer
 from . import __version__
+from .logging_utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 __all__ = [
     "main",

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -14,12 +14,13 @@ from typing import (
 import logging
 import math
 from itertools import islice
+from .logging_utils import get_logger
 
 from .value_utils import _convert_value
 
 T = TypeVar("T")
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 __all__ = [
     "MAX_MATERIALIZE_DEFAULT",

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import math
 from collections import deque
 from typing import Dict, Any, Literal
@@ -68,7 +67,9 @@ from .selector import (
     _apply_selector_hysteresis,
 )
 
-logger = logging.getLogger(__name__)
+from .logging_utils import get_logger
+
+logger = get_logger(__name__)
 
 
 def _update_node_sample(G, *, step: int) -> None:

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -13,9 +13,10 @@ from collections.abc import Mapping
 from .constants import ALIAS_THETA
 from .alias import get_attr
 from .helpers import node_set_checksum, edge_version_cache
+from .logging_utils import get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _ensure_kuramoto_cache(G, t) -> None:

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import importlib
 import warnings
-import logging
 from functools import lru_cache
 from typing import Any
 from collections import OrderedDict
 from dataclasses import dataclass, field
 import threading
+from .logging_utils import get_logger
 
 __all__ = ["optional_import", "get_numpy", "import_nodonx"]
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 _FAILED_IMPORT_LIMIT = 128  # keep only this many recent failures

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from functools import lru_cache
 import os
-import logging
+from .logging_utils import get_logger
 
 from .import_utils import optional_import
 import tempfile
@@ -97,7 +97,7 @@ def read_structured_file(path: Path) -> Any:
         raise StructuredFileError(path, e) from e
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def safe_write(

--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -1,0 +1,23 @@
+"""Logging utilities for TNFR.
+
+Provides a helper to obtain module-specific loggers with a
+consistent configuration across the project.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with a standard configuration."""
+
+    root = logging.getLogger()
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+        root.addHandler(handler)
+        root.setLevel(logging.INFO)
+    return logging.getLogger(name)

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -6,7 +6,6 @@ from collections import Counter, defaultdict
 from statistics import mean, median
 from typing import Any
 import heapq
-import logging
 import math
 
 from ..constants import (
@@ -30,9 +29,10 @@ from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks
 from ..observers import phase_sync, glyph_load, kuramoto_order
 from ..sense import sigma_vector
+from ..logging_utils import get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 LATENT_GLYPH = Glyph.SHA.value

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, TypeVar
 import logging
+from .logging_utils import get_logger
 
 T = TypeVar("T")
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 __all__ = ["_convert_value"]
 


### PR DESCRIPTION
## Summary
- add `logging_utils.get_logger` for consistent logging
- switch modules to use centralized logger helper

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda01729008321a32647ce1dac721a