### PR TITLE
Include window value in validation error

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -42,7 +42,7 @@ def validate_window(window: int, *, positive: bool = False) -> int:
     window_int = int(window)
     if window_int < 0 or (positive and window_int == 0):
         kind = "positive" if positive else "non-negative"
-        raise ValueError(f"'window' must be {kind}")
+        raise ValueError(f"'window'={window} must be {kind}")
     return window_int
 
 


### PR DESCRIPTION
## Summary
- include `window` value in `validate_window` error message for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c08d389cd08321bb6486c8d03511e9