### PR TITLE
refactor: replace get_rng with make_rng

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from .constants import DEFAULTS, INIT_DEFAULTS, VF_KEY, THETA_KEY
 from .helpers.numeric import clamp
-from .rng import get_rng
+from .rng import make_rng
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
@@ -144,7 +144,7 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))
     epi_val = float(G.graph.get("INIT_EPI_VALUE", 0.0))
 
-    rng_template = get_rng(seed, -1)
+    rng_template = make_rng(seed, -1)
     rng = random.Random()
     rng.setstate(rng_template.getstate())
     for _, nd in G.nodes(data=True):

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -39,7 +39,7 @@ from .helpers.cache import (
     ensure_node_offset_map,
 )
 from .alias import get_attr, set_attr
-from .rng import get_rng, base_seed, cache_enabled, clear_rng_cache as _clear_rng_cache
+from .rng import make_rng, base_seed, cache_enabled, clear_rng_cache as _clear_rng_cache
 from .callback_utils import invoke_callbacks
 from .glyph_history import append_metric
 from .import_utils import import_nodonx, optional_import
@@ -111,7 +111,7 @@ def random_jitter(node: NodoProtocol, amplitude: float) -> float:
     ``node``.
 
     The value is derived from ``(RANDOM_SEED, node.offset())`` and does
-    not store references to nodes. ``get_rng`` provides a global LRU
+    not store references to nodes. ``make_rng`` provides a global LRU
     cache keyed by ``(seed, key)`` so sequences advance deterministically
     across calls. The Blake2 hash used to derive ``seed`` is cached per
     node in ``_jitter_seed_hash`` keyed by ``(seed_root, scope_id)`` to
@@ -159,7 +159,7 @@ def random_jitter(node: NodoProtocol, amplitude: float) -> float:
     if cache_enabled():
         seq = _JITTER_SEQ.get(cache_key, 0)
         _JITTER_SEQ[cache_key] = seq + 1
-    rng = get_rng(seed, seed_key + seq)
+    rng = make_rng(seed, seed_key + seq)
     return rng.uniform(-amplitude, amplitude)
 
 
@@ -329,7 +329,7 @@ def _um_select_candidates(
     th: float,
 ):
     cand_list = list(candidates)
-    rng = get_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset())
+    rng = make_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset())
     if limit > 0 and len(cand_list) > limit:
         if mode == "proximity":
             cand_list = heapq.nsmallest(
@@ -815,7 +815,7 @@ def apply_topological_remesh(
     if n_before <= 1:
         return
     base_seed = 0 if seed is None else int(seed)
-    rnd = get_rng(base_seed, -2)
+    rnd = make_rng(base_seed, -2)
     rnd.seed(base_seed)
 
     if mode is None:

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -54,10 +54,8 @@ def make_rng(seed: int, key: int) -> random.Random:
     key_int = int(key)
     return random.Random(_seed_hash_for(seed_int, key_int))
 
-
-def get_rng(seed: int, key: int) -> random.Random:
-    """Return a ``random.Random`` for ``(seed, key)`` using :func:`make_rng`."""
-    return make_rng(seed, key)
+# Backwards compatibility alias
+get_rng = make_rng
 
 
 def clear_rng_cache() -> None:
@@ -81,7 +79,7 @@ def base_seed(G: Any) -> int:
 def _rng_for_step(seed: int, step: int) -> random.Random:
     """Return deterministic RNG for a simulation ``step``."""
 
-    return get_rng(seed, step)
+    return make_rng(seed, step)
 
 
 def set_cache_maxsize(size: int) -> None:
@@ -101,7 +99,6 @@ def set_cache_maxsize(size: int) -> None:
 
 
 __all__ = [
-    "get_rng",
     "make_rng",
     "set_cache_maxsize",
     "base_seed",

--- a/tests/test_make_rng.py
+++ b/tests/test_make_rng.py
@@ -1,7 +1,7 @@
 import random
 import hashlib
 import struct
-from tnfr.rng import get_rng, clear_rng_cache
+from tnfr.rng import make_rng, clear_rng_cache
 
 
 def _derive_seed(seed: int, key: int) -> int:
@@ -15,13 +15,13 @@ def _derive_seed(seed: int, key: int) -> int:
     )
 
 
-def test_get_rng_reproducible_sequence():
+def test_make_rng_reproducible_sequence():
     clear_rng_cache()
     seed = 123
     key = 456
-    rng1 = get_rng(seed, key)
+    rng1 = make_rng(seed, key)
     seq1 = [rng1.random() for _ in range(3)]
-    rng2 = get_rng(seed, key)
+    rng2 = make_rng(seed, key)
     seq2 = [rng2.random() for _ in range(3)]
 
     seed_int = _derive_seed(seed, key)

--- a/tests/test_make_rng_threadsafe.py
+++ b/tests/test_make_rng_threadsafe.py
@@ -1,12 +1,13 @@
 import threading
+import threading
 import random
 
 from tnfr import rng as rng_mod
-from tnfr.rng import get_rng, clear_rng_cache
+from tnfr.rng import make_rng, clear_rng_cache
 from tnfr.constants import DEFAULTS
 
 
-def test_get_rng_thread_safety(monkeypatch):
+def test_make_rng_thread_safety(monkeypatch):
     monkeypatch.setattr(rng_mod, "DEFAULTS", dict(DEFAULTS))
     monkeypatch.setitem(rng_mod.DEFAULTS, "JITTER_CACHE_SIZE", 4)
     clear_rng_cache()
@@ -17,7 +18,7 @@ def test_get_rng_thread_safety(monkeypatch):
 
     def worker():
         try:
-            rng = get_rng(123, 456)
+            rng = make_rng(123, 456)
             seq = [rng.random() for _ in range(3)]
             with lock:
                 results.append(seq)
@@ -46,5 +47,5 @@ def test_no_lock_when_cache_disabled(monkeypatch):
             pass
 
     monkeypatch.setattr(rng_mod, "_RNG_LOCK", FailLock())
-    rng = rng_mod.get_rng(123, 456)
+    rng = rng_mod.make_rng(123, 456)
     assert isinstance(rng, random.Random)


### PR DESCRIPTION
## Summary
- replace helper `get_rng` with direct `make_rng` implementation
- update initialization and operators to use `make_rng`
- rename and update tests for `make_rng`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cb710da08321a6b9297a77022759