### PR TITLE
refactor: remove glyph aliases

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -8,12 +8,8 @@ from typing import Any
 # realizar la importación en cada paso de la dinámica. Como los módulos de
 # origen no dependen de ``dynamics``, no se introducen ciclos.
 from ..operators import apply_remesh_if_globally_stable, apply_glyph
-from ..grammar import (
-    enforce_canonical_grammar,
-    on_applied_glyph,
-    AL,
-    EN,
-)
+from ..grammar import enforce_canonical_grammar, on_applied_glyph
+from ..types import Glyph
 from ..constants import (
     DEFAULTS,
     REMESH_DEFAULTS,
@@ -467,9 +463,9 @@ def parametric_glyph_selector(G, n) -> str:
 def _choose_glyph(G, n, selector, use_canon, h_al, h_en, al_max, en_max):
     """Select the glyph to apply on node ``n``."""
     if h_al[n] > al_max:
-        return AL
+        return Glyph.AL
     if h_en[n] > en_max:
-        return EN
+        return Glyph.EN
     g = selector(G, n)
     if use_canon:
         g = enforce_canonical_grammar(G, n, g)
@@ -536,10 +532,10 @@ def _apply_glyphs(G, selector, hist) -> None:
         apply_glyph(G, n, g, window=window)
         if use_canon:
             on_applied_glyph(G, n, g)
-        if g == AL:
+        if g == Glyph.AL:
             h_al[n] = 0
             h_en[n] = min(h_en[n], en_max)
-        elif g == EN:
+        elif g == Glyph.EN:
             h_en[n] = 0
 
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -16,35 +16,7 @@ from .glyph_history import recent_glyph
 from .types import Glyph
 from .operators import apply_glyph  # avoid repeated import inside functions
 
-# Nominal glyphs (to avoid typos)
-AL = Glyph.AL
-EN = Glyph.EN
-IL = Glyph.IL
-OZ = Glyph.OZ
-UM = Glyph.UM
-RA = Glyph.RA
-SHA = Glyph.SHA
-VAL = Glyph.VAL
-NUL = Glyph.NUL
-THOL = Glyph.THOL
-ZHIR = Glyph.ZHIR
-NAV = Glyph.NAV
-REMESH = Glyph.REMESH
-
 __all__ = [
-    "AL",
-    "EN",
-    "IL",
-    "OZ",
-    "UM",
-    "RA",
-    "SHA",
-    "VAL",
-    "NUL",
-    "THOL",
-    "ZHIR",
-    "NAV",
-    "REMESH",
     "CANON_COMPAT",
     "CANON_FALLBACK",
     "enforce_canonical_grammar",

--- a/tests/test_dynamics_helpers.py
+++ b/tests/test_dynamics_helpers.py
@@ -10,7 +10,7 @@ from tnfr.dynamics import (
     _choose_glyph,
     run,
 )
-from tnfr.grammar import AL, EN
+from tnfr.types import Glyph
 
 
 def test_init_and_refresh_dnfr_cache(graph_canon):
@@ -66,11 +66,11 @@ def test_choose_glyph_respects_lags(graph_canon):
     h_al = {0: 2}
     h_en = {0: 0}
     g = _choose_glyph(G, 0, selector, False, h_al, h_en, 1, 5)
-    assert g == AL
+    assert g == Glyph.AL
     h_al[0] = 0
     h_en[0] = 6
     g = _choose_glyph(G, 0, selector, False, h_al, h_en, 1, 5)
-    assert g == EN
+    assert g == Glyph.EN
 
 
 def test_run_rejects_negative_steps(graph_canon):

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -7,16 +7,8 @@ from tnfr.grammar import (
     enforce_canonical_grammar,
     on_applied_glyph,
     apply_glyph_with_grammar,
-    AL,
-    EN,
-    IL,
-    OZ,
-    ZHIR,
-    THOL,
-    SHA,
-    NUL,
-    NAV,
 )
+from tnfr.types import Glyph
 
 
 def test_compatibility_fallback(graph_canon):
@@ -24,8 +16,8 @@ def test_compatibility_fallback(graph_canon):
     G.add_node(0)
     inject_defaults(G)
     nd = G.nodes[0]
-    nd["glyph_history"] = deque([AL])
-    assert enforce_canonical_grammar(G, 0, IL) == EN
+    nd["glyph_history"] = deque([Glyph.AL])
+    assert enforce_canonical_grammar(G, 0, Glyph.IL) == Glyph.EN
 
 
 def test_precondition_oz_to_zhir(graph_canon):
@@ -33,11 +25,11 @@ def test_precondition_oz_to_zhir(graph_canon):
     G.add_node(0)
     inject_defaults(G)
     nd = G.nodes[0]
-    nd["glyph_history"] = deque([NAV])
+    nd["glyph_history"] = deque([Glyph.NAV])
     nd["ΔNFR"] = 0.0
-    assert enforce_canonical_grammar(G, 0, ZHIR) == OZ
-    nd["glyph_history"] = deque([OZ])
-    assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.OZ
+    nd["glyph_history"] = deque([Glyph.OZ])
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.ZHIR
 
 
 def test_thol_closure(graph_canon):
@@ -45,16 +37,16 @@ def test_thol_closure(graph_canon):
     G.add_node(0)
     inject_defaults(G)
     nd = G.nodes[0]
-    nd["glyph_history"] = deque([THOL])
-    on_applied_glyph(G, 0, THOL)
+    nd["glyph_history"] = deque([Glyph.THOL])
+    on_applied_glyph(G, 0, Glyph.THOL)
     st = nd["_GRAM"]
     st["thol_len"] = 2
     nd["ΔNFR"] = 0.0
     nd["Si"] = 0.7
-    assert enforce_canonical_grammar(G, 0, EN) == NUL
+    assert enforce_canonical_grammar(G, 0, Glyph.EN) == Glyph.NUL
     nd["Si"] = 0.1
     st["thol_len"] = 2
-    assert enforce_canonical_grammar(G, 0, EN) == SHA
+    assert enforce_canonical_grammar(G, 0, Glyph.EN) == Glyph.SHA
 
 
 def test_repeat_window_and_force(graph_canon):
@@ -62,7 +54,7 @@ def test_repeat_window_and_force(graph_canon):
     G.add_node(0)
     inject_defaults(G)
     nd = G.nodes[0]
-    nd["glyph_history"] = deque([ZHIR.value, "OZ"])
+    nd["glyph_history"] = deque([Glyph.ZHIR.value, "OZ"])
     G.graph["GRAMMAR"] = {
         "window": 3,
         "avoid_repeats": ["ZHIR"],
@@ -74,14 +66,14 @@ def test_repeat_window_and_force(graph_canon):
 
     nd["ΔNFR"] = 0.0
     nd["d2EPI_dt2"] = 0.0
-    assert enforce_canonical_grammar(G, 0, ZHIR) == NAV
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.NAV
 
     nd["ΔNFR"] = 0.6
-    assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.ZHIR
 
     nd["ΔNFR"] = 0.0
     nd["d2EPI_dt2"] = 0.9
-    assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.ZHIR
 
 
 def test_repeat_invalid_fallback_string(graph_canon):
@@ -89,13 +81,13 @@ def test_repeat_invalid_fallback_string(graph_canon):
     G.add_node(0)
     inject_defaults(G)
     nd = G.nodes[0]
-    nd["glyph_history"] = deque([ZHIR.value])
+    nd["glyph_history"] = deque([Glyph.ZHIR.value])
     G.graph["GRAMMAR"] = {
         "window": 3,
         "avoid_repeats": ["ZHIR"],
         "fallbacks": {"ZHIR": "NOPE"},
     }
-    assert enforce_canonical_grammar(G, 0, ZHIR) == IL
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.IL
 
 
 def test_repeat_invalid_fallback_type(graph_canon):
@@ -103,14 +95,14 @@ def test_repeat_invalid_fallback_type(graph_canon):
     G.add_node(0)
     inject_defaults(G)
     nd = G.nodes[0]
-    nd["glyph_history"] = deque([ZHIR.value])
+    nd["glyph_history"] = deque([Glyph.ZHIR.value])
     obj = object()
     G.graph["GRAMMAR"] = {
         "window": 3,
         "avoid_repeats": ["ZHIR"],
         "fallbacks": {"ZHIR": obj},
     }
-    assert enforce_canonical_grammar(G, 0, ZHIR) == IL
+    assert enforce_canonical_grammar(G, 0, Glyph.ZHIR) == Glyph.IL
 
 
 def test_lag_counters_enforced(graph_canon):
@@ -137,14 +129,14 @@ def test_apply_glyph_with_grammar_equivalence(graph_canon):
     inject_defaults(G_func)
 
     # Aplicación manual
-    g_eff = enforce_canonical_grammar(G_manual, 0, ZHIR)
+    g_eff = enforce_canonical_grammar(G_manual, 0, Glyph.ZHIR)
     from tnfr.operators import apply_glyph
 
     apply_glyph(G_manual, 0, g_eff, window=1)
     on_applied_glyph(G_manual, 0, g_eff)
 
     # Aplicación mediante helper
-    apply_glyph_with_grammar(G_func, [0], ZHIR, 1)
+    apply_glyph_with_grammar(G_func, [0], Glyph.ZHIR, 1)
 
     assert G_manual.nodes[0] == G_func.nodes[0]
 
@@ -154,29 +146,29 @@ def test_apply_glyph_with_grammar_multiple_nodes(graph_canon):
     G.add_node(0, theta=0.0)
     G.add_node(1)
     inject_defaults(G)
-    G.nodes[0]["glyph_history"] = deque([OZ])
+    G.nodes[0]["glyph_history"] = deque([Glyph.OZ])
 
-    apply_glyph_with_grammar(G, [0, 1], ZHIR, 1)
+    apply_glyph_with_grammar(G, [0, 1], Glyph.ZHIR, 1)
 
-    assert G.nodes[0]["glyph_history"][-1] == ZHIR
-    assert G.nodes[1]["glyph_history"][-1] == OZ
+    assert G.nodes[0]["glyph_history"][-1] == Glyph.ZHIR
+    assert G.nodes[1]["glyph_history"][-1] == Glyph.OZ
 
 
 def test_apply_glyph_with_grammar_accepts_iterables(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
     inject_defaults(G)
-    G.nodes[0]["glyph_history"] = deque([OZ])
-    G.nodes[1]["glyph_history"] = deque([OZ])
-    apply_glyph_with_grammar(G, G.nodes(), ZHIR, 1)
-    assert G.nodes[0]["glyph_history"][-1] == ZHIR
-    assert G.nodes[1]["glyph_history"][-1] == ZHIR
+    G.nodes[0]["glyph_history"] = deque([Glyph.OZ])
+    G.nodes[1]["glyph_history"] = deque([Glyph.OZ])
+    apply_glyph_with_grammar(G, G.nodes(), Glyph.ZHIR, 1)
+    assert G.nodes[0]["glyph_history"][-1] == Glyph.ZHIR
+    assert G.nodes[1]["glyph_history"][-1] == Glyph.ZHIR
 
     G2 = graph_canon()
     G2.add_nodes_from([0, 1])
     inject_defaults(G2)
-    G2.nodes[0]["glyph_history"] = deque([OZ])
-    G2.nodes[1]["glyph_history"] = deque([OZ])
-    apply_glyph_with_grammar(G2, (n for n in G2.nodes()), ZHIR, 1)
-    assert G2.nodes[0]["glyph_history"][-1] == ZHIR
-    assert G2.nodes[1]["glyph_history"][-1] == ZHIR
+    G2.nodes[0]["glyph_history"] = deque([Glyph.OZ])
+    G2.nodes[1]["glyph_history"] = deque([Glyph.OZ])
+    apply_glyph_with_grammar(G2, (n for n in G2.nodes()), Glyph.ZHIR, 1)
+    assert G2.nodes[0]["glyph_history"][-1] == Glyph.ZHIR
+    assert G2.nodes[1]["glyph_history"][-1] == Glyph.ZHIR


### PR DESCRIPTION
## Summary
- remove glyph alias exports and reference `Glyph` members directly
- clean up `__all__` to expose only grammar helpers
- update dynamics and tests to use `Glyph` constants

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0a069de548321ada94b9a952a9051