### PR TITLE
refactor: rename callable parameter for metrics

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -92,15 +92,15 @@ def _update_coherence(G, hist) -> None:
 
 
 def _record_metrics(
-    hist: dict[str, Any], *pairs: tuple[Any, str], callable: bool = False
+    hist: dict[str, Any], *pairs: tuple[Any, str], evaluate: bool = False
 ) -> None:
     """Record metrics using pairs of values and keys.
 
-    When ``callable`` is ``True`` the values are assumed to be callables and
+    When ``evaluate`` is ``True`` the values are assumed to be callables and
     will be evaluated before being recorded.
     """
     for value, key in pairs:
-        append_metric(hist, key, value() if callable else value)
+        append_metric(hist, key, value() if evaluate else value)
 
 
 def _update_phase_sync(G, hist) -> None:


### PR DESCRIPTION
## Summary
- rename `_record_metrics` parameter `callable` to `evaluate` in `metrics.core`
- adjust internal usage to respect new name

## Testing
- `PYTHONPATH=src pytest tests/test_metrics.py tests/test_export_metrics.py tests/test_update_tg_node.py tests/test_update_tg_performance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c070ab46508321a0d9f47dd48bdd69