### PR TITLE
Refactor compute_coherence to use generator expressions

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -74,13 +74,20 @@ def compute_coherence(
     """
     count = G.number_of_nodes()
     if count:
-        dnfr_vals: list[float] = []
-        depi_vals: list[float] = []
-        for _, nd in G.nodes(data=True):
-            dnfr_vals.append(abs(get_attr(nd, ALIAS_DNFR, 0.0)))
-            depi_vals.append(abs(get_attr(nd, ALIAS_dEPI, 0.0)))
-        dnfr_mean = math.fsum(dnfr_vals) / count
-        depi_mean = math.fsum(depi_vals) / count
+        dnfr_mean = (
+            math.fsum(
+                abs(get_attr(nd, ALIAS_DNFR, 0.0))
+                for _, nd in G.nodes(data=True)
+            )
+            / count
+        )
+        depi_mean = (
+            math.fsum(
+                abs(get_attr(nd, ALIAS_dEPI, 0.0))
+                for _, nd in G.nodes(data=True)
+            )
+            / count
+        )
     else:
         dnfr_mean = depi_mean = 0.0
     coherence = 1.0 / (1.0 + dnfr_mean + depi_mean)


### PR DESCRIPTION
## Summary
- Simplify `compute_coherence` by feeding generator expressions directly to `math.fsum` instead of building intermediate lists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0654d3308321b50a45df63353b78