### PR TITLE
Handle TypeError in token parser

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -24,6 +24,13 @@ def _flatten_tokens(obj: Any):
 def validate_token(
     tok: Any, pos: int, token_map: dict[str, Callable[[Any], Any]]
 ) -> Any:
+    """Validate a token and wrap handler errors with context.
+
+    The handler retrieved from ``token_map`` may raise ``KeyError``,
+    ``ValueError`` or ``TypeError``. These exceptions are intercepted and
+    re-raised as :class:`ValueError` with additional positional context.
+    """
+
     if isinstance(tok, dict):
         if len(tok) != 1:
             raise ValueError(
@@ -37,7 +44,7 @@ def validate_token(
             )
         try:
             return handler(val)
-        except (KeyError, ValueError) as e:
+        except (KeyError, ValueError, TypeError) as e:
             msg = f"{type(e).__name__}: {e} (posición {pos}, token {tok!r})"
             raise ValueError(msg) from e
     if isinstance(tok, str):

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -29,6 +29,19 @@ def test_parse_tokens_key_error_context(monkeypatch):
     assert isinstance(exc.value.__cause__, KeyError)
 
 
+def test_parse_tokens_type_error_context(monkeypatch):
+    def raiser(spec):
+        raise TypeError("boom")
+
+    monkeypatch.setitem(TOKEN_MAP, "RAISE_TYPE", raiser)
+    with pytest.raises(ValueError) as exc:
+        _parse_tokens([{"RAISE_TYPE": {}}])
+    msg = str(exc.value)
+    assert "posición 1" in msg
+    assert "RAISE_TYPE" in msg
+    assert isinstance(exc.value.__cause__, TypeError)
+
+
 def test_thol_invalid_close():
     with pytest.raises(ValueError) as exc:
         _parse_tokens([{"THOL": {"close": "XYZ"}}])


### PR DESCRIPTION
## Summary
- catch `TypeError` from token handlers and re-raise with positional context
- clarify `validate_token` docstring
- add tests covering `TypeError` propagation

## Testing
- `PYTHONPATH=src pytest tests/test_parse_tokens_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68beb646a7908321870e1a92542a3ab2