### PR TITLE
Respect pre-set root log level in logger setup

### DIFF
--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -15,16 +15,21 @@ __all__ = ["get_logger"]
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Return a logger with a standard configuration."""
+    """Return a logger with a standard configuration.
+
+    If the root logger has no handlers, it is configured with a default
+    format. A default log level of ``INFO`` is only set when the root
+    logger's level is ``NOTSET``; otherwise the existing level is
+    preserved.
+    """
 
     with _LOCK:
         root = logging.getLogger()
         if not root.handlers:
-            level = (
-                root.level if root.level != logging.WARNING else logging.INFO
-            )
-            logging.basicConfig(
-                level=level,
-                format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            )
+            kwargs = {
+                "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            }
+            if root.level == logging.NOTSET:
+                kwargs["level"] = logging.INFO
+            logging.basicConfig(**kwargs)
     return logging.getLogger(name)

--- a/tests/test_logging_threadsafe.py
+++ b/tests/test_logging_threadsafe.py
@@ -14,3 +14,21 @@ def test_get_logger_threadsafe():
     with ThreadPoolExecutor(max_workers=32) as ex:
         list(ex.map(lambda _: _worker(), range(64)))
     assert len(root.handlers) == 1
+
+
+def test_get_logger_preserves_existing_level():
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.ERROR)
+    get_logger("test_logger")
+    assert root.level == logging.ERROR
+    root.setLevel(logging.WARNING)
+
+
+def test_get_logger_sets_level_when_notset():
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(logging.NOTSET)
+    get_logger("test_logger")
+    assert root.level == logging.INFO
+    root.setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- Avoid overriding root logger level unless it is NOTSET
- Document default INFO level when root logger is NOTSET
- Test logger uses existing level or defaults to INFO

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0635efc2c8321b9a0964c7937e016