### PR TITLE
Refactor heap pruning to iterative loop in HistoryDict

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -104,17 +104,20 @@ class HistoryDict(dict):
     def _prune_heap(self) -> None:
         """Pop entries until the heap meets ``target``, discarding stale ones."""
         target = len(self._counts) + self._compact_every
+        stack: list[tuple[int, str]] = []
 
-        def prune(target: int) -> None:
+        while True:
             while len(self._heap) > target:
                 cnt, key = heapq.heappop(self._heap)
                 if self._counts.get(key) != cnt:
                     continue
-                prune(target - 1)
-                heapq.heappush(self._heap, (cnt, key))
+                stack.append((cnt, key))
+                target -= 1
+            if not stack:
                 break
-
-        prune(target)
+            cnt, key = stack.pop()
+            heapq.heappush(self._heap, (cnt, key))
+            target += 1
 
     def _pop_heap_key(self) -> str:
         """Pop and return the key with the smallest count from the heap."""


### PR DESCRIPTION
## Summary
- Replace recursive `_prune_heap` with iterative `while` loop to maintain heap size without recursion

## Testing
- `pytest tests/test_history_heap_bound.py tests/test_history_maxlen.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdae24366483218121e8c6386db388