### PR TITLE
Pre-cast default in list_mean to avoid repeated float conversions

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -88,10 +88,13 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Return the arithmetic mean of ``xs`` or ``default`` if empty."""
+    # Pre-cast ``default`` to anticipate errors and avoid multiple casting
+    result = float(default)
     try:
-        return float(fmean(xs))
+        result = float(fmean(xs))
     except (StatisticsError, ValueError, TypeError):
-        return float(default)
+        result = result  # default already converted
+    return result
 
 
 def angle_diff(a: float, b: float) -> float:


### PR DESCRIPTION
## Summary
- Pre-cast `default` to float before `try` in `list_mean`
- Reuse the pre-cast value in both `try` and `except` paths
- Add commentary on error anticipation to avoid repeated casting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde66ee8f08321a7834ee5c7580caf