### PR TITLE
Use direct assignment for recomputed max values

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -201,10 +201,10 @@ def _get_vf_dnfr_max(G) -> tuple[float, float]:
         )
         if vfmax is None:
             vfmax = maxes["_vfmax"]
-            G.graph.setdefault("_vfmax", vfmax)
         if dnfrmax is None:
             dnfrmax = maxes["_dnfrmax"]
-            G.graph.setdefault("_dnfrmax", dnfrmax)
+        G.graph["_vfmax"] = vfmax
+        G.graph["_dnfrmax"] = dnfrmax
     vfmax = 1.0 if vfmax == 0 else vfmax
     dnfrmax = 1.0 if dnfrmax == 0 else dnfrmax
     return vfmax, dnfrmax

--- a/tests/test_vf_dnfr_max_update.py
+++ b/tests/test_vf_dnfr_max_update.py
@@ -1,0 +1,23 @@
+import pytest
+
+from tnfr.alias import set_attr
+from tnfr.constants import ALIAS_VF, ALIAS_DNFR
+from tnfr.metrics_utils import _get_vf_dnfr_max
+
+
+def test_get_vf_dnfr_max_updates_graph_on_none(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([1, 2])
+    set_attr(G.nodes[1], ALIAS_VF, 0.5)
+    set_attr(G.nodes[2], ALIAS_VF, -1.5)
+    set_attr(G.nodes[1], ALIAS_DNFR, 0.2)
+    set_attr(G.nodes[2], ALIAS_DNFR, -0.4)
+    G.graph["_vfmax"] = None
+    G.graph["_dnfrmax"] = None
+
+    vfmax, dnfrmax = _get_vf_dnfr_max(G)
+
+    assert vfmax == pytest.approx(1.5)
+    assert dnfrmax == pytest.approx(0.4)
+    assert G.graph["_vfmax"] == pytest.approx(1.5)
+    assert G.graph["_dnfrmax"] == pytest.approx(0.4)


### PR DESCRIPTION
## Summary
- replace setdefault with direct assignments for `_vfmax` and `_dnfrmax`
- add regression test ensuring maxima cache updates from None values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1a28a9b5083218848be39f4273c38