### PR TITLE
Ensure RNG module imports random and hashlib

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -1,14 +1,14 @@
 """Deterministic RNG helpers."""
 from __future__ import annotations
 
-import hashlib
 import random
+import hashlib
 import struct
 import threading
 from typing import MutableMapping, Tuple
 
-from .constants import DEFAULTS
 from cachetools import LRUCache
+from .constants import DEFAULTS
 
 _RNG_LOCK = threading.Lock()
 _CACHE_MAXSIZE = int(DEFAULTS.get("JITTER_CACHE_SIZE", 128))


### PR DESCRIPTION
## Summary
- reorder import block in `rng.py` to explicitly import `random` and `hashlib`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdea8af09083219bdff46342a08cd8