### PR TITLE
Refactor callback registry to mapping-based structure

### DIFF
--- a/tests/test_ensure_callbacks.py
+++ b/tests/test_ensure_callbacks.py
@@ -52,5 +52,5 @@ def test_ensure_callbacks_only_processes_dirty_events(graph_canon):
 
     _ensure_callbacks(G)
 
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == []
-    assert G.graph["callbacks"][CallbackEvent.AFTER_STEP.value] == [dummy]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == {}
+    assert G.graph["callbacks"][CallbackEvent.AFTER_STEP.value] == {}

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -158,8 +158,8 @@ def test_attach_standard_observer_registers_callbacks(graph_canon):
 def test_attach_standard_observer_idempotent(graph_canon):
     G = graph_canon()
     attach_standard_observer(G)
-    callbacks = {ev: list(cbs) for ev, cbs in G.graph["callbacks"].items()}
+    callbacks = {ev: dict(cbs) for ev, cbs in G.graph["callbacks"].items()}
     attach_standard_observer(G)
     assert {
-        ev: list(cbs) for ev, cbs in G.graph["callbacks"].items()
+        ev: dict(cbs) for ev, cbs in G.graph["callbacks"].items()
     } == callbacks

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -20,23 +20,23 @@ def test_register_callback_replaces_existing(graph_canon):
 
     # initial registration
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb1, name="cb")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [
-        ("cb", cb1)
-    ]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == {
+        "cb": ("cb", cb1)
+    }
 
     # same name should replace existing
     register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="cb")
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [
-        ("cb", cb2)
-    ]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == {
+        "cb": ("cb", cb2)
+    }
 
     # same function with different name should also replace existing
     register_callback(
         G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="other"
     )
-    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == [
-        ("other", cb2)
-    ]
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == {
+        "other": ("other", cb2)
+    }
 
 
 def test_register_callback_rejects_tuple(graph_canon):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -19,13 +19,13 @@ def test_register_trace_idempotent(graph_canon):
     register_trace(G)
     # callbacks should be registered once and flag set
     assert G.graph["_trace_registered"] is True
-    before = list(G.graph["callbacks"]["before_step"])
-    after = list(G.graph["callbacks"]["after_step"])
+    before = dict(G.graph["callbacks"]["before_step"])
+    after = dict(G.graph["callbacks"]["after_step"])
 
     register_trace(G)
 
-    assert list(G.graph["callbacks"]["before_step"]) == before
-    assert list(G.graph["callbacks"]["after_step"]) == after
+    assert dict(G.graph["callbacks"]["before_step"]) == before
+    assert dict(G.graph["callbacks"]["after_step"]) == after
 
 
 def test_trace_metadata_contains_callback_names(graph_canon):


### PR DESCRIPTION
## Summary
- store callbacks as event-to-name mapping of `CallbackSpec`
- normalise callback registry to dictionaries and clean invalid entries
- adjust trace utilities and tests for new callback structure

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a83e04288321a2f30eb7ba92a077