### PR TITLE
Refactor RNG caching for thread safety

### DIFF
--- a/tests/test_get_rng.py
+++ b/tests/test_get_rng.py
@@ -26,8 +26,7 @@ def test_get_rng_reproducible_sequence():
 
     seed_int = _derive_seed(seed, key)
     rng_ref = random.Random(seed_int)
-    exp1 = [rng_ref.random() for _ in range(3)]
-    exp2 = [rng_ref.random() for _ in range(3)]
+    exp = [rng_ref.random() for _ in range(3)]
 
-    assert seq1 == exp1
-    assert seq2 == exp2
+    assert seq1 == exp
+    assert seq2 == exp

--- a/tests/test_get_rng_threadsafe.py
+++ b/tests/test_get_rng_threadsafe.py
@@ -9,19 +9,26 @@ def test_get_rng_thread_safety(monkeypatch):
     monkeypatch.setattr(rng_mod, "DEFAULTS", dict(DEFAULTS))
     monkeypatch.setitem(rng_mod.DEFAULTS, "JITTER_CACHE_SIZE", 4)
     get_rng.cache_clear()
+
+    results = []
     errors = []
+    lock = threading.Lock()
 
-    def worker(idx):
+    def worker():
         try:
-            rng = get_rng(123, idx)
-            rng.random()
+            rng = get_rng(123, 456)
+            seq = [rng.random() for _ in range(3)]
+            with lock:
+                results.append(seq)
         except Exception as e:  # pragma: no cover - should not happen
-            errors.append(e)
+            with lock:
+                errors.append(e)
 
-    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    threads = [threading.Thread(target=worker) for _ in range(20)]
     for t in threads:
         t.start()
     for t in threads:
         t.join()
 
     assert not errors
+    assert all(seq == results[0] for seq in results)

--- a/tests/test_rng_for_step.py
+++ b/tests/test_rng_for_step.py
@@ -1,3 +1,5 @@
+import threading
+
 from tnfr.rng import _rng_for_step, get_rng
 
 
@@ -18,3 +20,30 @@ def test_rng_for_step_changes_with_step():
     assert [rng1.random() for _ in range(3)] != [
         rng2.random() for _ in range(3)
     ]
+
+
+def test_rng_for_step_thread_independence():
+    get_rng.cache_clear()
+
+    results = []
+    errors = []
+    lock = threading.Lock()
+
+    def worker():
+        try:
+            rng = _rng_for_step(123, 5)
+            seq = [rng.random() for _ in range(3)]
+            with lock:
+                results.append(seq)
+        except Exception as e:  # pragma: no cover - should not happen
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    assert all(seq == results[0] for seq in results)


### PR DESCRIPTION
## Summary
- cache only preprocessed RNG seeds and create fresh `random.Random` per call
- test RNG functions to verify thread independence

## Testing
- `PYTHONPATH=src pytest tests/test_get_rng.py tests/test_get_rng_threadsafe.py tests/test_rng_for_step.py tests/test_node_sample.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf17faf7b083218ceec0019284aff4