### PR TITLE
Use incremental Kahan sum in weight normalization

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -108,6 +108,8 @@ def normalize_weights(
         return {}
     weights: dict[str, float] = {}
     negatives: dict[str, float] = {}
+    total = 0.0
+    comp = 0.0
     for k in keys:
         val = dict_like.get(k, default_float)
         ok, converted = _convert_value(
@@ -121,13 +123,26 @@ def normalize_weights(
         weights[k] = w
         if w < 0:
             negatives[k] = w
+        t = total + w
+        if abs(total) >= abs(w):
+            comp += (total - t) + w
+        else:
+            comp += (w - t) + total
+        total = t
     if negatives:
         if error_on_negative:
             raise ValueError(NEGATIVE_WEIGHTS_MSG % negatives)
         logger.warning(NEGATIVE_WEIGHTS_MSG, negatives)
-        for k in negatives:
+        for k, w in negatives.items():
+            sub = -w
+            t = total + sub
+            if abs(total) >= abs(sub):
+                comp += (total - t) + sub
+            else:
+                comp += (sub - t) + total
+            total = t
             weights[k] = 0.0
-    total = kahan_sum(weights.values())
+    total = float(total + comp)
     if total <= 0:
         uniform = 1.0 / len(keys)
         return {k: uniform for k in keys}


### PR DESCRIPTION
## Summary
- Accumulate weight totals with incremental Kahan algorithm during normalization
- Drop extra pass through weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf473a7d18832195450f6bd1934b53