### PR TITLE
Remove lock references from edge version cache entries

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -326,9 +326,9 @@ def edge_version_cache(
     Cache lookups and updates are serialized via ``_EDGE_CACHE_LOCK``.  A
     dedicated ``threading.Lock`` is maintained for each cache key so that
     different keys can be computed concurrently while still preventing
-    duplicate work for the same key.  Locks are kept in a
-    :class:`weakref.WeakValueDictionary` and are therefore cleaned up
-    automatically when their corresponding cache entries are evicted.
+    duplicate work for the same key.  Locks are stored in a
+    :class:`weakref.WeakValueDictionary` and thus cleaned up automatically
+    when no longer in use.
 
     When ``max_entries`` is a positive integer, only the most recent
     ``max_entries`` cache entries are kept (defaults to ``128``).  The
@@ -384,7 +384,7 @@ def edge_version_cache(
             entry = cache.get(key)
             if entry is not None and entry[0] == edge_version:
                 return entry[1]
-            cache[key] = (edge_version, value, lock)
+            cache[key] = (edge_version, value)
             return value
 
 


### PR DESCRIPTION
## Summary
- Simplify `edge_version_cache` to store only `(edge_version, value)` tuples
- Update cache entry logic and documentation to reflect removal of lock reference

## Testing
- `PYTHONPATH=src pytest tests/test_edge_version_cache_limit.py tests/test_edge_version_cache_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdacceb7848321a5bc762280b6b3c7