### PR TITLE
refactor: use single-pass variance in phase_sync

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -84,11 +84,21 @@ def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
     if not _has_nodes(G):
         return 1.0
     _, psi = _get_R_psi(G, R, psi)
-    diffs = (
-        angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
-        for _, data in G.nodes(data=True)
-    )
-    return 1.0 / (1.0 + statistics.pvariance(diffs))
+
+    # Variance via Welford's single-pass algorithm to avoid materializing
+    # intermediate generators while maintaining numerical stability.
+    n = 0
+    mean = 0.0
+    M2 = 0.0
+    for _, data in G.nodes(data=True):
+        diff = angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
+        n += 1
+        delta = diff - mean
+        mean += delta / n
+        M2 += delta * (diff - mean)
+
+    var = M2 / n if n else 0.0
+    return 1.0 / (1.0 + var)
 
 
 def kuramoto_order(


### PR DESCRIPTION
## Summary
- replace `statistics.pvariance` with single-pass Welford variance in `phase_sync`

## Testing
- `pytest tests/test_observers.py -q`
- `pytest tests/test_history.py tests/test_coherence_cache.py tests/test_local_phase_sync.py -q`
- `pytest` *(fails: ImportError: cannot import name '_flatten_tokens' from 'tnfr.cli.token_parser')*

------
https://chatgpt.com/codex/tasks/task_e_68bf00af12fc8321b11f4e79e232c54d