### PR TITLE
Lazily import orjson in JSON utilities

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -1,6 +1,11 @@
 
 from __future__ import annotations
 
+"""JSON serialization helpers.
+
+This module lazily imports :mod:`orjson` on first use of :func:`json_dumps`.
+"""
+
 import json
 import warnings
 import threading
@@ -10,7 +15,8 @@ from .import_utils import optional_import
 
 __all__ = ["json_dumps"]
 
-_orjson = optional_import("orjson")
+_orjson: Any | None = None
+_orjson_loaded = False
 _ignored_param_warned = False
 _warn_lock = threading.Lock()
 
@@ -33,6 +39,10 @@ def json_dumps(
     supported by :func:`orjson.dumps`. A warning is emitted only the first time
     such ignored parameters are detected.
     """
+    global _orjson, _orjson_loaded
+    if not _orjson_loaded:
+        _orjson = optional_import("orjson")
+        _orjson_loaded = True
     if _orjson is not None:
         if (
             ensure_ascii is not True

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,43 @@
+import warnings
+
+import tnfr.json_utils as json_utils
+
+
+class FakeOrjson:
+    OPT_SORT_KEYS = 1
+
+    @staticmethod
+    def dumps(obj, option=0, default=None):
+        return b"{}"
+
+
+def test_lazy_orjson_import(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_optional_import(name):
+        calls["n"] += 1
+        return FakeOrjson()
+
+    monkeypatch.setattr(json_utils, "optional_import", fake_optional_import)
+    monkeypatch.setattr(json_utils, "_orjson", None)
+    monkeypatch.setattr(json_utils, "_orjson_loaded", False)
+    monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
+
+    assert calls["n"] == 0
+    json_utils.json_dumps({})
+    assert calls["n"] == 1
+    json_utils.json_dumps({})
+    assert calls["n"] == 1
+
+
+def test_warns_once(monkeypatch):
+    monkeypatch.setattr(json_utils, "optional_import", lambda name: FakeOrjson())
+    monkeypatch.setattr(json_utils, "_orjson", None)
+    monkeypatch.setattr(json_utils, "_orjson_loaded", False)
+    monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        json_utils.json_dumps({}, ensure_ascii=False)
+        json_utils.json_dumps({}, ensure_ascii=False)
+    assert len(w) == 1


### PR DESCRIPTION
## Summary
- Lazily import `orjson` on first `json_dumps` call and cache the result
- Preserve ignored-parameter warning behavior under lazy import
- Add tests for `json_dumps` lazy import and one-time warning

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c067e304708321b61aae64215686d9