### PR TITLE
Refactor Si trig caching

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -141,7 +141,6 @@ def compute_Si_node(
     dnfrmax: float,
     cos_vals: Sequence[float],
     sin_vals: Sequence[float],
-    theta_vals: Sequence[float],
     theta_i: float,
     inplace: bool,
     np=None,
@@ -150,7 +149,7 @@ def compute_Si_node(
 
     Parameters
     ----------
-    cos_vals, sin_vals, theta_vals:
+    cos_vals, sin_vals:
         Pre-computed trigonometric values of the neighbouring nodes.
     theta_i:
         Phase of the current node.
@@ -212,17 +211,14 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
 
     cos_cache: Dict[Any, Sequence[float]] = {}
     sin_cache: Dict[Any, Sequence[float]] = {}
-    theta_cache: Dict[Any, Sequence[float]] = {}
     for n, neigh in neighbors.items():
         deg = len(neigh)
         if np is not None and deg:
             cos_cache[n] = np.fromiter((cos_th[v] for v in neigh), dtype=float, count=deg)
             sin_cache[n] = np.fromiter((sin_th[v] for v in neigh), dtype=float, count=deg)
-            theta_cache[n] = np.fromiter((thetas[v] for v in neigh), dtype=float, count=deg)
         else:
             cos_cache[n] = [cos_th[v] for v in neigh]
             sin_cache[n] = [sin_th[v] for v in neigh]
-            theta_cache[n] = [thetas[v] for v in neigh]
 
     out: Dict[Any, float] = {}
     for n, nd in G.nodes(data=True):
@@ -236,7 +232,6 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
             dnfrmax=dnfrmax,
             cos_vals=cos_cache[n],
             sin_vals=sin_cache[n],
-            theta_vals=theta_cache[n],
             theta_i=thetas[n],
             inplace=inplace,
             np=np,

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -21,7 +21,7 @@ def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch):
     captured = []
 
     def fake_compute_Si_node(n, nd, *, alpha, beta, gamma, vfmax, dnfrmax,
-                             cos_vals, sin_vals, theta_vals, theta_i,
+                             cos_vals, sin_vals, theta_i,
                              inplace, np=None):
         captured.append(np)
         return 0.0

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -70,9 +70,9 @@ def test_compute_Si_node():
     cos_th, sin_th, thetas = trig.cos, trig.sin, trig.theta
     neigh = [2]
     np_mod = get_numpy()
+    assert np_mod is not None
     cos_arr = np_mod.fromiter((cos_th[v] for v in neigh), dtype=float, count=len(neigh))
     sin_arr = np_mod.fromiter((sin_th[v] for v in neigh), dtype=float, count=len(neigh))
-    theta_arr = np_mod.fromiter((thetas[v] for v in neigh), dtype=float, count=len(neigh))
     Si = compute_Si_node(
         1,
         G.nodes[1],
@@ -83,7 +83,6 @@ def test_compute_Si_node():
         dnfrmax=1.0,
         cos_vals=cos_arr,
         sin_vals=sin_arr,
-        theta_vals=theta_arr,
         theta_i=thetas[1],
         inplace=True,
         np=np_mod,
@@ -108,7 +107,6 @@ def test_compute_Si_node():
     np_dummy = DummyNP()
     cos_arr = np_dummy.fromiter((cos_th[v] for v in neigh), dtype=float, count=len(neigh))
     sin_arr = np_dummy.fromiter((sin_th[v] for v in neigh), dtype=float, count=len(neigh))
-    theta_arr = np_dummy.fromiter((thetas[v] for v in neigh), dtype=float, count=len(neigh))
     Si_np = compute_Si_node(
         1,
         G.nodes[1],
@@ -119,7 +117,6 @@ def test_compute_Si_node():
         dnfrmax=1.0,
         cos_vals=cos_arr,
         sin_vals=sin_arr,
-        theta_vals=theta_arr,
         theta_i=thetas[1],
         inplace=False,
         np=np_dummy,


### PR DESCRIPTION
## Summary
- drop unused `theta_vals` parameter from `compute_Si_node`
- simplify `compute_Si` to cache only cosine and sine values
- adjust tests to the new interface

## Testing
- `PYTHONPATH=src pytest tests/test_si_helpers.py tests/test_compute_Si_numpy_usage.py`
- `pyright src/tnfr/metrics_utils.py tests/test_si_helpers.py tests/test_compute_Si_numpy_usage.py` *(fails: existing type errors in src/tnfr/metrics_utils.py)*

------
https://chatgpt.com/codex/tasks/task_e_68beb17d275c8321bac4d18ca11b9610