### PR TITLE
Simplify node checksum hashing

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -162,16 +162,15 @@ def node_set_checksum(
     node_iterable = G.nodes() if nodes is None else nodes
 
     hasher = hashlib.blake2b(digest_size=16)
-    token_hasher = hashlib.blake2b(digest_size=8)
 
     # Generate digests in stable order; `_iter_node_digests` sorts when needed
     # unless `presorted` indicates the nodes are already ordered.
     for digest in _iter_node_digests(node_iterable, presorted=presorted):
         hasher.update(digest)
-        token_hasher.update(digest)
 
-    checksum = hasher.hexdigest()
-    token = token_hasher.hexdigest()
+    digest = hasher.digest()
+    checksum = digest.hex()
+    token = digest[:8].hex()
     if store:
         # Cache the result using a short token to detect unchanged node sets.
         cached = graph.get("_node_set_checksum_cache")

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -66,6 +66,15 @@ def test_node_set_checksum_no_store_does_not_cache(graph_canon):
     assert "_node_set_checksum_cache" not in G.graph
 
 
+def test_node_set_checksum_cache_token_is_prefix(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([1, 2])
+    checksum = node_set_checksum(G)
+    token, stored_checksum = G.graph["_node_set_checksum_cache"]
+    assert stored_checksum == checksum
+    assert token == checksum[:16]
+
+
 def test_node_repr_cache_cleared_on_increment(graph_canon):
     nxG = graph_canon()
     _node_repr("foo")


### PR DESCRIPTION
## Summary
- derive node checksum and cache token from a single BLAKE2b digest
- store truncated digest for node-set caching
- test checksum cache token is prefix of full digest

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0bd83382883218835849d71a6ee20