### PR TITLE
Refine caching and utility helpers

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -149,7 +149,7 @@ def add_edge(
     if weight is None:
         return
 
-    if (exists_cb is None) ^ (set_cb is None):
+    if (exists_cb is None) != (set_cb is None):
         raise ValueError("exists_cb and set_cb must be provided together")
 
     if exists_cb is None and set_cb is None:

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -59,6 +59,7 @@ def set_cache_maxsize(size: int) -> None:
     new_size = int(size)
     with _RNG_LOCK:
         _CACHE_MAXSIZE = new_size
+        _RNG_CACHE.clear()
         if new_size > 0:
             _RNG_CACHE = LRUCache(maxsize=new_size)
         else:


### PR DESCRIPTION
## Summary
- keep edge version cache locks with strong references and reuse cached recursion limit
- simplify node edge validation and collection utilities
- prune history heap lazily and streamline glyph counting
- clear RNG cache when resizing

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdbabe8b7483218f38914bb476e984