### PR TITLE
Use comprehension for node digest tuple

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -260,19 +260,19 @@ def node_set_checksum(
     hasher = hashlib.blake2b(digest_size=16)
 
     if store:
-        digests: list[bytes] = []
-        for n in node_iterable:
-            d = hashlib.blake2b(
+        digest_tuple = tuple(
+            hashlib.blake2b(
                 _node_repr(n).encode("utf-8"), digest_size=16
             ).digest()
-            hasher.update(d)
-            digests.append(d)
-
-        digest_tuple = tuple(digests)
+            for n in node_iterable
+        )
 
         cached = graph.get("_node_set_checksum_cache")
         if cached and cached[0] == digest_tuple:
             return cached[1]
+
+        for d in digest_tuple:
+            hasher.update(d)
 
         checksum = hasher.hexdigest()
         graph["_node_set_checksum_cache"] = (digest_tuple, checksum)


### PR DESCRIPTION
## Summary
- build `digest_tuple` directly with a tuple comprehension
- hash and cache using the new digest tuple

## Testing
- `PYTHONPATH=src pytest tests/test_node_set_checksum.py`

------
https://chatgpt.com/codex/tasks/task_e_68bdb28664c8832195408c788a3c28ea