### PR TITLE
Refactor internal utilities for precision and performance

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -64,13 +64,17 @@ __all__ = [
 
 
 def _flatten_tokens(obj: Any):
-    """Recursive generator yielding each token in order."""
+    """Iteratively yield each token in order."""
 
-    if isinstance(obj, Sequence) and not isinstance(obj, str):
-        for item in obj:
-            yield from _flatten_tokens(item)
-    else:
-        yield obj
+    stack = [iter([obj])]
+    while stack:
+        for item in stack[-1]:
+            if isinstance(item, Sequence) and not isinstance(item, str):
+                stack.append(iter(item))
+                break
+            yield item
+        else:
+            stack.pop()
 
 
 def validate_token(tok: Any, pos: int) -> Any:

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -86,15 +86,16 @@ def _update_node_sample(G, *, step: int) -> None:
     graph = G.graph
     limit = int(graph.get("UM_CANDIDATE_COUNT", 0))
     current_n = G.number_of_nodes()
-    if limit <= 0 or current_n < 50 or limit >= current_n:
-        nodes = tuple(G.nodes())
-        graph["_node_sample"] = nodes
-        graph["_node_list"] = nodes
-        graph["_node_list_len"] = current_n
-        graph.pop("_node_list_checksum", None)
-        return
     nodes = graph.get("_node_list")
     stored_len = graph.get("_node_list_len")
+    if limit <= 0 or current_n < 50 or limit >= current_n:
+        if nodes is None or stored_len != current_n:
+            nodes = tuple(G.nodes())
+            graph["_node_list"] = nodes
+            graph["_node_list_len"] = current_n
+        graph["_node_sample"] = nodes
+        graph.pop("_node_list_checksum", None)
+        return
     dirty = bool(graph.pop("_node_list_dirty", False))
     if nodes is None or stored_len != current_n or dirty:
         nodes = tuple(G.nodes())

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -59,11 +59,8 @@ def _warn_failure(module: str, attr: str | None, err: Exception) -> None:
         first = module not in _WARNED_MODULES
         if first:
             _WARNED_MODULES.add(module)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
     logger.warning(msg)
-    if first:
-        warnings.warn(msg, RuntimeWarning, stacklevel=2)
-    else:
-        warnings.warn(msg, RuntimeWarning)
 
 
 @lru_cache(maxsize=128)

--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -7,17 +7,23 @@ consistent configuration across the project.
 from __future__ import annotations
 
 import logging
+import threading
+
+_LOCK = threading.Lock()
 
 
 def get_logger(name: str) -> logging.Logger:
     """Return a logger with a standard configuration."""
 
-    root = logging.getLogger()
-    if not root.handlers:
-        handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        )
-        root.addHandler(handler)
-        root.setLevel(logging.INFO)
+    with _LOCK:
+        root = logging.getLogger()
+        if not root.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                )
+            )
+            root.addHandler(handler)
+            root.setLevel(logging.INFO)
     return logging.getLogger(name)

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -118,17 +118,22 @@ def _sigma_from_iterable(
             "n": 0,
         }
 
-    xs = [first.real]
-    ys = [first.imag]
+    sum_x = first.real
+    sum_y = first.imag
+    c_x = 0.0
+    c_y = 0.0
     cnt = 1
     for z in iterator:
         zc = _to_complex(z)
-        xs.append(zc.real)
-        ys.append(zc.imag)
+        x_val = zc.real - c_x
+        t_x = sum_x + x_val
+        c_x = (t_x - sum_x) - x_val
+        sum_x = t_x
+        y_val = zc.imag - c_y
+        t_y = sum_y + y_val
+        c_y = (t_y - sum_y) - y_val
+        sum_y = t_y
         cnt += 1
-
-    sum_x = math.fsum(xs)
-    sum_y = math.fsum(ys)
     x = sum_x / cnt
     y = sum_y / cnt
     mag = math.hypot(x, y)

--- a/tests/test_cli_flatten_tokens.py
+++ b/tests/test_cli_flatten_tokens.py
@@ -4,3 +4,10 @@ from tnfr.cli import _flatten_tokens
 def test_flatten_tokens_accepts_tuples():
     data = ("a", ("b", ["c", ("d",)]))
     assert list(_flatten_tokens(data)) == ["a", "b", "c", "d"]
+
+
+def test_flatten_tokens_handles_deep_nesting():
+    data = "z"
+    for _ in range(1000):
+        data = [data]
+    assert list(_flatten_tokens(data)) == ["z"]

--- a/tests/test_is_immutable.py
+++ b/tests/test_is_immutable.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import Any
 
 from tnfr.constants import _is_immutable, _is_immutable_inner
 
@@ -69,3 +70,12 @@ class MutableDC:
 
 def test_is_immutable_mutable_dataclass():
     assert not _is_immutable(MutableDC([1, 2]))
+
+
+def test_is_immutable_detects_cycles():
+    lst: list[Any] = []
+    lst.append(lst)
+    assert not _is_immutable(lst)
+    d: dict[str, Any] = {}
+    d["self"] = d
+    assert not _is_immutable(d)

--- a/tests/test_logging_threadsafe.py
+++ b/tests/test_logging_threadsafe.py
@@ -1,0 +1,16 @@
+from concurrent.futures import ThreadPoolExecutor
+import logging
+
+from tnfr.logging_utils import get_logger
+
+
+def _worker():
+    get_logger("test_logger")
+
+
+def test_get_logger_threadsafe():
+    root = logging.getLogger()
+    root.handlers.clear()
+    with ThreadPoolExecutor(max_workers=32) as ex:
+        list(ex.map(lambda _: _worker(), range(64)))
+    assert len(root.handlers) == 1

--- a/tests/test_neighbors_map_cache.py
+++ b/tests/test_neighbors_map_cache.py
@@ -1,0 +1,16 @@
+import networkx as nx
+
+from tnfr.metrics_utils import ensure_neighbors_map
+from tnfr.helpers import increment_edge_version
+
+
+def test_neighbors_map_reuses_proxy():
+    G = nx.Graph()
+    G.add_edge(1, 2)
+    first = ensure_neighbors_map(G)
+    second = ensure_neighbors_map(G)
+    assert first is second
+    G.add_edge(2, 3)
+    increment_edge_version(G)
+    third = ensure_neighbors_map(G)
+    assert third is not first

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -28,7 +28,7 @@ def test_optional_import_clears_failures(monkeypatch):
     assert "fake_mod" not in _IMPORT_STATE
 
 
-def test_warns_with_stacklevel_2_only_once(monkeypatch):
+def test_warns_once_with_stacklevel_2(monkeypatch):
     def fake_import(name):
         raise ImportError("boom")
 
@@ -44,7 +44,7 @@ def test_warns_with_stacklevel_2_only_once(monkeypatch):
     optional_import("fake_mod.attr1")
     optional_import("fake_mod.attr2")
     optional_import.cache_clear()
-    assert stacklevels == [2, 1]
+    assert stacklevels == [2]
 
 
 def test_optional_import_removes_entry_on_success(monkeypatch):


### PR DESCRIPTION
## Summary
- avoid double traversal in coherence metric and cache neighbor proxy
- add immutability cycle detection
- improve optional import warnings, logging, token flattening, sigma accumulation, node sampling, glyph history, and more

## Testing
- `PYTHONPATH=src pytest tests/test_compute_coherence.py::test_compute_coherence_typical tests/test_compute_coherence.py::test_compute_coherence_precision_improved -q`
- `PYTHONPATH=src pytest tests/test_is_immutable.py::test_is_immutable_detects_cycles tests/test_is_immutable.py::test_is_immutable_nested_structures tests/test_is_immutable.py::test_is_immutable_detects_mutable tests/test_is_immutable.py::test_is_immutable_detects_set_and_bytearray tests/test_is_immutable.py::test_is_immutable_lists_dicts_nested tests/test_is_immutable.py::test_is_immutable_inner_handles_mapping_tag tests/test_is_immutable.py::test_is_immutable_inner_handles_dict_tag tests/test_is_immutable.py::test_is_immutable_inner_handles_set_tag tests/test_is_immutable.py::test_is_immutable_inner_handles_bytearray_tag tests/test_is_immutable.py::test_is_immutable_frozen_dataclass tests/test_is_immutable.py::test_is_immutable_mutable_dataclass -q`
- `PYTHONPATH=src pytest tests/test_optional_import.py::test_warns_once_with_stacklevel_2 tests/test_optional_import.py::test_optional_import_clears_failures tests/test_optional_import.py::test_optional_import_removes_entry_on_success -q`
- `PYTHONPATH=src pytest tests/test_logging_threadsafe.py::test_get_logger_threadsafe -q`
- `PYTHONPATH=src pytest tests/test_count_glyphs.py::test_count_glyphs_last_only_and_window tests/test_count_glyphs.py::test_count_glyphs_non_positive_window -q`
- `PYTHONPATH=src pytest tests/test_sense.py::test_sigma_vector_node_paths tests/test_sense.py::test_sigma_vector_from_graph_paths tests/test_sense.py::test_sigma_vector_from_graph_matches_naive tests/test_sense.py::test_sigma_from_vectors_accepts_single_complex tests/test_sense.py::test_sigma_from_vectors_rejects_invalid_iterable tests/test_sense.py::test_sigma_from_iterable_accepts_reals tests/test_sense.py::test_unknown_glyph_raises -q`
- `PYTHONPATH=src pytest tests/test_neighbors_map_cache.py::test_neighbors_map_reuses_proxy tests/test_compute_Si_numpy_usage.py::test_compute_Si_calls_get_numpy_once_and_propagates -q`
- `PYTHONPATH=src pytest tests/test_node_sample.py::test_node_sample_large_graph tests/test_node_sample.py::test_node_sample_small_graph tests/test_node_sample.py::test_node_sample_immutable_after_graph_change tests/test_node_sample.py::test_node_sample_deterministic_across_hashseed -q`
- `PYTHONPATH=src pytest tests/test_cli_flatten_tokens.py::test_flatten_tokens_accepts_tuples tests/test_cli_flatten_tokens.py::test_flatten_tokens_handles_deep_nesting -q`
- `PYTHONPATH=src pytest tests/test_history_heap_bound.py::test_heap_size_stays_bounded_under_churn tests/test_history_heap_bound.py::test_heap_size_skewed_churn -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb84901148321ab282c4fd29499c6