### PR TITLE
refactor: streamline numeric helpers

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -105,6 +105,10 @@ def normalize_weights(
         return {}
     weights: dict[str, float] = {}
     negatives: dict[str, float] = {}
+    total = 0.0
+    comp = 0.0
+    neg_total = 0.0
+    neg_comp = 0.0
     for k in keys:
         val = dict_like.get(k, default_float)
         ok, converted = _convert_value(
@@ -116,14 +120,27 @@ def normalize_weights(
         )
         w = converted if ok and converted is not None else default_float
         weights[k] = w
+        t = total + w
+        if abs(total) >= abs(w):
+            comp += (total - t) + w
+        else:
+            comp += (w - t) + total
+        total = t
         if w < 0:
             negatives[k] = w
-    total = kahan_sum(weights.values())
+            tneg = neg_total + w
+            if abs(neg_total) >= abs(w):
+                neg_comp += (neg_total - tneg) + w
+            else:
+                neg_comp += (w - tneg) + neg_total
+            neg_total = tneg
+    total += comp
     if negatives:
         if error_on_negative:
             raise ValueError(NEGATIVE_WEIGHTS_MSG % negatives)
         logger.warning(NEGATIVE_WEIGHTS_MSG, negatives)
-        total -= kahan_sum(negatives.values())
+        neg_total += neg_comp
+        total -= neg_total
         for k in negatives:
             weights[k] = 0.0
     if total <= 0:


### PR DESCRIPTION
## Summary
- avoid intermediate list in circular mean calculation
- compute weight normalization and negative tracking in one pass
- extract generator for node digest ordering and simplify checksum caching

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfe9ee43588321ab473cd727810a97