### PR TITLE
Refactor integrators and utilities

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -185,13 +185,12 @@ def _flatten_thol(item: THOL, stack: deque[Any]) -> None:
         else None
     )
     seq = ensure_collection(item.body, max_materialize=None)
-    rev_seq = tuple(reversed(seq))
 
     def _iter_reversed_body():
         for _ in range(repeats):
             if closing is not None:
                 yield closing
-            yield from rev_seq
+            yield from reversed(seq)
 
     stack.extend(_iter_reversed_body())
     stack.append(THOL_SENTINEL)
@@ -327,10 +326,7 @@ def play(
         repeats the body and optionally forces closure with SHA/NUL.
       - Glyphs are applied via ``enforce_canonical_grammar``.
     """
-    if step_fn is None:
-        from . import dynamics
-
-        step_fn = dynamics.step
+    step_fn = step_fn or get_step_fn()
 
     ops = _flatten(sequence)
     curr_target: Optional[list[Node]] = None

--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -34,22 +34,22 @@ def validate_token(
     if isinstance(tok, dict):
         if len(tok) != 1:
             raise ValueError(
-                f"Token inválido: {tok} (posición {pos}, token {tok!r})"
+                f"Invalid token: {tok} (position {pos}, token {tok!r})"
             )
         key, val = next(iter(tok.items()))
         handler = token_map.get(key)
         if handler is None:
             raise ValueError(
-                f"Token no reconocido: {key} (posición {pos}, token {tok!r})"
+                f"Unrecognized token: {key} (position {pos}, token {tok!r})"
             )
         try:
             return handler(val)
         except (KeyError, ValueError, TypeError) as e:
-            msg = f"{type(e).__name__}: {e} (posición {pos}, token {tok!r})"
+            msg = f"{type(e).__name__}: {e} (position {pos}, token {tok!r})"
             raise ValueError(msg) from e
     if isinstance(tok, str):
         return tok
-    raise ValueError(f"Token inválido: {tok} (posición {pos}, token {tok!r})")
+    raise ValueError(f"Invalid token: {tok} (position {pos}, token {tok!r})")
 
 
 def _parse_tokens(


### PR DESCRIPTION
## Summary
- annotate optional `dt` parameter and simplify step calculation
- deduplicate node state retrieval and RK4 intermediates
- streamline program helpers and standardize token parser messages

## Testing
- `pytest` *(fails: ModuleNotFoundError and circular import during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01a42348832192f128675432ae5f