### PR TITLE
Refactor neighbors map caching

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -33,8 +33,6 @@ _EDGE_CACHE_LOCK = threading.RLock()
 # Keys of cache entries dependent on the edge version.  Any change to the edge
 # set requires these to be dropped to avoid stale data.
 EDGE_VERSION_CACHE_KEYS = (
-    "_neighbors",
-    "_neighbors_version",
     "_cos_th",
     "_sin_th",
     "_thetas",

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -78,19 +78,11 @@ def compute_coherence(G) -> float:
 
 def ensure_neighbors_map(G) -> Mapping[Any, Sequence[Any]]:
     """Return cached neighbors list keyed by node as a read-only mapping."""
-    graph = G.graph
-    edge_version = int(graph.get("_edge_version", 0))
-    neighbors = graph.get("_neighbors")
-    if graph.get("_neighbors_version") != edge_version or neighbors is None:
-        neighbors = {n: list(G.neighbors(n)) for n in G}
-        graph["_neighbors"] = neighbors
-        graph["_neighbors_version"] = edge_version
-        graph["_neighbors_proxy"] = MappingProxyType(neighbors)
-    proxy = graph.get("_neighbors_proxy")
-    if proxy is None:
-        proxy = MappingProxyType(neighbors)
-        graph["_neighbors_proxy"] = proxy
-    return proxy
+
+    def builder() -> Mapping[Any, Sequence[Any]]:
+        return MappingProxyType({n: list(G.neighbors(n)) for n in G})
+
+    return edge_version_cache(G, "_neighbors", builder)
 
 
 def get_Si_weights(G: Any) -> tuple[float, float, float]:

--- a/tests/test_neighbors_map_cache.py
+++ b/tests/test_neighbors_map_cache.py
@@ -1,4 +1,5 @@
 import networkx as nx
+from types import MappingProxyType
 
 from tnfr.metrics_utils import ensure_neighbors_map
 from tnfr.helpers import increment_edge_version
@@ -8,6 +9,7 @@ def test_neighbors_map_reuses_proxy():
     G = nx.Graph()
     G.add_edge(1, 2)
     first = ensure_neighbors_map(G)
+    assert isinstance(first, MappingProxyType)
     second = ensure_neighbors_map(G)
     assert first is second
     G.add_edge(2, 3)


### PR DESCRIPTION
## Summary
- refactor `ensure_neighbors_map` to leverage `edge_version_cache`
- remove manual `_neighbors_version` handling and MappingProxy bookkeeping
- verify neighbor map caching immutability and reuse in tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde43b3f388321a706d52809e6b37e