### PR TITLE
Refactor token parser error chaining

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -38,7 +38,8 @@ def validate_token(
         try:
             return handler(val)
         except (KeyError, ValueError) as e:
-            raise type(e)(f"{e} (posición {pos}, token {tok!r})") from e
+            msg = f"{type(e).__name__}: {e} (posición {pos}, token {tok!r})"
+            raise ValueError(msg) from e
     if isinstance(tok, str):
         return tok
     raise ValueError(f"Token inválido: {tok} (posición {pos}, token {tok!r})")

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -13,6 +13,7 @@ def test_parse_tokens_value_error_context():
     msg = str(exc.value)
     assert "posición 1" in msg
     assert "WAIT" in msg
+    assert isinstance(exc.value.__cause__, ValueError)
 
 
 def test_parse_tokens_key_error_context(monkeypatch):
@@ -20,11 +21,12 @@ def test_parse_tokens_key_error_context(monkeypatch):
         return spec["missing"]
 
     monkeypatch.setitem(TOKEN_MAP, "RAISE", raiser)
-    with pytest.raises(KeyError) as exc:
+    with pytest.raises(ValueError) as exc:
         _parse_tokens([{"RAISE": {}}])
     msg = str(exc.value)
     assert "posición 1" in msg
     assert "RAISE" in msg
+    assert isinstance(exc.value.__cause__, KeyError)
 
 
 def test_thol_invalid_close():
@@ -33,3 +35,4 @@ def test_thol_invalid_close():
     msg = str(exc.value)
     assert "XYZ" in msg
     assert "Glyph" in msg
+    assert isinstance(exc.value.__cause__, ValueError)


### PR DESCRIPTION
## Summary
- ensure token validation rewraps handler errors as ValueError while preserving original exception as cause
- verify traceback chaining for invalid tokens in parser tests

## Testing
- `PYTHONPATH=src pytest tests/test_parse_tokens_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be97e236688321bf9592276adbbac8