### PR TITLE
Clarify adjacency caching contract for cached_nodes_and_A

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -408,14 +408,20 @@ def invalidate_edge_version_cache(G: Any) -> None:
 
 
 def cached_nodes_and_A(
-    G: nx.Graph, *, cache_size: int | None = 1
+    G: nx.Graph, *, cache_size: int | None = 1, require_numpy: bool = False
 ) -> tuple[list[int], Any]:
-    """Return list of nodes and adjacency matrix for ``G`` with caching."""
+    """Return list of nodes and adjacency matrix for ``G`` with caching.
+
+    ``A`` is ``None`` when NumPy is unavailable. When ``require_numpy`` is
+    ``True`` a :class:`RuntimeError` is raised if NumPy cannot be imported.
+    """
     nodes_list = list(G.nodes())
     checksum = node_set_checksum(G, nodes_list, store=False)
     key = f"_dnfr_{len(nodes_list)}_{checksum}"
     G.graph["_dnfr_nodes_checksum"] = checksum
     np = get_numpy()
+    if require_numpy and np is None:
+        raise RuntimeError("NumPy is required for adjacency caching")
 
     def builder() -> tuple[list[int], Any]:
         if np is not None:

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,5 +1,8 @@
+import pytest
+
 from tnfr import dynamics
 from tnfr.helpers.cache import (
+    cached_nodes_and_A,
     increment_edge_version,
     ensure_node_offset_map,
     _cache_node_list,
@@ -52,3 +55,20 @@ def test_cache_node_list_updates_on_dirty(graph_canon):
     G.graph["_node_list_dirty"] = True
     nodes3 = _cache_node_list(G)
     assert nodes3 is not nodes1
+
+
+def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
+    monkeypatch.setattr("tnfr.helpers.cache.get_numpy", lambda: None)
+    G = graph_canon()
+    G.add_edge(0, 1)
+    nodes, A = cached_nodes_and_A(G)
+    assert A is None
+    assert nodes == [0, 1]
+
+
+def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
+    monkeypatch.setattr("tnfr.helpers.cache.get_numpy", lambda: None)
+    G = graph_canon()
+    G.add_edge(0, 1)
+    with pytest.raises(RuntimeError):
+        cached_nodes_and_A(G, require_numpy=True)


### PR DESCRIPTION
## Summary
- Clarify that `cached_nodes_and_A` may return `None` for `A` when NumPy is unavailable
- Add optional `require_numpy` flag that raises `RuntimeError` if adjacency caching is requested without NumPy
- Test caching behaviour when NumPy is missing and ensure `RuntimeError` is raised when `require_numpy` is set

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0caa8c35c832185f853530975dce3