### PR TITLE
Refactor helpers into dedicated submodules

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -29,7 +29,7 @@ from ..scenarios import build_graph
 from ..presets import get_preset
 from ..config import apply_config
 from ..io import read_structured_file, safe_write
-from ..helpers import list_mean
+from ..helpers.numeric import list_mean
 from ..observers import attach_standard_observer
 from ..logging_utils import get_logger
 from ..types import Glyph

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -23,7 +23,7 @@ from .metric import (
 )
 
 try:  # pragma: no cover - optional dependency
-    from ..helpers import ensure_node_offset_map
+    from ..helpers.cache import ensure_node_offset_map
 except ImportError:  # noqa: BLE001 - allow any import error
     ensure_node_offset_map = None
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -33,15 +33,17 @@ from ..constants import (
 from ..gamma import eval_gamma
 from ..observers import glyph_load, kuramoto_order
 
-from ..helpers import (
+from ..helpers.numeric import (
     clamp,
     clamp01,
     angle_diff,
     neighbor_mean,
     neighbor_phase_mean,
+    _phase_mean_from_iter,
+)
+from ..helpers.cache import (
     cached_nodes_and_A,
     _cache_node_list,
-    _phase_mean_from_iter,
 )
 from ..alias import (
     get_attr,

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -5,13 +5,13 @@ from typing import Dict, Any, Callable
 
 from ..collections_utils import normalize_weights
 from ..constants import DEFAULTS, ALIAS_THETA, ALIAS_EPI, ALIAS_VF
-from ..helpers import (
+from ..helpers.numeric import (
     angle_diff,
     neighbor_mean,
     neighbor_phase_mean,
-    cached_nodes_and_A,
     _phase_mean_from_iter,
 )
+from ..helpers.cache import cached_nodes_and_A
 from ..alias import (
     get_attr,
     set_dnfr,

--- a/src/tnfr/dynamics/sampling.py
+++ b/src/tnfr/dynamics/sampling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..helpers import _cache_node_list
+from ..helpers.cache import _cache_node_list
 from ..rng import _rng_for_step, base_seed
 
 __all__ = ["update_node_sample"]

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 
 from .constants import ALIAS_THETA
 from .alias import get_attr
-from .helpers import node_set_checksum, edge_version_cache, get_graph_mapping
+from .helpers.cache import node_set_checksum, edge_version_cache, get_graph_mapping
 from .logging_utils import get_logger
 
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -11,7 +11,7 @@ from .constants import (
     get_param,
 )
 from .alias import get_attr
-from .helpers import clamp01
+from .helpers.numeric import clamp01
 from .glyph_history import recent_glyph
 from .types import Glyph
 from .operators import apply_glyph  # avoid repeated import inside functions

--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -14,7 +14,7 @@ def mark_dnfr_prep_dirty(G: Any) -> None:
     changed and cached arrays need to be refreshed.
     """
 
-    from .helpers import get_graph
+    from .helpers.cache import get_graph
 
     graph = get_graph(G)
     graph["_dnfr_prep_dirty"] = True

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from ..collections_utils import (
+    MAX_MATERIALIZE_DEFAULT,
+    ensure_collection,
+    normalize_weights,
+    normalize_counter,
+    mix_groups,
+)
+from ..graph_utils import mark_dnfr_prep_dirty
+
+from .numeric import (
+    clamp,
+    clamp01,
+    list_mean,
+    angle_diff,
+    neighbor_mean,
+    neighbor_phase_mean,
+    neighbor_phase_mean_list,
+    _phase_mean_from_iter,
+)
+from .history import (
+    push_glyph,
+    recent_glyph,
+    ensure_history,
+    last_glyph,
+    count_glyphs,
+)
+from .cache import (
+    get_graph,
+    get_graph_mapping,
+    node_set_checksum,
+    _stable_json,
+    _node_repr,
+    _cache_node_list,
+    ensure_node_index_map,
+    ensure_node_offset_map,
+    edge_version_cache,
+    cached_nodes_and_A,
+    invalidate_edge_version_cache,
+    increment_edge_version,
+)
+
+__all__ = [
+    "MAX_MATERIALIZE_DEFAULT",
+    "ensure_collection",
+    "clamp",
+    "clamp01",
+    "list_mean",
+    "angle_diff",
+    "normalize_weights",
+    "neighbor_mean",
+    "neighbor_phase_mean",
+    "neighbor_phase_mean_list",
+    "push_glyph",
+    "recent_glyph",
+    "ensure_history",
+    "last_glyph",
+    "count_glyphs",
+    "normalize_counter",
+    "mix_groups",
+    "ensure_node_index_map",
+    "ensure_node_offset_map",
+    "edge_version_cache",
+    "cached_nodes_and_A",
+    "invalidate_edge_version_cache",
+    "increment_edge_version",
+    "node_set_checksum",
+    "get_graph",
+    "get_graph_mapping",
+    "mark_dnfr_prep_dirty",
+]

--- a/src/tnfr/helpers/history.py
+++ b/src/tnfr/helpers/history.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from ..glyph_history import (
+    push_glyph,
+    recent_glyph,
+    ensure_history,
+    last_glyph,
+    count_glyphs,
+)
+
+__all__ = [
+    "push_glyph",
+    "recent_glyph",
+    "ensure_history",
+    "last_glyph",
+    "count_glyphs",
+]

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence, Dict
+import math
+from statistics import fmean, StatisticsError
+
+from ..import_utils import get_numpy, import_nodonx
+from ..alias import get_attr
+
+__all__ = [
+    "clamp",
+    "clamp01",
+    "list_mean",
+    "angle_diff",
+    "neighbor_mean",
+    "neighbor_phase_mean",
+    "neighbor_phase_mean_list",
+]
+
+
+def clamp(x: float, a: float, b: float) -> float:
+    """Return ``x`` clamped to the ``[a, b]`` interval."""
+    return max(a, min(b, x))
+
+
+def clamp01(x: float) -> float:
+    """Clamp ``x`` to the ``[0,1]`` interval."""
+    return clamp(float(x), 0.0, 1.0)
+
+
+def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
+    """Return the arithmetic mean of ``xs`` or ``default`` if empty."""
+    try:
+        return float(fmean(xs))
+    except (StatisticsError, ValueError, TypeError):
+        return float(default)
+
+
+def angle_diff(a: float, b: float) -> float:
+    """Return the minimal difference between two angles in radians."""
+    return (float(a) - float(b) + math.pi) % math.tau - math.pi
+
+
+def neighbor_mean(G, n, aliases: tuple[str, ...], default: float = 0.0) -> float:
+    """Mean of ``aliases`` attribute among neighbours of ``n``."""
+    vals = (get_attr(G.nodes[v], aliases, default) for v in G.neighbors(n))
+    return list_mean(vals, default)
+
+
+def _neighbor_phase_mean(node, trig) -> float:
+    """Internal helper delegating to :func:`neighbor_phase_mean_list`."""
+    fallback = trig.theta.get(node.n, 0.0)
+    neigh = node.G[node.n]
+    np = get_numpy()
+    return neighbor_phase_mean_list(
+        neigh, trig.cos, trig.sin, np=np, fallback=fallback
+    )
+
+
+def _phase_mean_from_iter(
+    it: Iterable[tuple[float, float] | None], fallback: float
+) -> float:
+    x = y = 0.0
+    cx = cy = 0.0  # Kahan compensation terms
+    count = 0
+    for cs in it:
+        if cs is None:
+            continue
+        cos_val, sin_val = cs
+        tx = cos_val - cx
+        vx = x + tx
+        cx = (vx - x) - tx
+        x = vx
+        ty = sin_val - cy
+        vy = y + ty
+        cy = (vy - y) - ty
+        y = vy
+        count += 1
+    if count == 0:
+        return fallback
+    return math.atan2(y, x)
+
+
+def neighbor_phase_mean_list(
+    neigh: Sequence[Any],
+    cos_th: Dict[Any, float],
+    sin_th: Dict[Any, float],
+    np=None,
+    fallback: float = 0.0,
+) -> float:
+    """Return circular mean of neighbour phases from cosine/sine mappings.
+
+    When ``np`` (NumPy) is provided, ``np.fromiter`` is used to compute the
+    averages. Otherwise, the mean is computed using the pure-Python
+    :func:`_phase_mean_from_iter` helper.
+    """
+    deg = len(neigh)
+    if deg == 0:
+        return fallback
+    if np is not None:
+        cos_vals = np.fromiter((cos_th[v] for v in neigh), dtype=float, count=deg)
+        sin_vals = np.fromiter((sin_th[v] for v in neigh), dtype=float, count=deg)
+        mean_cos = float(cos_vals.mean())
+        mean_sin = float(sin_vals.mean())
+        return float(np.arctan2(mean_sin, mean_cos))
+    return _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), fallback)
+
+
+def neighbor_phase_mean(obj, n=None) -> float:
+    """Circular mean of neighbour phases.
+
+    The :class:`NodoNX` import is cached after the first call.
+    """
+    NodoNX = import_nodonx()
+    node = NodoNX(obj, n) if n is not None else obj
+    if getattr(node, "G", None) is None:
+        raise TypeError("neighbor_phase_mean requires nodes bound to a graph")
+    from ..metrics_utils import get_trig_cache
+
+    trig = get_trig_cache(node.G)
+    return _neighbor_phase_mean(node, trig)

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -5,7 +5,7 @@ import random
 from typing import TYPE_CHECKING
 
 from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
-from .helpers import clamp
+from .helpers.numeric import clamp
 from .rng import get_rng
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -10,7 +10,8 @@ from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..collections_utils import normalize_weights
-from ..helpers import clamp01, ensure_node_index_map
+from ..helpers.numeric import clamp01
+from ..helpers.cache import ensure_node_index_map
 from ..metrics_utils import min_max_range
 from ..import_utils import get_numpy
 

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -17,7 +17,7 @@ from ..constants import (
 from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
-from ..helpers import clamp01
+from ..helpers.numeric import clamp01
 from ..metrics_utils import compute_dnfr_accel_max, min_max_range
 from .coherence import local_phase_sync, local_phase_sync_weighted, _similarity_abs
 

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -17,12 +17,12 @@ from .constants import (
 )
 from .alias import get_attr, set_attr, multi_recompute_abs_max
 from .collections_utils import normalize_weights
-from .helpers import (
+from .helpers.numeric import (
     clamp01,
     angle_diff,
-    edge_version_cache,
     neighbor_phase_mean_list,
 )
+from .helpers.cache import edge_version_cache
 from .import_utils import get_numpy
 
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -27,7 +27,7 @@ from .alias import (
     set_vf,
     set_dnfr,
 )
-from .helpers import increment_edge_version
+from .helpers.cache import increment_edge_version
 
 from .operators import apply_glyph_obj
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, Sequence
 
 from .constants import ALIAS_THETA, get_param
 from .alias import get_attr
-from .helpers import angle_diff
+from .helpers.numeric import angle_diff
 from .metrics_utils import compute_coherence
 from .callback_utils import register_callback
 from .glyph_history import ensure_history, count_glyphs, append_metric

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -25,11 +25,13 @@ from itertools import combinations
 from io import StringIO
 
 from .constants import DEFAULTS, REMESH_DEFAULTS, ALIAS_EPI, get_param
-from .helpers import (
+from .helpers.numeric import (
     list_mean,
     angle_diff,
     neighbor_phase_mean,
     neighbor_mean,
+)
+from .helpers.cache import (
     increment_edge_version,
     ensure_node_offset_map,
 )

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -9,7 +9,7 @@ from typing import MutableMapping, Tuple, Any
 
 from cachetools import LRUCache
 from .constants import DEFAULTS
-from .helpers import get_graph
+from .helpers.cache import get_graph
 
 _RNG_LOCK = threading.Lock()
 _CACHE_MAXSIZE = int(DEFAULTS.get("JITTER_CACHE_SIZE", 128))

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 from .constants import DEFAULTS
 from .constants.core import SELECTOR_THRESHOLD_DEFAULTS
-from .helpers import clamp01
+from .helpers.numeric import clamp01
 from .metrics_utils import compute_dnfr_accel_max
 
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -9,7 +9,7 @@ import networkx as nx
 
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
 from .alias import get_attr
-from .helpers import clamp01
+from .helpers.numeric import clamp01
 from .callback_utils import register_callback
 from .glyph_history import ensure_history, last_glyph, count_glyphs, append_metric
 from .constants_glyphs import (

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
 from .import_utils import optional_import
-from .helpers import get_graph_mapping
+from .helpers.cache import get_graph_mapping
 
 
 class _KuramotoFn(Protocol):

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 from tnfr import dynamics
-from tnfr.helpers import (
+from tnfr.helpers.cache import (
     increment_edge_version,
     ensure_node_offset_map,
     _cache_node_list,

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -3,7 +3,7 @@ import networkx as nx
 
 from tnfr.constants import THETA_PRIMARY
 from tnfr.metrics import coherence_matrix, local_phase_sync_weighted
-from tnfr.helpers import ensure_node_index_map
+from tnfr.helpers.cache import ensure_node_index_map
 
 
 def make_graph(offset=0):

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import THETA_PRIMARY, EPI_PRIMARY, VF_PRIMARY
-from tnfr.helpers import increment_edge_version, cached_nodes_and_A
+from tnfr.helpers.cache import increment_edge_version, cached_nodes_and_A
 
 
 def _counting_trig(monkeypatch):

--- a/tests/test_edge_version_cache_disable.py
+++ b/tests/test_edge_version_cache_disable.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from tnfr.helpers import edge_version_cache
+from tnfr.helpers.cache import edge_version_cache
 
 
 def test_edge_version_cache_disable():

--- a/tests/test_edge_version_cache_limit.py
+++ b/tests/test_edge_version_cache_limit.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from tnfr.helpers import edge_version_cache
+from tnfr.helpers.cache import edge_version_cache
 
 
 def test_edge_version_cache_limit():

--- a/tests/test_edge_version_cache_locks.py
+++ b/tests/test_edge_version_cache_locks.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from tnfr.helpers import edge_version_cache
+from tnfr.helpers.cache import edge_version_cache
 
 
 def test_edge_version_cache_prunes_locks():

--- a/tests/test_edge_version_cache_reentrant.py
+++ b/tests/test_edge_version_cache_reentrant.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from tnfr.helpers import edge_version_cache
+from tnfr.helpers.cache import edge_version_cache
 
 
 def test_edge_version_cache_reentrant():

--- a/tests/test_edge_version_cache_threadsafe.py
+++ b/tests/test_edge_version_cache_threadsafe.py
@@ -1,7 +1,7 @@
 import networkx as nx
 from concurrent.futures import ThreadPoolExecutor
 
-from tnfr.helpers import edge_version_cache, increment_edge_version
+from tnfr.helpers.cache import edge_version_cache, increment_edge_version
 
 
 def test_edge_version_cache_thread_safety():

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -7,7 +7,7 @@ import pytest
 from tnfr.constants import inject_defaults, merge_overrides
 from tnfr.dynamics import update_epi_via_nodal_equation
 from tnfr.gamma import eval_gamma, GAMMA_REGISTRY
-from tnfr.helpers import increment_edge_version
+from tnfr.helpers.cache import increment_edge_version
 
 
 def test_gamma_linear_integration(graph_canon):

--- a/tests/test_list_mean.py
+++ b/tests/test_list_mean.py
@@ -1,5 +1,5 @@
 import pytest
-from tnfr.helpers import list_mean
+from tnfr.helpers.numeric import list_mean
 
 
 def test_list_mean_non_empty():

--- a/tests/test_neighbor_phase_mean_no_graph.py
+++ b/tests/test_neighbor_phase_mean_no_graph.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tnfr.helpers import neighbor_phase_mean
+from tnfr.helpers.numeric import neighbor_phase_mean
 
 
 class DummyNeighbor:

--- a/tests/test_neighbor_phase_mean_performance.py
+++ b/tests/test_neighbor_phase_mean_performance.py
@@ -5,7 +5,7 @@ import math
 import networkx as nx
 import pytest
 
-from tnfr.helpers import neighbor_phase_mean
+from tnfr.helpers.numeric import neighbor_phase_mean
 from tnfr.constants import ALIAS_THETA
 from tnfr.node import NodoNX
 

--- a/tests/test_neighbors_map_cache.py
+++ b/tests/test_neighbors_map_cache.py
@@ -2,7 +2,7 @@ import networkx as nx
 from types import MappingProxyType
 
 from tnfr.metrics_utils import ensure_neighbors_map
-from tnfr.helpers import increment_edge_version
+from tnfr.helpers.cache import increment_edge_version
 
 
 def test_neighbors_map_reuses_proxy():

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -10,7 +10,7 @@ from tnfr.observers import phase_sync, kuramoto_order, glyph_load, wbar
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
 from tnfr.constants_glyphs import ANGLE_MAP
-from tnfr.helpers import angle_diff
+from tnfr.helpers.numeric import angle_diff
 from tnfr.alias import set_attr
 from tnfr.callback_utils import CallbackEvent
 from tnfr.observers import attach_standard_observer

--- a/tests/test_prepare_dnfr_data_performance.py
+++ b/tests/test_prepare_dnfr_data_performance.py
@@ -4,7 +4,7 @@ import pytest
 
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF
 from tnfr.dynamics import _prepare_dnfr_data
-from tnfr.helpers import cached_nodes_and_A
+from tnfr.helpers.cache import cached_nodes_and_A
 from tnfr.alias import get_attr
 
 

--- a/tests/test_selector_utils.py
+++ b/tests/test_selector_utils.py
@@ -11,7 +11,7 @@ from tnfr.selector import (
 )
 from tnfr.constants import DEFAULTS, ALIAS_DNFR, ALIAS_D2EPI
 from tnfr.constants.core import SELECTOR_THRESHOLD_DEFAULTS
-from tnfr.helpers import clamp01
+from tnfr.helpers.numeric import clamp01
 from tnfr.collections_utils import normalize_weights
 from tnfr.dynamics import _configure_selector_weights
 

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -9,7 +9,7 @@ from tnfr.metrics_utils import (
     get_trig_cache,
 )
 from tnfr.alias import get_attr, set_attr
-from tnfr.helpers import increment_edge_version
+from tnfr.helpers.cache import increment_edge_version
 
 
 def test_get_si_weights_normalization():

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from tnfr.helpers import _stable_json
+from tnfr.helpers.cache import _stable_json
 
 
 def test_stable_json_set_order_deterministic():

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -9,7 +9,7 @@ from tnfr.trace import (
     grammar_field,
     CallbackSpec,
 )
-from tnfr.helpers import get_graph_mapping
+from tnfr.helpers.cache import get_graph_mapping
 from tnfr.callback_utils import register_callback, invoke_callbacks
 from types import MappingProxyType
 

--- a/tests/test_trig_cache_reuse.py
+++ b/tests/test_trig_cache_reuse.py
@@ -4,7 +4,7 @@ import pytest
 
 from tnfr.constants import ALIAS_THETA, ALIAS_VF, ALIAS_DNFR
 from tnfr.metrics_utils import get_trig_cache, compute_Si
-from tnfr.helpers import neighbor_phase_mean
+from tnfr.helpers.numeric import neighbor_phase_mean
 from tnfr.alias import set_attr
 
 


### PR DESCRIPTION
## Summary
- Split `helpers.py` into `helpers.numeric`, `helpers.history`, and `helpers.cache`
- Update internal imports and tests to use the new submodules
- Re-export helper APIs in `helpers.__init__` to retain backwards compatibility

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bea5b7c3d48321ab827e5b478cdcf2