### PR TITLE
Restore optional import cache clearing via helper

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -22,6 +22,7 @@ __all__ = [
     "get_numpy",
     "import_nodonx",
     "prune_failed_imports",
+    "clear_optional_import_cache",
 ]
 
 
@@ -142,7 +143,7 @@ def optional_import(name: str, fallback: Any | None = None) -> Any | None:
     -----
     ``fallback`` is returned when the module is unavailable or the requested
     attribute does not exist. In both cases a warning is emitted and logged.
-    Use ``optional_import.cache_clear()`` to reset the internal cache and
+    Use :func:`clear_optional_import_cache` to reset the internal cache and
     failure registry after installing new optional dependencies.
     """
 
@@ -172,20 +173,14 @@ def optional_import(name: str, fallback: Any | None = None) -> Any | None:
     return fallback
 
 
-_optional_import_cache_clear = optional_import.cache_clear
-
-
-def _cache_clear() -> None:
-    """Clear ``optional_import`` cache and failure records."""
-    _optional_import_cache_clear()
+def clear_optional_import_cache() -> None:
+    """Clear ``optional_import`` cache, failure records and warning state."""
+    optional_import.cache_clear()
     with _IMPORT_STATE.lock:
         _IMPORT_STATE.clear()
     with _WARNED_LOCK:
         _WARNED_MODULES.clear()
         _WARNED_QUEUE.clear()
-
-
-optional_import.cache_clear = _cache_clear  # type: ignore[attr-defined]
 
 
 def prune_failed_imports() -> None:

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -7,7 +7,7 @@ from tnfr.import_utils import (
     optional_import,
     prune_failed_imports,
     _IMPORT_STATE,
-    _optional_import_cache_clear,
+    clear_optional_import_cache,
 )
 
 
@@ -21,10 +21,10 @@ def test_optional_import_clears_failures(monkeypatch):
         return types.SimpleNamespace(value=1)
 
     monkeypatch.setattr(importlib, "import_module", fake_import)
-    optional_import.cache_clear()
+    clear_optional_import_cache()
     assert optional_import("fake_mod") is None
     assert "fake_mod" in _IMPORT_STATE
-    optional_import.cache_clear()
+    clear_optional_import_cache()
     result = optional_import("fake_mod")
     assert result is not None
     assert "fake_mod" not in _IMPORT_STATE
@@ -42,11 +42,11 @@ def test_warns_once_then_debug(monkeypatch, caplog):
         stacklevels.append(stacklevel)
 
     monkeypatch.setattr(import_utils.warnings, "warn", fake_warn)
-    optional_import.cache_clear()
+    clear_optional_import_cache()
     with caplog.at_level(logging.DEBUG, logger=import_utils.logger.name):
         optional_import("fake_mod.attr1")
         optional_import("fake_mod.attr2")
-    optional_import.cache_clear()
+    clear_optional_import_cache()
     records = [
         r.levelno for r in caplog.records if r.name == import_utils.logger.name
     ]
@@ -64,10 +64,10 @@ def test_optional_import_removes_entry_on_success(monkeypatch):
         return types.SimpleNamespace(value=1)
 
     monkeypatch.setattr(importlib, "import_module", fake_import)
-    _optional_import_cache_clear()
+    clear_optional_import_cache()
     assert optional_import("fake_mod") is None
     assert "fake_mod" in _IMPORT_STATE
-    _optional_import_cache_clear()  # retry without clearing failure registry
+    optional_import.cache_clear()  # retry without clearing failure registry
     result = optional_import("fake_mod")
     assert result is not None
     assert "fake_mod" not in _IMPORT_STATE


### PR DESCRIPTION
## Summary
- restore original `optional_import.cache_clear`
- add public `clear_optional_import_cache()` wrapper that clears cache, failure records and warning state
- adjust tests to use `clear_optional_import_cache`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfd8c7bb60832198d793c7a4741309