### PR TITLE
Refactor gamma defaults and history helpers

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -56,14 +56,17 @@ def ensure_collection(
     if isinstance(it, (str, bytes, bytearray)):
         # Treat raw bytes/strings as single elements
         return cast(Collection[T], (it,))
-    if max_materialize is not None and max_materialize < 0:
-        raise ValueError("'max_materialize' must be non-negative")
+    if max_materialize is not None:
+        limit = int(max_materialize)
+        if limit < 0:
+            raise ValueError("'max_materialize' must be non-negative")
+    else:
+        limit = None
 
     try:
-        if max_materialize is None:
+        if limit is None:
             # No limit: consume iterable fully
             return tuple(it)
-        limit = max_materialize  # materialization cap
         if limit == 0:
             # Explicitly allow empty result without consumption
             return ()

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -173,12 +173,13 @@ def _flatten_thol(item: THOL, stack: deque[Any]) -> None:
         else None
     )
     seq = ensure_collection(item.body, max_materialize=None)
+    rev_seq = tuple(reversed(seq))
 
     def _iter_reversed_body():
         for _ in range(repeats):
             if closing is not None:
                 yield closing
-            yield from reversed(seq)
+            yield from rev_seq
 
     stack.extend(_iter_reversed_body())
     stack.append(THOL_SENTINEL)

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -73,3 +73,8 @@ def test_custom_error_msg():
 def test_non_iterable_error():
     with pytest.raises(TypeError):
         ensure_collection(42)  # type: ignore[arg-type]
+
+
+def test_max_materialize_accepts_float():
+    gen = (i for i in range(3))
+    assert ensure_collection(gen, max_materialize=3.0) == (0, 1, 2)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -135,7 +135,7 @@ def test_gamma_spec_normalized_once(graph_canon, monkeypatch):
     def fake_warn(*args, **kwargs):
         calls.append(1)
 
-    monkeypatch.setattr("tnfr.gamma.warnings.warn", fake_warn)
+    monkeypatch.setattr("tnfr.helpers.cache.warnings.warn", fake_warn)
     eval_gamma(G, 0, t=0.0)
     eval_gamma(G, 0, t=0.0)
     assert len(calls) == 1

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -19,6 +19,7 @@ from tnfr.program import (
     target,
     wait,
     THOL,
+    THOL_SENTINEL,
 )
 from tnfr.constants import get_param
 from tnfr.types import Glyph
@@ -213,3 +214,17 @@ def test_flatten_accepts_sequence_without_reversed():
 def test_thol_repeat_lt_one_raises():
     with pytest.raises(ValueError, match="repeat must be ≥1"):
         _flatten_thol(THOL(body=[], repeat=0), deque())
+
+
+def test_flatten_thol_multiple_repeats():
+    stack = deque()
+    _flatten_thol(THOL(body=[Glyph.AL, Glyph.RA], repeat=3), stack)
+    assert list(stack) == [
+        Glyph.RA,
+        Glyph.AL,
+        Glyph.RA,
+        Glyph.AL,
+        Glyph.RA,
+        Glyph.AL,
+        THOL_SENTINEL,
+    ]

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -45,6 +45,12 @@ def test_recent_glyph_history_lookup():
     assert recent_glyph(nd, "A", window=3)
 
 
+def test_recent_glyph_discards_non_iterable_history():
+    nd = {"glyph_history": 1}  # type: ignore[assignment]
+    assert not recent_glyph(nd, "A", window=1)
+    assert list(nd["glyph_history"]) == []
+
+
 @pytest.mark.slow
 def test_recent_glyph_benchmark():
     nd = _make_node([str(i) for i in range(1000)], window=1000)


### PR DESCRIPTION
## Summary
- centralize default gamma spec and hash reuse
- coerce `max_materialize` to int and support floats in `ensure_collection`
- harden glyph history utilities and `_flatten_thol`

## Testing
- `pytest tests/test_ensure_collection.py tests/test_program.py tests/test_recent_glyph.py`
- `pytest tests/test_gamma.py`


------
https://chatgpt.com/codex/tasks/task_e_68bec26f0a948321ad6ff69dd35b7b0c