### PR TITLE
Improve constant immutability and utility performance

### DIFF
--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -7,14 +7,16 @@ from typing import Dict, Any, Mapping
 from types import MappingProxyType
 
 
-SELECTOR_THRESHOLD_DEFAULTS = {
-    "si_hi": 0.66,
-    "si_lo": 0.33,
-    "dnfr_hi": 0.50,
-    "dnfr_lo": 0.10,
-    "accel_hi": 0.50,
-    "accel_lo": 0.10,
-}
+SELECTOR_THRESHOLD_DEFAULTS: Mapping[str, float] = MappingProxyType(
+    {
+        "si_hi": 0.66,
+        "si_lo": 0.33,
+        "dnfr_hi": 0.50,
+        "dnfr_lo": 0.10,
+        "accel_hi": 0.50,
+        "accel_lo": 0.10,
+    }
+)
 
 
 @dataclass(frozen=True)

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -177,6 +177,8 @@ class HistoryDict(dict):
     def __setitem__(self, key, value):  # type: ignore[override]
         super().__setitem__(key, value)
         if key in self._counts:
+            self._heap = [(cnt, k) for cnt, k in self._heap if k != key]
+            heapq.heapify(self._heap)
             heapq.heappush(self._heap, (self._counts[key], key))
         else:
             self._counts[key] = 0

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -180,9 +180,10 @@ def node_set_checksum(
     """
     graph = get_graph(G)
     node_iterable = G.nodes() if nodes is None else nodes
-    representations = [_node_repr(n) for n in node_iterable]
-    if not presorted:
-        representations.sort()
+    if presorted:
+        representations = map(_node_repr, node_iterable)
+    else:
+        representations = sorted(_node_repr(n) for n in node_iterable)
     hasher = hashlib.blake2b(digest_size=16)
     token_hasher = hashlib.blake2b(digest_size=8)
     for rep in representations:

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -39,15 +39,8 @@ def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
 
 
 def kahan_sum(values: Iterable[float]) -> float:
-    """Return the precise sum of ``values`` using Kahan compensation."""
-    total = 0.0
-    c = 0.0
-    for v in values:
-        y = float(v) - c
-        t = total + y
-        c = (t - total) - y
-        total = t
-    return total
+    """Return the precise sum of ``values``."""
+    return float(math.fsum(values))
 
 
 def angle_diff(a: float, b: float) -> float:
@@ -114,18 +107,14 @@ def neighbor_phase_mean_list(
     if deg == 0:
         return fallback
     if np is not None:
-        cos_vals = np.fromiter(
-            (cos_th[v] for v in neigh), dtype=float, count=deg
-        )
-        sin_vals = np.fromiter(
-            (sin_th[v] for v in neigh), dtype=float, count=deg
-        )
-        mean_cos = float(cos_vals.mean())
-        mean_sin = float(sin_vals.mean())
+        pairs = np.fromiter(
+            (val for v in neigh for val in (cos_th[v], sin_th[v])),
+            dtype=float,
+            count=deg * 2,
+        ).reshape(deg, 2)
+        mean_cos, mean_sin = pairs.mean(axis=0)
         return float(np.arctan2(mean_sin, mean_cos))
-    return _phase_mean_from_iter(
-        ((cos_th[v], sin_th[v]) for v in neigh), fallback
-    )
+    return _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), fallback)
 
 
 def neighbor_phase_mean(obj, n=None) -> float:

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -259,7 +259,8 @@ class NodoTNFR:
         return 0
 
     def all_nodes(self) -> Iterable["NodoTNFR"]:
-        return list(self.graph.get("_all_nodes", [self]))
+        nodes = self.graph.get("_all_nodes")
+        return nodes if nodes is not None else [self]
 
     def apply_glyph(self, glyph: str, window: Optional[int] = None) -> None:
         apply_glyph_obj(self, glyph, window=window)

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -19,6 +19,7 @@ from typing import Dict, Any, TYPE_CHECKING, Optional
 import math
 import hashlib
 import heapq
+import struct
 from operator import ge, le
 from functools import cache
 from itertools import combinations
@@ -132,7 +133,11 @@ def random_jitter(node: NodoProtocol, amplitude: float) -> float:
     cache_key = (seed_root, scope_id)
     seed = cache.get(cache_key)
     if seed is None:
-        seed_bytes = f"{seed_root}:{scope_id}".encode()
+        seed_bytes = struct.pack(
+            ">QQ",
+            seed_root & 0xFFFFFFFFFFFFFFFF,
+            scope_id & 0xFFFFFFFFFFFFFFFF,
+        )
         seed = int.from_bytes(
             hashlib.blake2b(seed_bytes, digest_size=8).digest(), "little"
         )

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -67,10 +67,15 @@ def _rng_for_step(seed: int, step: int) -> random.Random:
 
 
 def set_cache_maxsize(size: int) -> None:
-    """Update RNG cache maximum size."""
+    """Update RNG cache maximum size.
+
+    ``size`` must be a non-negative integer; ``0`` disables caching.
+    """
 
     global _CACHE_MAXSIZE, _RNG_CACHE
     new_size = int(size)
+    if new_size < 0:
+        raise ValueError("size must be non-negative")
     with _RNG_LOCK:
         _CACHE_MAXSIZE = new_size
         _RNG_CACHE.clear()


### PR DESCRIPTION
## Summary
- expose selector threshold defaults as an immutable MappingProxyType
- streamline numerical helpers and neighbor phase averaging
- harden cache utilities, RNG configuration, history tracking and jitter seeding

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed510e59c8321b75d070c5463b07e