### PR TITLE
Simplify alias validation

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -48,10 +48,12 @@ __all__ = [
 
 @lru_cache(maxsize=128)
 def _validate_aliases(aliases: tuple[str, ...]) -> tuple[str, ...]:
-    """Validate and cache ``aliases`` as a tuple of strings."""
+    """Validate and cache ``aliases`` as a tuple of strings.
 
-    if not isinstance(aliases, tuple):
-        raise TypeError("'aliases' must be a tuple of strings")
+    The caller is responsible for providing a tuple; this function only
+    ensures that at least one alias is present and that every element is
+    a string.
+    """
     if not aliases:
         raise ValueError("'aliases' must contain at least one key")
     for a in aliases:

--- a/tests/test_validate_aliases.py
+++ b/tests/test_validate_aliases.py
@@ -2,12 +2,6 @@ import pytest
 
 from tnfr.alias import _validate_aliases, AliasAccessor
 
-
-def test_rejects_string():
-    with pytest.raises(TypeError):
-        _validate_aliases("abc")
-
-
 def test_rejects_empty_iterable():
     with pytest.raises(ValueError):
         _validate_aliases(())


### PR DESCRIPTION
## Summary
- remove tuple type enforcement from `_validate_aliases`
- clarify `_validate_aliases` docstring
- adjust alias validation tests for new behavior

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf45699d9c8321afe0f5de365dfa85