### PR TITLE
chore: reorder typing imports

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Dict, Callable, TypeVar
 import hashlib
-import threading
 import json
-from functools import lru_cache
-from cachetools import LRUCache
+import threading
 import warnings
 from collections.abc import Mapping
+from functools import lru_cache
 from types import MappingProxyType
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Optional,
+    Tuple,
+    TypeVar,
+)
+
+from cachetools import LRUCache
 import networkx as nx
 
-from ..import_utils import get_numpy
 from ..graph_utils import mark_dnfr_prep_dirty
+from ..import_utils import get_numpy
 
 T = TypeVar("T")
 


### PR DESCRIPTION
## Summary
- reorder imports in cache helper to match project style
- expand typing imports with Optional and Tuple

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beca44ef5883219a8befc8f35e7fdb