### PR TITLE
Clarify THOL block materialization errors

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -193,7 +193,11 @@ def _flatten_thol(
         and item.force_close in {Glyph.SHA, Glyph.NUL}
         else None
     )
-    seq = ensure_collection(item.body, max_materialize=max_materialize)
+    seq = ensure_collection(
+        item.body,
+        max_materialize=max_materialize,
+        error_msg=f"THOL body exceeds max_materialize={max_materialize}",
+    )
     for _ in range(repeats):
         if closing is not None:
             stack.append(closing)

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -229,3 +229,12 @@ def test_flatten_thol_multiple_repeats():
         Glyph.AL,
         THOL_SENTINEL,
     ]
+
+
+def test_flatten_thol_body_limit_error_message():
+    stack = deque()
+    body = (Glyph.AL for _ in range(5))
+    with pytest.raises(
+        ValueError, match="THOL body exceeds max_materialize=3"
+    ):
+        _flatten_thol(THOL(body=body), stack, max_materialize=3)


### PR DESCRIPTION
## Summary
- provide contextual `error_msg` for THOL body materialization limit
- add regression test for the new message

## Testing
- `PYTHONPATH=src pytest tests/test_program.py tests/test_ensure_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a7270874832187e893e5dd90f9f5