### PR TITLE
Remove deprecated attach_defaults utility

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -155,22 +155,6 @@ _ALIAS_TARGET_TO_KEY: Dict[str, str] = {
 # -------------------------
 
 
-def attach_defaults(G, override: bool = False) -> None:
-    """Write combined ``DEFAULTS`` into ``G.graph``.
-
-    .. deprecated:: 0.0.0
-       Use :func:`inject_defaults` instead.
-
-    If ``override`` is ``True`` existing values are overwritten.
-    """
-    warnings.warn(
-        "attach_defaults is deprecated; use inject_defaults instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    inject_defaults(G, override=override)
-
-
 def inject_defaults(
     G, defaults: Mapping[str, Any] = DEFAULTS, override: bool = False
 ) -> None:


### PR DESCRIPTION
## Summary
- drop deprecated `attach_defaults` helper
- clean up unused references and exports

## Testing
- `pytest` *(fails: ImportError: cannot import name '_flatten_tokens' from 'tnfr.cli.token_parser')*

------
https://chatgpt.com/codex/tasks/task_e_68befcad4f2883218398cbce766899a1