### PR TITLE
Refactor json_dumps optional import

### DIFF
--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -19,8 +19,8 @@ def test_lazy_orjson_import(monkeypatch):
         return FakeOrjson()
 
     monkeypatch.setattr(json_utils, "optional_import", fake_optional_import)
+    json_utils._load_orjson.cache_clear()
     monkeypatch.setattr(json_utils, "_orjson", None)
-    monkeypatch.setattr(json_utils, "_orjson_loaded", False)
     monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
 
     assert calls["n"] == 0
@@ -32,8 +32,8 @@ def test_lazy_orjson_import(monkeypatch):
 
 def test_warns_once(monkeypatch):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: FakeOrjson())
+    json_utils._load_orjson.cache_clear()
     monkeypatch.setattr(json_utils, "_orjson", None)
-    monkeypatch.setattr(json_utils, "_orjson_loaded", False)
     monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
 
     with warnings.catch_warnings(record=True) as w:

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -13,8 +13,8 @@ class DummyOrjson:
 
 def _reset_json_utils(monkeypatch, module):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: module)
+    json_utils._load_orjson.cache_clear()
     monkeypatch.setattr(json_utils, "_orjson", None)
-    monkeypatch.setattr(json_utils, "_orjson_loaded", False)
     monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
 
 

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -3,10 +3,12 @@ import json
 import pytest
 
 from tnfr.helpers.cache import _stable_json
-from tnfr.json_utils import _orjson
+from tnfr import json_utils
 
 
 def test_stable_json_dict_order_deterministic():
+    json_utils._load_orjson.cache_clear()
+    json_utils._orjson = None
     obj = {"b": 1, "a": 2}
     res1 = _stable_json(obj)
     res2 = _stable_json(obj)
@@ -15,7 +17,7 @@ def test_stable_json_dict_order_deterministic():
 
 
 def test_stable_json_warns_with_orjson():
-    if _orjson is None:
+    if json_utils._orjson is None:
         pytest.skip("orjson not installed")
     with pytest.warns(UserWarning, match="ignored when using orjson"):
         _stable_json({"a": 1})


### PR DESCRIPTION
## Summary
- refactor json_dumps to cache optional orjson import via lru_cache
- clean up deprecated state flags and locks
- update tests for new import caching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b903aa8083219737f35303ce8c7e