### PR TITLE
refactor edge cache factory

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -230,12 +230,38 @@ def ensure_node_offset_map(G) -> Dict[Any, int]:
     return _ensure_node_map(G, key="_node_offset_map", sort=sort)
 
 
+def _make_edge_cache(max_entries: int, locks: dict) -> Any:
+    """Create an ``LRUCache`` for edge data with lock cleanup support.
+
+    The cache removes any per-key locks when entries are evicted.  For older
+    versions of :mod:`cachetools` lacking a ``callback`` parameter, a small
+    subclass provides equivalent behaviour.
+    """
+    try:
+        return LRUCache(max_entries, callback=lambda k, _: locks.pop(k, None))
+    except TypeError:  # pragma: no cover - legacy cachetools
+        class _LRUCache(LRUCache):
+            def __init__(self, maxsize, *, callback=None):
+                super().__init__(maxsize)
+                self._callback = callback
+
+            def popitem(self):  # type: ignore[override]
+                key, value = super().popitem()
+                cb = getattr(self, "_callback", None)
+                if cb is not None:
+                    cb(key, value)
+                return key, value
+
+        return _LRUCache(max_entries, callback=lambda k, v: locks.pop(k, None))
+
+
 def _get_edge_cache(graph: Any, max_entries: int | None, *, create: bool = True):
     """Return edge cache and lock mapping for ``graph``.
 
     When ``create`` is ``True`` missing structures are initialized according
     to ``max_entries``. Returns a tuple ``(cache, locks, use_lru)`` where
-    ``use_lru`` indicates whether an ``LRUCache`` is employed.
+    ``use_lru`` indicates whether an :class:`cachetools.LRUCache` is employed.
+    Actual cache construction is handled by :func:`_make_edge_cache`.
     """
     use_lru = bool(max_entries)
     locks = graph.get("_edge_version_cache_locks")
@@ -257,27 +283,7 @@ def _get_edge_cache(graph: Any, max_entries: int | None, *, create: bool = True)
             or (not use_lru and isinstance(cache, LRUCache))
         ):
             if use_lru:
-                try:
-                    cache = LRUCache(
-                        max_entries,
-                        callback=lambda k, _: locks.pop(k, None),
-                    )
-                except TypeError:  # pragma: no cover - legacy cachetools
-                    class _LRUCache(LRUCache):
-                        def __init__(self, maxsize, *, callback=None):
-                            super().__init__(maxsize)
-                            self._callback = callback
-
-                        def popitem(self):  # type: ignore[override]
-                            key, value = super().popitem()
-                            cb = getattr(self, "_callback", None)
-                            if cb is not None:
-                                cb(key, value)
-                            return key, value
-
-                    cache = _LRUCache(
-                        max_entries, callback=lambda k, v: locks.pop(k, None)
-                    )
+                cache = _make_edge_cache(max_entries, locks)
             else:
                 cache = {}
             graph["_edge_version_cache"] = cache


### PR DESCRIPTION
## Summary
- add `_make_edge_cache` helper to centralise LRU cache creation and legacy fallback
- reuse `_make_edge_cache` inside `_get_edge_cache`
- update documentation to mention new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebf2121608321ae17c17a85ef9ae7