### PR TITLE
Clear trig cache when theta changes

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -335,10 +335,21 @@ def _increment_trig_version(
 ) -> None:
     g = G.graph
     g["_trig_version"] = int(g.get("_trig_version", 0)) + 1
+    # Clear cached trigonometric values to avoid stale data. Any existing
+    # `_cos_th`, `_sin_th`, or `_thetas` entries are removed so that a fresh
+    # cache will be built on the next access.
+    g.pop("_cos_th", None)
+    g.pop("_sin_th", None)
+    g.pop("_thetas", None)
 
 
 def set_theta(G: "nx.Graph", n: Hashable, value: float) -> None:
-    """Set ``θ`` for node ``n`` and increment the trig cache version."""
+    """Set ``θ`` for node ``n`` and invalidate trig caches.
+
+    Updating a node's phase triggers invalidation of cached trigonometric
+    values. The per-graph ``_trig_version`` counter is incremented and any
+    previously cached cosines, sines or angles are cleared from ``G.graph``.
+    """
     set_attr_and_cache(
         G, n, ALIAS_THETA, value, extra=_increment_trig_version
     )

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -148,9 +148,11 @@ def get_trig_cache(G: Any, *, np: Any | None = None) -> TrigCache:
     """Return cached cosines and sines of ``θ`` per node.
 
     The cache is invalidated not only when the edge set changes but also when
-    node phases ``θ`` are updated. A per-graph ``_trig_version`` counter is
-    incremented whenever phases change and forms part of the cache key, forcing
-    a rebuild when the counter advances.
+    node phases ``θ`` are updated. Calling :func:`tnfr.alias.set_theta`
+    increments a per-graph ``_trig_version`` counter and purges any previously
+    stored ``_cos_th``, ``_sin_th`` or ``_thetas`` entries in ``G.graph``.
+    The counter forms part of the cache key, forcing a rebuild when it
+    advances.
     """
     version = G.graph.setdefault("_trig_version", 0)
     key = ("_trig", version)


### PR DESCRIPTION
## Summary
- Drop cached `_cos_th`, `_sin_th`, and `_thetas` entries when node phase `θ` is updated
- Clarify cache invalidation behaviour in `get_trig_cache` docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0990d97dc83218b55d349dd785d5b