### PR TITLE
Ensure thread-safe optional orjson import

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -19,6 +19,7 @@ _orjson: Any | None = None
 _orjson_loaded = False
 _ignored_param_warned = False
 _warn_lock = threading.Lock()
+_load_lock = threading.Lock()
 
 
 def json_dumps(
@@ -41,8 +42,10 @@ def json_dumps(
     """
     global _orjson, _orjson_loaded
     if not _orjson_loaded:
-        _orjson = optional_import("orjson")
-        _orjson_loaded = True
+        with _load_lock:
+            if not _orjson_loaded:
+                _orjson = optional_import("orjson")
+                _orjson_loaded = True
     if _orjson is not None:
         if (
             ensure_ascii is not True


### PR DESCRIPTION
## Summary
- protect lazy `orjson` import with a lock to avoid concurrent initialization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c096291ac083218b185f0b4ddc2435