### PR TITLE
Group tempfile import with standard library imports in io module

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -1,14 +1,15 @@
 """Structured file I/O utilities."""
 
 from __future__ import annotations
-from typing import Any, Callable
+
 import json
-from pathlib import Path
 import os
-from .logging_utils import get_logger
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
 
 from .import_utils import optional_import
-import tempfile
+from .logging_utils import get_logger
 
 
 tomllib = optional_import("tomllib") or optional_import("tomli")


### PR DESCRIPTION
## Summary
- Group `tempfile` with other standard library imports
- Keep relative imports grouped after stdlib/third-party imports

## Testing
- `pip install -e .`
- `pytest` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bef952ad90832188ce83bf8ff3017d