### PR TITLE
Validate finiteness of edge weights

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -91,8 +91,8 @@ def _add_edge_common(n1, n2, weight) -> Optional[float]:
         return None
 
     weight = float(weight)
-    if math.isnan(weight):
-        raise ValueError("Edge weight must be a number")
+    if not math.isfinite(weight):
+        raise ValueError("Edge weight must be a finite number")
     if weight < 0:
         raise ValueError("Edge weight must be non-negative")
 

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -111,3 +111,24 @@ def test_add_edge_rejects_negative_weight_existing_edge_nx():
     with pytest.raises(ValueError):
         a.add_edge(b, weight=-2.0)
     assert math.isclose(G[0][1]["weight"], 1.0)
+
+
+def test_add_edge_rejects_non_finite_weight():
+    a = NodoTNFR()
+    b = NodoTNFR()
+    for w in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError, match="Edge weight must be a finite number"):
+            a.add_edge(b, weight=w)
+        assert not a.has_edge(b)
+        assert not b.has_edge(a)
+
+
+def test_add_edge_rejects_non_finite_weight_nx():
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    a = NodoNX(G, 0)
+    b = NodoNX(G, 1)
+    for w in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError, match="Edge weight must be a finite number"):
+            a.add_edge(b, weight=w)
+        assert not a.has_edge(b)


### PR DESCRIPTION
## Summary
- ensure edge weights are finite before adding edges
- add regression tests guarding against NaN and infinite weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be952bab608321b9b4ed3744cf944e