### PR TITLE
Optimize node checksum hashing to reduce peak memory

### DIFF
--- a/tests/test_node_all_nodes.py
+++ b/tests/test_node_all_nodes.py
@@ -1,6 +1,12 @@
 """Pruebas de node all nodes."""
 
+import hashlib
+import tracemalloc
+
+import networkx as nx
+
 from tnfr.node import NodoTNFR
+from tnfr.helpers.cache import node_set_checksum, _node_repr, _hash_node
 
 
 def test_all_nodes_returns_full_list():
@@ -12,3 +18,31 @@ def test_all_nodes_returns_full_list():
 
     assert set(a.all_nodes()) == {a, b}
     assert set(b.all_nodes()) == {a, b}
+
+
+def _reference_checksum(G: nx.Graph) -> str:
+    reps = sorted(_node_repr(n) for n in G.nodes())
+    hasher = hashlib.blake2b(digest_size=16)
+    for rep in reps:
+        digest = hashlib.blake2b(rep.encode("utf-8"), digest_size=16).digest()
+        hasher.update(digest)
+    return hasher.hexdigest()
+
+
+def _peak_memory(fn, *args) -> int:
+    _node_repr.cache_clear()
+    _hash_node.cache_clear()
+    tracemalloc.start()
+    fn(*args)
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+    return peak
+
+
+def test_node_set_checksum_peak_memory_reduced():
+    G = nx.Graph()
+    for i in range(100_000):
+        G.add_node(f"node-{i:05d}" * 2)
+    peak_new = _peak_memory(node_set_checksum, G)
+    peak_old = _peak_memory(_reference_checksum, G)
+    assert peak_new < peak_old


### PR DESCRIPTION
## Summary
- Streamline `node_set_checksum` to incrementally merge sorted node digests, avoiding materialising the whole representation list
- Document new checksum strategy and its order-independent behavior
- Add stress test confirming reduced peak memory for large graphs

## Testing
- `PYTHONPATH=src python -m pytest tests/test_node_set_checksum.py tests/test_node_all_nodes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1ec60d488321a4afd2992072e251