### PR TITLE
Use slots in TrigCache dataclass

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -39,7 +39,7 @@ __all__ = [
 ]
 
 
-@dataclass
+@dataclass(slots=True)
 class TrigCache:
     cos: dict[Any, float]
     sin: dict[Any, float]


### PR DESCRIPTION
## Summary
- use `slots=True` in `TrigCache` dataclass to prevent dynamic attribute assignment and save memory
- verified no code assigns dynamic attributes to trig cache objects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfde5a735c8321ba01c0327d4e797d