### PR TITLE
Precompute neighbour trig arrays for Si metric

### DIFF
--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -7,7 +7,11 @@ from tnfr.alias import set_attr
 
 def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch):
     calls = 0
-    sentinel = object()
+    class DummyNP:
+        def fromiter(self, iterable, dtype=float, count=-1):
+            return list(iterable)
+
+    sentinel = DummyNP()
 
     def fake_get_numpy():
         nonlocal calls
@@ -17,7 +21,8 @@ def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch):
     captured = []
 
     def fake_compute_Si_node(n, nd, *, alpha, beta, gamma, vfmax, dnfrmax,
-                             cos_th, sin_th, thetas, neighbors, inplace, np=None):
+                             cos_vals, sin_vals, theta_vals, theta_i,
+                             inplace, np=None):
         captured.append(np)
         return 0.0
 


### PR DESCRIPTION
## Summary
- Optimize `compute_Si` by precomputing neighbour cosine, sine and theta arrays
- Update `compute_Si_node` to consume pre-built trigonometric arrays
- Adjust Si-related unit tests for new API and verify NumPy propagation

## Testing
- `PYTHONPATH=src pytest tests/test_si_helpers.py::test_compute_Si_node -q`
- `PYTHONPATH=src pytest tests/test_compute_Si_numpy_usage.py::test_compute_Si_calls_get_numpy_once_and_propagates -q`
- `PYTHONPATH=src pytest tests/test_trig_cache_reuse.py::test_trig_cache_reuse_between_modules -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea997e6d0832194126ba513d4c7d7