### PR TITLE
fix: copy overrides in merge_overrides

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -186,11 +186,15 @@ def inject_defaults(
 
 
 def merge_overrides(G, **overrides) -> None:
-    """Apply specific changes to ``G.graph``."""
+    """Apply specific changes to ``G.graph``.
+
+    Non-immutable values are deep-copied to avoid shared state with
+    :data:`DEFAULTS`.
+    """
     for key, value in overrides.items():
         if key not in DEFAULTS:
             raise KeyError(f"Parámetro desconocido: '{key}'")
-        G.graph[key] = value
+        G.graph[key] = value if _is_immutable(value) else copy.deepcopy(value)
 
 
 def get_param(G, key: str):

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -5,6 +5,7 @@ import networkx as nx
 import pytest
 from tnfr.config import load_config, apply_config
 from collections import UserDict
+from tnfr.constants import DEFAULTS, merge_overrides
 
 try:  # pragma: no cover - dependencia opcional
     import yaml  # type: ignore
@@ -77,3 +78,12 @@ def test_apply_config_passes_path_object(monkeypatch, tmp_path):
     G = nx.Graph()
     apply_config(G, path)
     assert received["path"] is path
+
+
+def test_merge_overrides_does_not_modify_defaults():
+    G = nx.Graph()
+    orig_enabled = DEFAULTS["TRACE"]["enabled"]
+    merge_overrides(G, TRACE=DEFAULTS["TRACE"])
+    assert G.graph["TRACE"] is not DEFAULTS["TRACE"]
+    G.graph["TRACE"]["enabled"] = not orig_enabled
+    assert DEFAULTS["TRACE"]["enabled"] == orig_enabled


### PR DESCRIPTION
## Summary
- avoid shared state in merge_overrides by deep-copying mutable values
- add test confirming merge_overrides doesn't mutate DEFAULTS

## Testing
- `PYTHONPATH=src pytest tests/test_config_apply.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf41bda7a483218c0d3ba2510797f5