### PR TITLE
Refactor gamma registry to use named entries

### DIFF
--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -6,7 +6,7 @@ import pytest
 
 from tnfr.constants import inject_defaults, merge_overrides
 from tnfr.dynamics import update_epi_via_nodal_equation
-from tnfr.gamma import eval_gamma, GAMMA_REGISTRY
+from tnfr.gamma import eval_gamma, GAMMA_REGISTRY, GammaEntry
 from tnfr.helpers.cache import increment_edge_version
 
 
@@ -304,7 +304,7 @@ def test_eval_gamma_unhandled_exception_propagates(graph_canon):
     def bad_gamma(G, node, t, cfg):
         raise RuntimeError("boom")
 
-    GAMMA_REGISTRY["bad"] = (bad_gamma, False)
+    GAMMA_REGISTRY["bad"] = GammaEntry(bad_gamma, False)
     try:
         with pytest.raises(RuntimeError):
             eval_gamma(G, 0, t=0.0, strict=False)

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -26,7 +26,7 @@ def test_gamma_kuramoto_tanh_registry(graph_canon):
     G.nodes[0]["θ"] = 0.0
     G.nodes[1]["θ"] = 0.0
     cfg = {"type": "kuramoto_tanh", "beta": 0.5, "k": 2.0, "R0": 0.0}
-    gamma_fn, _ = GAMMA_REGISTRY["kuramoto_tanh"]
+    gamma_fn = GAMMA_REGISTRY["kuramoto_tanh"].fn
     val = gamma_fn(G, 0, 0.0, cfg)
     assert abs(val) <= cfg["beta"]
 


### PR DESCRIPTION
## Summary
- add `GammaEntry` NamedTuple for gamma registry entries
- store registry entries as `GammaEntry` objects and update `eval_gamma`
- adjust tests for new registry structure

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beed26a0fc8321ac87c9830b60fd5f