### PR TITLE
refactor list_mean default handling

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -93,7 +93,7 @@ def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     try:
         result = float(fmean(xs))
     except (StatisticsError, ValueError, TypeError):
-        result = result  # default already converted
+        pass
     return result
 
 


### PR DESCRIPTION
## Summary
- simplify list_mean's exception handler by removing redundant assignment

## Testing
- `PYTHONPATH=src pytest tests/test_list_mean.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdec921a008321841211d4331de939