### PR TITLE
refactor: simplify observer node checks

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -76,26 +76,19 @@ def _get_R_psi(
     return R, psi
 
 
-def _has_nodes(G) -> bool:
-    return G.number_of_nodes() != 0
-
-
 def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
-    if not _has_nodes(G):
+    if not G.number_of_nodes():
         return 1.0
     _, psi = _get_R_psi(G, R, psi)
 
     # Variance via Welford's single-pass algorithm to avoid materializing
     # intermediate generators while maintaining numerical stability.
-    get_attr_ = get_attr
-    angle_diff_ = angle_diff
-    theta_alias = ALIAS_THETA
     # If performance is critical, consider extracting theta values into a list
     n = 0
     mean = 0.0
     M2 = 0.0
     for _, data in G.nodes(data=True):
-        diff = angle_diff_(get_attr_(data, theta_alias, 0.0), psi)
+        diff = angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
         n += 1
         delta = diff - mean
         mean += delta / n
@@ -109,7 +102,7 @@ def kuramoto_order(
     G, R: float | None = None, psi: float | None = None
 ) -> float:
     """R in [0,1], 1 means perfectly aligned phases."""
-    if not _has_nodes(G):
+    if not G.number_of_nodes():
         return 1.0
     R, _ = _get_R_psi(G, R, psi)
     return float(R)


### PR DESCRIPTION
## Summary
- inline node presence checks in `phase_sync` and `kuramoto_order`
- remove unused helper and aliases for clearer observer implementations

## Testing
- `PYTHONPATH=src pytest tests/test_observers.py tests/test_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0c6298778832194984260e82834eb