### PR TITLE
Track dirty callback lists per event

### DIFF
--- a/tests/test_ensure_callbacks.py
+++ b/tests/test_ensure_callbacks.py
@@ -34,3 +34,23 @@ def test_register_callback_cleans_unknown_events(graph_canon):
     register_callback(G, CallbackEvent.AFTER_STEP, cb, name="cb")
 
     assert list(G.graph["callbacks"]) == [CallbackEvent.AFTER_STEP.value]
+
+
+def test_ensure_callbacks_only_processes_dirty_events(graph_canon):
+    G = graph_canon()
+    from collections import defaultdict
+
+    dummy = object()
+    G.graph["callbacks"] = defaultdict(
+        list,
+        {
+            CallbackEvent.BEFORE_STEP.value: [dummy],
+            CallbackEvent.AFTER_STEP.value: [dummy],
+        },
+    )
+    G.graph["_callbacks_dirty"] = {CallbackEvent.BEFORE_STEP.value}
+
+    _ensure_callbacks(G)
+
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == []
+    assert G.graph["callbacks"][CallbackEvent.AFTER_STEP.value] == [dummy]


### PR DESCRIPTION
## Summary
- Replace single callbacks dirty flag with per-event markers and normalize only changed event lists
- Update register_callback to mark corresponding event lists as dirty
- Add regression test ensuring only flagged events are normalized

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0bab5283083218fed007bea3f2532