### PR TITLE
Refactor RNG helpers to use cached seed hash

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -37,18 +37,26 @@ def _make_cache(size: int) -> Tuple[MutableMapping[tuple[int, int], int], Callab
 _RNG_CACHE, _seed_hash_cached = _make_cache(_CACHE_MAXSIZE)
 
 
+def _seed_hash_for(seed_int: int, key_int: int) -> int:
+    """Return a seed hash for ``seed_int`` and ``key_int``.
+
+    Uses the cached hash when caching is enabled.
+    """
+
+    if _CACHE_MAXSIZE <= 0:
+        return _seed_hash(seed_int, key_int)
+    return _seed_hash_cached(seed_int, key_int)
+
+
 def make_rng(seed_int: int, key_int: int) -> random.Random:
-    return random.Random(_seed_hash(seed_int, key_int))
+    return random.Random(_seed_hash_for(seed_int, key_int))
 
 
 def get_rng(seed: int, key: int) -> random.Random:
     """Return a ``random.Random`` for ``(seed, key)`` using a cached seed."""
     seed_int = int(seed)
     key_int = int(key)
-    if _CACHE_MAXSIZE <= 0:
-        return random.Random(_seed_hash(seed_int, key_int))
-
-    seed_hash = _seed_hash_cached(seed_int, key_int)
+    seed_hash = _seed_hash_for(seed_int, key_int)
     return random.Random(seed_hash)
 
 


### PR DESCRIPTION
## Summary
- Add private `_seed_hash_for` helper that uses the cached seed hash when RNG caching is enabled
- Refactor `make_rng` and `get_rng` to use `_seed_hash_for` so both functions benefit from caching

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ba1c8de483219bca6aefa75257be