### PR TITLE
Sync edge cache locks after eviction

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -272,6 +272,10 @@ def _get_edge_cache(
             ):
                 cache = _make_edge_cache(max_entries, locks) if use_lru else {}
                 graph["_edge_version_cache"] = cache
+        if isinstance(cache, dict) and isinstance(locks, dict):
+            for key in list(locks.keys()):
+                if key not in cache:
+                    locks.pop(key, None)
     return cache, locks
 
 

--- a/tests/test_edge_version_cache_limit.py
+++ b/tests/test_edge_version_cache_limit.py
@@ -11,3 +11,13 @@ def test_edge_version_cache_limit():
     cache = G.graph["_edge_version_cache"]
     assert "a" not in cache
     assert "b" in cache and "c" in cache
+
+
+def test_edge_version_cache_lock_cleanup():
+    G = nx.Graph()
+    for i in range(10):
+        edge_version_cache(G, str(i), lambda i=i: i, max_entries=2)
+    cache = G.graph["_edge_version_cache"]
+    locks = G.graph["_edge_version_cache_locks"]
+    assert len(cache) <= 2
+    assert set(locks) == set(cache)


### PR DESCRIPTION
## Summary
- prune stale locks when edge cache entries are evicted
- test that edge cache locks stay bounded when evicting repeatedly

## Testing
- `PYTHONPATH=src pytest tests/test_edge_version_cache_limit.py tests/test_edge_version_cache_locks.py tests/test_edge_version_cache_disable.py tests/test_edge_version_cache_reentrant.py tests/test_edge_version_cache_threadsafe.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf16f0e2e48321965a75c8465b9558