### PR TITLE
feat: vectorize cos-sin computation

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -153,6 +153,18 @@ def _configure_dnfr_weights(G) -> dict:
     return weights
 
 
+def _compute_cos_sin(theta_list):
+    """Return ``(cos(theta), sin(theta))`` for ``theta_list``.
+
+    When :mod:`numpy` is available the computation is vectorised.
+    """
+    np = get_numpy()
+    if np is not None:
+        arr = np.array(theta_list, dtype=float)
+        return list(np.cos(arr)), list(np.sin(arr))
+    return [math.cos(t) for t in theta_list], [math.sin(t) for t in theta_list]
+
+
 def _init_dnfr_cache(G, nodes, prev_cache, checksum, dirty):
     """Initialise or reuse cached ΔNFR arrays."""
     if prev_cache and prev_cache.get("checksum") == checksum and not dirty:
@@ -168,8 +180,7 @@ def _init_dnfr_cache(G, nodes, prev_cache, checksum, dirty):
     theta = [0.0] * len(nodes)
     epi = [0.0] * len(nodes)
     vf = [0.0] * len(nodes)
-    cos_theta = [0.0] * len(nodes)
-    sin_theta = [0.0] * len(nodes)
+    cos_theta, sin_theta = _compute_cos_sin(theta)
     cache = {
         "checksum": checksum,
         "idx": idx,
@@ -192,8 +203,9 @@ def _refresh_dnfr_vectors(G, nodes, theta, epi, vf, cos_theta, sin_theta):
         theta[i] = th
         epi[i] = get_attr(nd, ALIAS_EPI, 0.0)
         vf[i] = get_attr(nd, ALIAS_VF, 0.0)
-        cos_theta[i] = math.cos(th)
-        sin_theta[i] = math.sin(th)
+    cos_vals, sin_vals = _compute_cos_sin(theta)
+    cos_theta[:] = cos_vals
+    sin_theta[:] = sin_vals
 
 
 def _prepare_dnfr_data(G, *, cache_size: int | None = 1) -> dict:

--- a/tests/test_dynamics_helpers.py
+++ b/tests/test_dynamics_helpers.py
@@ -8,6 +8,7 @@ from tnfr.dynamics import (
     _refresh_dnfr_vectors,
     _compute_neighbor_means,
     _choose_glyph,
+    _compute_cos_sin,
 )
 from tnfr.grammar import AL, EN
 
@@ -24,6 +25,28 @@ def test_init_and_refresh_dnfr_cache(graph_canon):
     cache2, *_rest, refreshed2 = _init_dnfr_cache(G, nodes, cache, 1, False)
     assert not refreshed2
     assert cache2 is cache
+
+
+def test_compute_cos_sin_uses_numpy(monkeypatch):
+    calls = []
+
+    class FakeNP:
+        def array(self, arr, dtype=float):
+            return arr
+
+        def cos(self, arr):
+            calls.append("cos")
+            return [1.0] * len(arr)
+
+        def sin(self, arr):
+            calls.append("sin")
+            return [0.0] * len(arr)
+
+    monkeypatch.setattr("tnfr.dynamics.get_numpy", lambda: FakeNP())
+    cos, sin = _compute_cos_sin([0.0, 1.0])
+    assert calls == ["cos", "sin"]
+    assert cos == [1.0, 1.0]
+    assert sin == [0.0, 0.0]
 
 
 def test_compute_neighbor_means_list():


### PR DESCRIPTION
## Summary
- add `_compute_cos_sin` helper with optional numpy vectorization
- reuse new helper in `_init_dnfr_cache` and `_refresh_dnfr_vectors`
- cover helper with dedicated unit test

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddf0543488321884d0dfb262bf7d5