### PR TITLE
Avoid materializing too many items

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Collection, Sequence
 from typing import Any, TypeVar, cast
-from itertools import islice
 import logging
 from .logging_utils import get_logger
 
@@ -73,7 +72,11 @@ def ensure_collection(
         if limit == 0:
             # Explicitly allow empty result without consumption
             return ()
-        materialized = list(islice(it, limit + 1))
+        materialized: list[T] = []
+        for item in it:
+            materialized.append(item)
+            if len(materialized) > limit:
+                break
         if len(materialized) > limit:
             examples = ", ".join(repr(x) for x in materialized[:3])
             msg = error_msg or (


### PR DESCRIPTION
## Summary
- manually accumulate iterable items in ensure_collection instead of using islice
- stop iteration once limit+1 elements are collected

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_ensure_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf113830088321bd6b31ea3706be15