### PR TITLE
refactor: adopt builtin typing

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -9,7 +9,6 @@ alias-based attribute access. Legacy wrappers ``alias_get`` and
 from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from typing import (
-    Dict,
     Any,
     Callable,
     TypeVar,
@@ -62,7 +61,7 @@ def _validate_aliases(aliases: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _alias_resolve(
-    d: Dict[str, Any],
+    d: dict[str, Any],
     aliases: Sequence[str],
     *,
     conv: Callable[[Any], T],
@@ -158,7 +157,7 @@ class AliasAccessor(Generic[T]):
 
     def get(
         self,
-        d: Dict[str, Any],
+        d: dict[str, Any],
         aliases: Iterable[str],
         default: Optional[T] = None,
         *,
@@ -178,7 +177,7 @@ class AliasAccessor(Generic[T]):
 
     def set(
         self,
-        d: Dict[str, Any],
+        d: dict[str, Any],
         aliases: Iterable[str],
         value: Any,
         conv: Callable[[Any], T] | None = None,
@@ -194,7 +193,7 @@ class _Getter(Protocol[T]):
     @overload
     def __call__(
         self,
-        d: Dict[str, Any],
+        d: dict[str, Any],
         aliases: Iterable[str],
         default: T = ...,  # noqa: D401 - documented in get_attr
         *,
@@ -206,7 +205,7 @@ class _Getter(Protocol[T]):
     @overload
     def __call__(
         self,
-        d: Dict[str, Any],
+        d: dict[str, Any],
         aliases: Iterable[str],
         default: None = ...,  # noqa: D401 - documented in get_attr
         *,
@@ -219,7 +218,7 @@ class _Getter(Protocol[T]):
 class _Setter(Protocol[T]):
     def __call__(
         self,
-        d: Dict[str, Any],
+        d: dict[str, Any],
         aliases: Iterable[str],
         value: Any,
         conv: Callable[[Any], T] | None = ...,
@@ -253,8 +252,8 @@ def recompute_abs_max(
 
 
 def multi_recompute_abs_max(
-    G: "nx.Graph", alias_map: Dict[str, tuple[str, ...]]
-) -> Dict[str, float]:
+    G: "nx.Graph", alias_map: dict[str, tuple[str, ...]]
+) -> dict[str, float]:
     """Return absolute maxima for each entry in ``alias_map``.
 
     ``G`` is a :class:`networkx.Graph`. ``alias_map`` maps result keys to

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-from typing import Any, TYPE_CHECKING, Dict
+from typing import Any, TYPE_CHECKING
 from enum import Enum
 from collections import defaultdict, deque
 from collections.abc import Callable, Mapping, Sequence
@@ -168,7 +168,7 @@ def register_callback(
 def invoke_callbacks(
     G: "nx.Graph",
     event: CallbackEvent | str,
-    ctx: Dict[str, Any] | None = None,
+    ctx: dict[str, Any] | None = None,
 ) -> None:
     """Invoke all callbacks registered for ``event`` with context ``ctx``."""
     event = _normalize_event(event)

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 from collections.abc import Mapping
 import threading
 import copy
@@ -142,7 +142,7 @@ def _is_immutable(value: Any) -> bool:
 # Unimos los diccionarios en orden de menor a mayor prioridad para que los
 # valores de ``METRIC_DEFAULTS`` sobrescriban al resto,
 # como hacía ``ChainMap``.
-_DEFAULTS_COMBINED: Dict[str, Any] = (
+_DEFAULTS_COMBINED: dict[str, Any] = (
     CORE_DEFAULTS | INIT_DEFAULTS | REMESH_DEFAULTS | METRIC_DEFAULTS
 )
 DEFAULTS: Mapping[str, Any] = MappingProxyType(_DEFAULTS_COMBINED)
@@ -152,11 +152,11 @@ DEFAULTS: Mapping[str, Any] = MappingProxyType(_DEFAULTS_COMBINED)
 # -------------------------
 # "REMESH_TAU" era el nombre original para la memoria de REMESH. Hoy se
 # desglosa en ``REMESH_TAU_GLOBAL`` y ``REMESH_TAU_LOCAL``.
-ALIASES: Dict[str, tuple[str, ...]] = {
+ALIASES: dict[str, tuple[str, ...]] = {
     "REMESH_TAU": ("REMESH_TAU_GLOBAL", "REMESH_TAU_LOCAL"),
 }
 
-_ALIAS_TARGET_TO_KEY: Dict[str, str] = {
+_ALIAS_TARGET_TO_KEY: dict[str, str] = {
     target: alias for alias, targets in ALIASES.items() for target in targets
 }
 

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict, field
-from typing import Dict, Any, Mapping
+from typing import Any, Mapping
 from types import MappingProxyType
 
 
@@ -30,7 +30,7 @@ class CoreDefaults:
     VF_MIN: float = 0.0
     VF_MAX: float = 1.0
     THETA_WRAP: bool = True
-    DNFR_WEIGHTS: Dict[str, float] = field(
+    DNFR_WEIGHTS: dict[str, float] = field(
         default_factory=lambda: {
             "phase": 0.34,
             "epi": 0.33,
@@ -38,12 +38,12 @@ class CoreDefaults:
             "topo": 0.0,
         }
     )
-    SI_WEIGHTS: Dict[str, float] = field(
+    SI_WEIGHTS: dict[str, float] = field(
         default_factory=lambda: {"alpha": 0.34, "beta": 0.33, "gamma": 0.33}
     )
     PHASE_K_GLOBAL: float = 0.05
     PHASE_K_LOCAL: float = 0.15
-    PHASE_ADAPT: Dict[str, Any] = field(
+    PHASE_ADAPT: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "R_hi": 0.90,
@@ -67,7 +67,7 @@ class CoreDefaults:
     GLYPH_SELECTOR_MARGIN: float = 0.05
     VF_ADAPT_TAU: int = 5
     VF_ADAPT_MU: float = 0.1
-    GLYPH_FACTORS: Dict[str, float] = field(
+    GLYPH_FACTORS: dict[str, float] = field(
         default_factory=lambda: {
             "AL_boost": 0.05,
             "EN_mix": 0.25,
@@ -85,7 +85,7 @@ class CoreDefaults:
             "REMESH_alpha": 0.5,
         }
     )
-    GLYPH_THRESHOLDS: Dict[str, float] = field(
+    GLYPH_THRESHOLDS: dict[str, float] = field(
         default_factory=lambda: {"hi": 0.66, "lo": 0.33, "dnfr": 1e-3}
     )
     NAV_RANDOM: bool = True
@@ -94,7 +94,7 @@ class CoreDefaults:
     JITTER_CACHE_SIZE: int = 256
     OZ_NOISE_MODE: bool = False
     OZ_SIGMA: float = 0.1
-    GRAMMAR: Dict[str, Any] = field(
+    GRAMMAR: dict[str, Any] = field(
         default_factory=lambda: {
             "window": 3,
             "avoid_repeats": ["ZHIR", "OZ", "THOL"],
@@ -103,13 +103,13 @@ class CoreDefaults:
             "fallbacks": {"ZHIR": "NAV", "OZ": "ZHIR", "THOL": "NAV"},
         }
     )
-    SELECTOR_WEIGHTS: Dict[str, float] = field(
+    SELECTOR_WEIGHTS: dict[str, float] = field(
         default_factory=lambda: {"w_si": 0.5, "w_dnfr": 0.3, "w_accel": 0.2}
     )
-    SELECTOR_THRESHOLDS: Dict[str, float] = field(
+    SELECTOR_THRESHOLDS: dict[str, float] = field(
         default_factory=lambda: dict(SELECTOR_THRESHOLD_DEFAULTS)
     )
-    GAMMA: Dict[str, Any] = field(
+    GAMMA: dict[str, Any] = field(
         default_factory=lambda: {"type": "none", "beta": 0.0, "R0": 0.0}
     )
     CALLBACKS_STRICT: bool = False

--- a/src/tnfr/constants/init.py
+++ b/src/tnfr/constants/init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
-from typing import Dict, Any
+from typing import Any
 import math
 
 
@@ -21,4 +21,4 @@ class InitDefaults:
 
 
 INIT_DEFAULTS = asdict(InitDefaults())
-DEFAULTS_PART: Dict[str, Any] = INIT_DEFAULTS
+DEFAULTS_PART: dict[str, Any] = INIT_DEFAULTS

--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -3,21 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict, field
-from typing import Dict, Any
+from typing import Any
 from types import MappingProxyType
 
 
 @dataclass(frozen=True)
 class MetricDefaults:
     PHASE_HISTORY_MAXLEN: int = 50
-    STOP_EARLY: Dict[str, Any] = field(
+    STOP_EARLY: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": False,
             "window": 25,
             "fraction": 0.90,
         }
     )
-    SIGMA: Dict[str, Any] = field(
+    SIGMA: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "weight": "Si",  # "Si" | "EPI" | "1"
@@ -26,7 +26,7 @@ class MetricDefaults:
             "per_node": False,
         }
     )
-    TRACE: Dict[str, Any] = field(
+    TRACE: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "capture": [
@@ -44,14 +44,14 @@ class MetricDefaults:
             "history_key": "trace_meta",
         }
     )
-    METRICS: Dict[str, Any] = field(
+    METRICS: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "save_by_node": True,
             "normalize_series": False,
         }
     )
-    GRAMMAR_CANON: Dict[str, Any] = field(
+    GRAMMAR_CANON: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "zhir_requires_oz_window": 3,
@@ -62,7 +62,7 @@ class MetricDefaults:
             "si_high": 0.66,
         }
     )
-    COHERENCE: Dict[str, Any] = field(
+    COHERENCE: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "scope": "neighbors",
@@ -75,7 +75,7 @@ class MetricDefaults:
             "stats_history_key": "W_stats",
         }
     )
-    DIAGNOSIS: Dict[str, Any] = field(
+    DIAGNOSIS: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
             "window": 16,
@@ -106,4 +106,4 @@ GRAMMAR_CANON = MappingProxyType(METRIC_DEFAULTS["GRAMMAR_CANON"])
 COHERENCE = MappingProxyType(METRIC_DEFAULTS["COHERENCE"])
 DIAGNOSIS = MappingProxyType(METRIC_DEFAULTS["DIAGNOSIS"])
 
-DEFAULTS_PART: Dict[str, Any] = METRIC_DEFAULTS
+DEFAULTS_PART: dict[str, Any] = METRIC_DEFAULTS

--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-from typing import Dict
 
 from .types import Glyph
 
@@ -62,7 +61,7 @@ GLYPH_GROUPS = {
 # Ángulos canónicos para todos los glyphs reconocidos. Las categorías
 # anteriores se distribuyen uniformemente en el círculo y se ajustan a
 # orientaciones semánticas específicas en el plano σ.
-ANGLE_MAP: Dict[str, float] = {
+ANGLE_MAP: dict[str, float] = {
     # AL no participa en el plano σ pero se incluye por completitud.
     # Comparte el ángulo base (0 rad) con IL de forma intencionada.
     Glyph.AL.value: 0.0,

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from collections import deque
-from typing import Dict, Any
+from typing import Any
 
 # Importar compute_Si y apply_glyph a nivel de módulo evita el coste de
 # realizar la importación en cada paso de la dinámica. Como los módulos de
@@ -108,7 +108,7 @@ def _log_clamp(hist, node, attr, value, lo, hi):
         hist.append({"node": node, "attr": attr, "value": float(value)})
 
 
-def apply_canonical_clamps(nd: Dict[str, Any], G=None, node=None) -> None:
+def apply_canonical_clamps(nd: dict[str, Any], G=None, node=None) -> None:
     g = G.graph if G is not None else DEFAULTS
     eps_min = float(g.get("EPI_MIN", DEFAULTS["EPI_MIN"]))
     eps_max = float(g.get("EPI_MAX", DEFAULTS["EPI_MAX"]))
@@ -154,8 +154,8 @@ def validate_canon(G) -> None:
 
 
 def _read_adaptive_params(
-    g: Dict[str, Any],
-) -> tuple[Dict[str, Any], float, float]:
+    g: dict[str, Any],
+) -> tuple[dict[str, Any], float, float]:
     """Obtain configuration and current values for phase adaptation."""
     cfg = g.get("PHASE_ADAPT", DEFAULTS.get("PHASE_ADAPT", {}))
     kG = float(g.get("PHASE_K_GLOBAL", DEFAULTS["PHASE_K_GLOBAL"]))
@@ -163,7 +163,7 @@ def _read_adaptive_params(
     return cfg, kG, kL
 
 
-def _compute_state(G, cfg: Dict[str, Any]) -> tuple[str, float, float]:
+def _compute_state(G, cfg: dict[str, Any]) -> tuple[str, float, float]:
     """Return current state (stable/dissonant/transition) and metrics."""
     R = kuramoto_order(G)
     win = int(
@@ -186,7 +186,7 @@ def _compute_state(G, cfg: Dict[str, Any]) -> tuple[str, float, float]:
 
 
 def _smooth_adjust_k(
-    kG: float, kL: float, state: str, cfg: Dict[str, Any]
+    kG: float, kL: float, state: str, cfg: dict[str, Any]
 ) -> tuple[float, float]:
     """Smoothly update kG/kL toward targets according to state."""
     kG_min = float(cfg.get("kG_min", 0.01))

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Dict, Any, Callable
+from typing import Any, Callable
 
 from ..collections_utils import normalize_weights
 from ..constants import DEFAULTS, ALIAS_THETA, ALIAS_EPI, ALIAS_VF
@@ -443,9 +443,9 @@ def set_delta_nfr_hook(
 
 def _apply_dnfr_hook(
     G,
-    grads: Dict[str, Callable[[Any, Any], float]],
+    grads: dict[str, Callable[[Any, Any], float]],
     *,
-    weights: Dict[str, float],
+    weights: dict[str, float],
     hook_name: str,
     note: str | None = None,
 ) -> None:

--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Dict, Any, Literal
+from typing import Any, Literal
 
 import networkx as nx
 
@@ -73,7 +73,7 @@ def prepare_integration_params(
 def _integrate_euler(G, dt_step: float, t_local: float):
     """One explicit Euler integration step."""
     gamma_map = {n: eval_gamma(G, n, t_local) for n in G.nodes}
-    new_states: Dict[Any, tuple[float, float, float]] = {}
+    new_states: dict[Any, tuple[float, float, float]] = {}
     for n, nd in G.nodes(data=True):
         vf, dnfr, dEPI_dt_prev, epi_i = _node_state(nd)
 
@@ -93,7 +93,7 @@ def _integrate_rk4(G, dt_step: float, t_local: float):
     g_mid_map = {n: eval_gamma(G, n, t_mid) for n in G.nodes}
     g4_map = {n: eval_gamma(G, n, t_end) for n in G.nodes}
 
-    new_states: Dict[Any, tuple[float, float, float]] = {}
+    new_states: dict[Any, tuple[float, float, float]] = {}
     for n, nd in G.nodes(data=True):
         vf, dnfr, dEPI_dt_prev, epi_i = _node_state(nd)
 
@@ -166,7 +166,7 @@ def integrar_epi_euler(G, dt: float | None = None) -> None:
     update_epi_via_nodal_equation(G, dt=dt, method="euler")
 
 
-def _node_state(nd: Dict[str, Any]) -> tuple[float, float, float, float]:
+def _node_state(nd: dict[str, Any]) -> tuple[float, float, float, float]:
     """Return common node state attributes.
 
     Extracts ``νf``, ``ΔNFR``, previous ``dEPI/dt`` and current ``EPI``

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -1,7 +1,7 @@
 """Gamma registry."""
 
 from __future__ import annotations
-from typing import Dict, Any, Tuple, Callable, NamedTuple
+from typing import Any, Callable, NamedTuple
 import math
 import cmath
 import logging
@@ -50,7 +50,7 @@ def _ensure_kuramoto_cache(G, t) -> None:
     nodes_sig = (len(G), checksum)
     max_steps = int(G.graph.get("KURAMOTO_CACHE_STEPS", 1))
 
-    def builder() -> Dict[str, float]:
+    def builder() -> dict[str, float]:
         R, psi = kuramoto_R_psi(G)
         return {"R": R, "psi": psi}
 
@@ -59,7 +59,7 @@ def _ensure_kuramoto_cache(G, t) -> None:
     G.graph["_kuramoto_cache"] = entry
 
 
-def kuramoto_R_psi(G) -> Tuple[float, float]:
+def kuramoto_R_psi(G) -> tuple[float, float]:
     """Return ``(R, ψ)`` for Kuramoto order using θ from all nodes."""
     acc = 0 + 0j
     n = 0
@@ -150,11 +150,11 @@ def _gamma_params(
 # -----------------
 
 
-def gamma_none(G, node, t, cfg: Dict[str, Any]) -> float:
+def gamma_none(G, node, t, cfg: dict[str, Any]) -> float:
     return 0.0
 
 
-def gamma_kuramoto_linear(G, node, t, cfg: Dict[str, Any]) -> float:
+def gamma_kuramoto_linear(G, node, t, cfg: dict[str, Any]) -> float:
     """Linear Kuramoto coupling for Γi(R).
 
     Formula: Γ = β · (R - R0) · cos(θ_i - ψ)
@@ -170,7 +170,7 @@ def gamma_kuramoto_linear(G, node, t, cfg: Dict[str, Any]) -> float:
     return beta * (R - R0) * math.cos(th_i - psi)
 
 
-def gamma_kuramoto_bandpass(G, node, t, cfg: Dict[str, Any]) -> float:
+def gamma_kuramoto_bandpass(G, node, t, cfg: dict[str, Any]) -> float:
     """Γ = β · R(1-R) · sign(cos(θ_i - ψ))"""
     (beta,) = _gamma_params(cfg, beta=0.0)
     th_i, R, psi = _kuramoto_common(G, node, cfg)
@@ -178,7 +178,7 @@ def gamma_kuramoto_bandpass(G, node, t, cfg: Dict[str, Any]) -> float:
     return beta * R * (1.0 - R) * sgn
 
 
-def gamma_kuramoto_tanh(G, node, t, cfg: Dict[str, Any]) -> float:
+def gamma_kuramoto_tanh(G, node, t, cfg: dict[str, Any]) -> float:
     """Saturating tanh coupling for Γi(R).
 
     Formula: Γ = β · tanh(k·(R - R0)) · cos(θ_i - ψ)
@@ -191,7 +191,7 @@ def gamma_kuramoto_tanh(G, node, t, cfg: Dict[str, Any]) -> float:
     return beta * math.tanh(k * (R - R0)) * math.cos(th_i - psi)
 
 
-def gamma_harmonic(G, node, t, cfg: Dict[str, Any]) -> float:
+def gamma_harmonic(G, node, t, cfg: dict[str, Any]) -> float:
     """Harmonic forcing aligned with the global phase field.
 
     Formula: Γ = β · sin(ω·t + φ) · cos(θ_i - ψ)
@@ -205,7 +205,7 @@ def gamma_harmonic(G, node, t, cfg: Dict[str, Any]) -> float:
 
 
 class GammaEntry(NamedTuple):
-    fn: Callable[[Any, Any, Any, Dict[str, Any]], float]
+    fn: Callable[[Any, Any, Any, dict[str, Any]], float]
     needs_kuramoto: bool
 
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -1,7 +1,7 @@
 """Grammar rules."""
 
 from __future__ import annotations
-from typing import Dict, Any, Set, Iterable, Optional, Callable
+from typing import Any, Iterable, Optional, Callable
 
 from .constants import (
     DEFAULTS,
@@ -57,7 +57,7 @@ __all__ = [
 # -------------------------
 
 
-def _gram_state(nd: Dict[str, Any]) -> Dict[str, Any]:
+def _gram_state(nd: dict[str, Any]) -> dict[str, Any]:
     """Create or return the node grammar state.
 
     Fields:
@@ -70,7 +70,7 @@ def _gram_state(nd: Dict[str, Any]) -> Dict[str, Any]:
 # -------------------------
 # Canonical compatibilities (allowed next glyphs)
 # -------------------------
-CANON_COMPAT: Dict[Glyph, Set[Glyph]] = {
+CANON_COMPAT: dict[Glyph, set[Glyph]] = {
     # Inicio / apertura
     Glyph.AL: {Glyph.EN, Glyph.RA, Glyph.NAV, Glyph.VAL, Glyph.UM},
     Glyph.EN: {Glyph.IL, Glyph.UM, Glyph.RA, Glyph.NAV},
@@ -100,7 +100,7 @@ CANON_COMPAT: Dict[Glyph, Set[Glyph]] = {
 }
 
 # Canonical fallbacks when a transition is not allowed
-CANON_FALLBACK: Dict[Glyph, Glyph] = {
+CANON_FALLBACK: dict[Glyph, Glyph] = {
     Glyph.AL: Glyph.EN,
     Glyph.EN: Glyph.IL,
     Glyph.IL: Glyph.RA,
@@ -124,7 +124,7 @@ def _coerce_glyph(val: Any) -> Glyph | Any:
         return val
 
 
-def _glyph_fallback(cand_key: str, fallbacks: Dict[str, Any]) -> Glyph | str:
+def _glyph_fallback(cand_key: str, fallbacks: dict[str, Any]) -> Glyph | str:
     """Determine fallback glyph for ``cand_key`` and return converted value."""
     glyph_key = _coerce_glyph(cand_key)
     canon_fb = (
@@ -169,7 +169,7 @@ def _accel_norm(G, nd) -> float:
 
 
 def _check_repeats(
-    G, n, cand: Glyph | str, cfg: Dict[str, Any]
+    G, n, cand: Glyph | str, cfg: dict[str, Any]
 ) -> Glyph | str:
     """Avoid recent repetitions according to ``cfg``."""
     nd = G.nodes[n]
@@ -187,8 +187,8 @@ def _maybe_force(
     n,
     cand: str,
     original: str,
-    cfg: Dict[str, Any],
-    accessor: Callable[[Any, Dict[str, Any]], float],
+    cfg: dict[str, Any],
+    accessor: Callable[[Any, dict[str, Any]], float],
     key: str,
 ) -> str:
     """Restore ``original`` if ``accessor`` exceeds ``key`` threshold."""
@@ -200,7 +200,7 @@ def _maybe_force(
     return cand
 
 
-def _check_oz_to_zhir(G, n, cand: str, cfg: Dict[str, Any]) -> str:
+def _check_oz_to_zhir(G, n, cand: str, cfg: dict[str, Any]) -> str:
     nd = G.nodes[n]
     if cand == Glyph.ZHIR:
         win = int(cfg.get("zhir_requires_oz_window", 3))
@@ -211,7 +211,7 @@ def _check_oz_to_zhir(G, n, cand: str, cfg: Dict[str, Any]) -> str:
 
 
 def _check_thol_closure(
-    G, n, cand: str, cfg: Dict[str, Any], st: Dict[str, Any]
+    G, n, cand: str, cfg: dict[str, Any], st: dict[str, Any]
 ) -> str:
     nd = G.nodes[n]
     if st.get("thol_open", False):

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 
 from ..constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_SI, COHERENCE
@@ -140,12 +140,12 @@ def _wij_vectorized(
 def _wij_loops(
     G,
     nodes: Sequence[Any],
-    node_to_index: Dict[Any, int],
+    node_to_index: dict[Any, int],
     th_vals: Sequence[float],
     epi_vals: Sequence[float],
     vf_vals: Sequence[float],
     si_vals: Sequence[float],
-    wnorm: Dict[str, float],
+    wnorm: dict[str, float],
     epi_min: float,
     epi_max: float,
     vf_min: float,

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import Counter, defaultdict
 from statistics import mean, median
 
-from typing import Any, Dict, Callable
+from typing import Any, Callable
 
 import heapq
 import math
@@ -47,7 +47,7 @@ TgRun = "run"
 # -------------
 
 
-def _tg_state(nd: Dict[str, Any]) -> Dict[str, Any]:
+def _tg_state(nd: dict[str, Any]) -> dict[str, Any]:
     """Internal per-node structure for accumulating run times per glyph.
     Fields: curr (current glyph), run (accumulated time in current glyph)
     """
@@ -92,7 +92,7 @@ def _update_coherence(G, hist) -> None:
 
 
 def _record_metrics(
-    hist: Dict[str, Any], *pairs: tuple[Callable[[], Any], str]
+    hist: dict[str, Any], *pairs: tuple[Callable[[], Any], str]
 ) -> None:
     """Record metrics using pairs of callables and keys."""
     for fn, key in pairs:
@@ -409,13 +409,13 @@ def register_metrics_callbacks(G) -> None:
 # -------------
 
 
-def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
+def Tg_global(G, normalize: bool = True) -> dict[str, float]:
     """Total glyph time per class. If ``normalize=True``, return fractions
     of the total."""
     hist = ensure_history(G)
-    tg_total: Dict[str, float] = hist.get("Tg_total", {})
+    tg_total: dict[str, float] = hist.get("Tg_total", {})
     total = sum(tg_total.values()) or 1.0
-    out: Dict[str, float] = {}
+    out: dict[str, float] = {}
 
     def add(g):
         val = float(tg_total.get(g, 0.0))
@@ -427,21 +427,21 @@ def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
 
 def Tg_by_node(
     G, n, normalize: bool = False
-) -> Dict[str, float | list[float]]:
+) -> dict[str, float | list[float]]:
     """Per-node summary: if ``normalize`` return mean run per glyph;
     otherwise list runs."""
     hist = ensure_history(G)
     rec = hist.get("Tg_by_node", {}).get(n, {})
     if not normalize:
         # convertir default dict → list para serializar
-        out: Dict[str, list[float]] = {}
+        out: dict[str, list[float]] = {}
 
         def copy_runs(g):
             out[g] = list(rec.get(g, []))
 
         for_each_glyph(copy_runs)
         return out
-    out: Dict[str, float] = {}
+    out: dict[str, float] = {}
 
     def add(g):
         runs = rec.get(g, [])
@@ -451,7 +451,7 @@ def Tg_by_node(
     return out
 
 
-def latency_series(G) -> Dict[str, list[float]]:
+def latency_series(G) -> dict[str, list[float]]:
     hist = ensure_history(G)
     xs = hist.get("latency_index", [])
     return {
@@ -460,12 +460,12 @@ def latency_series(G) -> Dict[str, list[float]]:
     }
 
 
-def glyphogram_series(G) -> Dict[str, list[float]]:
+def glyphogram_series(G) -> dict[str, list[float]]:
     hist = ensure_history(G)
     xs = hist.get("glyphogram", [])
     if not xs:
         return {"t": []}
-    out: Dict[str, list[float]] = {
+    out: dict[str, list[float]] = {
         "t": [float(x.get("t", i)) for i, x in enumerate(xs)]
     }
 
@@ -485,11 +485,11 @@ def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
     return heapq.nlargest(k, tg.items(), key=lambda kv: kv[1])
 
 
-def glyph_dwell_stats(G, n) -> Dict[str, Dict[str, float]]:
+def glyph_dwell_stats(G, n) -> dict[str, dict[str, float]]:
     """Per-node statistics: mean/median/max of runs per glyph."""
     hist = ensure_history(G)
     rec = hist.get("Tg_by_node", {}).get(n, {})
-    out: Dict[str, Dict[str, float]] = {}
+    out: dict[str, dict[str, float]] = {}
 
     def add(g):
         runs = list(rec.get(g, []))

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence, Iterable, Mapping
+from typing import Any, Sequence, Iterable, Mapping
 from types import MappingProxyType
 import math
 
@@ -41,9 +41,9 @@ __all__ = [
 
 @dataclass
 class TrigCache:
-    cos: Dict[Any, float]
-    sin: Dict[Any, float]
-    theta: Dict[Any, float]
+    cos: dict[Any, float]
+    sin: dict[Any, float]
+    theta: dict[Any, float]
 
 
 def compute_dnfr_accel_max(G) -> dict:
@@ -121,9 +121,9 @@ def get_Si_weights(G: Any) -> tuple[float, float, float]:
 
 def _build_trig_cache(G: Any) -> TrigCache:
     """Construct trigonometric cache for ``G``."""
-    cos_th: Dict[Any, float] = {}
-    sin_th: Dict[Any, float] = {}
-    thetas: Dict[Any, float] = {}
+    cos_th: dict[Any, float] = {}
+    sin_th: dict[Any, float] = {}
+    thetas: dict[Any, float] = {}
     for n, nd in G.nodes(data=True):
         th = get_attr(nd, ALIAS_THETA, 0.0)
         thetas[n] = th
@@ -147,7 +147,7 @@ def get_trig_cache(G: Any) -> TrigCache:
 
 def compute_Si_node(
     n: Any,
-    nd: Dict[str, Any],
+    nd: dict[str, Any],
     *,
     alpha: float,
     beta: float,
@@ -196,7 +196,7 @@ def _get_vf_dnfr_max(G) -> tuple[float, float]:
     return vfmax, dnfrmax
 
 
-def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
+def compute_Si(G, *, inplace: bool = True) -> dict[Any, float]:
     """Compute ``Si`` per node and write it to ``G.nodes[n]['Si']``."""
     neighbors = ensure_neighbors_map(G)
     alpha, beta, gamma = get_Si_weights(G)
@@ -216,7 +216,7 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
             neigh, cos_th, sin_th, np=np, fallback=fallback
         )
 
-    out: Dict[Any, float] = {}
+    out: dict[Any, float] = {}
     for n, nd in G.nodes(data=True):
         neigh = neighbors[n]
         th_bar = phase_mean_fn(neigh, fallback=thetas[n])

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Callable, Deque, Dict, Iterable, Optional, Protocol, TypeVar
+from typing import Callable, Deque, Iterable, Optional, Protocol, TypeVar
 from enum import Enum
 from collections import deque
 from collections.abc import Hashable
@@ -206,7 +206,7 @@ class NodoProtocol(Protocol):
     epi_kind: str
     dnfr: float
     d2EPI: float
-    graph: Dict[str, object]
+    graph: dict[str, object]
 
     def neighbors(self) -> Iterable[NodoProtocol | Hashable]: ...
 
@@ -239,8 +239,8 @@ class NodoTNFR:
     epi_kind: str = ""
     dnfr: float = 0.0
     d2EPI: float = 0.0
-    graph: Dict[str, object] = field(default_factory=dict)
-    _neighbors: Dict["NodoTNFR", float] = field(default_factory=dict)
+    graph: dict[str, object] = field(default_factory=dict)
+    _neighbors: dict["NodoTNFR", float] = field(default_factory=dict)
     _glyph_history: Deque[str] = field(
         default_factory=lambda: deque(
             maxlen=DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 7)

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -15,7 +15,7 @@ Note on REMESH α (alpha) precedence:
 
 # operators.py — TNFR canónica (ASCII-safe)
 from __future__ import annotations
-from typing import Dict, Any, TYPE_CHECKING, Optional
+from typing import Any, TYPE_CHECKING, Optional
 import math
 import hashlib
 import heapq
@@ -37,10 +37,12 @@ from .helpers.cache import (
     ensure_node_offset_map,
 )
 from .alias import get_attr, set_attr
-from .rng import get_rng, base_seed
+from .rng import get_rng, base_seed, cache_enabled
 from .callback_utils import invoke_callbacks
 from .glyph_history import append_metric
 from .import_utils import import_nodonx, optional_import
+
+_JITTER_SEQ: dict[tuple[int, int], int] = {}
 
 if TYPE_CHECKING:
     from .node import NodoProtocol
@@ -67,6 +69,7 @@ def _node_offset(G, n) -> int:
 def clear_rng_cache() -> None:
     """Clear cached RNGs."""
     get_rng.cache_clear()
+    _JITTER_SEQ.clear()
 
 
 @cache
@@ -142,11 +145,15 @@ def random_jitter(node: NodoProtocol, amplitude: float) -> float:
             hashlib.blake2b(seed_bytes, digest_size=8).digest(), "little"
         )
         cache[cache_key] = seed
-    rng = get_rng(seed, seed_key)
+    seq = 0
+    if cache_enabled():
+        seq = _JITTER_SEQ.get(cache_key, 0)
+        _JITTER_SEQ[cache_key] = seq + 1
+    rng = get_rng(seed, seed_key + seq)
     return rng.uniform(-amplitude, amplitude)
 
 
-def get_glyph_factors(node: NodoProtocol) -> Dict[str, Any]:
+def get_glyph_factors(node: NodoProtocol) -> dict[str, Any]:
     """Return glyph factors for ``node`` with defaults."""
     return node.graph.get("GLYPH_FACTORS", DEFAULTS["GLYPH_FACTORS"])
 
@@ -238,22 +245,22 @@ def _mix_epi_with_neighbors(
     return epi_bar, dominant
 
 
-def _op_AL(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # AL — Emisión
+def _op_AL(node: NodoProtocol, gf: dict[str, Any]) -> None:  # AL — Emisión
     f = float(gf.get("AL_boost", 0.05))
     node.EPI = node.EPI + f
 
 
-def _op_EN(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # EN — Recepción
+def _op_EN(node: NodoProtocol, gf: dict[str, Any]) -> None:  # EN — Recepción
     mix = float(gf.get("EN_mix", 0.25))
     _mix_epi_with_neighbors(node, mix, Glyph.EN)
 
 
-def _op_IL(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # IL — Coherencia
+def _op_IL(node: NodoProtocol, gf: dict[str, Any]) -> None:  # IL — Coherencia
     factor = float(gf.get("IL_dnfr_factor", 0.7))
     node.dnfr = factor * getattr(node, "dnfr", 0.0)
 
 
-def _op_OZ(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # OZ — Disonancia
+def _op_OZ(node: NodoProtocol, gf: dict[str, Any]) -> None:  # OZ — Disonancia
     factor = float(gf.get("OZ_dnfr_factor", 1.3))
     dnfr = getattr(node, "dnfr", 0.0)
     if bool(node.graph.get("OZ_NOISE_MODE", False)):
@@ -303,7 +310,7 @@ def _um_select_candidates(
     return cand_list
 
 
-def _op_UM(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # UM — Coupling
+def _op_UM(node: NodoProtocol, gf: dict[str, Any]) -> None:  # UM — Coupling
     """Align phase and optionally create functional links.
 
     Link search can be reduced by evaluating only a subset of candidates.
@@ -356,12 +363,12 @@ def _op_UM(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # UM — Coupling
                 node.add_edge(j, compat)
 
 
-def _op_RA(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # RA — Resonancia
+def _op_RA(node: NodoProtocol, gf: dict[str, Any]) -> None:  # RA — Resonancia
     diff = float(gf.get("RA_epi_diff", 0.15))
     _mix_epi_with_neighbors(node, diff, Glyph.RA)
 
 
-def _op_SHA(node: NodoProtocol, gf: Dict[str, Any]) -> None:  # SHA — Silencio
+def _op_SHA(node: NodoProtocol, gf: dict[str, Any]) -> None:  # SHA — Silencio
     factor = float(gf.get("SHA_vf_factor", 0.85))
     node.vf = factor * node.vf
 
@@ -378,7 +385,7 @@ def _op_scale(node: NodoProtocol, glyph: Glyph, factor: float) -> None:
 
 
 def _make_scale_op(glyph: Glyph):
-    def _op(node: NodoProtocol, gf: Dict[str, Any]) -> None:
+    def _op(node: NodoProtocol, gf: dict[str, Any]) -> None:
         factor_val = float(gf.get("VAL_scale", _SCALE_FACTORS[Glyph.VAL]))
         factor_nul = float(gf.get("NUL_scale", _SCALE_FACTORS[Glyph.NUL]))
         factor = factor_val if glyph is Glyph.VAL else factor_nul
@@ -388,21 +395,21 @@ def _make_scale_op(glyph: Glyph):
 
 
 def _op_THOL(
-    node: NodoProtocol, gf: Dict[str, Any]
+    node: NodoProtocol, gf: dict[str, Any]
 ) -> None:  # THOL — Autoorganización
     a = float(gf.get("THOL_accel", 0.10))
     node.dnfr = node.dnfr + a * getattr(node, "d2EPI", 0.0)
 
 
 def _op_ZHIR(
-    node: NodoProtocol, gf: Dict[str, Any]
+    node: NodoProtocol, gf: dict[str, Any]
 ) -> None:  # ZHIR — Mutación
     shift = float(gf.get("ZHIR_theta_shift", math.pi / 2))
     node.theta = node.theta + shift
 
 
 def _op_NAV(
-    node: NodoProtocol, gf: Dict[str, Any]
+    node: NodoProtocol, gf: dict[str, Any]
 ) -> None:  # NAV — Transición
     dnfr = node.dnfr
     vf = node.vf
@@ -423,7 +430,7 @@ def _op_NAV(
 
 
 def _op_REMESH(
-    node: NodoProtocol, gf: Dict[str, Any] | None = None
+    node: NodoProtocol, gf: dict[str, Any] | None = None
 ) -> None:  # REMESH — aviso
     step_idx = len(node.graph.get("history", {}).get("C_steps", []))
     last_warn = node.graph.get("_remesh_warn_step", None)

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -6,7 +6,7 @@ import random
 import hashlib
 import struct
 import threading
-from typing import MutableMapping, Tuple, Any
+from typing import MutableMapping, Any
 
 from cachetools import LRUCache
 from .constants import DEFAULTS
@@ -14,7 +14,7 @@ from .helpers.cache import get_graph
 
 _RNG_LOCK = threading.Lock()
 _CACHE_MAXSIZE = int(DEFAULTS.get("JITTER_CACHE_SIZE", 128))
-_RNG_CACHE: MutableMapping[Tuple[int, int], int] = LRUCache(
+_RNG_CACHE: MutableMapping[tuple[int, int], int] = LRUCache(
     maxsize=max(1, _CACHE_MAXSIZE)
 )
 
@@ -58,6 +58,11 @@ def _cache_clear() -> None:
 get_rng.cache_clear = _cache_clear  # type: ignore[attr-defined]
 
 
+def cache_enabled() -> bool:
+    """Return ``True`` if RNG caching is enabled."""
+    return _CACHE_MAXSIZE > 0
+
+
 def base_seed(G: Any) -> int:
     """Return base RNG seed stored in ``G.graph``."""
     graph = get_graph(G)
@@ -89,4 +94,4 @@ def set_cache_maxsize(size: int) -> None:
             _RNG_CACHE = {}
 
 
-__all__ = ["get_rng", "make_rng", "set_cache_maxsize", "base_seed"]
+__all__ = ["get_rng", "make_rng", "set_cache_maxsize", "base_seed", "cache_enabled"]

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from collections.abc import Sequence
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -44,7 +44,7 @@ def _selector_thresholds(G: "nx.Graph") -> dict:
         "accel_lo": (None, SELECTOR_THRESHOLD_DEFAULTS["accel_lo"]),
     }
 
-    out: Dict[str, float] = {}
+    out: dict[str, float] = {}
     for key, (legacy, default) in specs.items():
         if legacy is not None:
             val = thr_sel.get(key, thr_def.get(legacy, default))
@@ -63,7 +63,7 @@ def _norms_para_selector(G: "nx.Graph") -> dict:
 
 
 def _calc_selector_score(
-    Si: float, dnfr: float, accel: float, weights: Dict[str, float]
+    Si: float, dnfr: float, accel: float, weights: dict[str, float]
 ) -> float:
     """Compute a weighted score assuming normalised weights."""
     return (
@@ -79,11 +79,11 @@ def dist_to_threshold(value: float, hi: float, lo: float) -> float:
 
 
 def _apply_selector_hysteresis(
-    nd: Dict[str, Any],
+    nd: dict[str, Any],
     Si: float,
     dnfr: float,
     accel: float,
-    thr: Dict[str, float],
+    thr: dict[str, float],
     margin: float,
 ) -> str | None:
     """Apply hysteresis, returning the previous glyph when close to

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -1,7 +1,7 @@
 """Sense calculations."""
 
 from __future__ import annotations
-from typing import Dict, Iterable, List, TypeVar
+from typing import Iterable, TypeVar
 import math
 from collections import Counter
 
@@ -26,7 +26,7 @@ from .constants_glyphs import (
 # Canon: orden circular de glyphs y ángulos
 # -------------------------
 
-GLYPH_UNITS: Dict[str, complex] = {
+GLYPH_UNITS: dict[str, complex] = {
     g: complex(math.cos(a), math.sin(a)) for g, a in ANGLE_MAP.items()
 }
 
@@ -51,7 +51,7 @@ __all__ = [
 T = TypeVar("T")
 
 
-def _resolve_glyph(g: str, mapping: Dict[str, T]) -> T:
+def _resolve_glyph(g: str, mapping: dict[str, T]) -> T:
     """Return ``mapping[g]`` or raise ``KeyError`` with a standard message."""
 
     try:
@@ -112,7 +112,7 @@ def _to_complex(val: complex | float | int) -> complex:
 def _sigma_from_iterable(
     values: Iterable[complex | float | int] | complex | float | int,
     fallback_angle: float = 0.0,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Normalise vectors in the σ-plane.
 
     ``values`` may contain complex or real numbers; real inputs are promoted to
@@ -163,8 +163,8 @@ _sigma_from_vectors = _sigma_from_iterable
 
 
 def _ema_update(
-    prev: Dict[str, float], current: Dict[str, float], alpha: float
-) -> Dict[str, float]:
+    prev: dict[str, float], current: dict[str, float], alpha: float
+) -> dict[str, float]:
     """Exponential moving average update for σ vectors."""
     x = (1 - alpha) * prev["x"] + alpha * current["x"]
     y = (1 - alpha) * prev["y"] + alpha * current["y"]
@@ -175,7 +175,7 @@ def _ema_update(
 
 def sigma_vector_node(
     G, n, weight_mode: str | None = None
-) -> Dict[str, float] | None:
+) -> dict[str, float] | None:
     cfg = _sigma_cfg(G)
     nd = G.nodes[n]
     nw = _node_weight(nd, weight_mode or cfg.get("weight", "Si"))
@@ -197,7 +197,7 @@ def sigma_vector_node(
     }
 
 
-def sigma_vector(dist: Dict[str, float]) -> Dict[str, float]:
+def sigma_vector(dist: dict[str, float]) -> dict[str, float]:
     """Compute Σ⃗ from a glyph distribution.
 
     ``dist`` may contain raw counts or proportions. All ``(glyph, weight)``
@@ -211,7 +211,7 @@ def sigma_vector(dist: Dict[str, float]) -> Dict[str, float]:
 
 def sigma_vector_from_graph(
     G: nx.Graph, weight_mode: str | None = None
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Global vector in the σ sense plane for a graph.
 
     Parameters
@@ -223,7 +223,7 @@ def sigma_vector_from_graph(
 
     Returns
     -------
-    Dict[str, float]
+    dict[str, float]
         Cartesian components, magnitude and angle of the average vector.
     """
 
@@ -298,7 +298,7 @@ def register_sigma_callback(G) -> None:
 # -------------------------
 
 
-def sigma_series(G, key: str | None = None) -> Dict[str, List[float]]:
+def sigma_series(G, key: str | None = None) -> dict[str, list[float]]:
     cfg = _sigma_cfg(G)
     key = key or cfg.get("history_key", "sigma_global")
     hist = G.graph.get("history", {})
@@ -312,7 +312,7 @@ def sigma_series(G, key: str | None = None) -> Dict[str, List[float]]:
     }
 
 
-def sigma_rose(G, steps: int | None = None) -> Dict[str, int]:
+def sigma_rose(G, steps: int | None = None) -> dict[str, int]:
     """Histogram of glyphs in the last ``steps`` steps (or all)."""
     hist = G.graph.get("history", {})
     counts = hist.get("sigma_counts", [])

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -1,7 +1,7 @@
 """Structural analysis."""
 
 from __future__ import annotations
-from typing import Iterable, Tuple, List
+from typing import Iterable
 import networkx as nx
 
 from .dynamics import (
@@ -26,7 +26,7 @@ def create_nfr(
     theta: float = 0.0,
     graph: nx.Graph | None = None,
     dnfr_hook=dnfr_epi_vf_mixed,
-) -> Tuple[nx.Graph, str]:
+) -> tuple[nx.Graph, str]:
     """Create a graph with an initialised NFR node.
 
     Returns the tuple ``(G, name)`` for convenience.
@@ -68,7 +68,7 @@ class Operador:
 
 # Derivados concretos -------------------------------------------------------
 #
-def operador_factory(*pairs: Tuple[str, str]) -> dict[str, type[Operador]]:
+def operador_factory(*pairs: tuple[str, str]) -> dict[str, type[Operador]]:
     """Dynamically build ``Operador`` subclasses.
 
     Each ``(name, glyph)`` pair produces a concrete subclass with the
@@ -126,7 +126,7 @@ _TRAMO_INTERMEDIO = {"disonancia", "acoplamiento", "resonancia"}
 _CIERRE_VALIDO = {"silencio", "transicion", "recursividad"}
 
 
-def _verify_token_format(nombres: List[str]) -> Tuple[bool, str]:
+def _verify_token_format(nombres: list[str]) -> tuple[bool, str]:
     """Check basic type and format of the token list."""
     if not nombres:
         return False, "empty sequence"
@@ -141,7 +141,7 @@ def _verify_token_format(nombres: List[str]) -> Tuple[bool, str]:
     return True, "ok"
 
 
-def _validate_logical_coherence(nombres: List[str]) -> Tuple[bool, str]:
+def _validate_logical_coherence(nombres: list[str]) -> tuple[bool, str]:
     """Validate logical coherence of the sequence."""
     i_rec = i_coh = -1
     found_intermedio = False
@@ -172,7 +172,7 @@ def _validate_logical_coherence(nombres: List[str]) -> Tuple[bool, str]:
     return True, "ok"
 
 
-def validate_sequence(nombres: List[str]) -> Tuple[bool, str]:
+def validate_sequence(nombres: list[str]) -> tuple[bool, str]:
     """Validate minimal TNFR syntax rules."""
     ok, msg = _verify_token_format(nombres)
     if not ok:

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -7,7 +7,7 @@ structures as immutable snapshots.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional, Protocol, NamedTuple
+from typing import Any, Callable, Optional, Protocol, NamedTuple
 
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
@@ -22,7 +22,7 @@ class _KuramotoFn(Protocol):
 class _SigmaVectorFn(Protocol):
     def __call__(
         self, G: Any, weight_mode: str | None = None
-    ) -> Dict[str, float]: ...
+    ) -> dict[str, float]: ...
 
 
 class CallbackSpec(NamedTuple):
@@ -43,7 +43,7 @@ kuramoto_R_psi: _KuramotoFn = optional_import(
 
 def _sigma_fallback(
     G: Any, weight_mode: str | None = None
-) -> Dict[str, float]:
+) -> dict[str, float]:
     return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 
@@ -68,7 +68,7 @@ __all__ = [
 def _trace_setup(
     G,
 ) -> tuple[
-    Optional[Dict[str, Any]], set[str], Optional[Dict[str, Any]], Optional[str]
+    Optional[dict[str, Any]], set[str], Optional[dict[str, Any]], Optional[str]
 ]:
     """Common configuration for trace snapshots.
 
@@ -92,7 +92,7 @@ def _callback_names(callbacks: list[CallbackSpec]) -> list[str]:
     return [cb.name or getattr(cb.func, "__name__", "fn") for cb in callbacks]
 
 
-def mapping_field(G, graph_key: str, out_key: str) -> Dict[str, Any]:
+def mapping_field(G, graph_key: str, out_key: str) -> dict[str, Any]:
     """Helper to copy mappings from ``G.graph`` into trace output."""
     mapping = get_graph_mapping(
         G, graph_key, f"G.graph[{graph_key!r}] no es un mapeo; se ignora"
@@ -102,7 +102,7 @@ def mapping_field(G, graph_key: str, out_key: str) -> Dict[str, Any]:
 
 def make_mapping_field(
     graph_key: str, out_key: str
-) -> Callable[[Any], Dict[str, Any]]:
+) -> Callable[[Any], dict[str, Any]]:
     """Return a field function reading ``graph_key`` into ``out_key``."""
 
     def field(G):
@@ -119,7 +119,7 @@ def make_mapping_field(
 def _new_trace_meta(
     G, phase: str
 ) -> Optional[
-    tuple[Dict[str, Any], set[str], Optional[Dict[str, Any]], Optional[str]]
+    tuple[dict[str, Any], set[str], Optional[dict[str, Any]], Optional[str]]
 ]:
     """Initialise trace metadata for a ``phase``.
 
@@ -131,7 +131,7 @@ def _new_trace_meta(
     if not cfg:
         return None
 
-    meta: Dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": phase}
+    meta: dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": phase}
     return meta, capture, hist, key
 
 
@@ -141,7 +141,7 @@ def _new_trace_meta(
 
 
 def _trace_capture(
-    G, phase: str, fields: Dict[str, Callable[[Any], Dict[str, Any]]]
+    G, phase: str, fields: dict[str, Callable[[Any], dict[str, Any]]]
 ) -> None:
     """Capture ``fields`` for a ``phase`` and store the snapshot.
 

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Any
+from typing import Any
 
 __all__ = ["NodeState", "Glyph"]
 
@@ -15,7 +15,7 @@ class NodeState:
     theta: float = 0.0  # θ
     Si: float = 0.0
     epi_kind: str = ""
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 class Glyph(str, Enum):


### PR DESCRIPTION
## Summary
- replace `typing` collections like `Dict` and `List` with builtin generics
- remove unused typing imports and modernize annotations
- ensure deterministic jitter by tracking per-node sequence with cache-aware RNG helper

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf1ba97f108321b4b303edd37a3cff