### PR TITLE
feat: implement kahan summation

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -39,8 +39,23 @@ def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
 
 
 def kahan_sum(values: Iterable[float]) -> float:
-    """Return the precise sum of ``values``."""
-    return float(math.fsum(values))
+    """Return a compensated sum of ``values`` using Kahan summation.
+
+    The implementation follows the Kahan–Babuška (Neumaier) algorithm,
+    which keeps track of a small correction term to reduce floating point
+    error. It is more accurate than the built-in :func:`sum` while being
+    cheaper than :func:`math.fsum`.
+    """
+    total = 0.0
+    c = 0.0
+    for v in values:
+        t = total + v
+        if abs(total) >= abs(v):
+            c += (total - t) + v
+        else:
+            c += (v - t) + total
+        total = t
+    return float(total + c)
 
 
 def angle_diff(a: float, b: float) -> float:

--- a/tests/test_kahan_sum.py
+++ b/tests/test_kahan_sum.py
@@ -1,0 +1,12 @@
+import math
+
+import pytest
+
+from tnfr.helpers.numeric import kahan_sum
+
+
+def test_kahan_sum_compensates_cancellation():
+    xs = [1e16, 1.0, -1e16]
+    assert sum(xs) == 0.0
+    result = kahan_sum(xs)
+    assert result == pytest.approx(math.fsum(xs))


### PR DESCRIPTION
## Summary
- implement Kahan–Babuška (Neumaier) compensated summation in `kahan_sum`
- add regression test exercising cancellation and matching `math.fsum`

## Testing
- `PYTHONPATH=src pytest tests/test_kahan_sum.py tests/test_normalize_weights.py tests/test_sense.py`

------
https://chatgpt.com/codex/tasks/task_e_68befe840ba883218acfccfbb83230c7