### PR TITLE
Normalize topology input for build_graph

### DIFF
--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -23,6 +23,8 @@ def build_graph(
     if n <= 0:
         raise ValueError("n must be a positive integer")
 
+    topology = topology.lower()
+
     if topology == "ring":
         G = nx.cycle_graph(n)
     elif topology == "complete":
@@ -36,7 +38,7 @@ def build_graph(
         valid = ["ring", "complete", "erdos"]
         raise ValueError(
             f"Invalid topology '{topology}'. "
-            f"Valid options are: {', '.join(valid)}"
+            f"Accepted options are: {', '.join(valid)}"
         )
 
     # Valores canónicos para inicialización

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -19,6 +19,19 @@ def test_build_graph_valid_topologies():
         assert nx.is_isomorphic(G, ref_graph)
 
 
+def test_build_graph_mixed_case_topologies():
+    n = 6
+    seed = 1
+    references = {
+        "Ring": nx.cycle_graph(n),
+        "Complete": nx.complete_graph(n),
+        "ERDoS": nx.gnp_random_graph(n, 3.0 / n, seed=seed),
+    }
+    for topology, ref_graph in references.items():
+        G = build_graph(n=n, topology=topology, seed=seed)
+        assert nx.is_isomorphic(G, ref_graph)
+
+
 def test_build_graph_invalid_topology():
     with pytest.raises(ValueError):
         build_graph(n=5, topology="invalid", seed=1)


### PR DESCRIPTION
## Summary
- ensure `build_graph` accepts topology names case-insensitively
- clarify error message with normalized options
- test mixed-case topology names

## Testing
- `PYTHONPATH=src pytest tests/test_scenarios.py`

------
https://chatgpt.com/codex/tasks/task_e_68be937f8c7c83219fa265204f79e29c