### PR TITLE
refactor: unify token error formatting

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -31,25 +31,23 @@ def validate_token(
     re-raised as :class:`ValueError` with additional positional context.
     """
 
+    tok_info = f"(pos {pos}, token {tok!r})"
+
     if isinstance(tok, dict):
         if len(tok) != 1:
-            raise ValueError(
-                f"Invalid token: {tok} (position {pos}, token {tok!r})"
-            )
+            raise ValueError(f"Invalid token: {tok} {tok_info}")
         key, val = next(iter(tok.items()))
         handler = token_map.get(key)
         if handler is None:
-            raise ValueError(
-                f"Unrecognized token: {key} (position {pos}, token {tok!r})"
-            )
+            raise ValueError(f"Unrecognized token: {key} {tok_info}")
         try:
             return handler(val)
         except (KeyError, ValueError, TypeError) as e:
-            msg = f"{type(e).__name__}: {e} (position {pos}, token {tok!r})"
+            msg = f"{type(e).__name__}: {e} {tok_info}"
             raise ValueError(msg) from e
     if isinstance(tok, str):
         return tok
-    raise ValueError(f"Invalid token: {tok} (position {pos}, token {tok!r})")
+    raise ValueError(f"Invalid token: {tok} {tok_info}")
 
 
 def _parse_tokens(


### PR DESCRIPTION
## Summary
- factor repeated token position info into `tok_info`
- reuse `tok_info` for invalid/unrecognized tokens and handler errors
- test: ensure unified format for token parsing errors

## Testing
- `PYTHONPATH=src pytest tests/test_parse_tokens_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c07192965483219d7eda877e9da21f