### PR TITLE
Expose CLI token flattener and localize error messages

### DIFF
--- a/src/tnfr/cli/token_parser.py
+++ b/src/tnfr/cli/token_parser.py
@@ -5,6 +5,7 @@ from ..types import Glyph
 from ..token_parser import (
     validate_token as _tp_validate_token,
     _parse_tokens as _tp_parse_tokens,
+    _flatten_tokens as _tp_flatten_tokens,
 )
 
 
@@ -14,6 +15,10 @@ def validate_token(tok: Any, pos: int) -> Any:
 
 def _parse_tokens(obj: Any) -> list[Any]:
     return _tp_parse_tokens(obj, TOKEN_MAP)
+
+
+def _flatten_tokens(obj: Any):
+    return _tp_flatten_tokens(obj)
 
 
 def parse_thol(spec: dict[str, Any]) -> Any:

--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -34,22 +34,22 @@ def validate_token(
     if isinstance(tok, dict):
         if len(tok) != 1:
             raise ValueError(
-                f"Invalid token: {tok} (position {pos}, token {tok!r})"
+                f"Invalid token: {tok} (posición {pos}, token {tok!r})"
             )
         key, val = next(iter(tok.items()))
         handler = token_map.get(key)
         if handler is None:
             raise ValueError(
-                f"Unrecognized token: {key} (position {pos}, token {tok!r})"
+                f"Unrecognized token: {key} (posición {pos}, token {tok!r})"
             )
         try:
             return handler(val)
         except (KeyError, ValueError, TypeError) as e:
-            msg = f"{type(e).__name__}: {e} (position {pos}, token {tok!r})"
+            msg = f"{type(e).__name__}: {e} (posición {pos}, token {tok!r})"
             raise ValueError(msg) from e
     if isinstance(tok, str):
         return tok
-    raise ValueError(f"Invalid token: {tok} (position {pos}, token {tok!r})")
+    raise ValueError(f"Invalid token: {tok} (posición {pos}, token {tok!r})")
 
 
 def _parse_tokens(


### PR DESCRIPTION
## Summary
- Re-export `_flatten_tokens` from `tnfr.cli.token_parser` so CLI utilities can flatten nested token structures
- Translate token parser error context to Spanish, using `posición` in validation messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0400e07c83219d6d20c96a6a94d4