### PR TITLE
Refactor import prune state and add thread safety test

### DIFF
--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -118,7 +118,7 @@ def test_failure_log_bounded_without_frequent_prune(monkeypatch):
         state.failed.clear()
     monkeypatch.setattr(state, "limit", 3)
     monkeypatch.setattr(import_utils, "_FAILED_IMPORT_PRUNE_INTERVAL", 10.0)
-    monkeypatch.setattr(import_utils, "_LAST_FAILED_IMPORT_PRUNE", 0.0)
+    monkeypatch.setattr(import_utils._IMPORT_STATE, "last_prune", 0.0)
     monkeypatch.setattr(import_utils.time, "monotonic", lambda: 1.0)
 
     calls = {"n": 0}

--- a/tests/test_warn_failure_threadsafe.py
+++ b/tests/test_warn_failure_threadsafe.py
@@ -1,0 +1,41 @@
+import threading
+import warnings
+
+import tnfr.import_utils as import_utils
+from tnfr.import_utils import _WARNED_LOCK, _WARNED_MODULES, _IMPORT_STATE, _warn_failure
+
+
+def test_warn_failure_thread_safety(monkeypatch):
+    """Ensure _warn_failure can run concurrently without races."""
+
+    monkeypatch.setattr(import_utils, "_FAILED_IMPORT_PRUNE_INTERVAL", 0.0)
+
+    with _WARNED_LOCK:
+        _WARNED_MODULES.clear()
+    with _IMPORT_STATE.lock:
+        _IMPORT_STATE.clear()
+        _IMPORT_STATE.last_prune = 0.0
+
+    errors: list[Exception] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                _warn_failure("mod", None, ImportError("boom"))
+        except Exception as e:  # pragma: no cover - should not happen
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    with _WARNED_LOCK:
+        assert len(_WARNED_MODULES) == 1 and "mod" in _WARNED_MODULES
+    assert _IMPORT_STATE.last_prune > 0.0
+

--- a/tests/test_warned_modules_prune.py
+++ b/tests/test_warned_modules_prune.py
@@ -19,7 +19,7 @@ def test_warned_modules_pruning(monkeypatch):
     with _WARNED_LOCK:
         assert "mod" in _WARNED_MODULES
         _WARNED_MODULES["mod"] = time.monotonic() - (_FAILED_IMPORT_MAX_AGE + 1)
-    monkeypatch.setattr(import_utils, "_LAST_FAILED_IMPORT_PRUNE", 0.0)
+    monkeypatch.setattr(import_utils._IMPORT_STATE, "last_prune", 0.0)
     monkeypatch.setattr(import_utils, "_FAILED_IMPORT_PRUNE_INTERVAL", 0.0)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")


### PR DESCRIPTION
## Summary
- track last prune time in _ImportState instead of module global
- update failed import pruning and warning logic to use shared state
- add concurrent warning test to guard against race conditions

## Testing
- `pytest tests/test_import_utils.py tests/test_optional_import.py tests/test_warned_modules_prune.py tests/test_warn_failure_emit.py tests/test_warn_failure_threadsafe.py`
- `pytest` *(fails: LRUCache.__init__() got an unexpected keyword argument 'callback')*


------
https://chatgpt.com/codex/tasks/task_e_68c1adf1d8a8832183661926d21cd205