### PR TITLE
fix: guard against None in edge_version_cache max_entries check

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -297,7 +297,7 @@ def edge_version_cache(
 
     When ``max_entries`` is a positive integer-like value, only the most recent
     ``max_entries`` cache entries are kept (defaults to ``128``).  If
-    ``max_entries`` is ``None`` the cache may grow without bound.  A
+    ``max_entries`` is ``None`` the cache may grow without bound.  An explicit
     ``max_entries`` value of ``0`` disables caching entirely and ``builder``
     is executed on each invocation.  ``max_entries`` is coerced to ``int`` on
     entry and validated to be non-negative. The ``builder`` is executed
@@ -308,7 +308,7 @@ def edge_version_cache(
         max_entries = int(max_entries)
         if max_entries < 0:
             raise ValueError("max_entries must be non-negative or None")
-    if max_entries == 0:
+    if max_entries is not None and max_entries == 0:
         return builder()
 
     graph = get_graph(G)


### PR DESCRIPTION
## Summary
- handle `max_entries=None` when checking for disabled caching
- clarify `edge_version_cache` docstring about explicit 0 disabling cache

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bebb596c6883219d68c73223b1fa82