### PR TITLE
chore: update callback utilities imports

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, DefaultDict, TYPE_CHECKING
+from typing import Any, Callable, Dict, DefaultDict, TYPE_CHECKING
 from enum import Enum
-from collections import defaultdict, deque
+from collections import deque, defaultdict
 from collections.abc import Mapping, Sequence
 import traceback
 from .logging_utils import get_logger
@@ -33,7 +33,7 @@ _CALLBACK_EVENTS: set[str] = {e.value for e in CallbackEvent}
 _CALLBACK_ERROR_LIMIT = 100  # keep only this many recent callback errors
 
 
-Callback = Callable[["nx.Graph", dict[str, Any]], None]
+Callback = Callable[["nx.Graph", Dict[str, Any]], None]
 CallbackRegistry = DefaultDict[str, list["CallbackSpec"]]
 
 
@@ -165,7 +165,7 @@ def register_callback(
 def invoke_callbacks(
     G: "nx.Graph",
     event: CallbackEvent | str,
-    ctx: dict[str, Any] | None = None,
+    ctx: Dict[str, Any] | None = None,
 ) -> None:
     """Invoke all callbacks registered for ``event`` with context ``ctx``."""
     event = _normalize_event(event)


### PR DESCRIPTION
## Summary
- add missing typing Dict import and standardize collection imports
- use Dict-based type hints to satisfy linters

## Testing
- `ruff check src/tnfr/callback_utils.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beccb76a208321953b6cc8a90bd9e5