### PR TITLE
Normalize user-facing messages to English

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -95,7 +95,7 @@ def _alias_resolve(
             if not strict:
                 lvl = log_level if log_level is not None else logging.DEBUG
                 logger.log(
-                    lvl, "No se pudo convertir el valor para %r: %s", key, exc
+                    lvl, "Could not convert value for %r: %s", key, exc
                 )
     if default is not None:
         try:
@@ -105,16 +105,16 @@ def _alias_resolve(
             if not strict:
                 lvl = logging.WARNING if log_level is None else log_level
                 logger.log(
-                    lvl, "No se pudo convertir el valor para 'default': %s", exc
+                    lvl, "Could not convert value for 'default': %s", exc
                 )
 
     if errors:
         if strict:
             err_msg = "; ".join(f"{k!r}: {e}" for k, e in errors)
-            raise ValueError(f"No se pudieron convertir valores para {err_msg}")
+            raise ValueError(f"Could not convert values for {err_msg}")
         lvl = log_level if log_level is not None else logging.DEBUG
         summary = "; ".join(f"{k!r}: {e}" for k, e in errors)
-        logger.log(lvl, "No se pudieron convertir valores para %s", summary)
+        logger.log(lvl, "Could not convert values for %s", summary)
 
     return None
 

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -114,8 +114,8 @@ def normalize_weights(
         weights[k] = w
     if negatives:
         if error_on_negative:
-            raise ValueError(f"Pesos negativos detectados: {negatives}")
-        logger.warning("Pesos negativos detectados: %s", negatives)
+            raise ValueError(f"Negative weights detected: {negatives}")
+        logger.warning("Negative weights detected: %s", negatives)
     total = math.fsum(weights.values())
     if total <= 0:
         uniform = 1.0 / len(keys)

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -33,7 +33,7 @@ else:  # pragma: no cover - depende de pyyaml
 
 def _missing_dependency(name: str) -> Callable[[str], Any]:
     def _raise(_: str) -> Any:
-        raise ImportError(f"{name} no está instalado")
+        raise ImportError(f"{name} is not installed")
 
     return _raise
 
@@ -61,21 +61,21 @@ def _get_parser(suffix: str) -> Callable[[str], Any]:
 
 
 ERROR_MESSAGES = {
-    OSError: "No se pudo leer {path}: {e}",
-    UnicodeDecodeError: "Error de codificación al leer {path}: {e}",
-    json.JSONDecodeError: "Error al parsear archivo JSON en {path}: {e}",
-    YAMLError: "Error al parsear archivo YAML en {path}: {e}",
-    ImportError: "Dependencia faltante al parsear {path}: {e}",
+    OSError: "Could not read {path}: {e}",
+    UnicodeDecodeError: "Encoding error while reading {path}: {e}",
+    json.JSONDecodeError: "Error parsing JSON file at {path}: {e}",
+    YAMLError: "Error parsing YAML file at {path}: {e}",
+    ImportError: "Missing dependency parsing {path}: {e}",
 }
 if has_toml:
-    ERROR_MESSAGES[TOMLDecodeError] = "Error al parsear archivo TOML en {path}: {e}"
+    ERROR_MESSAGES[TOMLDecodeError] = "Error parsing TOML file at {path}: {e}"
 
 
 def _format_structured_file_error(path: Path, e: Exception) -> str:
     for exc, msg in ERROR_MESSAGES.items():
         if isinstance(e, exc):
             return msg.format(path=path, e=e)
-    return f"Error al parsear {path}: {e}"
+    return f"Error parsing {path}: {e}"
 
 
 class StructuredFileError(Exception):

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -34,7 +34,7 @@ def _convert_value(
             raise
         level = log_level if log_level is not None else logging.DEBUG
         if key is not None:
-            logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)
+            logger.log(level, "Could not convert value for %r: %s", key, exc)
         else:
-            logger.log(level, "No se pudo convertir el valor: %s", exc)
+            logger.log(level, "Could not convert value: %s", exc)
         return False, None

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -1,4 +1,4 @@
-"""Pruebas de alias get strict."""
+"""Tests for ``alias_get`` in strict mode."""
 
 import logging
 import pytest
@@ -10,14 +10,14 @@ def test_alias_get_logs_on_error(caplog):
     with caplog.at_level(logging.DEBUG):
         result = alias_get(d, ("x",), int)
     assert result is None
-    assert any("No se pudo convertir" in m for m in caplog.messages)
+    assert any("Could not convert" in m for m in caplog.messages)
 
 
 def test_alias_get_custom_log_level(caplog):
     d = {"x": "abc"}
     with caplog.at_level(logging.WARNING):
         alias_get(d, ("x",), int, log_level=logging.WARNING)
-    assert any("No se pudo convertir" in m for m in caplog.messages)
+    assert any("Could not convert" in m for m in caplog.messages)
 
 
 def test_alias_get_strict_raises():

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -1,4 +1,4 @@
-"""Pruebas de load_config y apply_config."""
+"""Tests for ``load_config`` and ``apply_config``."""
 
 import json
 import networkx as nx
@@ -19,7 +19,7 @@ except ImportError:  # pragma: no cover - skip if not installed
             ".yaml",
             lambda data: yaml.safe_dump(data),
             marks=pytest.mark.skipif(
-                yaml is None, reason="pyyaml no está instalado"
+                yaml is None, reason="pyyaml not installed"
             ),
         ),
     ],

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -9,7 +9,7 @@ def test_normalize_weights_warns_on_negative_value(caplog):
     weights = {"a": -1.0, "b": 2.0}
     with caplog.at_level("WARNING"):
         norm = normalize_weights(weights, ("a", "b"))
-    assert any("Pesos negativos" in m for m in caplog.messages)
+    assert any("Negative weights" in m for m in caplog.messages)
     assert norm["a"] == 0.0
     assert math.isclose(norm["b"], 1.0)
 
@@ -23,7 +23,7 @@ def test_normalize_weights_raises_on_negative_value():
 def test_normalize_weights_warns_on_negative_default(caplog):
     with caplog.at_level("WARNING"):
         normalize_weights({}, ("a", "b"), default=-0.5)
-    assert any("Pesos negativos" in m for m in caplog.messages)
+    assert any("Negative weights" in m for m in caplog.messages)
 
 
 def test_normalize_weights_raises_on_negative_default():
@@ -35,7 +35,7 @@ def test_normalize_weights_warns_on_non_numeric_value(caplog):
     weights = {"a": "not-a-number", "b": 2.0}
     with caplog.at_level("WARNING"):
         norm = normalize_weights(weights, ("a", "b"), default=1.0)
-    assert any("No se pudo convertir" in m for m in caplog.messages)
+    assert any("Could not convert" in m for m in caplog.messages)
     assert math.isclose(math.fsum(norm.values()), 1.0)
     assert norm == pytest.approx({"a": 1 / 3, "b": 2 / 3})
 

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -1,4 +1,4 @@
-"""Pruebas de read structured file errors."""
+"""Tests for ``read_structured_file`` error handling."""
 
 import pytest
 import importlib.util
@@ -14,7 +14,7 @@ def test_read_structured_file_missing_file(tmp_path: Path):
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("No se pudo leer")
+    assert msg.startswith("Could not read")
     assert str(path) in msg
 
 
@@ -43,7 +43,7 @@ def test_read_structured_file_permission_error(
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("No se pudo leer")
+    assert msg.startswith("Could not read")
     assert str(path) in msg
 
 
@@ -53,7 +53,7 @@ def test_read_structured_file_corrupt_json(tmp_path: Path):
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Error al parsear archivo JSON en")
+    assert msg.startswith("Error parsing JSON file at")
     assert str(path) in msg
 
 
@@ -64,7 +64,7 @@ def test_read_structured_file_corrupt_yaml(tmp_path: Path):
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Error al parsear archivo YAML en")
+    assert msg.startswith("Error parsing YAML file at")
     assert str(path) in msg
 
 
@@ -76,7 +76,7 @@ def test_read_structured_file_corrupt_toml(tmp_path: Path):
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Error al parsear archivo TOML en")
+    assert msg.startswith("Error parsing TOML file at")
     assert str(path) in msg
 
 
@@ -87,7 +87,7 @@ def test_read_structured_file_missing_dependency(
     path.write_text("a: 1", encoding="utf-8")
 
     def fake_safe_load(_: str) -> None:
-        raise ImportError("pyyaml no está instalado")
+        raise ImportError("pyyaml is not installed")
 
     monkeypatch.setattr(io_mod, "yaml", type("Y", (), {"safe_load": fake_safe_load}))
     io_mod._get_parser.cache_clear()
@@ -95,7 +95,7 @@ def test_read_structured_file_missing_dependency(
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Dependencia faltante al parsear")
+    assert msg.startswith("Missing dependency parsing")
     assert str(path) in msg
     assert "pyyaml" in msg
 
@@ -107,7 +107,7 @@ def test_read_structured_file_missing_dependency_toml(
     path.write_text("a = 1", encoding="utf-8")
 
     def fake_loads(_: str) -> None:
-        raise ImportError("toml no está instalado")
+        raise ImportError("toml is not installed")
 
     monkeypatch.setattr(io_mod, "tomllib", type("T", (), {"loads": fake_loads}))
     io_mod._get_parser.cache_clear()
@@ -115,7 +115,7 @@ def test_read_structured_file_missing_dependency_toml(
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Dependencia faltante al parsear")
+    assert msg.startswith("Missing dependency parsing")
     assert str(path) in msg
     assert "toml" in msg.lower()
 
@@ -126,7 +126,7 @@ def test_read_structured_file_unicode_error(tmp_path: Path):
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Error de codificación al leer")
+    assert msg.startswith("Encoding error while reading")
     assert str(path) in msg
 
 
@@ -139,8 +139,8 @@ def test_json_error_not_reported_as_toml(monkeypatch: pytest.MonkeyPatch) -> Non
 
     err = JSONDecodeError("msg", "", 0)
     msg = io_mod._format_structured_file_error(Path("data.json"), err)
-    assert msg.startswith("Error al parsear archivo JSON en")
-    assert not msg.startswith("Error al parsear archivo TOML")
+    assert msg.startswith("Error parsing JSON file at")
+    assert not msg.startswith("Error parsing TOML file")
 
 
 def test_import_error_not_reported_as_toml(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -152,8 +152,8 @@ def test_import_error_not_reported_as_toml(monkeypatch: pytest.MonkeyPatch) -> N
 
     err = ImportError("dep missing")
     msg = io_mod._format_structured_file_error(Path("data.toml"), err)
-    assert msg.startswith("Dependencia faltante al parsear")
-    assert not msg.startswith("Error al parsear archivo TOML")
+    assert msg.startswith("Missing dependency parsing")
+    assert not msg.startswith("Error parsing TOML file")
 
 
 def test_read_structured_file_ignores_missing_yaml_when_parsing_json(
@@ -181,5 +181,5 @@ def test_read_structured_file_unhandled_error(
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
     msg = str(excinfo.value)
-    assert msg.startswith("Error al parsear")
+    assert msg.startswith("Error parsing")
     assert str(path) in msg

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,4 @@
-"""Pruebas de validators."""
+"""Tests for validators."""
 
 import pytest
 from tnfr.scenarios import build_graph
@@ -55,7 +55,7 @@ def test_validator_sigma_norm(monkeypatch):
         run_validators(G)
 
 
-def test_validator_glyph_invalido():
+def test_validator_invalid_glyph():
     G = _base_graph()
     n0 = list(G.nodes())[0]
     set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
@@ -64,7 +64,7 @@ def test_validator_glyph_invalido():
         run_validators(G)
 
 
-def test_validator_glyph_valido():
+def test_validator_valid_glyph():
     G = _base_graph()
     run_validators(G)
 
@@ -76,7 +76,7 @@ def test_read_structured_file_json(tmp_path):
     assert data == {"x": 1}
 
 
-@pytest.mark.skipif(tomllib is None, reason="tomllib/tomli no está instalado")
+@pytest.mark.skipif(tomllib is None, reason="tomllib/tomli not installed")
 def test_read_structured_file_toml(tmp_path):
     path = tmp_path / "cfg.toml"
     path.write_text("x = 1", encoding="utf-8")


### PR DESCRIPTION
## Summary
- translate negative weight warnings to English
- replace Spanish structured file I/O error messages with English variants
- convert value/alias conversion logs and related tests to English

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdbbcb3b308321a76b86e59125b730