### PR TITLE
Accept iterable aliases

### DIFF
--- a/tests/test_alias_iterable.py
+++ b/tests/test_alias_iterable.py
@@ -1,15 +1,15 @@
-"""Pruebas de helpers de alias con secuencias genéricas."""
+"""Pruebas de helpers de alias con iterables genéricos."""
 
 import pytest
 from tnfr.alias import alias_get, alias_set
 
 
-def test_alias_get_accepts_hashable_sequence():
+def test_alias_get_accepts_hashable_iterable():
     d = {"b": "1"}
     assert alias_get(d, ("a", "b"), int) == 1
 
 
-def test_alias_set_accepts_hashable_sequence():
+def test_alias_set_accepts_hashable_iterable():
     d = {}
     alias_set(d, ("x", "y"), int, "5")
     assert d["x"] == 5
@@ -22,9 +22,18 @@ def test_alias_rejects_str():
         alias_set({}, "x", int, 1)
 
 
-def test_alias_accepts_list_sequence():
+def test_alias_accepts_list_iterable():
     d = {"b": "1"}
     assert alias_get(d, ["a", "b"], int) == 1
     d2 = {}
     alias_set(d2, ["x", "y"], int, "5")
+    assert d2["x"] == 5
+
+
+def test_alias_accepts_generator_iterable():
+    d = {"b": "1"}
+    aliases = (a for a in ("a", "b"))
+    assert alias_get(d, aliases, int) == 1
+    d2 = {}
+    alias_set(d2, (a for a in ("x", "y")), int, "5")
     assert d2["x"] == 5

--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -18,8 +18,12 @@ def test_rejects_non_string_elements():
         _validate_aliases(("a", 1))
 
 
-def test_accepts_list_sequence():
+def test_accepts_list_iterable():
     assert _validate_aliases(["a"]) == ("a",)
+
+
+def test_accepts_generator_iterable():
+    assert _validate_aliases((x for x in ["a", "b"])) == ("a", "b")
 
 
 def test_alias_get_reports_all_failures():


### PR DESCRIPTION
## Summary
- Allow `_validate_aliases` and public alias helpers to accept any `Iterable[str]`
- Convert alias iterables to tuples before validation to keep caching stable
- Add tests ensuring generators and other iterables work with alias helpers

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be089d17388321aa640ef5bffe4b09