### PR TITLE
Optimize HistoryDict heap index updates

### DIFF
--- a/tests/test_history_heap_index.py
+++ b/tests/test_history_heap_index.py
@@ -29,3 +29,26 @@ def test_eviction_updates_heap_index():
     assert "c" not in hist._heap_index
     assert len(hist._heap_index) == len(hist._counts)
 
+
+def test_get_increment_updates_heap_index():
+    hist = HistoryDict()
+    hist.get_increment("a")
+    assert hist._heap_index["a"] == 0
+    assert hist._heap[0] == (1, "a")
+
+
+def test_setdefault_tracks_heap_index():
+    hist = HistoryDict()
+    hist.setdefault("a", [])
+    assert hist._heap_index["a"] == 0
+    assert hist._heap[0] == (0, "a")
+
+
+def test_prune_heap_keeps_index_consistent():
+    hist = HistoryDict({f"k{i}": [] for i in range(3)}, compact_every=1)
+    for _ in range(5):
+        hist.get_increment("k0")
+    assert len(hist._heap_index) == len(hist._counts)
+    for k, idx in hist._heap_index.items():
+        assert hist._heap[idx][1] == k
+

--- a/tests/test_history_increment_performance.py
+++ b/tests/test_history_increment_performance.py
@@ -1,0 +1,23 @@
+import time
+from collections import Counter
+import pytest
+
+from tnfr.glyph_history import HistoryDict
+
+
+@pytest.mark.slow
+def test_increment_performance():
+    n = 5000
+    hist = HistoryDict()
+    start = time.perf_counter()
+    for i in range(n):
+        hist.get_increment(f"k{i}")
+    t_hist = time.perf_counter() - start
+
+    counter = Counter()
+    start = time.perf_counter()
+    for i in range(n):
+        counter[f"k{i}"] += 1
+    t_counter = time.perf_counter() - start
+
+    assert t_hist <= t_counter * 10


### PR DESCRIPTION
## Summary
- Update `HistoryDict` heap logic to adjust `_heap_index` incrementally instead of rebuilding on every mutation
- Add unit tests verifying index maintenance and performance during history operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c06cbcc1fc8321b92fed6eb0221b66