### PR TITLE
Warn when orjson ignores JSON options

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from typing import Any, Callable
 
 from .import_utils import optional_import
@@ -28,6 +29,12 @@ def json_dumps(
     are ignored because they are not supported by ``orjson.dumps``.
     """
     if _orjson is not None:
+        if ensure_ascii is not True or separators != (",", ":"):
+            warnings.warn(
+                "'ensure_ascii' and 'separators' are ignored when using orjson",
+                UserWarning,
+                stacklevel=2,
+            )
         option = _orjson.OPT_SORT_KEYS if sort_keys else 0
         data = _orjson.dumps(obj, option=option, default=default)
         return data if to_bytes else data.decode("utf-8")

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -1,6 +1,9 @@
 import json
 
+import pytest
+
 from tnfr.helpers.cache import _stable_json
+from tnfr.json_utils import _orjson
 
 
 def test_stable_json_dict_order_deterministic():
@@ -9,3 +12,10 @@ def test_stable_json_dict_order_deterministic():
     res2 = _stable_json(obj)
     assert res1 == res2
     assert json.loads(res1) == {"a": 2, "b": 1}
+
+
+def test_stable_json_warns_with_orjson():
+    if _orjson is None:
+        pytest.skip("orjson not installed")
+    with pytest.warns(UserWarning, match="ignored when using orjson"):
+        _stable_json({"a": 1})


### PR DESCRIPTION
## Summary
- warn that ensure_ascii and separators options are ignored when using orjson
- test that _stable_json triggers a warning when orjson is available

## Testing
- `PYTHONPATH=src pytest tests/test_stable_json.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf1ae6eaec8321a6b7178e87451694