### PR TITLE
Refactor window validation in recent_glyph

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -44,8 +44,6 @@ def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
 
 def recent_glyph(nd: Dict[str, Any], glyph: str, window: int) -> bool:
     """Return ``True`` if ``glyph`` appeared in last ``window`` emissions."""
-    if window == 0:
-        return False
     window = _validate_window(window)
     if window == 0:
         return False


### PR DESCRIPTION
## Summary
- simplify `recent_glyph` by validating window once and checking for zero only after validation

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdec0eb75c83218833448037dc9c2c