### PR TITLE
Refactor history handling and JSON utilities

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import warnings
 import threading
-from typing import Any, Callable
+from typing import Any, Callable, overload, Literal
 
 from functools import lru_cache
 from .import_utils import optional_import
@@ -48,7 +48,8 @@ def _json_dumps_orjson(
         with _warn_lock:
             if not _ignored_param_warned:
                 warnings.warn(
-                    "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson",
+                    "'ensure_ascii', 'separators', 'cls' and extra kwargs are "
+                    "ignored when using orjson",
                     UserWarning,
                     stacklevel=3,
                 )
@@ -82,6 +83,36 @@ def _json_dumps_std(
     return result if not to_bytes else result.encode("utf-8")
 
 
+@overload
+def json_dumps(
+    obj: Any,
+    *,
+    sort_keys: bool = ...,
+    default: Callable[[Any], Any] | None = ...,
+    ensure_ascii: bool = ...,
+    separators: tuple[str, str] = ...,
+    cls: type[json.JSONEncoder] | None = ...,
+    to_bytes: Literal[True] = ...,
+    **kwargs: Any,
+) -> bytes:
+    ...
+
+
+@overload
+def json_dumps(
+    obj: Any,
+    *,
+    sort_keys: bool = ...,
+    default: Callable[[Any], Any] | None = ...,
+    ensure_ascii: bool = ...,
+    separators: tuple[str, str] = ...,
+    cls: type[json.JSONEncoder] | None = ...,
+    to_bytes: Literal[False],
+    **kwargs: Any,
+) -> str:
+    ...
+
+
 def json_dumps(
     obj: Any,
     *,
@@ -112,7 +143,7 @@ def json_dumps(
             cls=cls,
             to_bytes=to_bytes,
             **kwargs,
-    )
+        )
     return _json_dumps_std(
         obj,
         sort_keys=sort_keys,
@@ -127,4 +158,4 @@ def json_dumps(
 
 def json_dumps_str(obj: Any, **kwargs: Any) -> str:
     """``json_dumps`` wrapper that always returns ``str``."""
-    return json_dumps(obj, to_bytes=False, **kwargs)  # type: ignore[arg-type]
+    return json_dumps(obj, to_bytes=False, **kwargs)

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -20,7 +20,7 @@ from .collections_utils import ensure_collection, MAX_MATERIALIZE_DEFAULT
 from .glyph_history import ensure_history
 
 if TYPE_CHECKING:  # pragma: no cover
-    import networkx as nx  # type: ignore[import-untyped]
+    import networkx as nx  # type: ignore[import-untyped]  # noqa: F401
 
 # Basic types
 Node = Any
@@ -208,27 +208,50 @@ def _flatten_thol(
     stack.append(THOL_SENTINEL)
 
 
-def _flatten_target(item: TARGET, stack: deque[Any], ops: list[tuple[OpTag, Any]], max_materialize: int | None) -> None:
+def _flatten_target(
+    item: TARGET,
+    stack: deque[Any],
+    ops: list[tuple[OpTag, Any]],
+    max_materialize: int | None,
+) -> None:
     ops.append((OpTag.TARGET, item))
 
 
-def _flatten_wait(item: WAIT, stack: deque[Any], ops: list[tuple[OpTag, Any]], max_materialize: int | None) -> None:
+def _flatten_wait(
+    item: WAIT,
+    stack: deque[Any],
+    ops: list[tuple[OpTag, Any]],
+    max_materialize: int | None,
+) -> None:
     steps = max(1, int(getattr(item, "steps", 1)))
     ops.append((OpTag.WAIT, steps))
 
 
-def _flatten_thol_proxy(item: THOL, stack: deque[Any], ops: list[tuple[OpTag, Any]], max_materialize: int | None) -> None:
+def _flatten_thol_proxy(
+    item: THOL,
+    stack: deque[Any],
+    ops: list[tuple[OpTag, Any]],
+    max_materialize: int | None,
+) -> None:
     _flatten_thol(item, stack, max_materialize=max_materialize)
 
 
-def _flatten_glyph(item: Glyph | str, stack: deque[Any], ops: list[tuple[OpTag, Any]], max_materialize: int | None) -> None:
+def _flatten_glyph(
+    item: Glyph | str,
+    stack: deque[Any],
+    ops: list[tuple[OpTag, Any]],
+    max_materialize: int | None,
+) -> None:
     g = item.value if isinstance(item, Glyph) else str(item)
     if g not in GLYPHS_CANONICAL_SET:
         raise ValueError(f"Non-canonical glyph: {g}")
     ops.append((OpTag.GLYPH, g))
 
 
-_TOKEN_DISPATCH: dict[type, Callable[[Any, deque[Any], list[tuple[OpTag, Any]], int | None], None]] = {
+_TOKEN_DISPATCH: dict[
+    type,
+    Callable[[Any, deque[Any], list[tuple[OpTag, Any]], int | None], None],
+] = {
     TARGET: _flatten_target,
     WAIT: _flatten_wait,
     THOL: _flatten_thol_proxy,


### PR DESCRIPTION
## Summary
- add `current_step_idx` helper and use `ensure_history` for glyph event logging
- return copy of default glyph factors to avoid mutation leaks
- improve `json_dumps` overloads and tighten formatting
- fix PEP8 long lines and mark type-only networkx import

## Testing
- `flake8 src/tnfr/operators.py src/tnfr/program.py src/tnfr/json_utils.py src/tnfr/glyph_history.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1b6a4e5c8832186c6dee309cf0515