### PR TITLE
Add slots to operator classes

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -83,7 +83,12 @@ def operador_factory(*pairs: Tuple[str, str]) -> dict[str, type[Operador]]:
         cls = type(
             class_name,
             (Operador,),
-            {"name": nombre, "glyph": glyph, "__module__": __name__},
+            {
+                "name": nombre,
+                "glyph": glyph,
+                "__module__": __name__,
+                "__slots__": (),
+            },
         )
         registry[nombre] = cls
     return registry


### PR DESCRIPTION
## Summary
- prevent dynamic attributes in operador_factory by adding `__slots__` to generated classes

## Testing
- `PYTHONPATH=src pytest tests/test_structural.py tests/test_operators.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdad835af08321be3bd6aeb73f97de