### PR TITLE
Cache NodoNX import once and test

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -134,9 +134,18 @@ def _phase_mean_from_iter(
     return math.atan2(y, x)
 
 
+@lru_cache(maxsize=1)
+def _get_nodonx():
+    """Return :class:`NodoNX` caching the deferred import."""
+    return import_nodonx()
+
+
 def neighbor_phase_mean(obj, n=None) -> float:
-    """Circular mean of neighbour phases."""
-    NodoNX = import_nodonx()
+    """Circular mean of neighbour phases.
+
+    The :class:`NodoNX` import is cached after the first call.
+    """
+    NodoNX = _get_nodonx()
 
     node = NodoNX(obj, n) if n is not None else obj
     if getattr(node, "G", None) is None:

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -156,7 +156,10 @@ def get_numpy(*, warn: bool = False) -> Any | None:
 
 @lru_cache(maxsize=1)
 def import_nodonx():
-    """Lazily import :class:`NodoNX` to avoid circular dependencies."""
+    """Lazily import :class:`NodoNX` to avoid circular dependencies.
+
+    The import is cached after the first successful call.
+    """
     from .node import NodoNX
 
     return NodoNX

--- a/tests/test_import_nodonx_cache.py
+++ b/tests/test_import_nodonx_cache.py
@@ -1,0 +1,41 @@
+import networkx as nx
+from tnfr.constants import ALIAS_THETA, ALIAS_VF, ALIAS_DNFR
+from tnfr.alias import set_attr
+from tnfr.helpers import neighbor_phase_mean
+import tnfr.helpers as helpers
+
+
+def test_import_nodonx_called_once(monkeypatch):
+    calls = 0
+
+    def mock_import_nodonx():
+        nonlocal calls
+        calls += 1
+
+        class DummyNode:
+            def __init__(self, G, n):
+                self.G = G
+                self.n = n
+
+            def neighbors(self):
+                return self.G.neighbors(self.n)
+
+        return DummyNode
+
+    monkeypatch.setattr(helpers, "import_nodonx", mock_import_nodonx)
+    helpers._get_nodonx.cache_clear()
+
+    G = nx.Graph()
+    G.add_edge(1, 2)
+    set_attr(G.nodes[1], ALIAS_THETA, 0.0)
+    set_attr(G.nodes[2], ALIAS_THETA, 0.0)
+    set_attr(G.nodes[1], ALIAS_VF, 0.0)
+    set_attr(G.nodes[2], ALIAS_VF, 0.0)
+    set_attr(G.nodes[1], ALIAS_DNFR, 0.0)
+    set_attr(G.nodes[2], ALIAS_DNFR, 0.0)
+
+    neighbor_phase_mean(G, 1)
+    neighbor_phase_mean(G, 1)
+
+    assert calls == 1
+    helpers._get_nodonx.cache_clear()


### PR DESCRIPTION
## Summary
- cache deferred NodoNX import via module-level helper
- document cached import and replace direct call with stored reference
- verify import is executed once in helper test

## Testing
- `PYTHONPATH=src pytest tests/test_import_nodonx_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde56d4db48321af3214e914019372