### PR TITLE
Add tests for optional import caching and JSON dumps warnings

### DIFF
--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,0 +1,19 @@
+import sys
+import types
+
+from tnfr.import_utils import clear_optional_import_cache, optional_import
+
+
+def test_optional_import_success_and_failure(monkeypatch):
+    clear_optional_import_cache()
+    fallback = object()
+    # module missing -> fallback returned
+    assert optional_import("fake_mod", fallback) is fallback
+    # insert fake module
+    fake_mod = types.ModuleType("fake_mod")
+    monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
+    # cached failure still returns fallback
+    assert optional_import("fake_mod", fallback) is fallback
+    # clearing cache allows successful import
+    clear_optional_import_cache()
+    assert optional_import("fake_mod") is fake_mod

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -1,0 +1,36 @@
+import warnings
+
+import tnfr.json_utils as json_utils
+
+
+class DummyOrjson:
+    OPT_SORT_KEYS = 1
+
+    @staticmethod
+    def dumps(obj, option=0, default=None):
+        return b"{}"
+
+
+def _reset_json_utils(monkeypatch, module):
+    monkeypatch.setattr(json_utils, "optional_import", lambda name: module)
+    monkeypatch.setattr(json_utils, "_orjson", None)
+    monkeypatch.setattr(json_utils, "_orjson_loaded", False)
+    monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
+
+
+def test_json_dumps_without_orjson(monkeypatch):
+    _reset_json_utils(monkeypatch, None)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = json_utils.json_dumps({"a": 1}, ensure_ascii=False)
+    assert result == b'{"a":1}'
+    assert w == []
+
+
+def test_json_dumps_with_orjson_warns(monkeypatch):
+    _reset_json_utils(monkeypatch, DummyOrjson())
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        json_utils.json_dumps({"a": 1}, ensure_ascii=False)
+    assert len(w) == 1
+    assert "ignored" in str(w[0].message)


### PR DESCRIPTION
## Summary
- test optional_import failure caching and cache clearing
- test json_dumps behavior with and without orjson and related warnings

## Testing
- `pytest tests/test_import_utils.py tests/test_json_utils_extra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09a987e688321bced02efbec87065