### PR TITLE
chore: remove unused flatten tokens import

### DIFF
--- a/src/tnfr/cli/token_parser.py
+++ b/src/tnfr/cli/token_parser.py
@@ -2,8 +2,7 @@ from typing import Any, Callable
 
 from ..program import block, wait, target
 from ..types import Glyph
-from ..token_parser import (  # noqa: F401
-    _flatten_tokens,
+from ..token_parser import (
     validate_token as _tp_validate_token,
     _parse_tokens as _tp_parse_tokens,
 )


### PR DESCRIPTION
## Summary
- remove unused `_flatten_tokens` import from CLI token parser

## Testing
- `PYTHONPATH=src pytest` *(fails: ImportError: cannot import name '_flatten_tokens')*

------
https://chatgpt.com/codex/tasks/task_e_68bef8a595d88321854de2371c59a89c