### PR TITLE
Refactor helpers and cache internals

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -3,7 +3,9 @@
 ``AliasAccessor`` provides the main implementation for dealing with
 alias-based attribute access.  The module-level :func:`alias_get` and
 ``alias_set`` functions are thin wrappers over a shared
-``AliasAccessor`` instance kept for backward compatibility.
+``AliasAccessor`` instance kept for backward compatibility.  These
+wrappers are deprecated in favour of :func:`get_attr` and
+:func:`set_attr`.
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from typing import (
 )
 import logging
 from functools import lru_cache
+import warnings
 from .logging_utils import get_logger
 
 from .constants import ALIAS_VF, ALIAS_DNFR
@@ -210,9 +213,17 @@ def alias_get(
 ) -> Optional[T]:
     """Return the value for the first existing key in ``aliases``.
 
+    .. deprecated:: 4.5
+       Use :func:`get_attr` instead.
+
     This is a convenience wrapper over a shared :class:`AliasAccessor`
     instance.
     """
+    warnings.warn(
+        "alias_get is deprecated; use get_attr instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _alias_accessor.get(
         d,
         aliases,
@@ -231,9 +242,17 @@ def alias_set(
 ) -> T:
     """Assign ``value`` converted to the first available key in ``aliases``.
 
+    .. deprecated:: 4.5
+       Use :func:`set_attr` instead.
+
     This is a convenience wrapper over a shared :class:`AliasAccessor`
     instance.
     """
+    warnings.warn(
+        "alias_set is deprecated; use set_attr instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _alias_accessor.set(d, aliases, value, conv=conv)
 
 

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:  # pragma: no cover - only for type checkers
 
 def load_config(path: str | Path) -> Mapping[str, Any]:
     """Read a JSON/YAML file and return a mapping with parameters."""
-    data = read_structured_file(Path(path))
+    path_obj = path if isinstance(path, Path) else Path(path)
+    data = read_structured_file(path_obj)
     if not isinstance(data, Mapping):
         raise ValueError("Configuration file must contain an object")
     return data
@@ -25,6 +26,5 @@ def apply_config(G: nx.Graph, path: str | Path) -> None:
 
     Reuses :func:`inject_defaults` to keep canonical default semantics.
     """
-    path = Path(path)
     cfg = load_config(path)
     inject_defaults(G, cfg, override=True)

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -106,9 +106,11 @@ class HistoryDict(dict):
         target = len(self._counts) + self._compact_every
         if len(self._heap) <= target:
             return
-        new_heap = [
-            h for h in heapq.nsmallest(target, self._heap) if self._counts.get(h[1]) == h[0]
-        ]
+        new_heap: list[tuple[int, str]] = []
+        while self._heap and len(new_heap) < target:
+            cnt, key = heapq.heappop(self._heap)
+            if self._counts.get(key) == cnt:
+                new_heap.append((cnt, key))
         heapq.heapify(new_heap)
         self._heap = new_heap
 

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -1,4 +1,7 @@
-"""TNFR programming language."""
+"""TNFR programming language.
+
+Public exports are declared in ``__all__`` for explicit star imports.
+"""
 
 from __future__ import annotations
 from typing import Any, Optional, Union
@@ -16,6 +19,26 @@ from .glyph_history import ensure_history
 # Basic types
 Node = Any
 AdvanceFn = Callable[[Any], None]  # normalmente dynamics.step
+_STEP_FN: Optional[AdvanceFn] = None
+
+__all__ = [
+    "WAIT",
+    "TARGET",
+    "THOL",
+    "Token",
+    "THOL_SENTINEL",
+    "_flatten_thol",
+    "_flatten",
+    "_handle_target",
+    "_handle_wait",
+    "_handle_glyph",
+    "seq",
+    "block",
+    "target",
+    "wait",
+    "play",
+    "basic_canonical_example",
+]
 
 # ---------------------
 # DSL constructs
@@ -104,8 +127,11 @@ def _apply_glyph_to_targets(
 
 
 def _advance(G, step_fn: Optional[AdvanceFn] = None):
+    global _STEP_FN
     if step_fn is None:
-        from .dynamics import step as step_fn
+        if _STEP_FN is None:
+            from .dynamics import step as _STEP_FN
+        step_fn = _STEP_FN
     step_fn(G)
 
 

--- a/tests/test_alias_deprecation.py
+++ b/tests/test_alias_deprecation.py
@@ -1,0 +1,14 @@
+import warnings
+from tnfr.alias import alias_get, alias_set
+
+def test_alias_get_warns():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alias_get({}, ("x",), int)
+        assert any(issubclass(i.category, DeprecationWarning) for i in w)
+
+def test_alias_set_warns():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        alias_set({}, ("x",), int, 1)
+        assert any(issubclass(i.category, DeprecationWarning) for i in w)

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,7 +1,11 @@
 import networkx as nx
 
 from tnfr import dynamics
-from tnfr.helpers import increment_edge_version, ensure_node_offset_map
+from tnfr.helpers import (
+    increment_edge_version,
+    ensure_node_offset_map,
+    _cache_node_list,
+)
 
 
 def test_cached_nodes_and_A_reuse_and_invalidate():
@@ -39,3 +43,14 @@ def test_node_offset_map_updates_on_node_addition():
     mapping2 = ensure_node_offset_map(G)
     assert mapping2 is not mapping1
     assert mapping2[2] == 2
+
+
+def test_cache_node_list_updates_on_dirty():
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    nodes1 = _cache_node_list(G)
+    nodes2 = _cache_node_list(G)
+    assert nodes1 is nodes2
+    G.graph["_node_list_dirty"] = True
+    nodes3 = _cache_node_list(G)
+    assert nodes3 is not nodes1

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -54,3 +54,26 @@ def test_load_config_accepts_mapping(monkeypatch, tmp_path):
     path.write_text("{}", encoding="utf-8")
     loaded = load_config(path)
     assert loaded == data
+
+
+def test_load_config_accepts_str(tmp_path):
+    cfg = {"RANDOM_SEED": 7}
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = load_config(str(path))
+    assert loaded == cfg
+
+
+def test_apply_config_passes_path_object(monkeypatch, tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text("{}", encoding="utf-8")
+    received = {}
+
+    def fake_load(p):
+        received["path"] = p
+        return {}
+
+    monkeypatch.setattr("tnfr.config.load_config", fake_load)
+    G = nx.Graph()
+    apply_config(G, path)
+    assert received["path"] is path

--- a/tests/test_edge_version_cache_reentrant.py
+++ b/tests/test_edge_version_cache_reentrant.py
@@ -1,0 +1,17 @@
+import networkx as nx
+from tnfr.helpers import edge_version_cache
+
+
+def test_edge_version_cache_reentrant():
+    G = nx.Graph()
+    calls = []
+
+    def builder():
+        if not calls:
+            calls.append("outer")
+            return edge_version_cache(G, "k", builder)
+        calls.append("inner")
+        return "ok"
+
+    assert edge_version_cache(G, "k", builder) == "ok"
+    assert calls == ["outer", "inner"]

--- a/tests/test_history_heap_bound.py
+++ b/tests/test_history_heap_bound.py
@@ -1,4 +1,5 @@
 from tnfr.glyph_history import HistoryDict
+import timeit
 
 
 def test_heap_size_stays_bounded_under_churn():
@@ -14,3 +15,12 @@ def test_heap_size_skewed_churn():
         key = "k0" if i % 2 == 0 else f"k{(i % 9) + 1}"
         _ = hist.get_increment(key)
     assert len(hist._heap) <= len(hist._counts) + hist._compact_every
+
+
+def test_prune_heap_performance():
+    hist = HistoryDict({f"k{i}": [] for i in range(100)}, compact_every=5)
+    def churn():
+        for i in range(5_000):
+            hist.get_increment(f"k{i % 100}")
+    t = timeit.timeit(churn, number=1)
+    assert t < 1.0

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -78,3 +78,11 @@ def test_node_repr_cache_cleared_on_increment():
     assert h._node_repr.cache_info().currsize > 0
     increment_edge_version(nxG)
     assert h._node_repr.cache_info().currsize == 0
+
+
+def test_hash_node_matches_manual():
+    obj = ("a", 1)
+    manual = hashlib.blake2b(
+        h._node_repr(obj).encode("utf-8"), digest_size=16
+    ).digest()
+    assert h._hash_node(obj) == manual

--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -1,0 +1,23 @@
+import networkx as nx
+import tnfr.dynamics as dyn
+from tnfr.program import _advance
+
+
+def test_advance_caches_step(monkeypatch):
+    G = nx.Graph()
+    G.add_node(0)
+    calls = []
+
+    def first_step(G):
+        calls.append(1)
+
+    def second_step(G):
+        calls.append(2)
+
+    monkeypatch.setattr(dyn, "step", first_step)
+    monkeypatch.setattr("tnfr.program._STEP_FN", None)
+    _advance(G)
+    monkeypatch.setattr(dyn, "step", second_step)
+    _advance(G)
+    assert calls == [1, 1]
+    monkeypatch.setattr("tnfr.program._STEP_FN", None)

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -7,9 +7,9 @@ from tnfr.trace import (
     _callback_names,
     gamma_field,
     grammar_field,
-    _safe_graph_mapping,
     CallbackSpec,
 )
+from tnfr.helpers import get_graph_mapping
 from tnfr.callback_utils import register_callback, invoke_callbacks
 from types import MappingProxyType
 
@@ -88,11 +88,11 @@ def test_grammar_field_non_mapping_warns(graph_canon):
     assert out == {}
 
 
-def test_safe_graph_mapping_accepts_mapping_proxy(graph_canon):
+def test_get_graph_mapping_accepts_mapping_proxy(graph_canon):
     G = graph_canon()
     data = MappingProxyType({"a": 1})
     G.graph["foo"] = data
-    out = _safe_graph_mapping(G, "foo")
+    out = get_graph_mapping(G, "foo", "msg")
     assert out == {"a": 1}
     out["b"] = 2
     assert "b" not in data


### PR DESCRIPTION
## Summary
- extract reusable node digest helper and consolidate node caching
- unify DNFR sample hooks behind a generic applicator
- deprecate alias_get/alias_set and centralize graph mapping checks
- cache dynamics.step import, optimize HistoryDict heap pruning, and many misc fixes

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdf545d9e48321bc5ec2b51c062234