### PR TITLE
Prune stale warnings on import failure

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -91,6 +91,7 @@ def _warn_failure(
         :func:`warnings.warn`, ``"log"`` uses :func:`logger.warning` and
         ``"both"`` emits to both destinations.
     """
+    prune_failed_imports()
     msg = (
         f"Failed to import module '{module}': {err}"
         if isinstance(err, ImportError)

--- a/tests/test_warned_modules_prune.py
+++ b/tests/test_warned_modules_prune.py
@@ -6,7 +6,6 @@ from tnfr.import_utils import (
     _WARNED_MODULES,
     _WARNED_LOCK,
     _FAILED_IMPORT_MAX_AGE,
-    prune_failed_imports,
 )
 
 
@@ -16,14 +15,12 @@ def test_warned_modules_pruning():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         _warn_failure("mod", None, ImportError("boom"))
-        _warn_failure("mod", None, ImportError("boom"))
     with _WARNED_LOCK:
         assert "mod" in _WARNED_MODULES
         _WARNED_MODULES["mod"] = time.monotonic() - (_FAILED_IMPORT_MAX_AGE + 1)
-    prune_failed_imports()
-    with _WARNED_LOCK:
-        assert "mod" not in _WARNED_MODULES
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         _warn_failure("mod", None, ImportError("boom"))
         assert len(w) == 1
+    with _WARNED_LOCK:
+        assert "mod" in _WARNED_MODULES


### PR DESCRIPTION
## Summary
- prune expired entries from `_WARNED_MODULES` whenever `_warn_failure` runs
- adjust pruning test to rely on new automatic cleanup

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0a39ce0008321ab08378399bf1881