### PR TITLE
refactor: make import warnings configurable

### DIFF
--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -50,7 +50,7 @@ def test_warns_once_then_debug(monkeypatch, caplog):
     records = [
         r.levelno for r in caplog.records if r.name == import_utils.logger.name
     ]
-    assert records == [logging.WARNING, logging.DEBUG]
+    assert records == [logging.DEBUG]
     assert stacklevels == [2]
 
 

--- a/tests/test_warn_failure_emit.py
+++ b/tests/test_warn_failure_emit.py
@@ -1,0 +1,41 @@
+import logging
+import warnings
+
+from tnfr.import_utils import _warn_failure, _WARNED_MODULES, _WARNED_LOCK
+
+
+def _clear_warned():
+    with _WARNED_LOCK:
+        _WARNED_MODULES.clear()
+
+
+def test_warn_failure_warns_only(caplog):
+    _clear_warned()
+    with caplog.at_level(logging.WARNING):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _warn_failure("mod_warn", None, ImportError("boom"))
+        assert len(w) == 1
+        assert not caplog.records
+
+
+def test_warn_failure_logs_only(caplog):
+    _clear_warned()
+    with caplog.at_level(logging.WARNING):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _warn_failure("mod_log", None, ImportError("boom"), emit="log")
+        assert len(w) == 0
+        assert len(caplog.records) == 1
+        assert "mod_log" in caplog.records[0].message
+
+
+def test_warn_failure_both(caplog):
+    _clear_warned()
+    with caplog.at_level(logging.WARNING):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _warn_failure("mod_both", None, ImportError("boom"), emit="both")
+        assert len(w) == 1
+        assert len(caplog.records) == 1
+        assert "mod_both" in caplog.records[0].message


### PR DESCRIPTION
## Summary
- add `emit` option to `_warn_failure` to choose warning destination
- adjust tests for new default and cover logging/warning combinations

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee7aa43d4832199904921f9fd7023