### PR TITLE
Run failed import pruning periodically

### DIFF
--- a/tests/test_warned_modules_prune.py
+++ b/tests/test_warned_modules_prune.py
@@ -1,6 +1,7 @@
 import warnings
 import time
 
+import tnfr.import_utils as import_utils
 from tnfr.import_utils import (
     _warn_failure,
     _WARNED_MODULES,
@@ -9,7 +10,7 @@ from tnfr.import_utils import (
 )
 
 
-def test_warned_modules_pruning():
+def test_warned_modules_pruning(monkeypatch):
     with _WARNED_LOCK:
         _WARNED_MODULES.clear()
     with warnings.catch_warnings():
@@ -18,6 +19,8 @@ def test_warned_modules_pruning():
     with _WARNED_LOCK:
         assert "mod" in _WARNED_MODULES
         _WARNED_MODULES["mod"] = time.monotonic() - (_FAILED_IMPORT_MAX_AGE + 1)
+    monkeypatch.setattr(import_utils, "_LAST_FAILED_IMPORT_PRUNE", 0.0)
+    monkeypatch.setattr(import_utils, "_FAILED_IMPORT_PRUNE_INTERVAL", 0.0)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         _warn_failure("mod", None, ImportError("boom"))


### PR DESCRIPTION
## Summary
- prune failed import records and warnings only at periodic intervals
- test that failure registry remains bounded without frequent pruning
- adjust warned modules pruning test for scheduled cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4ad081c832185f053f45d8abb8d