### PR TITLE
Remove parser cache in structured file parser

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import Any, Callable
 import json
 from pathlib import Path
-from functools import lru_cache
 import os
 from .logging_utils import get_logger
 
@@ -52,12 +51,11 @@ PARSERS = {
 }
 
 
-@lru_cache(maxsize=None)
 def _get_parser(suffix: str) -> Callable[[str], Any]:
-    parser = PARSERS.get(suffix)
-    if parser is None:
-        raise ValueError(f"Unsupported suffix: {suffix}")
-    return parser
+    try:
+        return PARSERS[suffix]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported suffix: {suffix}") from exc
 
 
 ERROR_MESSAGES = {

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -90,7 +90,6 @@ def test_read_structured_file_missing_dependency(
         raise ImportError("pyyaml is not installed")
 
     monkeypatch.setattr(io_mod, "yaml", type("Y", (), {"safe_load": fake_safe_load}))
-    io_mod._get_parser.cache_clear()
 
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
@@ -110,7 +109,6 @@ def test_read_structured_file_missing_dependency_toml(
         raise ImportError("toml is not installed")
 
     monkeypatch.setattr(io_mod, "tomllib", type("T", (), {"loads": fake_loads}))
-    io_mod._get_parser.cache_clear()
 
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
@@ -163,7 +161,6 @@ def test_read_structured_file_ignores_missing_yaml_when_parsing_json(
     path.write_text("{\"a\": 1}", encoding="utf-8")
     monkeypatch.setattr(io_mod, "yaml", None)
     monkeypatch.setattr(io_mod, "tomllib", None)
-    io_mod._get_parser.cache_clear()
     assert read_structured_file(path) == {"a": 1}
 
 


### PR DESCRIPTION
## Summary
- Drop `lru_cache` from `_get_parser` for structured file parsing
- Simplify `_get_parser` to direct dictionary lookup and handle unsupported suffixes
- Adjust tests to reflect non-cached parser retrieval

## Testing
- `PYTHONPATH=src pytest tests/test_read_structured_file_errors.py tests/test_validators.py::test_read_structured_file_json tests/test_validators.py::test_read_structured_file_toml tests/test_validators.py::test_read_structured_file_invalid_extension -q`

------
https://chatgpt.com/codex/tasks/task_e_68bde386b6c083219e3e1d6cc1a0b8c0