### PR TITLE
Include position in invalid token errors

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -35,7 +35,7 @@ def validate_token(
 
     if isinstance(tok, dict):
         if len(tok) != 1:
-            raise ValueError(f"Invalid token: {tok} {tok_info}")
+            raise ValueError(f"Invalid token: {tok} (pos {pos})")
         key, val = next(iter(tok.items()))
         handler = token_map.get(key)
         if handler is None:
@@ -47,7 +47,7 @@ def validate_token(
             raise ValueError(msg) from e
     if isinstance(tok, str):
         return tok
-    raise ValueError(f"Invalid token: {tok} {tok_info}")
+    raise ValueError(f"Invalid token: {tok} (pos {pos})")
 
 
 def _parse_tokens(

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -75,4 +75,7 @@ def test_parse_tokens_error_format_unified(monkeypatch):
             _parse_tokens(tokens)
         msg = str(exc.value)
         assert msg.startswith(start)
-        assert msg.endswith(f"(pos 1, token {tokens[0]!r})")
+        expected_end = (
+            "(pos 1)" if start == "Invalid token" else f"(pos 1, token {tokens[0]!r})"
+        )
+        assert msg.endswith(expected_end)


### PR DESCRIPTION
## Summary
- include token position in `Invalid token` ValueError messages
- update token parsing tests for new error message format

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0983405cc83219dba65fb592ac83f