### PR TITLE
refactor: respect existing logging config

### DIFF
--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -18,12 +18,9 @@ def get_logger(name: str) -> logging.Logger:
     with _LOCK:
         root = logging.getLogger()
         if not root.handlers:
-            handler = logging.StreamHandler()
-            handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-                )
+            level = root.level if root.level != logging.WARNING else logging.INFO
+            logging.basicConfig(
+                level=level,
+                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             )
-            root.addHandler(handler)
-            root.setLevel(logging.INFO)
     return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- avoid altering root logger if configured
- use `logging.basicConfig` with previous level when needed

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdbd2153d883219879a09e883dee3f