### PR TITLE
Refactor numeric utilities and standardize tests

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import argparse
-import json
 
 from pathlib import Path
-from typing import Any, Iterable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
@@ -44,19 +43,11 @@ from .token_parser import _parse_tokens
 logger = get_logger(__name__)
 
 
-def _default(obj: Any) -> Any:
-    if isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
-        return list(obj)
-    raise TypeError(
-        f"Object of type {obj.__class__.__name__} is not JSON serializable"
-    )
-
-
 def _save_json(path: str, data: Any) -> None:
-    def _write(f):
-        json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
-
-    safe_write(path, _write)
+    payload = json_dumps(
+        data, ensure_ascii=False, indent=2, to_bytes=False, default=list
+    )
+    safe_write(path, lambda f: f.write(payload))
 
 
 def _attach_callbacks(G: "nx.Graph") -> None:

--- a/src/tnfr/cli/token_parser.py
+++ b/src/tnfr/cli/token_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable
+from functools import partial
 
 from ..program import block, wait, target
 from ..types import Glyph
@@ -10,26 +11,23 @@ from ..token_parser import (
     _flatten_tokens as _tp_flatten_tokens,
 )
 
-
-def validate_token(tok: Any, pos: int) -> Any:
-    return _tp_validate_token(tok, pos, TOKEN_MAP)
-
-
-def _parse_tokens(obj: Any) -> list[Any]:
-    return _tp_parse_tokens(obj, TOKEN_MAP)
-
-
-def _flatten_tokens(obj: Any):
-    return _tp_flatten_tokens(obj)
+__all__ = [
+    "validate_token",
+    "_parse_tokens",
+    "_flatten_tokens",
+    "parse_thol",
+    "TOKEN_MAP",
+]
 
 
 def parse_thol(spec: dict[str, Any]) -> Any:
     """Parse the specification of a ``THOL`` block."""
     close = spec.get("close")
     if isinstance(close, str):
-        if close not in Glyph.__members__:
+        close_enum = Glyph.__members__.get(close)
+        if close_enum is None:
             raise ValueError(f"Glyph de cierre desconocido: {close!r}")
-        close = Glyph[close]
+        close = close_enum
 
     return block(
         *_parse_tokens(spec.get("body", [])),
@@ -43,3 +41,8 @@ TOKEN_MAP: dict[str, Callable[[Any], Any]] = {
     "TARGET": lambda v: target(v),
     "THOL": parse_thol,
 }
+
+
+validate_token = partial(_tp_validate_token, token_map=TOKEN_MAP)
+_parse_tokens = partial(_tp_parse_tokens, token_map=TOKEN_MAP)
+_flatten_tokens = _tp_flatten_tokens

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -8,8 +8,8 @@ from tnfr.helpers.cache import (
 )
 
 
-def test_cached_nodes_and_A_reuse_and_invalidate():
-    G = nx.Graph()
+def test_cached_nodes_and_A_reuse_and_invalidate(graph_canon):
+    G = graph_canon()
     G.add_edges_from([(0, 1), (1, 2)])
     data1 = dynamics._prepare_dnfr_data(G)
     nodes1 = data1["nodes"]
@@ -21,8 +21,8 @@ def test_cached_nodes_and_A_reuse_and_invalidate():
     assert data3["nodes"] is not nodes1
 
 
-def test_cached_nodes_and_A_invalidate_on_node_addition():
-    G = nx.Graph()
+def test_cached_nodes_and_A_invalidate_on_node_addition(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     data1 = dynamics._prepare_dnfr_data(G)
     nodes1 = data1["nodes"]
@@ -32,8 +32,8 @@ def test_cached_nodes_and_A_invalidate_on_node_addition():
     assert data2["nodes"] is not nodes1
 
 
-def test_node_offset_map_updates_on_node_addition():
-    G = nx.Graph()
+def test_node_offset_map_updates_on_node_addition(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     mapping1 = ensure_node_offset_map(G)
     assert mapping1[0] == 0
@@ -45,8 +45,8 @@ def test_node_offset_map_updates_on_node_addition():
     assert mapping2[2] == 2
 
 
-def test_cache_node_list_updates_on_dirty():
-    G = nx.Graph()
+def test_cache_node_list_updates_on_dirty(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     nodes1 = _cache_node_list(G)
     nodes2 = _cache_node_list(G)

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -6,8 +6,8 @@ from tnfr.metrics import coherence_matrix, local_phase_sync_weighted
 from tnfr.helpers.cache import ensure_node_index_map
 
 
-def make_graph(offset=0):
-    G = nx.Graph()
+def make_graph(graph_canon, offset=0):
+    G = graph_canon()
     G.add_node(offset)
     G.add_node(offset + 1)
     G.add_edge(offset, offset + 1)
@@ -16,9 +16,9 @@ def make_graph(offset=0):
     return G
 
 
-def test_local_phase_sync_independent_graphs():
-    G1 = make_graph(0)
-    G2 = make_graph(10)
+def test_local_phase_sync_independent_graphs(graph_canon):
+    G1 = make_graph(graph_canon, 0)
+    G2 = make_graph(graph_canon, 10)
 
     nodes1, W1 = coherence_matrix(G1)
     nodes2, W2 = coherence_matrix(G2)
@@ -42,8 +42,8 @@ def test_local_phase_sync_independent_graphs():
     assert ensure_node_index_map(G1) is map1
 
 
-def test_node_index_map_invalidation():
-    G = make_graph(0)
+def test_node_index_map_invalidation(graph_canon):
+    G = make_graph(graph_canon, 0)
     coherence_matrix(G)
     mapping1 = ensure_node_index_map(G)
 

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -5,7 +5,7 @@ from tnfr.metrics_utils import compute_Si
 from tnfr.alias import set_attr
 
 
-def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch):
+def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch, graph_canon):
     calls = 0
 
     class DummyNP:
@@ -33,7 +33,7 @@ def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch):
         fake_neighbor_phase_mean_list,
     )
 
-    G = nx.Graph()
+    G = graph_canon()
     G.add_edge(1, 2)
     for n in G.nodes:
         set_attr(G.nodes[n], ALIAS_THETA, 0.0)

--- a/tests/test_compute_coherence.py
+++ b/tests/test_compute_coherence.py
@@ -21,8 +21,8 @@ def naive_compute_coherence(G):
     return 1.0 / (1.0 + dnfr_mean + depi_mean)
 
 
-def test_compute_coherence_typical():
-    G = nx.Graph()
+def test_compute_coherence_typical(graph_canon):
+    G = graph_canon()
     G.add_node(0, dnfr=0.1, dEPI=0.2)
     G.add_node(1, dnfr=0.4, dEPI=0.5)
     result = compute_coherence(G)
@@ -30,8 +30,8 @@ def test_compute_coherence_typical():
     assert result == pytest.approx(expected)
 
 
-def test_compute_coherence_precision_improved():
-    G = nx.Graph()
+def test_compute_coherence_precision_improved(graph_canon):
+    G = graph_canon()
     G.add_node(0, dnfr=1e16)
     for i in range(1, 11):
         G.add_node(i, dnfr=1.0)
@@ -47,8 +47,8 @@ def test_compute_coherence_precision_improved():
     assert abs(result - expected) < abs(naive - expected)
 
 
-def test_compute_coherence_return_means():
-    G = nx.Graph()
+def test_compute_coherence_return_means(graph_canon):
+    G = graph_canon()
     G.add_node(0, dnfr=0.1, dEPI=0.2)
     G.add_node(1, dnfr=0.4, dEPI=0.5)
     C, dnfr_mean, depi_mean = compute_coherence(G, return_means=True)

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover - skip if not installed
         ),
     ],
 )
-def test_apply_config_injects_graph_params(tmp_path, suffix, dump):
+def test_apply_config_injects_graph_params(tmp_path, suffix, dump, graph_canon):
     cfg = {"RANDOM_SEED": 123, "INIT_THETA_MIN": -1.23}
     path = tmp_path / f"cfg{suffix}"
     path.write_text(dump(cfg), encoding="utf-8")
@@ -34,7 +34,7 @@ def test_apply_config_injects_graph_params(tmp_path, suffix, dump):
     loaded = load_config(path)
     assert loaded == cfg
 
-    G = nx.Graph()
+    G = graph_canon()
     G.add_node(0)
     G.graph["RANDOM_SEED"] = 0
     G.graph["INIT_THETA_MIN"] = 0.0
@@ -65,7 +65,7 @@ def test_load_config_accepts_str(tmp_path):
     assert loaded == cfg
 
 
-def test_apply_config_passes_path_object(monkeypatch, tmp_path):
+def test_apply_config_passes_path_object(monkeypatch, tmp_path, graph_canon):
     path = tmp_path / "cfg.json"
     path.write_text("{}", encoding="utf-8")
     received = {}
@@ -75,13 +75,13 @@ def test_apply_config_passes_path_object(monkeypatch, tmp_path):
         return {}
 
     monkeypatch.setattr("tnfr.config.load_config", fake_load)
-    G = nx.Graph()
+    G = graph_canon()
     apply_config(G, path)
     assert received["path"] is path
 
 
-def test_merge_overrides_does_not_modify_defaults():
-    G = nx.Graph()
+def test_merge_overrides_does_not_modify_defaults(graph_canon):
+    G = graph_canon()
     orig_enabled = DEFAULTS["TRACE"]["enabled"]
     merge_overrides(G, TRACE=DEFAULTS["TRACE"])
     assert G.graph["TRACE"] is not DEFAULTS["TRACE"]

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -7,8 +7,8 @@ import pytest
 from tnfr.glyph_history import count_glyphs
 
 
-def test_count_glyphs_last_only_and_window():
-    G = nx.Graph()
+def test_count_glyphs_last_only_and_window(graph_canon):
+    G = graph_canon()
     G.add_node(0, glyph_history=deque(["A", "B"]))
     G.add_node(1)
 
@@ -19,8 +19,8 @@ def test_count_glyphs_last_only_and_window():
     assert recent == Counter({"A": 1, "B": 1})
 
 
-def test_count_glyphs_non_positive_window():
-    G = nx.Graph()
+def test_count_glyphs_non_positive_window(graph_canon):
+    G = graph_canon()
     G.add_node(0, glyph_history=deque(["A", "B"]))
     G.add_node(1, glyph_history=deque(["C"]))
 

--- a/tests/test_dnfr_hooks.py
+++ b/tests/test_dnfr_hooks.py
@@ -4,8 +4,8 @@ from tnfr.dynamics import dnfr_phase_only, dnfr_epi_vf_mixed, dnfr_laplacian
 from tnfr.alias import get_attr
 
 
-def test_dnfr_phase_only_computes_gradient():
-    G = nx.Graph()
+def test_dnfr_phase_only_computes_gradient(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     G.nodes[0][ALIAS_THETA[0]] = 0.0
     G.nodes[1][ALIAS_THETA[0]] = 1.5707963267948966  # pi/2
@@ -14,8 +14,8 @@ def test_dnfr_phase_only_computes_gradient():
     assert get_attr(G.nodes[1], ALIAS_DNFR, 0.0) == -0.5
 
 
-def test_dnfr_epi_vf_mixed_sets_average():
-    G = nx.Graph()
+def test_dnfr_epi_vf_mixed_sets_average(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     G.nodes[0][ALIAS_EPI[0]] = 1.0
     G.nodes[0][ALIAS_VF[0]] = 0.0
@@ -26,8 +26,8 @@ def test_dnfr_epi_vf_mixed_sets_average():
     assert get_attr(G.nodes[1], ALIAS_DNFR, 1.0) == 0.0
 
 
-def test_dnfr_laplacian_respects_weights():
-    G = nx.Graph()
+def test_dnfr_laplacian_respects_weights(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     G.graph["DNFR_WEIGHTS"] = {"epi": 1.0, "vf": 0.0}
     G.nodes[0][ALIAS_EPI[0]] = 1.0

--- a/tests/test_dynamics_helpers.py
+++ b/tests/test_dynamics_helpers.py
@@ -29,8 +29,8 @@ def test_init_and_refresh_dnfr_cache(graph_canon):
     assert cache2 is cache
 
 
-def test_compute_neighbor_means_list():
-    G = nx.Graph()
+def test_compute_neighbor_means_list(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     data = {
         "w_topo": 0.0,

--- a/tests/test_edge_version_cache_disable.py
+++ b/tests/test_edge_version_cache_disable.py
@@ -3,8 +3,8 @@ import networkx as nx
 from tnfr.helpers.cache import edge_version_cache
 
 
-def test_edge_version_cache_disable():
-    G = nx.Graph()
+def test_edge_version_cache_disable(graph_canon):
+    G = graph_canon()
     calls = 0
 
     def builder():

--- a/tests/test_edge_version_cache_limit.py
+++ b/tests/test_edge_version_cache_limit.py
@@ -3,8 +3,8 @@ import networkx as nx
 from tnfr.helpers.cache import edge_version_cache
 
 
-def test_edge_version_cache_limit():
-    G = nx.Graph()
+def test_edge_version_cache_limit(graph_canon):
+    G = graph_canon()
     edge_version_cache(G, "a", lambda: 1, max_entries=2)
     edge_version_cache(G, "b", lambda: 2, max_entries=2)
     edge_version_cache(G, "c", lambda: 3, max_entries=2)
@@ -13,8 +13,8 @@ def test_edge_version_cache_limit():
     assert "b" in cache and "c" in cache
 
 
-def test_edge_version_cache_lock_cleanup():
-    G = nx.Graph()
+def test_edge_version_cache_lock_cleanup(graph_canon):
+    G = graph_canon()
     for i in range(10):
         edge_version_cache(G, str(i), lambda i=i: i, max_entries=2)
     cache = G.graph["_edge_version_cache"]

--- a/tests/test_edge_version_cache_locks.py
+++ b/tests/test_edge_version_cache_locks.py
@@ -3,8 +3,8 @@ import networkx as nx
 from tnfr.helpers.cache import edge_version_cache
 
 
-def test_edge_version_cache_prunes_locks():
-    G = nx.Graph()
+def test_edge_version_cache_prunes_locks(graph_canon):
+    G = graph_canon()
     for i in range(5):
         edge_version_cache(G, str(i), lambda i=i: i, max_entries=2)
     locks = G.graph["_edge_version_cache_locks"]

--- a/tests/test_edge_version_cache_reentrant.py
+++ b/tests/test_edge_version_cache_reentrant.py
@@ -2,8 +2,8 @@ import networkx as nx
 from tnfr.helpers.cache import edge_version_cache
 
 
-def test_edge_version_cache_reentrant():
-    G = nx.Graph()
+def test_edge_version_cache_reentrant(graph_canon):
+    G = graph_canon()
     calls = []
 
     def builder():

--- a/tests/test_edge_version_cache_threadsafe.py
+++ b/tests/test_edge_version_cache_threadsafe.py
@@ -4,8 +4,8 @@ from concurrent.futures import ThreadPoolExecutor
 from tnfr.helpers.cache import edge_version_cache, increment_edge_version
 
 
-def test_edge_version_cache_thread_safety():
-    G = nx.Graph()
+def test_edge_version_cache_thread_safety(graph_canon):
+    G = graph_canon()
     calls = 0
 
     def builder():

--- a/tests/test_ensure_history_trim_performance.py
+++ b/tests/test_ensure_history_trim_performance.py
@@ -7,8 +7,8 @@ from tnfr.constants import inject_defaults
 
 
 @pytest.mark.slow
-def test_ensure_history_trim_performance():
-    G = nx.Graph()
+def test_ensure_history_trim_performance(graph_canon):
+    G = graph_canon()
     inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 1000
     G.graph["HISTORY_COMPACT_EVERY"] = 100

--- a/tests/test_inject_defaults_tuple.py
+++ b/tests/test_inject_defaults_tuple.py
@@ -6,10 +6,10 @@ from tnfr.constants import inject_defaults, DEFAULTS
 import tnfr.constants as const
 
 
-def test_mutating_graph_tuple_does_not_affect_defaults(monkeypatch):
+def test_mutating_graph_tuple_does_not_affect_defaults(monkeypatch, graph_canon):
     tup = ([1], {"a": 1})
     monkeypatch.setitem(const._DEFAULTS_COMBINED, "_test_tuple", tup)
-    G = nx.Graph()
+    G = graph_canon()
     inject_defaults(G)
     assert (
         G.graph["_test_tuple"] is not const._DEFAULTS_COMBINED["_test_tuple"]

--- a/tests/test_local_phase_sync.py
+++ b/tests/test_local_phase_sync.py
@@ -9,22 +9,22 @@ from tnfr.metrics import (
 )
 
 
-def make_graph():
-    G = nx.Graph()
+def make_graph(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     G.nodes[0][THETA_PRIMARY] = 0.0
     G.nodes[1][THETA_PRIMARY] = 0.0
     return G
 
 
-def test_local_phase_sync_unweighted():
-    G = make_graph()
+def test_local_phase_sync_unweighted(graph_canon):
+    G = make_graph(graph_canon)
     r = local_phase_sync(G, 0)
     assert r == pytest.approx(1.0)
 
 
-def test_local_phase_sync_with_weights():
-    G = make_graph()
+def test_local_phase_sync_with_weights(graph_canon):
+    G = make_graph(graph_canon)
     nodes, W = coherence_matrix(G)
     r = local_phase_sync_weighted(G, nodes[0], nodes_order=nodes, W_row=W)
     assert r == pytest.approx(1.0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -27,10 +27,10 @@ from tnfr.constants import METRIC_DEFAULTS
 from tnfr.types import Glyph
 
 
-def test_track_stability_updates_hist():
+def test_track_stability_updates_hist(graph_canon):
     """_track_stability aggregates stability and derivatives."""
 
-    G = nx.Graph()
+    G = graph_canon()
     hist = {"stable_frac": [], "delta_Si": [], "B": []}
 
     G.add_node(0)
@@ -74,10 +74,10 @@ def test_update_sigma_uses_default_window(graph_canon):
     assert hist == expected
 
 
-def test_aggregate_si_computes_stats():
+def test_aggregate_si_computes_stats(graph_canon):
     """_aggregate_si computes mean and fractions."""
 
-    G = nx.Graph()
+    G = graph_canon()
     inject_defaults(G)
     hist = {"Si_mean": [], "Si_hi_frac": [], "Si_lo_frac": []}
     G.add_node(0)
@@ -94,10 +94,10 @@ def test_aggregate_si_computes_stats():
     assert hist["Si_lo_frac"][0] == pytest.approx(1 / 3)
 
 
-def test_compute_advanced_metrics_populates_history():
+def test_compute_advanced_metrics_populates_history(graph_canon):
     """_compute_advanced_metrics records glyph-based metrics."""
 
-    G = nx.Graph()
+    G = graph_canon()
     inject_defaults(G)
     hist: dict[str, Any] = {}
     cfg = G.graph["METRICS"]
@@ -183,9 +183,9 @@ def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
     assert hist_false.get("Tg_by_node", {}) == {}
 
 
-def test_latency_index_uses_max_denominator():
+def test_latency_index_uses_max_denominator(graph_canon):
     """Latency index uses max(1, n_total) to avoid zero division."""
-    G = nx.Graph()
+    G = graph_canon()
     hist = {}
     _update_latency_index(G, hist, n_total=0, n_latent=2, t=0)
     assert hist["latency_index"][0]["value"] == 2.0

--- a/tests/test_neighbors_map_cache.py
+++ b/tests/test_neighbors_map_cache.py
@@ -5,8 +5,8 @@ from tnfr.metrics_utils import ensure_neighbors_map
 from tnfr.helpers.cache import increment_edge_version
 
 
-def test_neighbors_map_reuses_proxy():
-    G = nx.Graph()
+def test_neighbors_map_reuses_proxy(graph_canon):
+    G = graph_canon()
     G.add_edge(1, 2)
     first = ensure_neighbors_map(G)
     assert isinstance(first, MappingProxyType)

--- a/tests/test_node_all_nodes.py
+++ b/tests/test_node_all_nodes.py
@@ -39,8 +39,8 @@ def _peak_memory(fn, *args) -> int:
     return peak
 
 
-def test_node_set_checksum_peak_memory_reduced():
-    G = nx.Graph()
+def test_node_set_checksum_peak_memory_reduced(graph_canon):
+    G = graph_canon()
     for i in range(100_000):
         G.add_node(f"node-{i:05d}" * 2)
     peak_new = _peak_memory(node_set_checksum, G)

--- a/tests/test_node_sample.py
+++ b/tests/test_node_sample.py
@@ -10,8 +10,8 @@ import subprocess
 import sys
 
 
-def test_node_sample_large_graph():
-    G = build_graph(80)
+def test_node_sample_large_graph(graph_canon):
+    G = build_graph(80, graph_canon)
     G.graph["UM_CANDIDATE_COUNT"] = 10
     step(G, use_Si=False, apply_glyphs=False)
     sample = G.graph.get("_node_sample")
@@ -20,8 +20,8 @@ def test_node_sample_large_graph():
     assert set(sample).issubset(set(G.nodes()))
 
 
-def test_node_sample_small_graph():
-    G = build_graph(20)
+def test_node_sample_small_graph(graph_canon):
+    G = build_graph(20, graph_canon)
     G.graph["UM_CANDIDATE_COUNT"] = 5
     step(G, use_Si=False, apply_glyphs=False)
     sample = G.graph.get("_node_sample")
@@ -29,8 +29,8 @@ def test_node_sample_small_graph():
     assert len(sample) == len(G.nodes())
 
 
-def test_node_sample_immutable_after_graph_change():
-    G = build_graph(20)
+def test_node_sample_immutable_after_graph_change(graph_canon):
+    G = build_graph(20, graph_canon)
     _update_node_sample(G, step=0)
     sample = G.graph["_node_sample"]
     G.add_node(99)
@@ -38,16 +38,16 @@ def test_node_sample_immutable_after_graph_change():
     assert 99 not in sample
 
 
-def test_node_sample_deterministic_with_seed():
+def test_node_sample_deterministic_with_seed(graph_canon):
     clear_rng_cache()
-    G1 = build_graph(80)
+    G1 = build_graph(80, graph_canon)
     G1.graph["UM_CANDIDATE_COUNT"] = 10
     G1.graph["RANDOM_SEED"] = 123
     _update_node_sample(G1, step=5)
     sample1 = G1.graph["_node_sample"]
 
     clear_rng_cache()
-    G2 = build_graph(80)
+    G2 = build_graph(80, graph_canon)
     G2.graph["UM_CANDIDATE_COUNT"] = 10
     G2.graph["RANDOM_SEED"] = 123
     _update_node_sample(G2, step=5)

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -11,16 +11,16 @@ from tnfr.helpers.cache import (
 )
 
 
-def build_graph():
-    G = nx.Graph()
+def build_graph(graph_canon):
+    G = graph_canon()
     G.add_node(("foo", 1))
     G.add_node(("foo", 2))
     return G
 
 
-def test_node_set_checksum_object_stable():
-    checksum1 = node_set_checksum(build_graph())
-    checksum2 = node_set_checksum(build_graph())
+def test_node_set_checksum_object_stable(graph_canon):
+    checksum1 = node_set_checksum(build_graph(graph_canon))
+    checksum2 = node_set_checksum(build_graph(graph_canon))
     assert checksum1 == checksum2
 
 
@@ -35,21 +35,21 @@ def _reference_checksum(G):
     return hasher.hexdigest()
 
 
-def test_node_set_checksum_compatibility():
-    G = nx.Graph()
+def test_node_set_checksum_compatibility(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([1, 2, 3])
     assert node_set_checksum(G) == _reference_checksum(G)
 
 
-def test_node_set_checksum_iterable_equivalence():
-    G = nx.Graph()
+def test_node_set_checksum_iterable_equivalence(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([3, 1, 2])
     gen = (n for n in G.nodes())
     assert node_set_checksum(G, gen) == node_set_checksum(G)
 
 
-def test_node_set_checksum_presorted_performance():
-    G = nx.Graph()
+def test_node_set_checksum_presorted_performance(graph_canon):
+    G = graph_canon()
     G.add_nodes_from(range(1000))
     nodes = list(G.nodes())
     nodes.sort(key=_node_repr)
@@ -60,23 +60,23 @@ def test_node_set_checksum_presorted_performance():
     assert t_presorted <= t_unsorted * 3.0
 
 
-def test_node_set_checksum_no_store_does_not_cache():
-    G = nx.Graph()
+def test_node_set_checksum_no_store_does_not_cache(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([1, 2])
     node_set_checksum(G, store=False)
     assert "_node_set_checksum_cache" not in G.graph
 
 
-def test_node_repr_cache_cleared_on_increment():
-    nxG = nx.Graph()
+def test_node_repr_cache_cleared_on_increment(graph_canon):
+    nxG = graph_canon()
     _node_repr("foo")
     assert _node_repr.cache_info().currsize > 0
     increment_edge_version(nxG)
     assert _node_repr.cache_info().currsize == 0
 
 
-def test_hash_node_cache_cleared_on_increment():
-    nxG = nx.Graph()
+def test_hash_node_cache_cleared_on_increment(graph_canon):
+    nxG = graph_canon()
     _hash_node(("foo", 1))
     assert _hash_node.cache_info().currsize > 0
     increment_edge_version(nxG)

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -16,8 +16,8 @@ def test_add_edge_stores_weight():
     assert math.isclose(b.edge_weight(a), 2.5)
 
 
-def test_add_edge_stores_weight_nx():
-    G = nx.Graph()
+def test_add_edge_stores_weight_nx(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     a = NodoNX(G, 0)
     b = NodoNX(G, 1)
@@ -42,8 +42,8 @@ def test_add_edge_preserves_weight_by_default():
     assert math.isclose(b.edge_weight(a), 1.0)
 
 
-def test_add_edge_preserves_weight_by_default_nx():
-    G = nx.Graph()
+def test_add_edge_preserves_weight_by_default_nx(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     a = NodoNX(G, 0)
     b = NodoNX(G, 1)
@@ -61,8 +61,8 @@ def test_add_edge_overwrite():
     assert math.isclose(b.edge_weight(a), 2.0)
 
 
-def test_add_edge_overwrite_nx():
-    G = nx.Graph()
+def test_add_edge_overwrite_nx(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     a = NodoNX(G, 0)
     b = NodoNX(G, 1)
@@ -80,8 +80,8 @@ def test_add_edge_rejects_negative_weight():
     assert not b.has_edge(a)
 
 
-def test_add_edge_rejects_negative_weight_nx():
-    G = nx.Graph()
+def test_add_edge_rejects_negative_weight_nx(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     G.add_node(1)
     a = NodoNX(G, 0)
@@ -101,8 +101,8 @@ def test_add_edge_rejects_negative_weight_existing_edge():
     assert math.isclose(b.edge_weight(a), 1.0)
 
 
-def test_add_edge_rejects_negative_weight_existing_edge_nx():
-    G = nx.Graph()
+def test_add_edge_rejects_negative_weight_existing_edge_nx(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     G.add_node(1)
     a = NodoNX(G, 0)
@@ -125,8 +125,8 @@ def test_add_edge_rejects_non_finite_weight():
         assert not b.has_edge(a)
 
 
-def test_add_edge_rejects_non_finite_weight_nx():
-    G = nx.Graph()
+def test_add_edge_rejects_non_finite_weight_nx(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     a = NodoNX(G, 0)
     b = NodoNX(G, 1)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -59,8 +59,8 @@ def test_rng_cache_disabled_with_size_zero(graph_canon):
     set_cache_maxsize(DEFAULTS["JITTER_CACHE_SIZE"])
 
 
-def test_um_candidate_subset_proximity():
-    G = nx.Graph()
+def test_um_candidate_subset_proximity(graph_canon):
+    G = graph_canon()
     inject_defaults(G)
     for i, th in enumerate([0.0, 0.1, 0.2, 1.0]):
         G.add_node(i, **{"θ": th, "EPI": 0.5, "Si": 0.5})

--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -5,8 +5,8 @@ import tnfr.program as program
 from tnfr.program import _advance
 
 
-def test_advance_caches_step(monkeypatch):
-    G = nx.Graph()
+def test_advance_caches_step(monkeypatch, graph_canon):
+    G = graph_canon()
     G.add_node(0)
     calls = []
 
@@ -25,8 +25,8 @@ def test_advance_caches_step(monkeypatch):
     program._load_step_fn.cache_clear()
 
 
-def test_advance_thread_safe(monkeypatch):
-    G = nx.Graph()
+def test_advance_thread_safe(monkeypatch, graph_canon):
+    G = graph_canon()
     G.add_node(0)
     calls = []
 

--- a/tests/test_rng_base_seed.py
+++ b/tests/test_rng_base_seed.py
@@ -2,14 +2,14 @@ import networkx as nx
 from tnfr.rng import base_seed, set_cache_maxsize, clear_rng_cache
 
 
-def test_base_seed_returns_value():
-    G = nx.Graph()
+def test_base_seed_returns_value(graph_canon):
+    G = graph_canon()
     G.graph["RANDOM_SEED"] = 123
     assert base_seed(G) == 123
 
 
-def test_base_seed_defaults_to_zero():
-    G = nx.Graph()
+def test_base_seed_defaults_to_zero(graph_canon):
+    G = graph_canon()
     assert base_seed(G) == 0
 
 

--- a/tests/test_selector_utils.py
+++ b/tests/test_selector_utils.py
@@ -99,8 +99,8 @@ def _selector_thresholds_original(G: nx.Graph) -> dict:
     }
 
 
-def test_selector_thresholds_defaults():
-    G = nx.Graph()
+def test_selector_thresholds_defaults(graph_canon):
+    G = graph_canon()
     thr = _selector_thresholds(G)
     sel_def = DEFAULTS["SELECTOR_THRESHOLDS"]
     assert thr["si_hi"] == sel_def["si_hi"]
@@ -111,19 +111,19 @@ def test_selector_thresholds_defaults():
     assert thr["accel_lo"] == sel_def["accel_lo"]
 
 
-def test_selector_thresholds_refactor_equivalent_defaults():
-    G = nx.Graph()
+def test_selector_thresholds_refactor_equivalent_defaults(graph_canon):
+    G = graph_canon()
     assert _selector_thresholds(G) == _selector_thresholds_original(G)
 
 
-def test_selector_thresholds_refactor_equivalent_legacy():
-    G = nx.Graph()
+def test_selector_thresholds_refactor_equivalent_legacy(graph_canon):
+    G = graph_canon()
     G.graph["GLYPH_THRESHOLDS"] = {"hi": 0.9, "lo": 0.2}
     assert _selector_thresholds(G) == _selector_thresholds_original(G)
 
 
-def test_selector_thresholds_refactor_equivalent_overrides():
-    G = nx.Graph()
+def test_selector_thresholds_refactor_equivalent_overrides(graph_canon):
+    G = graph_canon()
     G.graph["SELECTOR_THRESHOLDS"] = {
         "si_hi": 0.9,
         "si_lo": 0.2,
@@ -135,8 +135,8 @@ def test_selector_thresholds_refactor_equivalent_overrides():
     assert _selector_thresholds(G) == _selector_thresholds_original(G)
 
 
-def test_norms_para_selector_computes_max():
-    G = nx.Graph()
+def test_norms_para_selector_computes_max(graph_canon):
+    G = graph_canon()
     G.add_node(0, **{ALIAS_DNFR[-1]: 2.0, ALIAS_D2EPI[-2]: 1.0})
     G.add_node(1, **{ALIAS_DNFR[-1]: -3.0, ALIAS_D2EPI[-2]: 0.5})
     norms = _norms_para_selector(G)
@@ -152,8 +152,8 @@ def test_calc_selector_score_assumes_normalized_weights():
     assert _calc_selector_score(0.0, 1.0, 1.0, W) == 0.0
 
 
-def test_configure_selector_weights_normalizes():
-    G = nx.Graph()
+def test_configure_selector_weights_normalizes(graph_canon):
+    G = graph_canon()
     G.graph["SELECTOR_WEIGHTS"] = {"w_si": 2.0, "w_dnfr": 1.0, "w_accel": 1.0}
     weights = _configure_selector_weights(G)
     assert weights == pytest.approx(

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -16,15 +16,15 @@ from tnfr.sense import (
 from tnfr.types import Glyph
 
 
-def _make_graph():
-    G = nx.Graph()
+def _make_graph(graph_canon):
+    G = graph_canon()
     G.add_node(0, glyph_history=[Glyph.AL.value], Si=1.0, EPI=2.0)
     G.add_node(1, Si=0.3, EPI=1.5)
     return G
 
 
-def test_sigma_vector_node_paths():
-    G = _make_graph()
+def test_sigma_vector_node_paths(graph_canon):
+    G = _make_graph(graph_canon)
     sv_si = sigma_vector_node(G, 0)
     assert sv_si and sv_si["glyph"] == Glyph.AL.value
     assert sv_si["w"] == 1.0
@@ -34,8 +34,8 @@ def test_sigma_vector_node_paths():
     assert sv_epi["mag"] == pytest.approx(2 * sv_si["mag"])
 
 
-def test_sigma_vector_from_graph_paths():
-    G = _make_graph()
+def test_sigma_vector_from_graph_paths(graph_canon):
+    G = _make_graph(graph_canon)
     sv_si = sigma_vector_from_graph(G)
     sv_epi = sigma_vector_from_graph(G, weight_mode="EPI")
     assert sv_si["n"] == 1
@@ -57,10 +57,10 @@ def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
     return vec
 
 
-def test_sigma_vector_from_graph_matches_naive():
+def test_sigma_vector_from_graph_matches_naive(graph_canon):
     """La versión optimizada coincide con el cálculo ingenuo y no es
     más lenta."""
-    G_opt = nx.Graph()
+    G_opt = graph_canon()
     glyphs = list(Glyph)
     for i in range(1000):
         g = glyphs[i % len(glyphs)].value

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -12,8 +12,8 @@ from tnfr.alias import get_attr, set_attr, set_theta
 from tnfr.helpers.cache import increment_edge_version
 
 
-def test_get_si_weights_normalization():
-    G = nx.Graph()
+def test_get_si_weights_normalization(graph_canon):
+    G = graph_canon()
     G.graph["SI_WEIGHTS"] = {"alpha": 2, "beta": 1, "gamma": 1}
     alpha, beta, gamma = get_Si_weights(G)
     assert (alpha, beta, gamma) == pytest.approx((0.5, 0.25, 0.25))
@@ -29,8 +29,8 @@ def test_get_si_weights_normalization():
     }
 
 
-def test_get_trig_cache():
-    G = nx.Graph()
+def test_get_trig_cache(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([1, 2])
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, math.pi / 2)
@@ -43,8 +43,8 @@ def test_get_trig_cache():
     assert thetas[2] == pytest.approx(math.pi / 2)
 
 
-def test_get_trig_cache_invalidation_on_version():
-    G = nx.Graph()
+def test_get_trig_cache_invalidation_on_version(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     set_attr(G.nodes[0], ALIAS_THETA, 0.0)
     trig1 = get_trig_cache(G)
@@ -58,8 +58,8 @@ def test_get_trig_cache_invalidation_on_version():
     assert 1 in trig3.cos and 1 not in trig1.cos
 
 
-def test_get_trig_cache_invalidation_on_phase_change():
-    G = nx.Graph()
+def test_get_trig_cache_invalidation_on_phase_change(graph_canon):
+    G = graph_canon()
     G.add_edge(1, 2)
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, 0.0)
@@ -70,8 +70,8 @@ def test_get_trig_cache_invalidation_on_phase_change():
     assert trig2.theta[1] == pytest.approx(math.pi / 2)
 
 
-def test_compute_Si_node():
-    G = nx.Graph()
+def test_compute_Si_node(graph_canon):
+    G = graph_canon()
     G.add_edge(1, 2)
     set_attr(G.nodes[1], ALIAS_VF, 0.5)
     set_attr(G.nodes[1], ALIAS_DNFR, 0.2)

--- a/tests/test_trig_cache_reuse.py
+++ b/tests/test_trig_cache_reuse.py
@@ -8,7 +8,7 @@ from tnfr.helpers.numeric import neighbor_phase_mean
 from tnfr.alias import set_attr
 
 
-def test_trig_cache_reuse_between_modules(monkeypatch):
+def test_trig_cache_reuse_between_modules(monkeypatch, graph_canon):
     cos_calls = 0
     sin_calls = 0
     orig_cos = math.cos
@@ -27,7 +27,7 @@ def test_trig_cache_reuse_between_modules(monkeypatch):
     monkeypatch.setattr(math, "cos", cos_wrapper)
     monkeypatch.setattr(math, "sin", sin_wrapper)
 
-    G = nx.Graph()
+    G = graph_canon()
     G.add_edge(1, 2)
     set_attr(G.nodes[1], ALIAS_THETA, 0.0)
     set_attr(G.nodes[2], ALIAS_THETA, math.pi / 2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,8 @@ import networkx as nx
 from tnfr.constants import inject_defaults
 
 
-def build_graph(n):
-    G = nx.Graph()
+def build_graph(n, graph_canon=None):
+    G = graph_canon() if graph_canon is not None else nx.Graph()
     inject_defaults(G)
     for i in range(n):
         G.add_node(i, **{"θ": 0.0, "EPI": 0.0})


### PR DESCRIPTION
## Summary
- Deduplicate weight normalization by reusing `kahan_sum` and simplify negative handling
- Streamline phase-mean helper to delegate accumulation to `kahan_sum2d`
- Remove thin CLI token parser wrappers and improve THOL glyph resolution
- Use `json_utils.json_dumps` for CLI JSON output
- Standardize tests to build graphs via `graph_canon`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04d32e14c8321a1eca51e8cb76aaf