### PR TITLE
Cache NodoNX import in jitter seed resolution

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -85,7 +85,8 @@ def _get_networkx_modules():
 
 
 def _resolve_jitter_seed(node: NodoProtocol) -> tuple[int, int]:
-    if isinstance(node, import_nodonx()):
+    NodoNX = import_nodonx()  # cache import to avoid repeated lookups
+    if isinstance(node, NodoNX):
         return _node_offset(node.G, node.n), id(node.G)
     uid = getattr(node, "_noise_uid", None)
     if uid is None:


### PR DESCRIPTION
## Summary
- Cache result of `import_nodonx()` in `_resolve_jitter_seed`
- Use cached `NodoNX` class for `isinstance` check to avoid repeated lookups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb7767cd48321b88b888466d39434