### PR TITLE
feat: add thread-safe step function getter

### DIFF
--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -1,3 +1,4 @@
+import threading
 import networkx as nx
 import tnfr.dynamics as dyn
 from tnfr.program import _advance
@@ -15,9 +16,42 @@ def test_advance_caches_step(monkeypatch):
         calls.append(2)
 
     monkeypatch.setattr(dyn, "step", first_step)
-    monkeypatch.setattr("tnfr.program._STEP_FN", None)
+    monkeypatch.setattr("tnfr.program._StepFnCache.step_fn", None)
     _advance(G)
     monkeypatch.setattr(dyn, "step", second_step)
     _advance(G)
     assert calls == [1, 1]
-    monkeypatch.setattr("tnfr.program._STEP_FN", None)
+    monkeypatch.setattr("tnfr.program._StepFnCache.step_fn", None)
+
+
+def test_advance_thread_safe(monkeypatch):
+    G = nx.Graph()
+    G.add_node(0)
+    calls = []
+
+    def first_step(G):
+        calls.append(1)
+
+    def second_step(G):
+        calls.append(2)
+
+    monkeypatch.setattr(dyn, "step", first_step)
+    monkeypatch.setattr("tnfr.program._StepFnCache.step_fn", None)
+
+    barrier = threading.Barrier(5)
+
+    def worker():
+        barrier.wait()
+        _advance(G)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    monkeypatch.setattr(dyn, "step", second_step)
+    _advance(G)
+
+    assert calls == [1] * 6
+    monkeypatch.setattr("tnfr.program._StepFnCache.step_fn", None)


### PR DESCRIPTION
## Summary
- replace global step cache with `_StepFnCache` and expose `get_step_fn`
- use new getter in `_advance`
- add concurrent tests for step function caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea8983af483218f85d0817c3a7dca