### PR TITLE
Use consistent language in token parser

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -34,22 +34,22 @@ def validate_token(
     if isinstance(tok, dict):
         if len(tok) != 1:
             raise ValueError(
-                f"Invalid token: {tok} (posición {pos}, token {tok!r})"
+                f"Invalid token: {tok} (position {pos}, token {tok!r})"
             )
         key, val = next(iter(tok.items()))
         handler = token_map.get(key)
         if handler is None:
             raise ValueError(
-                f"Unrecognized token: {key} (posición {pos}, token {tok!r})"
+                f"Unrecognized token: {key} (position {pos}, token {tok!r})"
             )
         try:
             return handler(val)
         except (KeyError, ValueError, TypeError) as e:
-            msg = f"{type(e).__name__}: {e} (posición {pos}, token {tok!r})"
+            msg = f"{type(e).__name__}: {e} (position {pos}, token {tok!r})"
             raise ValueError(msg) from e
     if isinstance(tok, str):
         return tok
-    raise ValueError(f"Invalid token: {tok} (posición {pos}, token {tok!r})")
+    raise ValueError(f"Invalid token: {tok} (position {pos}, token {tok!r})")
 
 
 def _parse_tokens(

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -11,7 +11,7 @@ def test_parse_tokens_value_error_context():
     with pytest.raises(ValueError) as exc:
         _parse_tokens([{"WAIT": "x"}])
     msg = str(exc.value)
-    assert "posición 1" in msg
+    assert "position 1" in msg
     assert "WAIT" in msg
     assert isinstance(exc.value.__cause__, ValueError)
 
@@ -24,7 +24,7 @@ def test_parse_tokens_key_error_context(monkeypatch):
     with pytest.raises(ValueError) as exc:
         _parse_tokens([{"RAISE": {}}])
     msg = str(exc.value)
-    assert "posición 1" in msg
+    assert "position 1" in msg
     assert "RAISE" in msg
     assert isinstance(exc.value.__cause__, KeyError)
 
@@ -37,7 +37,7 @@ def test_parse_tokens_type_error_context(monkeypatch):
     with pytest.raises(ValueError) as exc:
         _parse_tokens([{"RAISE_TYPE": {}}])
     msg = str(exc.value)
-    assert "posición 1" in msg
+    assert "position 1" in msg
     assert "RAISE_TYPE" in msg
     assert isinstance(exc.value.__cause__, TypeError)
 


### PR DESCRIPTION
## Summary
- switch token parser error strings to English for consistency
- adjust token parsing tests to expect new messages

## Testing
- `pytest` *(fails: tests/test_kahan_sum.py::test_kahan_sum_compensates_cancellation - assert 1.0 == 0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c06525fb7883219bbb486c7dfa6f4e