### PR TITLE
refactor: rely on encoder depth check

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -121,7 +121,6 @@ class _Encoder(json.JSONEncoder):
 
 def _stable_json(obj: Any, max_depth: int = 10) -> str:
     """Return a JSON string with deterministic ordering."""
-    _check_depth(obj, 0, max_depth)
     return json_dumps(
         obj,
         sort_keys=True,


### PR DESCRIPTION
## Summary
- remove redundant _check_depth call in _stable_json

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf070784b08321b67895ce02cb207a