### PR TITLE
docs: document fallback errors and export

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -19,6 +19,8 @@ else:  # pragma: no cover - depende de tomllib/tomli
     has_toml = False
 
     class TOMLDecodeError(Exception):
+        """Fallback error used when tomllib/tomli is missing."""
+
         pass
 
 
@@ -28,6 +30,8 @@ if yaml is not None:
 else:  # pragma: no cover - depende de pyyaml
 
     class YAMLError(Exception):
+        """Fallback error used when pyyaml is missing."""
+
         pass
 
 
@@ -163,4 +167,10 @@ def safe_write(
             tmp_path.unlink(missing_ok=True)
 
 
-__all__ = ["read_structured_file", "safe_write", "StructuredFileError"]
+__all__ = [
+    "read_structured_file",
+    "safe_write",
+    "StructuredFileError",
+    "TOMLDecodeError",
+    "YAMLError",
+]


### PR DESCRIPTION
## Summary
- document fallback TOMLDecodeError and YAMLError
- export the fallback errors for better autocomplete

## Testing
- `PYTHONPATH=src pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68beeb7991e08321936a885ee5672bcb