### PR TITLE
Warn modules only once

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -59,7 +59,12 @@ def _warn_failure(module: str, attr: str | None, err: Exception) -> None:
         first = module not in _WARNED_MODULES
         if first:
             _WARNED_MODULES.add(module)
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+
+    if not first:
+        logger.debug(msg)
+        return
+
+    warnings.warn(msg, RuntimeWarning, stacklevel=2)
     logger.warning(msg)
 
 

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -1,5 +1,6 @@
 import types
 import importlib
+import logging
 
 import tnfr.import_utils as import_utils
 from tnfr.import_utils import (
@@ -28,22 +29,25 @@ def test_optional_import_clears_failures(monkeypatch):
     assert "fake_mod" not in _IMPORT_STATE
 
 
-def test_warns_once_with_stacklevel_2(monkeypatch):
+def test_warns_once_then_debug(monkeypatch, caplog):
     def fake_import(name):
         raise ImportError("boom")
 
     monkeypatch.setattr(importlib, "import_module", fake_import)
 
-    stacklevels = []
+    stacklevels: list[int] = []
 
     def fake_warn(msg, category=None, stacklevel=1):
         stacklevels.append(stacklevel)
 
     monkeypatch.setattr(import_utils.warnings, "warn", fake_warn)
     optional_import.cache_clear()
-    optional_import("fake_mod.attr1")
-    optional_import("fake_mod.attr2")
+    with caplog.at_level(logging.DEBUG, logger=import_utils.logger.name):
+        optional_import("fake_mod.attr1")
+        optional_import("fake_mod.attr2")
     optional_import.cache_clear()
+    records = [r.levelno for r in caplog.records if r.name == import_utils.logger.name]
+    assert records == [logging.WARNING, logging.DEBUG]
     assert stacklevels == [2]
 
 


### PR DESCRIPTION
## Summary
- only warn once per module when optional import fails
- log subsequent import failures at DEBUG level
- expand tests for optional imports to cover new logging policy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde2dd865883218ed558ec565288a9