### PR TITLE
Use shared window validator in wbar

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -22,12 +22,27 @@ __all__ = [
 ]
 
 
-def validate_window(window: int) -> int:
-    """Validate and coerce ``window`` to a non-negative ``int``."""
+def validate_window(window: int, *, positive: bool = False) -> int:
+    """Validate and coerce ``window`` to an ``int``.
+
+    Parameters
+    ----------
+    window:
+        Value to validate.
+    positive:
+        If ``True``, ``window`` must be strictly positive; otherwise it may be
+        zero.
+
+    Returns
+    -------
+    int
+        The coerced ``int`` value if validation succeeds.
+    """
 
     window_int = int(window)
-    if window_int < 0:
-        raise ValueError("'window' must be non-negative")
+    if window_int < 0 or (positive and window_int == 0):
+        kind = "positive" if positive else "non-negative"
+        raise ValueError(f"'window' must be {kind}")
     return window_int
 
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -120,9 +120,7 @@ def glyph_load(G, window: int | None = None) -> dict:
     """
     window_int: int | None = None
     if window is not None:
-        window_int = validate_window(window)
-        if window_int == 0:
-            raise ValueError("window must be positive")
+        window_int = validate_window(window, positive=True)
     total = count_glyphs(G, window=window_int, last_only=(window_int == 1))
     dist, count = normalize_counter(total)
     if count == 0:
@@ -151,8 +149,9 @@ def wbar(G, window: int | None = None) -> float:
         return compute_coherence(G)
     if not isinstance(cs, (list, tuple)):
         cs = list(cs)
-    w = validate_window(get_param(G, "WBAR_WINDOW") if window is None else window)
-    if w == 0:
-        raise ValueError("window must be positive")
+    w = validate_window(
+        get_param(G, "WBAR_WINDOW") if window is None else window,
+        positive=True,
+    )
     w = min(len(cs), w)
     return float(statistics.fmean(cs[-w:]))

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -125,17 +125,19 @@ def test_wbar_list_and_deque_same_result(graph_canon):
     assert wbar(G, window=2) == pytest.approx(expected)
 
 
-def test_wbar_rejects_non_positive_window(graph_canon):
+@pytest.mark.parametrize("w", [0, -1])
+def test_wbar_rejects_non_positive_window(graph_canon, w):
     G = graph_canon()
     G.graph["history"] = {"C_steps": [0.1, 0.2]}
     with pytest.raises(ValueError):
-        wbar(G, window=0)
+        wbar(G, window=w)
 
 
-def test_glyph_load_rejects_non_positive_window(graph_canon):
+@pytest.mark.parametrize("w", [0, -1])
+def test_glyph_load_rejects_non_positive_window(graph_canon, w):
     G = graph_canon()
     with pytest.raises(ValueError):
-        glyph_load(G, window=0)
+        glyph_load(G, window=w)
 
 
 def test_wbar_uses_default_window(graph_canon):


### PR DESCRIPTION
## Summary
- allow `validate_window` to enforce positive values
- use shared validation in `wbar` and `glyph_load`
- extend tests for invalid windows

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0729943b8832195aa295734dc169f