### PR TITLE
Refactor alias accessor to share validation logic

### DIFF
--- a/tests/test_alias_accessor_usage.py
+++ b/tests/test_alias_accessor_usage.py
@@ -22,3 +22,8 @@ def test_get_and_set_work_with_functions_and_object(getter, setter):
     assert getter(d, ("a", "b"), default=None) == 1
     setter(d, ("b", "c"), "2")
     assert getter(d, ("b", "c"), default=None) == 2
+
+
+def test_get_uses_accessor_default():
+    acc = AliasAccessor(int, default=7)
+    assert acc.get({}, ("x", "y")) == 7


### PR DESCRIPTION
## Summary
- add AliasAccessor._prepare to centralize alias validation and conv/default resolution
- reuse _prepare in get and set to remove duplication
- test AliasAccessor default handling via new test

## Testing
- `PYTHONPATH=src pytest tests/test_alias_accessor_usage.py tests/test_alias_cache.py tests/test_alias_iterable.py tests/test_validate_aliases.py tests/test_alias_helpers_threadsafe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bebffe25948321a06a0ca735cc1500