### PR TITLE
chore: remove unused networkx imports in tests

### DIFF
--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,5 +1,3 @@
-import networkx as nx
-
 from tnfr import dynamics
 from tnfr.helpers.cache import (
     increment_edge_version,

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -1,7 +1,6 @@
 """Tests for ``load_config`` and ``apply_config``."""
 
 import json
-import networkx as nx
 import pytest
 from tnfr.config import load_config, apply_config
 from collections import UserDict

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -1,6 +1,5 @@
 """Pruebas de count glyphs."""
 
-import networkx as nx
 from collections import deque, Counter
 import pytest
 

--- a/tests/test_dnfr_hooks.py
+++ b/tests/test_dnfr_hooks.py
@@ -1,4 +1,3 @@
-import networkx as nx
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
 from tnfr.dynamics import dnfr_phase_only, dnfr_epi_vf_mixed, dnfr_laplacian
 from tnfr.alias import get_attr

--- a/tests/test_dynamics_helpers.py
+++ b/tests/test_dynamics_helpers.py
@@ -1,7 +1,6 @@
 """Tests for dynamics helpers."""
 
 import pytest
-import networkx as nx
 
 from tnfr.dynamics import (
     _init_dnfr_cache,

--- a/tests/test_edge_version_cache_disable.py
+++ b/tests/test_edge_version_cache_disable.py
@@ -1,5 +1,3 @@
-import networkx as nx
-
 from tnfr.helpers.cache import edge_version_cache
 
 

--- a/tests/test_edge_version_cache_limit.py
+++ b/tests/test_edge_version_cache_limit.py
@@ -1,5 +1,3 @@
-import networkx as nx
-
 from tnfr.helpers.cache import edge_version_cache
 
 

--- a/tests/test_edge_version_cache_locks.py
+++ b/tests/test_edge_version_cache_locks.py
@@ -1,5 +1,3 @@
-import networkx as nx
-
 from tnfr.helpers.cache import edge_version_cache
 
 

--- a/tests/test_edge_version_cache_reentrant.py
+++ b/tests/test_edge_version_cache_reentrant.py
@@ -1,4 +1,3 @@
-import networkx as nx
 from tnfr.helpers.cache import edge_version_cache
 
 

--- a/tests/test_edge_version_cache_threadsafe.py
+++ b/tests/test_edge_version_cache_threadsafe.py
@@ -1,4 +1,3 @@
-import networkx as nx
 from concurrent.futures import ThreadPoolExecutor
 
 from tnfr.helpers.cache import edge_version_cache, increment_edge_version

--- a/tests/test_ensure_history_trim_performance.py
+++ b/tests/test_ensure_history_trim_performance.py
@@ -1,6 +1,5 @@
 import time
 import pytest
-import networkx as nx
 
 from tnfr.glyph_history import HistoryDict, ensure_history
 from tnfr.constants import inject_defaults

--- a/tests/test_inject_defaults_tuple.py
+++ b/tests/test_inject_defaults_tuple.py
@@ -1,6 +1,5 @@
 """Pruebas para ``inject_defaults`` con tuplas mutables."""
 
-import networkx as nx
 
 from tnfr.constants import inject_defaults, DEFAULTS
 

--- a/tests/test_local_phase_sync.py
+++ b/tests/test_local_phase_sync.py
@@ -1,4 +1,3 @@
-import networkx as nx
 import pytest
 
 from tnfr.constants import THETA_PRIMARY

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,6 @@
 """Pruebas de metrics."""
 
 import pytest
-import networkx as nx
 from typing import Any
 
 from tnfr.constants import (

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -1,5 +1,4 @@
 import hashlib
-import networkx as nx
 import timeit
 
 from tnfr.helpers.cache import (

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -2,7 +2,6 @@
 
 import math
 import pytest
-import networkx as nx
 from tnfr.node import NodoTNFR, NodoNX
 
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -9,7 +9,6 @@ from tnfr.operators import (
 )
 from types import SimpleNamespace
 from tnfr.constants import inject_defaults
-import networkx as nx
 import pytest
 
 

--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -1,5 +1,4 @@
 import threading
-import networkx as nx
 import tnfr.dynamics as dyn
 import tnfr.program as program
 from tnfr.program import _advance

--- a/tests/test_rng_base_seed.py
+++ b/tests/test_rng_base_seed.py
@@ -1,4 +1,3 @@
-import networkx as nx
 from tnfr.rng import base_seed, set_cache_maxsize, clear_rng_cache
 
 

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -1,7 +1,6 @@
 """Pruebas de sense."""
 
 import time
-import networkx as nx
 import pytest
 
 from tnfr.sense import (

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -1,4 +1,3 @@
-import networkx as nx
 import pytest
 import math
 


### PR DESCRIPTION
## Summary
- remove unused `networkx` imports from tests

## Testing
- `pyflakes tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0aadf1d28832189e68572fa5cb5d7