### PR TITLE
Deduplicate keys in normalize_weights

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -137,6 +137,7 @@ def normalize_weights(
 
     ``keys`` may be any iterable of strings. Sequences and other collections
     are used directly while non-collection iterables are materialized.
+    Repeated keys are automatically collapsed preserving their first occurrence.
 
     Negative weights are handled according to ``error_on_negative``. When
     ``True`` a :class:`ValueError` is raised. Otherwise negatives are logged,
@@ -147,6 +148,7 @@ def normalize_weights(
     """
     if not isinstance(keys, Collection):
         keys = list(keys)
+    keys = list(dict.fromkeys(keys))
     default_float = float(default)
     if not keys:
         return {}

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -66,3 +66,15 @@ def test_normalize_weights_high_precision():
     norm = normalize_weights(weights, weights.keys())
     assert all(v == 0.1 for v in norm.values())
     assert math.isclose(math.fsum(norm.values()), 1.0)
+
+
+def test_normalize_weights_deduplicates_keys():
+    cu._warned_negative_keys.clear()
+    weights = {"a": -1.0, "b": -1.0}
+    dup_keys = ["a", "b", "a"]
+    unique_keys = ["a", "b"]
+    norm_dup = normalize_weights(weights, dup_keys)
+    norm_unique = normalize_weights(weights, unique_keys)
+    expected = {"a": 0.5, "b": 0.5}
+    assert norm_dup == norm_unique
+    assert norm_dup == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- Ensure normalize_weights collapses duplicate keys while preserving order
- Document behavior for repeated keys
- Test that duplicate keys produce the same distribution as unique keys

## Testing
- `PYTHONPATH=src pytest tests/test_normalize_weights.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa1b89048321b7088b4748323e43