### PR TITLE
Use hexdigest for node checksum and validate cache token

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -167,9 +167,9 @@ def node_set_checksum(
     for digest in _iter_node_digests(node_iterable, presorted=presorted):
         hasher.update(digest)
 
-    digest = hasher.digest()
-    checksum = digest.hex()
-    token = digest[:8].hex()
+    hash_hex = hasher.hexdigest()
+    checksum = hash_hex
+    token = hash_hex[:16]
     if store:
         # Cache the result using a short token to detect unchanged node sets.
         cached = graph.get("_node_set_checksum_cache")

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -73,6 +73,7 @@ def test_node_set_checksum_cache_token_is_prefix(graph_canon):
     token, stored_checksum = G.graph["_node_set_checksum_cache"]
     assert stored_checksum == checksum
     assert token == checksum[:16]
+    assert len(token) == 16
 
 
 def test_node_repr_cache_cleared_on_increment(graph_canon):


### PR DESCRIPTION
## Summary
- compute node set checksum using `hexdigest` and derive token from hex prefix
- test that cache stores token as 16-char prefix of checksum

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1abb3a7f88321adf71cbe0de8aa0e