### PR TITLE
Add warn_once parameter to normalize_weights

### DIFF
--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -2,10 +2,12 @@
 
 import math
 import pytest
+import tnfr.collections_utils as cu
 from tnfr.collections_utils import normalize_weights
 
 
 def test_normalize_weights_warns_on_negative_value(caplog):
+    cu._warned_negative_keys.clear()
     weights = {"a": -1.0, "b": 2.0}
     with caplog.at_level("WARNING"):
         norm = normalize_weights(weights, ("a", "b"))
@@ -21,6 +23,7 @@ def test_normalize_weights_raises_on_negative_value():
 
 
 def test_normalize_weights_warns_on_negative_default(caplog):
+    cu._warned_negative_keys.clear()
     with caplog.at_level("WARNING"):
         normalize_weights({}, ("a", "b"), default=-0.5)
     assert any("Negative weights" in m for m in caplog.messages)
@@ -38,6 +41,18 @@ def test_normalize_weights_warns_on_non_numeric_value(caplog):
     assert any("Could not convert" in m for m in caplog.messages)
     assert math.isclose(math.fsum(norm.values()), 1.0)
     assert norm == pytest.approx({"a": 1 / 3, "b": 2 / 3})
+
+
+def test_normalize_weights_warn_once(caplog):
+    cu._warned_negative_keys.clear()
+    weights = {"x": -1.0}
+    with caplog.at_level("WARNING"):
+        normalize_weights(weights, ("x",))
+    assert any("Negative weights" in m for m in caplog.messages)
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        normalize_weights(weights, ("x",))
+    assert not any("Negative weights" in m for m in caplog.messages)
 
 
 def test_normalize_weights_raises_on_non_numeric_value():


### PR DESCRIPTION
## Summary
- add `warn_once` option to `normalize_weights` to suppress duplicate warnings
- track warned keys globally so negatives only warn once
- extend tests for `normalize_weights` to cover new behavior

## Testing
- `PYTHONPATH=src pytest tests/test_normalize_weights.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c099bcd8d883218101fdbced6c2edb