### PR TITLE
Validate k in glyph_top metric

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -451,8 +451,11 @@ def glyphogram_series(G) -> dict[str, list[float]]:
 
 def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
     """Top-k structural operators by ``Tg_global`` (fraction)."""
+    k = int(k)
+    if k <= 0:
+        raise ValueError("k must be a positive integer")
     tg = Tg_global(G, normalize=True)
-    return heapq.nlargest(max(1, int(k)), tg.items(), key=lambda kv: kv[1])
+    return heapq.nlargest(k, tg.items(), key=lambda kv: kv[1])
 
 
 def glyph_dwell_stats(G, n) -> dict[str, dict[str, float]]:


### PR DESCRIPTION
## Summary
- ensure glyph_top's k is a positive integer
- use `heapq.nlargest` directly with validated k

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bded0416608321a5dad9fe471079fc