### PR TITLE
Improve utility robustness and add validation

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -97,12 +97,6 @@ __all__ = [
     "step",
     "run",
 ]
-
-
-def _param(G, name):
-    return float(G.graph.get(name) if G is not None else DEFAULTS[name])
-
-
 def _log_clamp(hist, node, attr, value, lo, hi):
     if value < lo or value > hi:
         hist.append({"node": node, "attr": attr, "value": float(value)})
@@ -649,7 +643,10 @@ def run(
     use_Si: bool = True,
     apply_glyphs: bool = True,
 ) -> None:
-    for _ in range(int(steps)):
+    steps_int = int(steps)
+    if steps_int < 0:
+        raise ValueError("'steps' must be non-negative")
+    for _ in range(steps_int):
         step(G, dt=dt, use_Si=use_Si, apply_glyphs=apply_glyphs)
         # Early-stop opcional
         stop_cfg = G.graph.get(

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -39,7 +39,11 @@ def _ensure_glyph_history(nd: dict[str, Any], window: int) -> deque:
     window_int = _validate_window(window)
     hist = nd.get("glyph_history")
     if not isinstance(hist, deque) or hist.maxlen != window_int:
-        seq = hist if isinstance(hist, Iterable) else []
+        seq = (
+            hist
+            if isinstance(hist, Iterable) and not isinstance(hist, (str, bytes))
+            else []
+        )
         hist = deque(seq, maxlen=window_int)
         nd["glyph_history"] = hist
     return hist

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -107,9 +107,12 @@ def _phase_mean_from_iter(
     """
 
     found = False
-    # Filter out ``None`` values and mark when at least one pair is seen
-    cos_sin_pairs = ((found := True) and cs for cs in it if cs is not None)
-    total_cos, total_sin = kahan_sum2d(cos_sin_pairs)
+    pairs: list[tuple[float, float]] = []
+    for cs in it:
+        if cs is not None:
+            found = True
+            pairs.append(cs)
+    total_cos, total_sin = kahan_sum2d(pairs)
     if not found:
         return fallback
     return math.atan2(total_sin, total_cos)

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -28,17 +28,23 @@ def json_dumps(
 ) -> bytes | str:
     """Serialize ``obj`` to JSON using ``orjson`` when available.
 
-    When :mod:`orjson` is used, the ``ensure_ascii`` and ``separators`` options
-    are ignored because they are not supported by ``orjson.dumps``. A warning is
-    emitted only the first time such ignored parameters are detected.
+    When :mod:`orjson` is used, the ``ensure_ascii``, ``separators``, ``cls``
+    and any additional keyword arguments are ignored because they are not
+    supported by :func:`orjson.dumps`. A warning is emitted only the first time
+    such ignored parameters are detected.
     """
     if _orjson is not None:
-        if ensure_ascii is not True or separators != (",", ":"):
+        if (
+            ensure_ascii is not True
+            or separators != (",", ":")
+            or cls is not None
+            or kwargs
+        ):
             global _ignored_param_warned
             with _warn_lock:
                 if not _ignored_param_warned:
                     warnings.warn(
-                        "'ensure_ascii' and 'separators' are ignored when using orjson",
+                        "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson",
                         UserWarning,
                         stacklevel=2,
                     )

--- a/tests/test_dynamics_helpers.py
+++ b/tests/test_dynamics_helpers.py
@@ -8,6 +8,7 @@ from tnfr.dynamics import (
     _refresh_dnfr_vectors,
     _compute_neighbor_means,
     _choose_glyph,
+    run,
 )
 from tnfr.grammar import AL, EN
 
@@ -70,3 +71,9 @@ def test_choose_glyph_respects_lags(graph_canon):
     h_en[0] = 6
     g = _choose_glyph(G, 0, selector, False, h_al, h_en, 1, 5)
     assert g == EN
+
+
+def test_run_rejects_negative_steps(graph_canon):
+    G = graph_canon()
+    with pytest.raises(ValueError):
+        run(G, steps=-1)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -3,6 +3,7 @@
 import pytest
 
 from tnfr.metrics import _metrics_step
+from tnfr.glyph_history import push_glyph
 
 
 def test_phase_sync_and_kuramoto_recorded(graph_canon):
@@ -14,3 +15,9 @@ def test_phase_sync_and_kuramoto_recorded(graph_canon):
     assert hist["phase_sync"][-1] == pytest.approx(1.0)
     assert "kuramoto_R" in hist
     assert hist["kuramoto_R"][-1] == pytest.approx(1.0)
+
+
+def test_string_history_is_discarded():
+    nd = {"glyph_history": "ABC"}
+    push_glyph(nd, "Z", 5)
+    assert list(nd["glyph_history"]) == ["Z"]

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -73,6 +73,18 @@ def test_optional_import_removes_entry_on_success(monkeypatch):
     assert "fake_mod" not in _IMPORT_STATE
 
 
+def test_optional_import_handles_distinct_fallbacks(monkeypatch):
+    def fake_import(name):
+        raise ImportError("boom")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    clear_optional_import_cache()
+    fb1: list[str] = []
+    fb2: dict[str, int] = {}
+    assert optional_import("fake_mod", fb1) is fb1
+    assert optional_import("fake_mod", fb2) is fb2
+
+
 def test_record_prunes_expired_entries(monkeypatch):
     state = import_utils._IMPORT_STATE
     with state.lock:


### PR DESCRIPTION
## Summary
- Refactor phase mean calculation for clarity
- Decouple optional import cache from fallbacks and add tests
- Warn on ignored parameters in `json_dumps`
- Remove unused dynamics helper and validate `run` steps
- Prevent string history from splitting into chars

## Testing
- `PYTHONPATH=src pytest tests/test_neighbor_phase_mean_no_graph.py tests/test_optional_import.py tests/test_history.py tests/test_dynamics_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfe2b626048321925ed8f00d17e929