### PR TITLE
Avoid repeated alias_map iteration in multi_recompute_abs_max

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -256,8 +256,11 @@ def multi_recompute_abs_max(
     """
 
     maxima = {k: 0.0 for k in alias_map}
+    # Micro-optimization: materialize alias_map items once to avoid
+    # repeated dictionary lookups during iteration.
+    items = list(alias_map.items())
     for _, nd in G.nodes(data=True):
-        for key, aliases in alias_map.items():
+        for key, aliases in items:
             val = abs(get_attr(nd, aliases, 0.0))
             if val > maxima[key]:
                 maxima[key] = val


### PR DESCRIPTION
## Summary
- Micro-optimize multi_recompute_abs_max by materializing `alias_map.items()` once
- Iterate over cached items for faster node traversal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1aad0af288321af8435340e360b70