### PR TITLE
Declare public symbols via __all__ lists

### DIFF
--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -11,6 +11,8 @@ from .constants import inject_defaults
 if TYPE_CHECKING:  # pragma: no cover - only for type checkers
     import networkx as nx
 
+__all__ = ["load_config", "apply_config"]
+
 
 def load_config(path: str | Path) -> Mapping[str, Any]:
     """Read a JSON/YAML file and return a mapping with parameters."""

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -71,6 +71,26 @@ from .logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = [
+    "default_compute_delta_nfr",
+    "set_delta_nfr_hook",
+    "dnfr_phase_only",
+    "dnfr_epi_vf_mixed",
+    "dnfr_laplacian",
+    "prepare_integration_params",
+    "update_epi_via_nodal_equation",
+    "apply_dnfr_field",
+    "integrar_epi_euler",
+    "apply_canonical_clamps",
+    "validate_canon",
+    "coordinate_global_local_phase",
+    "adapt_vf_by_coherence",
+    "default_glyph_selector",
+    "parametric_glyph_selector",
+    "step",
+    "run",
+]
+
 
 def _update_node_sample(G, *, step: int) -> None:
     """Refresh ``G.graph['_node_sample']`` with a random subset of nodes.

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -18,6 +18,17 @@ from .logging_utils import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = [
+    "kuramoto_R_psi",
+    "gamma_none",
+    "gamma_kuramoto_linear",
+    "gamma_kuramoto_bandpass",
+    "gamma_kuramoto_tanh",
+    "gamma_harmonic",
+    "GAMMA_REGISTRY",
+    "eval_gamma",
+]
+
 
 def _ensure_kuramoto_cache(G, t) -> None:
     """Cache ``(R, ψ)`` for the current step ``t`` using ``edge_version_cache``."""

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -31,6 +31,27 @@ ZHIR = Glyph.ZHIR
 NAV = Glyph.NAV
 REMESH = Glyph.REMESH
 
+__all__ = [
+    "AL",
+    "EN",
+    "IL",
+    "OZ",
+    "UM",
+    "RA",
+    "SHA",
+    "VAL",
+    "NUL",
+    "THOL",
+    "ZHIR",
+    "NAV",
+    "REMESH",
+    "CANON_COMPAT",
+    "CANON_FALLBACK",
+    "enforce_canonical_grammar",
+    "on_applied_glyph",
+    "apply_glyph_with_grammar",
+]
+
 # -------------------------
 # Per-node grammar state
 # -------------------------

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -11,6 +11,8 @@ from .rng import get_rng
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
 
+__all__ = ["init_node_attrs"]
+
 
 def _init_phase(
     nd: dict,

--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -11,6 +11,8 @@ import threading
 
 _LOCK = threading.Lock()
 
+__all__ = ["get_logger"]
+
 
 def get_logger(name: str) -> logging.Logger:
     """Return a logger with a standard configuration."""

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
 
 # API de alto nivel
+__all__ = ["preparar_red", "step", "run"]
 
 
 def preparar_red(

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -44,6 +44,16 @@ if TYPE_CHECKING:
 from .types import Glyph
 from collections import deque
 
+__all__ = [
+    "clear_rng_cache",
+    "random_jitter",
+    "get_glyph_factors",
+    "apply_glyph_obj",
+    "apply_glyph",
+    "apply_network_remesh",
+    "apply_remesh_if_globally_stable",
+]
+
 
 def _node_offset(G, n) -> int:
     """Deterministic node index used for jitter seeds."""

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -9,6 +9,13 @@ ARRANQUE_BASICO = seq(Glyph.AL, Glyph.EN)
 CIERRE_BASICO = seq(Glyph.RA, Glyph.SHA)
 NUCLEO_VAL_UM = seq(Glyph.VAL, Glyph.UM)
 
+__all__ = [
+    "ARRANQUE_BASICO",
+    "CIERRE_BASICO",
+    "NUCLEO_VAL_UM",
+    "get_preset",
+]
+
 
 _PRESETS = {
     "arranque_resonante": ARRANQUE_BASICO

--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -6,6 +6,8 @@ import networkx as nx
 from .constants import inject_defaults
 from .initialization import init_node_attrs
 
+__all__ = ["build_graph"]
+
 
 def build_graph(
     n: int = 24,

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -25,6 +25,19 @@ GLYPH_UNITS: Dict[str, complex] = {
     g: complex(math.cos(a), math.sin(a)) for g, a in ANGLE_MAP.items()
 }
 
+__all__ = [
+    "GLYPH_UNITS",
+    "glyph_angle",
+    "glyph_unit",
+    "sigma_vector_node",
+    "sigma_vector",
+    "sigma_vector_from_graph",
+    "push_sigma_snapshot",
+    "register_sigma_callback",
+    "sigma_series",
+    "sigma_rose",
+]
+
 # -------------------------
 # Utilidades básicas
 # -------------------------

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Any
 
+__all__ = ["NodeState", "Glyph"]
+
 
 @dataclass(slots=True)
 class NodeState:

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -10,6 +10,8 @@ from .constants_glyphs import GLYPHS_CANONICAL_SET
 
 EPS = 1e-9
 
+__all__ = ["run_validators"]
+
 
 def _require_attr(data, alias, node, name):
     """Return attribute value or raise if missing."""


### PR DESCRIPTION
## Summary
- add explicit `__all__` declarations to modules like grammar, gamma, dynamics, operators and others to document intended public API
- expose helpers such as `run_validators`, `sigma_vector`, `init_node_attrs`, `build_graph` and more

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be031a101c832190475c44ffefe95f