### PR TITLE
Refactor lazy imports and tighten caches

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -176,7 +176,7 @@ def invoke_callbacks(
     )
     ctx = ctx or {}
     err_list = G.graph.get("_callback_errors")
-    if not isinstance(err_list, deque):
+    if not isinstance(err_list, deque) or err_list.maxlen != _CALLBACK_ERROR_LIMIT:
         err_list = deque(maxlen=_CALLBACK_ERROR_LIMIT)
         G.graph["_callback_errors"] = err_list
     # ``cbs`` is a list and callbacks are not modified during iteration,

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -118,7 +118,7 @@ def _iter_node_digests(
 
 
 def _update_node_cache(
-    G: nx.Graph,
+    graph: Any,
     nodes: Iterable[Any],
     key_prefix: str,
     value: Any | None = None,
@@ -126,7 +126,7 @@ def _update_node_cache(
     checksum: str | None = None,
     presorted: bool = False,
 ) -> str:
-    """Store ``value`` and its node checksum in ``G.graph``.
+    """Store ``value`` and its node checksum in ``graph``.",
 
     ``nodes`` is the iterable used to compute the checksum. When ``value`` is
     ``None`` it defaults to ``nodes``. The computed checksum is returned.
@@ -135,9 +135,8 @@ def _update_node_cache(
     """
     if checksum is None:
         checksum = node_set_checksum(
-            G, nodes, presorted=presorted, store=False
+            graph, nodes, presorted=presorted, store=False
         )
-    graph = get_graph(G)
     graph[key_prefix] = nodes if value is None else value
     graph[f"{key_prefix}_checksum"] = checksum
     return checksum
@@ -195,11 +194,11 @@ def _cache_node_list(G: nx.Graph) -> tuple[Any, ...]:
     dirty = bool(graph.pop("_node_list_dirty", False))
     if nodes is None or stored_len != current_n or dirty:
         nodes = tuple(G.nodes())
-        _update_node_cache(G, nodes, "_node_list")
+        _update_node_cache(graph, nodes, "_node_list")
         graph["_node_list_len"] = current_n
     else:
         if "_node_list_checksum" not in graph:
-            _update_node_cache(G, nodes, "_node_list")
+            _update_node_cache(graph, nodes, "_node_list")
     return nodes
 
 
@@ -217,7 +216,7 @@ def _ensure_node_map(G, *, key: str, sort: bool = False) -> dict[Any, int]:
     checksum_key = f"{key}_checksum"
     if mapping is None or G.graph.get(checksum_key) != checksum:
         mapping = {node: idx for idx, node in enumerate(nodes)}
-        _update_node_cache(G, nodes, key, mapping, checksum=checksum)
+        _update_node_cache(G.graph, nodes, key, mapping, checksum=checksum)
     return mapping
 
 

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -15,7 +15,6 @@ from .import_utils import optional_import
 
 __all__ = ["json_dumps"]
 
-_orjson: Any | None = None
 _ignored_param_warned = False
 _warn_lock = threading.Lock()
 
@@ -23,9 +22,7 @@ _warn_lock = threading.Lock()
 @lru_cache(maxsize=1)
 def _load_orjson() -> Any | None:
     """Lazily import :mod:`orjson` once."""
-    global _orjson
-    _orjson = optional_import("orjson")
-    return _orjson
+    return optional_import("orjson")
 
 
 def _json_dumps_orjson(

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -25,18 +25,12 @@ AdvanceFn = Callable[[Any], None]  # normalmente dynamics.step
 
 
 @lru_cache(maxsize=1)
-def _load_step_fn() -> AdvanceFn:
+def get_step_fn() -> AdvanceFn:
     """Return the dynamics ``step`` function, caching the import."""
 
     from .dynamics import step as step_impl
 
     return step_impl
-
-
-def get_step_fn() -> AdvanceFn:
-    """Return cached dynamics ``step`` function, initialising lazily."""
-
-    return _load_step_fn()
 
 
 __all__ = [

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -48,16 +48,16 @@ def _seed_hash_for(seed_int: int, key_int: int) -> int:
     return _seed_hash_cached(seed_int, key_int)
 
 
-def make_rng(seed_int: int, key_int: int) -> random.Random:
+def make_rng(seed: int, key: int) -> random.Random:
+    """Return a ``random.Random`` for ``seed`` and ``key``."""
+    seed_int = int(seed)
+    key_int = int(key)
     return random.Random(_seed_hash_for(seed_int, key_int))
 
 
 def get_rng(seed: int, key: int) -> random.Random:
-    """Return a ``random.Random`` for ``(seed, key)`` using a cached seed."""
-    seed_int = int(seed)
-    key_int = int(key)
-    seed_hash = _seed_hash_for(seed_int, key_int)
-    return random.Random(seed_hash)
+    """Return a ``random.Random`` for ``(seed, key)`` using :func:`make_rng`."""
+    return make_rng(seed, key)
 
 
 def clear_rng_cache() -> None:

--- a/tests/test_callback_errors_limit.py
+++ b/tests/test_callback_errors_limit.py
@@ -1,0 +1,27 @@
+from collections import deque
+
+from tnfr.callback_utils import (
+    CallbackEvent,
+    invoke_callbacks,
+    register_callback,
+    _CALLBACK_ERROR_LIMIT,
+)
+
+
+def test_callback_error_list_resets_limit(graph_canon):
+    G = graph_canon()
+
+    def failing_cb(G, ctx):
+        raise RuntimeError("boom")
+
+    register_callback(G, CallbackEvent.BEFORE_STEP, failing_cb, name="fail")
+    original = deque(maxlen=None)
+    G.graph["_callback_errors"] = original
+
+    invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
+
+    err_list = G.graph.get("_callback_errors")
+    assert err_list is not original
+    assert err_list.maxlen == _CALLBACK_ERROR_LIMIT
+    assert len(err_list) == 1
+

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -20,7 +20,6 @@ def test_lazy_orjson_import(monkeypatch):
 
     monkeypatch.setattr(json_utils, "optional_import", fake_optional_import)
     json_utils._load_orjson.cache_clear()
-    monkeypatch.setattr(json_utils, "_orjson", None)
     monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
 
     assert calls["n"] == 0
@@ -33,7 +32,6 @@ def test_lazy_orjson_import(monkeypatch):
 def test_warns_once(monkeypatch):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: FakeOrjson())
     json_utils._load_orjson.cache_clear()
-    monkeypatch.setattr(json_utils, "_orjson", None)
     monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
 
     with warnings.catch_warnings(record=True) as w:

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -14,7 +14,6 @@ class DummyOrjson:
 def _reset_json_utils(monkeypatch, module):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: module)
     json_utils._load_orjson.cache_clear()
-    monkeypatch.setattr(json_utils, "_orjson", None)
     monkeypatch.setattr(json_utils, "_ignored_param_warned", False)
 
 

--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -16,12 +16,12 @@ def test_advance_caches_step(monkeypatch, graph_canon):
         calls.append(2)
 
     monkeypatch.setattr(dyn, "step", first_step)
-    program._load_step_fn.cache_clear()
+    program.get_step_fn.cache_clear()
     _advance(G)
     monkeypatch.setattr(dyn, "step", second_step)
     _advance(G)
     assert calls == [1, 1]
-    program._load_step_fn.cache_clear()
+    program.get_step_fn.cache_clear()
 
 
 def test_advance_thread_safe(monkeypatch, graph_canon):
@@ -36,7 +36,7 @@ def test_advance_thread_safe(monkeypatch, graph_canon):
         calls.append(2)
 
     monkeypatch.setattr(dyn, "step", first_step)
-    program._load_step_fn.cache_clear()
+    program.get_step_fn.cache_clear()
 
     barrier = threading.Barrier(5)
 
@@ -54,4 +54,4 @@ def test_advance_thread_safe(monkeypatch, graph_canon):
     _advance(G)
 
     assert calls == [1] * 6
-    program._load_step_fn.cache_clear()
+    program.get_step_fn.cache_clear()


### PR DESCRIPTION
## Summary
- streamline JSON helpers by removing redundant orjson global
- cache step function directly in program module
- consolidate RNG constructors and normalize seeds in one place
- enforce callback error deque size and add regression test
- avoid redundant graph lookups in node cache helpers

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0c044a9108321a7872218f47a17cc