### PR TITLE
Refactor compute_coherence to single node loop

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -74,14 +74,13 @@ def compute_coherence(
     """
     count = G.number_of_nodes()
     if count:
-        dnfr_sum = math.fsum(
-            abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)
-        )
-        depi_sum = math.fsum(
-            abs(get_attr(nd, ALIAS_dEPI, 0.0)) for _, nd in G.nodes(data=True)
-        )
-        dnfr_mean = dnfr_sum / count
-        depi_mean = depi_sum / count
+        dnfr_vals: list[float] = []
+        depi_vals: list[float] = []
+        for _, nd in G.nodes(data=True):
+            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
+            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
+        dnfr_mean = math.fsum(dnfr_vals) / count
+        depi_mean = math.fsum(depi_vals) / count
     else:
         dnfr_mean = depi_mean = 0.0
     coherence = 1.0 / (1.0 + dnfr_mean + depi_mean)


### PR DESCRIPTION
## Summary
- Iterate once over nodes in `compute_coherence` to collect `dnfr` and `dEPI` values for mean calculation.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beef05060c83218e48c13b76c24520