### PR TITLE
Handle RNG cache clearing when disabled

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -79,6 +79,7 @@ def set_cache_maxsize(size: int) -> None:
     """Update RNG cache maximum size.
 
     ``size`` must be a non-negative integer; ``0`` disables caching.
+    If caching is disabled, ``get_rng.cache_clear`` has no effect.
     """
 
     global _CACHE_MAXSIZE, _RNG_CACHE
@@ -90,8 +91,10 @@ def set_cache_maxsize(size: int) -> None:
         _RNG_CACHE.clear()
         if new_size > 0:
             _RNG_CACHE = LRUCache(maxsize=new_size)
+            get_rng.cache_clear = _cache_clear  # type: ignore[attr-defined]
         else:
             _RNG_CACHE = {}
+            get_rng.cache_clear = lambda: None  # type: ignore[attr-defined]
 
 
 __all__ = ["get_rng", "make_rng", "set_cache_maxsize", "base_seed", "cache_enabled"]

--- a/tests/test_rng_base_seed.py
+++ b/tests/test_rng_base_seed.py
@@ -1,5 +1,5 @@
 import networkx as nx
-from tnfr.rng import base_seed
+from tnfr.rng import base_seed, get_rng, set_cache_maxsize
 
 
 def test_base_seed_returns_value():
@@ -11,3 +11,14 @@ def test_base_seed_returns_value():
 def test_base_seed_defaults_to_zero():
     G = nx.Graph()
     assert base_seed(G) == 0
+
+
+def test_cache_clear_no_fail_when_cache_disabled():
+    import tnfr.rng as rng_module
+
+    old_size = rng_module._CACHE_MAXSIZE
+    set_cache_maxsize(0)
+    try:
+        assert get_rng.cache_clear() is None
+    finally:
+        set_cache_maxsize(old_size)


### PR DESCRIPTION
## Summary
- ensure `get_rng.cache_clear` becomes a no-op when RNG cache is disabled
- document cache clearing behavior in `set_cache_maxsize`
- test that disabling the cache leaves `cache_clear` safe to call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf428d4a9c832180d8c86a5d35db3e