### PR TITLE
Expose optional mean values from coherence metric

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -67,10 +67,16 @@ def for_each_glyph(fn) -> None:
 
 
 def _update_coherence(G, hist) -> None:
-    """Update global coherence and its moving average."""
+    """Update coherence and related means.
 
-    C = compute_coherence(G)
+    Records instantaneous coherence ``C`` along with the mean absolute
+    ``ΔNFR`` and ``dEPI`` values, and updates the moving average ``W̄``.
+    """
+
+    C, dnfr_mean, depi_mean = compute_coherence(G, return_means=True)
     append_metric(hist, "C_steps", C)
+    append_metric(hist, "dnfr_mean", dnfr_mean)
+    append_metric(hist, "depi_mean", depi_mean)
 
     wbar_w = int(get_param(G, "WBAR_WINDOW"))
     cs = hist["C_steps"]

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -54,8 +54,24 @@ def compute_dnfr_accel_max(G) -> dict:
     return maxes
 
 
-def compute_coherence(G) -> float:
-    """Compute global coherence C(t) from ΔNFR and dEPI."""
+def compute_coherence(
+    G, *, return_means: bool = False
+) -> float | tuple[float, float, float]:
+    """Compute global coherence ``C`` from ``ΔNFR`` and ``dEPI``.
+
+    Parameters
+    ----------
+    G:
+        Graph containing ``dnfr`` and ``dEPI`` attributes per node.
+    return_means:
+        If ``True``, also return the means of ``|ΔNFR|`` and ``|dEPI|``.
+
+    Returns
+    -------
+    float or tuple
+        ``C`` when ``return_means`` is ``False`` (default). When ``True``, a
+        tuple ``(C, dnfr_mean, depi_mean)`` is returned.
+    """
     count = G.number_of_nodes()
     if count:
         dnfr_vals = []
@@ -68,7 +84,8 @@ def compute_coherence(G) -> float:
         depi_mean = math.fsum(depi_vals) / count
     else:
         dnfr_mean = depi_mean = 0.0
-    return 1.0 / (1.0 + dnfr_mean + depi_mean)
+    coherence = 1.0 / (1.0 + dnfr_mean + depi_mean)
+    return (coherence, dnfr_mean, depi_mean) if return_means else coherence
 
 
 def ensure_neighbors_map(G) -> Mapping[Any, Sequence[Any]]:

--- a/tests/test_compute_coherence.py
+++ b/tests/test_compute_coherence.py
@@ -44,3 +44,16 @@ def test_compute_coherence_precision_improved():
     )
     assert result == expected
     assert abs(result - expected) < abs(naive - expected)
+
+
+def test_compute_coherence_return_means():
+    G = nx.Graph()
+    G.add_node(0, dnfr=0.1, dEPI=0.2)
+    G.add_node(1, dnfr=0.4, dEPI=0.5)
+    C, dnfr_mean, depi_mean = compute_coherence(G, return_means=True)
+    expected_dnfr = (0.1 + 0.4) / 2
+    expected_depi = (0.2 + 0.5) / 2
+    expected_C = 1.0 / (1.0 + expected_dnfr + expected_depi)
+    assert C == pytest.approx(expected_C)
+    assert dnfr_mean == pytest.approx(expected_dnfr)
+    assert depi_mean == pytest.approx(expected_depi)


### PR DESCRIPTION
## Summary
- Allow `metrics_utils.compute_coherence` to return mean `|ΔNFR|` and `|dEPI|`
- Record dnfr_mean and depi_mean in metrics history
- Test extended return form of `compute_coherence`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be95afee588321ae8785b66114bd8e