### PR TITLE
Use orjson for faster JSON serialization when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ pip install tnfr
 * Install extras:
   * NumPy: `pip install tnfr[numpy]`
   * YAML: `pip install tnfr[yaml]`
-  * Both: `pip install tnfr[numpy,yaml]`
+  * orjson (faster JSON serialization): `pip install tnfr[orjson]`
+  * All: `pip install tnfr[numpy,yaml,orjson]`
+* When `orjson` is unavailable the engine falls back to Python's built-in
+  `json` module.
 
 For optional JavaScript tooling, install the Node.js dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 [project.optional-dependencies]
 numpy = ["numpy>=1.24"]
 yaml = ["pyyaml>=6.0"]
+orjson = ["orjson>=3"]
 
 [project.scripts]
 tnfr = "tnfr.cli:main"

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -34,6 +34,7 @@ from ..helpers.numeric import list_mean
 from ..observers import attach_standard_observer
 from ..logging_utils import get_logger
 from ..types import Glyph
+from ..json_utils import fast_dumps
 
 from .arguments import _args_to_dict
 from .token_parser import _parse_tokens
@@ -240,5 +241,5 @@ def cmd_metrics(args: argparse.Namespace) -> int:
     if args.save:
         _save_json(args.save, out)
     else:
-        logger.info("%s", json.dumps(out, ensure_ascii=False, indent=2))
+        logger.info("%s", fast_dumps(out).decode("utf-8"))
     return 0

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -6,7 +6,6 @@ import math
 import cmath
 import logging
 import hashlib
-import json
 from collections.abc import Mapping
 
 from .constants import ALIAS_THETA
@@ -16,15 +15,14 @@ from .helpers.cache import (
     edge_version_cache,
     get_graph_mapping,
 )
+from .json_utils import fast_dumps
 from .logging_utils import get_logger
 
 
 logger = get_logger(__name__)
 
 DEFAULT_GAMMA: Mapping[str, str] = {"type": "none"}
-DEFAULT_GAMMA_DUMPED = json.dumps(DEFAULT_GAMMA, sort_keys=True).encode(
-    "utf-8"
-)
+DEFAULT_GAMMA_DUMPED = fast_dumps(DEFAULT_GAMMA, sort_keys=True)
 DEFAULT_GAMMA_HASH = hashlib.blake2b(
     DEFAULT_GAMMA_DUMPED, digest_size=16
 ).hexdigest()
@@ -98,7 +96,7 @@ def _get_gamma_spec(G) -> Mapping[str, Any]:
             dumped = DEFAULT_GAMMA_DUMPED
             cur_hash = DEFAULT_GAMMA_HASH
         else:
-            dumped = json.dumps(spec, sort_keys=True).encode("utf-8")
+            dumped = fast_dumps(spec, sort_keys=True)
             cur_hash = hashlib.blake2b(dumped, digest_size=16).hexdigest()
         if cached is not None and prev_hash == cur_hash:
             return cached

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -14,7 +14,7 @@ from cachetools import LRUCache
 import networkx as nx
 
 from ..graph_utils import mark_dnfr_prep_dirty
-from ..import_utils import get_numpy
+from ..import_utils import get_numpy, optional_import
 
 T = TypeVar("T")
 
@@ -69,56 +69,72 @@ def get_graph_mapping(
     return MappingProxyType(data)
 
 
+_ORJSON = optional_import("orjson")
+
+
+def _stable_default(o: Any) -> Any:
+    if isinstance(o, set):
+        return sorted(o, key=lambda x: repr(x))
+    slots = getattr(o, "__slots__", None)
+    if slots:
+        return {s: getattr(o, s) for s in slots if hasattr(o, s)}
+    if hasattr(o, "__dict__"):
+        return o.__dict__
+    r = repr(o)
+    return r.split(" at ", 1)[0] + ">" if " at " in r else r
+
+
+def _check_depth(o: Any, depth: int, max_depth: int) -> None:
+    if depth > max_depth:
+        raise ValueError(f"max depth {max_depth} exceeded")
+    if isinstance(o, dict):
+        for v in o.values():
+            _check_depth(v, depth + 1, max_depth)
+    elif isinstance(o, (list, tuple, set)):
+        for item in o:
+            _check_depth(item, depth + 1, max_depth)
+    else:
+        slots = getattr(o, "__slots__", None)
+        if slots:
+            for s in slots:
+                if hasattr(o, s):
+                    _check_depth(getattr(o, s), depth + 1, max_depth)
+        if hasattr(o, "__dict__"):
+            _check_depth(o.__dict__, depth + 1, max_depth)
+
+
 class _Encoder(json.JSONEncoder):
     def __init__(self, *args, max_depth: int = 10, **kwargs):
         self._max_depth = max_depth
         super().__init__(*args, **kwargs)
 
     def default(self, o):
-        if isinstance(o, set):
-            return sorted(o, key=lambda x: repr(x))
-        slots = getattr(o, "__slots__", None)
-        if slots:
-            return {s: getattr(o, s) for s in slots if hasattr(o, s)}
-        if hasattr(o, "__dict__"):
-            return o.__dict__
-        r = repr(o)
-        return r.split(" at ", 1)[0] + ">" if " at " in r else r
+        return _stable_default(o)
 
     def encode(self, o):
         try:
-            self._check_depth(o, 0)
+            _check_depth(o, 0, self._max_depth)
         except RecursionError as exc:
             raise ValueError("circular reference detected") from exc
         return super().encode(o)
 
-    def _check_depth(self, o, depth):
-        if depth > self._max_depth:
-            raise ValueError(f"max depth {self._max_depth} exceeded")
-        if isinstance(o, dict):
-            for v in o.values():
-                self._check_depth(v, depth + 1)
-        elif isinstance(o, (list, tuple, set)):
-            for item in o:
-                self._check_depth(item, depth + 1)
-        else:
-            slots = getattr(o, "__slots__", None)
-            if slots:
-                for s in slots:
-                    if hasattr(o, s):
-                        self._check_depth(getattr(o, s), depth + 1)
-            if hasattr(o, "__dict__"):
-                self._check_depth(o.__dict__, depth + 1)
-
 
 def _stable_json(obj: Any, max_depth: int = 10) -> str:
     """Return a JSON string with deterministic ordering."""
+    if _ORJSON is not None:
+        _check_depth(obj, 0, max_depth)
+        return _ORJSON.dumps(
+            obj,
+            option=_ORJSON.OPT_SORT_KEYS,
+            default=_stable_default,
+        ).decode("utf-8")
     return json.dumps(
         obj,
         sort_keys=True,
         ensure_ascii=False,
         cls=_Encoder,
         max_depth=max_depth,
+        separators=(",", ":"),
     )
 
 

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .import_utils import optional_import
+
+__all__ = ["fast_dumps"]
+
+_orjson = optional_import("orjson")
+
+
+def fast_dumps(obj: Any, *, sort_keys: bool = False) -> bytes:
+    """Serialize ``obj`` to JSON using ``orjson`` when available.
+
+    Returns ``bytes`` for compatibility with :func:`hashlib` and other
+    consumers.  When ``orjson`` is missing the standard :mod:`json` module is
+    used with compact separators to reduce overhead.
+    """
+    if _orjson is not None:
+        option = _orjson.OPT_SORT_KEYS if sort_keys else 0
+        return _orjson.dumps(obj, option=option)
+    return json.dumps(
+        obj, sort_keys=sort_keys, separators=(",", ":")
+    ).encode("utf-8")

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import csv
-import json
 from itertools import zip_longest, tee
 
 from ..glyph_history import ensure_history
 from ..io import safe_write
 from ..constants_glyphs import GLYPHS_CANONICAL
 from .core import glyphogram_series
+from ..json_utils import fast_dumps
 
 
 def _write_csv(path, headers, rows):
@@ -119,5 +119,5 @@ def export_metrics(G, base_path: str, fmt: str = "csv") -> None:
         json_path = base_path + ".json"
         safe_write(
             json_path,
-            lambda f: json.dump(data, f, ensure_ascii=False, indent=2),
+            lambda f: f.write(fast_dumps(data).decode("utf-8")),
         )


### PR DESCRIPTION
## Summary
- add `fast_dumps` helper using `orjson` when available
- streamline JSON output across CLI, gamma registry, caches and exports
- document optional `orjson` dependency

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bee485854483218391720b657ee367