### PR TITLE
refactor: remove fast_dumps helper

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -34,7 +34,7 @@ from ..helpers.numeric import list_mean
 from ..observers import attach_standard_observer
 from ..logging_utils import get_logger
 from ..types import Glyph
-from ..json_utils import fast_dumps
+from ..json_utils import json_dumps
 
 from .arguments import _args_to_dict
 from .token_parser import _parse_tokens
@@ -241,5 +241,5 @@ def cmd_metrics(args: argparse.Namespace) -> int:
     if args.save:
         _save_json(args.save, out)
     else:
-        logger.info("%s", fast_dumps(out).decode("utf-8"))
+        logger.info("%s", json_dumps(out).decode("utf-8"))
     return 0

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -15,14 +15,14 @@ from .helpers.cache import (
     edge_version_cache,
     get_graph_mapping,
 )
-from .json_utils import fast_dumps
+from .json_utils import json_dumps
 from .logging_utils import get_logger
 
 
 logger = get_logger(__name__)
 
 DEFAULT_GAMMA: Mapping[str, str] = {"type": "none"}
-DEFAULT_GAMMA_DUMPED = fast_dumps(DEFAULT_GAMMA, sort_keys=True)
+DEFAULT_GAMMA_DUMPED = json_dumps(DEFAULT_GAMMA, sort_keys=True)
 DEFAULT_GAMMA_HASH = hashlib.blake2b(
     DEFAULT_GAMMA_DUMPED, digest_size=16
 ).hexdigest()
@@ -97,7 +97,7 @@ def _get_gamma_spec(G) -> Mapping[str, Any]:
             dumped = DEFAULT_GAMMA_DUMPED
             cur_hash = DEFAULT_GAMMA_HASH
         else:
-            dumped = fast_dumps(spec, sort_keys=True)
+            dumped = json_dumps(spec, sort_keys=True)
             cur_hash = hashlib.blake2b(dumped, digest_size=16).hexdigest()
         if cached is not None and prev_hash == cur_hash:
             return cached

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -1,3 +1,4 @@
+
 from __future__ import annotations
 
 import json
@@ -5,7 +6,7 @@ from typing import Any, Callable
 
 from .import_utils import optional_import
 
-__all__ = ["fast_dumps", "json_dumps"]
+__all__ = ["json_dumps"]
 
 _orjson = optional_import("orjson")
 
@@ -36,12 +37,3 @@ def json_dumps(
         **kwargs,
     )
     return result if not to_bytes else result.encode("utf-8")
-
-
-def fast_dumps(obj: Any, *, sort_keys: bool = False) -> bytes:
-    """Serialize ``obj`` to JSON and return ``bytes``.
-
-    Uses :func:`json_dumps` with compact separators. ``orjson`` is employed
-    when available otherwise falling back to :mod:`json`.
-    """
-    return json_dumps(obj, sort_keys=sort_keys, to_bytes=True)

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -9,7 +9,7 @@ from ..glyph_history import ensure_history
 from ..io import safe_write
 from ..constants_glyphs import GLYPHS_CANONICAL
 from .core import glyphogram_series
-from ..json_utils import fast_dumps
+from ..json_utils import json_dumps
 
 
 def _write_csv(path, headers, rows):
@@ -119,5 +119,5 @@ def export_metrics(G, base_path: str, fmt: str = "csv") -> None:
         json_path = base_path + ".json"
         safe_write(
             json_path,
-            lambda f: f.write(fast_dumps(data).decode("utf-8")),
+            lambda f: f.write(json_dumps(data).decode("utf-8")),
         )


### PR DESCRIPTION
## Summary
- remove `fast_dumps` helper and only expose `json_dumps`
- update modules to use `json_dumps` directly

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf07ba251c832190fa66d4980a0ecc