### PR TITLE
Add phase version invalidation for trig cache

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -24,7 +24,7 @@ import logging
 from functools import lru_cache
 from .logging_utils import get_logger
 
-from .constants import ALIAS_VF, ALIAS_DNFR
+from .constants import ALIAS_VF, ALIAS_DNFR, ALIAS_THETA
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
@@ -41,6 +41,7 @@ __all__ = [
     "set_attr_with_max",
     "set_vf",
     "set_dnfr",
+    "set_theta",
     "recompute_abs_max",
     "multi_recompute_abs_max",
 ]
@@ -281,3 +282,11 @@ def set_vf(G: "nx.Graph", n: Hashable, value: float, *, update_max: bool = True)
 def set_dnfr(G: "nx.Graph", n: Hashable, value: float) -> None:
     """Set ``ΔNFR`` for node ``n`` and update the global maximum."""
     set_attr_with_max(G, n, ALIAS_DNFR, value, cache="_dnfrmax")
+
+
+def set_theta(G: "nx.Graph", n: Hashable, value: float) -> None:
+    """Set ``θ`` for node ``n`` and increment the trig cache version."""
+    val = float(value)
+    set_attr(G.nodes[n], ALIAS_THETA, val)
+    g = G.graph
+    g["_trig_version"] = int(g.get("_trig_version", 0)) + 1

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -47,11 +47,12 @@ from ..helpers.cache import (
 )
 from ..alias import (
     get_attr,
-    set_attr,
     get_attr_str,
     set_attr_str,
     set_vf,
     set_dnfr,
+    set_attr,
+    set_theta,
     multi_recompute_abs_max,
 )
 from ..metrics_utils import compute_Si, compute_dnfr_accel_max, get_trig_cache
@@ -147,7 +148,11 @@ def apply_canonical_clamps(nd: Dict[str, Any], G=None, node=None) -> None:
     else:
         set_attr(nd, ALIAS_VF, clamp(vf, vf_min, vf_max))
     if G.graph.get("THETA_WRAP") if G is not None else DEFAULTS["THETA_WRAP"]:
-        set_attr(nd, ALIAS_THETA, ((th + math.pi) % (2 * math.pi) - math.pi))
+        new_th = ((th + math.pi) % (2 * math.pi) - math.pi)
+        if G is not None and node is not None:
+            set_theta(G, node, new_th)
+        else:
+            set_attr(nd, ALIAS_THETA, new_th)
 
 
 def validate_canon(G) -> None:
@@ -300,7 +305,7 @@ def coordinate_global_local_phase(
         thL = neighbor_phase_mean(G, n)
         dG = angle_diff(thG, th)
         dL = angle_diff(thL, th)
-        set_attr(nd, ALIAS_THETA, th + kG * dG + kL * dL)
+        set_theta(G, n, th + kG * dG + kL * dL)
 
 
 # -------------------------

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -126,8 +126,16 @@ def _build_trig_cache(G: Any) -> TrigCache:
 
 
 def get_trig_cache(G: Any) -> TrigCache:
-    """Return cached cosines and sines of ``θ`` per node."""
-    return edge_version_cache(G, "_trig", lambda: _build_trig_cache(G))
+    """Return cached cosines and sines of ``θ`` per node.
+
+    The cache is invalidated not only when the edge set changes but also when
+    node phases ``θ`` are updated. A per-graph ``_trig_version`` counter is
+    incremented whenever phases change and forms part of the cache key, forcing
+    a rebuild when the counter advances.
+    """
+    version = G.graph.setdefault("_trig_version", 0)
+    key = ("_trig", version)
+    return edge_version_cache(G, key, lambda: _build_trig_cache(G))
 
 
 def compute_Si_node(

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -26,6 +26,7 @@ from .alias import (
     set_attr_str,
     set_vf,
     set_dnfr,
+    set_theta,
 )
 from .helpers.cache import increment_edge_version
 
@@ -271,7 +272,7 @@ class NodoNX(NodoProtocol):
 
     EPI = _nx_attr_property(ALIAS_EPI)
     vf = _nx_attr_property(ALIAS_VF, setter=set_vf, use_graph_setter=True)
-    theta = _nx_attr_property(ALIAS_THETA)
+    theta = _nx_attr_property(ALIAS_THETA, setter=set_theta, use_graph_setter=True)
     Si = _nx_attr_property(ALIAS_SI)
     epi_kind = _nx_attr_property(
         ALIAS_EPI_KIND,

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -1,6 +1,7 @@
 import math
 import networkx as nx
 import pytest
+import math
 
 from tnfr.constants import ALIAS_DNFR, ALIAS_SI, ALIAS_THETA, ALIAS_VF
 from tnfr.metrics_utils import (
@@ -9,7 +10,7 @@ from tnfr.metrics_utils import (
     get_trig_cache,
     get_numpy,
 )
-from tnfr.alias import get_attr, set_attr
+from tnfr.alias import get_attr, set_attr, set_theta
 from tnfr.helpers.cache import increment_edge_version
 
 
@@ -57,6 +58,18 @@ def test_get_trig_cache_invalidation_on_version():
     trig3 = get_trig_cache(G)
     assert trig3 is not trig1
     assert 1 in trig3.cos and 1 not in trig1.cos
+
+
+def test_get_trig_cache_invalidation_on_phase_change():
+    G = nx.Graph()
+    G.add_edge(1, 2)
+    set_attr(G.nodes[1], ALIAS_THETA, 0.0)
+    set_attr(G.nodes[2], ALIAS_THETA, 0.0)
+    trig1 = get_trig_cache(G)
+    set_theta(G, 1, math.pi / 2)
+    trig2 = get_trig_cache(G)
+    assert trig2 is not trig1
+    assert trig2.theta[1] == pytest.approx(math.pi / 2)
 
 
 def test_compute_Si_node():


### PR DESCRIPTION
## Summary
- Track per-graph `_trig_version` and include it in trig cache keys
- Increment phase version whenever node angles change via `set_theta`
- Invalidate trig cache automatically when phases update
- Add test covering phase change invalidation

## Testing
- `pip install -e .`
- `pip install numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb2e3487083219f022e493e2e3f7e