### PR TITLE
Refactor phase mean helper in compute_Si

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -201,19 +201,14 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
     cos_th, sin_th, thetas = trig.cos, trig.sin, trig.theta
     np = get_numpy()
 
-    if np is None:
-
-        def phase_mean_fn(neigh, *, fallback):
+    def phase_mean_fn(neigh, *, fallback):
+        if np is None:
             return neighbor_phase_mean_list(
                 neigh, cos_th, sin_th, fallback=fallback
             )
-
-    else:
-
-        def phase_mean_fn(neigh, *, fallback):
-            return neighbor_phase_mean_list(
-                neigh, cos_th, sin_th, np=np, fallback=fallback
-            )
+        return neighbor_phase_mean_list(
+            neigh, cos_th, sin_th, np=np, fallback=fallback
+        )
 
     out: Dict[Any, float] = {}
     for n, nd in G.nodes(data=True):


### PR DESCRIPTION
## Summary
- Replace duplicated `phase_mean_fn` definitions with a single helper that conditionally uses NumPy when available
- Simplify `compute_Si` by reusing this helper in the main loop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee33ea774832181606e3668f16cda