### PR TITLE
Add dedicated TOML parser helper

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -48,13 +48,16 @@ def _parse_yaml(text: str) -> Any:
     return getattr(yaml, "safe_load", _missing_dependency("pyyaml"))(text)
 
 
+def _parse_toml(text: str) -> Any:
+    """Parse TOML ``text`` using ``tomllib`` or ``tomli``."""
+    return getattr(tomllib, "loads", _missing_dependency("tomllib/tomli"))(text)
+
+
 PARSERS = {
     ".json": json.loads,
     ".yaml": _parse_yaml,
     ".yml": _parse_yaml,
-    ".toml": lambda text: getattr(
-        tomllib, "loads", _missing_dependency("tomllib/tomli")
-    )(text),
+    ".toml": _parse_toml,
 }
 
 

--- a/tests/test_parse_toml.py
+++ b/tests/test_parse_toml.py
@@ -1,0 +1,27 @@
+"""Tests for TOML parser integration with ``read_structured_file``."""
+
+from pathlib import Path
+
+import pytest
+import tnfr.io as io_mod
+from tnfr.io import read_structured_file
+
+
+def test_read_structured_file_invokes_toml_parser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "data.toml"
+    content = "a = 1"
+    path.write_text(content, encoding="utf-8")
+
+    called = {}
+
+    def fake_parse(text: str) -> dict[str, int]:
+        called["text"] = text
+        return {"a": 1}
+
+    monkeypatch.setattr(io_mod, "_parse_toml", fake_parse)
+    monkeypatch.setitem(io_mod.PARSERS, ".toml", fake_parse)
+
+    assert read_structured_file(path) == {"a": 1}
+    assert called["text"] == content


### PR DESCRIPTION
## Summary
- refactor TOML parsing into dedicated `_parse_toml` using `tomllib`/`tomli`
- hook the new parser into `PARSERS`
- test that TOML files invoke the parser

## Testing
- `PYTHONPATH=src pytest tests/test_parse_toml.py tests/test_read_structured_file_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1b0a2e7c08321885b6633770c0a9f