### PR TITLE
Cache hash_node and clear on graph mutations

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -265,6 +265,7 @@ def _node_repr(n: Any) -> str:
     return _stable_json(n)
 
 
+@lru_cache(maxsize=1024)
 def _hash_node(obj: Any) -> bytes:
     """Return a stable digest for ``obj`` used in node checksums."""
     return hashlib.blake2b(
@@ -500,5 +501,6 @@ def increment_edge_version(G: Any) -> None:
     invalidate_edge_version_cache(G)
     mark_dnfr_prep_dirty(G)
     _node_repr.cache_clear()
+    _hash_node.cache_clear()
     for key in EDGE_VERSION_CACHE_KEYS:
         graph.pop(key, None)

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -80,6 +80,14 @@ def test_node_repr_cache_cleared_on_increment():
     assert h._node_repr.cache_info().currsize == 0
 
 
+def test_hash_node_cache_cleared_on_increment():
+    nxG = nx.Graph()
+    h._hash_node(("foo", 1))
+    assert h._hash_node.cache_info().currsize > 0
+    increment_edge_version(nxG)
+    assert h._hash_node.cache_info().currsize == 0
+
+
 def test_hash_node_matches_manual():
     obj = ("a", 1)
     manual = hashlib.blake2b(


### PR DESCRIPTION
## Summary
- cache `_hash_node` results with `functools.lru_cache`
- clear `_hash_node` and `_node_repr` caches when graph edges/nodes change
- add regression test to ensure `_hash_node` cache invalidation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be026f25408321a783437f4db9f0cf