### PR TITLE
Centralize topology validation and handle probability conversion

### DIFF
--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -6,6 +6,8 @@ import networkx as nx
 from .constants import inject_defaults
 from .initialization import init_node_attrs
 
+VALID_TOPOLOGIES = ("ring", "complete", "erdos")
+
 __all__ = ["build_graph"]
 
 
@@ -24,22 +26,21 @@ def build_graph(
         raise ValueError("n must be a positive integer")
 
     topology = topology.lower()
+    if topology not in VALID_TOPOLOGIES:
+        raise ValueError(
+            f"Invalid topology '{topology}'. "
+            f"Accepted options are: {', '.join(VALID_TOPOLOGIES)}"
+        )
 
     if topology == "ring":
         G = nx.cycle_graph(n)
     elif topology == "complete":
         G = nx.complete_graph(n)
-    elif topology == "erdos":
-        prob = p if p is not None else 3.0 / n
+    else:  # topology == "erdos"
+        prob = float(p) if p is not None else 3.0 / n
         if not 0.0 <= prob <= 1.0:
-            raise ValueError("p must be between 0 and 1")
+            raise ValueError(f"p must be between 0 and 1; received {prob}")
         G = nx.gnp_random_graph(n, prob, seed=seed)
-    else:
-        valid = ["ring", "complete", "erdos"]
-        raise ValueError(
-            f"Invalid topology '{topology}'. "
-            f"Accepted options are: {', '.join(valid)}"
-        )
 
     # Valores canónicos para inicialización
     inject_defaults(G)


### PR DESCRIPTION
## Summary
- define `VALID_TOPOLOGIES` constant for supported graph types
- convert `p` to float and report offending value when out of range

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0a8aabd6c8321b9ed329a19d85427