### PR TITLE
Ensure callbacks use provided context

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -174,7 +174,8 @@ def invoke_callbacks(
     strict = bool(
         G.graph.get("CALLBACKS_STRICT", DEFAULTS["CALLBACKS_STRICT"])
     )
-    ctx = ctx or {}
+    if ctx is None:
+        ctx = {}
     err_list = G.graph.get("_callback_errors")
     if not isinstance(err_list, deque) or err_list.maxlen != _CALLBACK_ERROR_LIMIT:
         err_list = deque(maxlen=_CALLBACK_ERROR_LIMIT)

--- a/tests/test_invoke_callbacks.py
+++ b/tests/test_invoke_callbacks.py
@@ -1,0 +1,17 @@
+"""Tests for invoke_callbacks context handling."""
+
+from tnfr.callback_utils import CallbackEvent, invoke_callbacks, register_callback
+
+
+def test_invoke_callbacks_preserves_context(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        ctx["called"] = ctx.get("called", 0) + 1
+
+    register_callback(G, CallbackEvent.BEFORE_STEP, cb)
+
+    ctx = {}
+    invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
+
+    assert ctx["called"] == 1


### PR DESCRIPTION
## Summary
- Respect empty context dictionaries when invoking callbacks
- Add regression test for context mutation persistence

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a60439348321918007af7624d4ea