### PR TITLE
Use frozenset for canonical glyph set

### DIFF
--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -27,7 +27,7 @@ GLYPHS_CANONICAL: tuple[str, ...] = (
     Glyph.REMESH.value,  # 12
 )
 
-GLYPHS_CANONICAL_SET: set[str] = set(GLYPHS_CANONICAL)
+GLYPHS_CANONICAL_SET: frozenset[str] = frozenset(GLYPHS_CANONICAL)
 
 ESTABILIZADORES = (
     Glyph.IL.value,


### PR DESCRIPTION
## Summary
- use frozenset to hold canonical glyphs

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdee4393948321906d407f353f9c94