### PR TITLE
feat: improve collection handling

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -172,7 +172,7 @@ def _flatten_thol(item: THOL, stack: deque[Any]) -> None:
         and item.force_close in {Glyph.SHA, Glyph.NUL}
         else None
     )
-    seq = ensure_collection(item.body)
+    seq = ensure_collection(item.body, max_materialize=None)
 
     def _iter_reversed_body():
         for _ in range(repeats):
@@ -192,7 +192,7 @@ def _flatten(seq: Sequence[Token]) -> list[tuple[str, Any]]:
     when ``THOL`` blocks are nested.
     """
     ops: list[tuple[str, Any]] = []
-    stack: deque[Any] = deque(reversed(ensure_collection(seq)))
+    stack: deque[Any] = deque(reversed(ensure_collection(seq, max_materialize=None)))
 
     while stack:
         item = stack.pop()

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -29,7 +29,10 @@ def test_max_materialize_limit():
     gen = (i for i in range(5))
     with pytest.raises(ValueError) as exc:
         ensure_collection(gen, max_materialize=3)
-    assert str(exc.value) == "Iterable produced 4 items, exceeds limit 3"
+    assert (
+        str(exc.value)
+        == "Iterable produced 4 items, exceeds limit 3; first items: [0, 1, 2]"
+    )
     assert list(gen) == [4]
 
 
@@ -59,6 +62,12 @@ def test_none_disables_limit():
     gen = (i for i in range(1001))
     data = ensure_collection(gen, max_materialize=None)
     assert len(data) == 1001
+
+
+def test_custom_error_msg():
+    gen = (i for i in range(5))
+    with pytest.raises(ValueError, match="custom message"):
+        ensure_collection(gen, max_materialize=3, error_msg="custom message")
 
 
 def test_non_iterable_error():


### PR DESCRIPTION
## Summary
- document default materialization limit and allow customizing error message
- include sample elements when materialization limit exceeded
- disable default materialization limit in critical program paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec10a5bc88321b27d46c42e10fccf