### PR TITLE
Simplify neighbor phase mean calculation

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -146,19 +146,20 @@ def neighbor_phase_mean_list(
     np=None,
     fallback: float = 0.0,
 ) -> float:
-    """Return circular mean of neighbour phases from cosine/sine mappings."""
+    """Return circular mean of neighbour phases from cosine/sine mappings.
+
+    When ``np`` (NumPy) is provided, ``np.fromiter`` is used to compute the
+    averages. Otherwise, the mean is computed using the pure-Python
+    :func:`_phase_mean_from_iter` helper.
+    """
     deg = len(neigh)
     if deg == 0:
         return fallback
     if np is not None:
-        if hasattr(np, "fromiter"):
-            cos_vals = np.fromiter((cos_th[v] for v in neigh), dtype=float, count=deg)
-            sin_vals = np.fromiter((sin_th[v] for v in neigh), dtype=float, count=deg)
-            mean_cos = float(cos_vals.mean())
-            mean_sin = float(sin_vals.mean())
-        else:
-            vals = np.array([(cos_th[v], sin_th[v]) for v in neigh], dtype=float)
-            mean_cos, mean_sin = vals.mean(axis=0)
+        cos_vals = np.fromiter((cos_th[v] for v in neigh), dtype=float, count=deg)
+        sin_vals = np.fromiter((sin_th[v] for v in neigh), dtype=float, count=deg)
+        mean_cos = float(cos_vals.mean())
+        mean_sin = float(sin_vals.mean())
         return float(np.arctan2(mean_sin, mean_cos))
     return _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), fallback)
 

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -86,14 +86,15 @@ def test_compute_Si_node():
     assert get_attr(G.nodes[1], ALIAS_SI, 0.0) == pytest.approx(0.7)
 
     class DummyNP:
-        def array(self, iterable, dtype=float):
-            class Arr(list):
-                def mean(self, axis=None):
-                    if axis == 0:
-                        cols = len(self[0])
-                        return [sum(row[i] for row in self) / len(self) for i in range(cols)]
-                    return sum(self) / len(self)
-            return Arr(list(iterable))
+        class Arr(list):
+            def mean(self, axis=None):
+                if axis == 0:
+                    cols = len(self[0])
+                    return [sum(row[i] for row in self) / len(self) for i in range(cols)]
+                return sum(self) / len(self)
+
+        def fromiter(self, iterable, dtype=float, count=-1):
+            return self.Arr(list(iterable))
 
         def arctan2(self, y, x):
             return math.atan2(y, x)


### PR DESCRIPTION
## Summary
- Always use `np.fromiter` in `neighbor_phase_mean_list` when NumPy is provided
- Update docstrings and tests for simplified logic

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be8dd2c6c48321b87ca862d70a0b45