### PR TITLE
refactor: extract mean phase helper

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -127,6 +127,39 @@ def precompute_trigonometry(G: Any) -> TrigCache:
     return get_trig_cache(G)
 
 
+def _mean_phase(
+    neigh: Sequence[Any],
+    cos_th: Dict[Any, float],
+    sin_th: Dict[Any, float],
+    np,
+    th_i: float,
+) -> float:
+    """Return mean phase for neighbours of a node.
+
+    Parameters
+    ----------
+    neigh:
+        Sequence of neighbour identifiers.
+    cos_th, sin_th:
+        Mappings from node to ``cos(θ)`` and ``sin(θ)`` respectively.
+    np:
+        Optional :mod:`numpy`-like module. When ``None`` a pure Python
+        implementation is used.
+    th_i:
+        Fallback phase used when ``neigh`` is empty.
+    """
+    deg = len(neigh)
+    if deg:
+        if np is not None:
+            cos_vals = np.fromiter((cos_th[v] for v in neigh), float, count=deg)
+            sin_vals = np.fromiter((sin_th[v] for v in neigh), float, count=deg)
+            return float(
+                np.arctan2(float(sin_vals.mean()), float(cos_vals.mean()))
+            )
+        return _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), th_i)
+    return th_i
+
+
 def compute_Si_node(
     n: Any,
     nd: Dict[str, Any],
@@ -149,16 +182,7 @@ def compute_Si_node(
 
     th_i = thetas[n]
     neigh = neighbors[n]
-    deg = len(neigh)
-    if deg:
-        if np is not None:
-            cos_vals = np.fromiter((cos_th[v] for v in neigh), float, count=deg)
-            sin_vals = np.fromiter((sin_th[v] for v in neigh), float, count=deg)
-            th_bar = float(np.arctan2(float(sin_vals.mean()), float(cos_vals.mean())))
-        else:
-            th_bar = _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), th_i)
-    else:
-        th_bar = th_i
+    th_bar = _mean_phase(neigh, cos_th, sin_th, np, th_i)
     disp_fase = abs(angle_diff(th_i, th_bar)) / math.pi
 
     dnfr = get_attr(nd, ALIAS_DNFR, 0.0)

--- a/tests/test_mean_phase.py
+++ b/tests/test_mean_phase.py
@@ -1,0 +1,34 @@
+import math
+import pytest
+
+from tnfr.metrics_utils import _mean_phase
+
+
+def test_mean_phase_without_numpy():
+    neigh = [1, 2]
+    cos_th = {1: math.cos(0.0), 2: math.cos(math.pi / 2)}
+    sin_th = {1: math.sin(0.0), 2: math.sin(math.pi / 2)}
+    th_i = 0.0
+    th_bar = _mean_phase(neigh, cos_th, sin_th, None, th_i)
+    assert th_bar == pytest.approx(math.pi / 4)
+
+
+def test_mean_phase_with_numpy_stub():
+    neigh = [1, 2]
+    cos_th = {1: math.cos(0.0), 2: math.cos(math.pi / 2)}
+    sin_th = {1: math.sin(0.0), 2: math.sin(math.pi / 2)}
+    th_i = 0.0
+
+    class DummyNP:
+        def fromiter(self, iterable, dtype, count):
+            vals = list(iterable)
+            class Arr(list):
+                def mean(self):
+                    return sum(self) / len(self)
+            return Arr(vals)
+
+        def arctan2(self, y, x):
+            return math.atan2(y, x)
+
+    th_bar = _mean_phase(neigh, cos_th, sin_th, DummyNP(), th_i)
+    assert th_bar == pytest.approx(math.pi / 4)


### PR DESCRIPTION
## Summary
- factor out neighbour phase averaging into `_mean_phase`, using numpy when available
- streamline `compute_Si_node` to leverage `_mean_phase`
- add unit tests for `_mean_phase` covering numpy and pure-Python paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde85ff70083219dc445a02b282745