### PR TITLE
Improve caching and safety across utilities

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -108,11 +108,27 @@ def safe_write(
     encoding: str | None = "utf-8",
     **open_kwargs: Any,
 ) -> None:
-    """Write to ``path`` ensuring parent directory exists and handle errors."""
+    """Write to ``path`` ensuring parent directory exists and handle errors.
+
+    Parameters
+    ----------
+    path:
+        Destination file path.
+    write:
+        Callback receiving the opened file object and performing the actual
+        write.
+    mode:
+        File mode passed to :func:`open`. Text modes (default) use UTF-8
+        encoding unless ``encoding`` is ``None``. When a binary mode is used
+        (``'b'`` in ``mode``) no encoding parameter is supplied so ``write`` may
+        write bytes.
+    encoding:
+        Encoding for text modes. Ignored for binary modes.
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     open_params = dict(mode=mode, **open_kwargs)
-    if encoding is not None:
+    if "b" not in mode and encoding is not None:
         open_params["encoding"] = encoding
     tmp_path: Path | None = None
     try:

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence, Iterable
+from typing import Any, Dict, Sequence, Iterable, Mapping
+from types import MappingProxyType
 import math
 
 from .constants import (
@@ -66,8 +67,8 @@ def compute_coherence(G) -> float:
     return 1.0 / (1.0 + dnfr_mean + depi_mean)
 
 
-def ensure_neighbors_map(G) -> Dict[Any, Sequence[Any]]:
-    """Return cached neighbors list keyed by node."""
+def ensure_neighbors_map(G) -> Mapping[Any, Sequence[Any]]:
+    """Return cached neighbors list keyed by node as a read-only mapping."""
     graph = G.graph
     edge_version = int(graph.get("_edge_version", 0))
     neighbors = graph.get("_neighbors")
@@ -75,7 +76,7 @@ def ensure_neighbors_map(G) -> Dict[Any, Sequence[Any]]:
         neighbors = {n: list(G.neighbors(n)) for n in G}
         graph["_neighbors"] = neighbors
         graph["_neighbors_version"] = edge_version
-    return neighbors
+    return MappingProxyType(neighbors)
 
 
 def get_Si_weights(G: Any) -> tuple[float, float, float]:


### PR DESCRIPTION
## Summary
- Avoid unnecessary digest collection in `node_set_checksum`
- Honor binary modes in `safe_write` and document behavior
- Harden callback registry and neighbor cache handling
- Cache serialized GAMMA specs and guard `wbar` history access

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda96d55c48321a18fe8bd9ad8aacb