### PR TITLE
feat(cli): share argument specs helper

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -2,12 +2,7 @@ import argparse
 from typing import Any
 
 from ..gamma import GAMMA_REGISTRY
-
-
-# Helper to build reusable argument specification lists
-
-def specs(*pairs: tuple[str, dict[str, Any]]) -> list[tuple[str, dict[str, Any]]]:
-    return list(pairs)
+from .utils import specs
 
 
 GRAMMAR_ARG_SPECS = specs(

--- a/src/tnfr/cli/utils.py
+++ b/src/tnfr/cli/utils.py
@@ -1,0 +1,15 @@
+"""Utilities for CLI modules."""
+
+from typing import Any
+
+
+def specs(*pairs: tuple[str, dict[str, Any]]) -> list[tuple[str, dict[str, Any]]]:
+    """Build a list of argument specifications.
+
+    Each pair contains an option string and a mapping of keyword arguments for
+    :meth:`argparse.ArgumentParser.add_argument`. The helper simply converts the
+    variadic sequence into a list, which makes the specs reusable across
+    parsers.
+    """
+
+    return list(pairs)


### PR DESCRIPTION
## Summary
- add `tnfr.cli.utils.specs` for reusable argument definitions
- use shared `specs` in `cli.arguments`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beccbd37b8832180c0fb7c801b5bfc