### PR TITLE
Refactor warning registry

### DIFF
--- a/tests/test_warn_failure_emit.py
+++ b/tests/test_warn_failure_emit.py
@@ -1,12 +1,13 @@
 import logging
 import warnings
 
-from tnfr.import_utils import _warn_failure, _WARNED_MODULES, _WARNED_LOCK
+from tnfr.import_utils import _warn_failure, _WARNED_MODULES, _WARNED_LOCK, _WARNED_QUEUE
 
 
 def _clear_warned():
     with _WARNED_LOCK:
         _WARNED_MODULES.clear()
+        _WARNED_QUEUE.clear()
 
 
 def test_warn_failure_warns_only(caplog):

--- a/tests/test_warned_modules_eviction.py
+++ b/tests/test_warned_modules_eviction.py
@@ -4,12 +4,14 @@ from tnfr.import_utils import (
     _WARNED_MODULES,
     _WARNED_LIMIT,
     _WARNED_LOCK,
+    _WARNED_QUEUE,
 )
 
 
 def test_warned_modules_eviction():
     with _WARNED_LOCK:
         _WARNED_MODULES.clear()
+        _WARNED_QUEUE.clear()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         for i in range(_WARNED_LIMIT + 5):


### PR DESCRIPTION
## Summary
- replace warning registry OrderedDict with set and deque
- simplify failure warning handling and eviction logic
- update tests for new warning tracking structure

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf104e6f848321968bfa2607bd55f1