### PR TITLE
Use math.fsum for coherence metric

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -51,29 +51,16 @@ def compute_dnfr_accel_max(G) -> dict:
 
 def compute_coherence(G) -> float:
     """Compute global coherence C(t) from ΔNFR and dEPI."""
-    dnfr_sum = 0.0
-    dnfr_c = 0.0
-    depi_sum = 0.0
-    depi_c = 0.0
-    count = 0
-    for _, nd in G.nodes(data=True):
-        dnfr_val = abs(get_attr(nd, ALIAS_DNFR, 0.0))
-        y = dnfr_val - dnfr_c
-        t = dnfr_sum + y
-        dnfr_c = (t - dnfr_sum) - y
-        dnfr_sum = t
-
-        depi_val = abs(get_attr(nd, ALIAS_dEPI, 0.0))
-        y = depi_val - depi_c
-        t = depi_sum + y
-        depi_c = (t - depi_sum) - y
-        depi_sum = t
-
-        count += 1
-
+    count = G.number_of_nodes()
     if count:
-        dnfr_mean = dnfr_sum / count
-        depi_mean = depi_sum / count
+        dnfr_mean = math.fsum(
+            abs(get_attr(nd, ALIAS_DNFR, 0.0))
+            for _, nd in G.nodes(data=True)
+        ) / count
+        depi_mean = math.fsum(
+            abs(get_attr(nd, ALIAS_dEPI, 0.0))
+            for _, nd in G.nodes(data=True)
+        ) / count
     else:
         dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)


### PR DESCRIPTION
## Summary
- simplify coherence calculation by using math.fsum on generator expressions

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda3f6a0648321838d7148b143b44c