### PR TITLE
Aggregate alias resolution errors into a single log

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -92,27 +92,20 @@ def _alias_resolve(
             return conv(d[key])
         except (ValueError, TypeError) as exc:
             errors.append((key, exc))
-            if not strict:
-                lvl = log_level if log_level is not None else logging.DEBUG
-                logger.log(
-                    lvl, "Could not convert value for %r: %s", key, exc
-                )
     if default is not None:
         try:
             return conv(default)
         except (ValueError, TypeError) as exc:
             errors.append(("default", exc))
-            if not strict:
-                lvl = logging.WARNING if log_level is None else log_level
-                logger.log(
-                    lvl, "Could not convert value for 'default': %s", exc
-                )
 
     if errors:
         if strict:
             err_msg = "; ".join(f"{k!r}: {e}" for k, e in errors)
             raise ValueError(f"Could not convert values for {err_msg}")
-        lvl = log_level if log_level is not None else logging.DEBUG
+        if log_level is not None:
+            lvl = log_level
+        else:
+            lvl = logging.WARNING if any(k == "default" for k, _ in errors) else logging.DEBUG
         summary = "; ".join(f"{k!r}: {e}" for k, e in errors)
         logger.log(lvl, "Could not convert values for %s", summary)
 

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -13,6 +13,16 @@ def test_alias_get_logs_on_error(caplog):
     assert any("Could not convert" in m for m in caplog.messages)
 
 
+def test_alias_get_logs_once_for_multiple_errors(caplog):
+    d = {"x": "abc", "y": "def"}
+    with caplog.at_level(logging.DEBUG):
+        result = alias_get(d, ("x", "y"), int)
+    assert result is None
+    messages = [m for m in caplog.messages if "Could not convert" in m]
+    assert len(messages) == 1
+    assert "'x'" in messages[0] and "'y'" in messages[0]
+
+
 def test_alias_get_custom_log_level(caplog):
     d = {"x": "abc"}
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary
- simplify `_alias_resolve` error handling to collect all conversion failures and log them once
- log at WARNING when default value conversion fails, otherwise at DEBUG
- add regression test ensuring multiple conversion errors produce a single log entry

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde23f705c8321beb65a31a96d2640