### PR TITLE
Short-circuit recent_glyph when window is zero

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -44,6 +44,8 @@ def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
 
 def recent_glyph(nd: Dict[str, Any], glyph: str, window: int) -> bool:
     """Return ``True`` if ``glyph`` appeared in last ``window`` emissions."""
+    if window == 0:
+        return False
     window = _validate_window(window)
     if window == 0:
         return False

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -26,6 +26,12 @@ def test_recent_glyph_window_zero():
     assert not recent_glyph(nd, "B", window=0)
 
 
+def test_recent_glyph_window_zero_does_not_modify_node():
+    nd = {}
+    assert not recent_glyph(nd, "B", window=0)
+    assert nd == {}
+
+
 def test_recent_glyph_window_negative():
     nd = _make_node(["A", "B"], current="B")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Return False before initializing glyph history when recent_glyph window is zero
- Add regression test to ensure node remains unchanged for zero window

## Testing
- `PYTHONPATH=src pytest tests/test_recent_glyph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde4467fdc8321948a5d1772fe60e6