### PR TITLE
Treat max_entries=0 as disabling edge version cache

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -352,13 +352,18 @@ def edge_version_cache(
     and cleared when the cache is invalidated.
 
     When ``max_entries`` is a positive integer, only the most recent
-    ``max_entries`` cache entries are kept (defaults to ``128``).  The
-    ``builder`` is executed outside the global lock when a cache miss occurs,
-    so it **must** be pure and yield identical results across concurrent
-    invocations.
+    ``max_entries`` cache entries are kept (defaults to ``128``).  If
+    ``max_entries`` is ``None`` the cache may grow without bound.  A
+    ``max_entries`` value of ``0`` disables caching entirely and ``builder``
+    is executed on each invocation.  The ``builder`` is executed outside the
+    global lock when a cache miss occurs, so it **must** be pure and yield
+    identical results across concurrent invocations.
     """
     if max_entries is not None and max_entries < 0:
         raise ValueError("max_entries must be non-negative or None")
+    if max_entries == 0:
+        return builder()
+
     graph = get_graph(G)
     use_lru = bool(max_entries)
 

--- a/tests/test_edge_version_cache_disable.py
+++ b/tests/test_edge_version_cache_disable.py
@@ -1,0 +1,20 @@
+import networkx as nx
+
+from tnfr.helpers import edge_version_cache
+
+
+def test_edge_version_cache_disable():
+    G = nx.Graph()
+    calls = 0
+
+    def builder():
+        nonlocal calls
+        calls += 1
+        return object()
+
+    first = edge_version_cache(G, "k", builder, max_entries=0)
+    second = edge_version_cache(G, "k", builder, max_entries=0)
+
+    assert calls == 2
+    assert first is not second
+    assert "_edge_version_cache" not in G.graph


### PR DESCRIPTION
## Summary
- handle `max_entries=0` by bypassing the edge version cache
- document cache behaviour in `edge_version_cache`
- add tests ensuring cache is skipped when `max_entries=0`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bded807ed8832181755bfbcc21d46d