### PR TITLE
Refactor helpers and metrics utilities

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -82,7 +82,7 @@ def ensure_collection(
     if isinstance(it, Collection) and not isinstance(it, (str, bytes, bytearray)):
         return it
     if isinstance(it, (str, bytes, bytearray)):
-        return cast(Collection[T], (it,))
+        return (cast(T, it),)
 
     # Step 2: validate limit
     limit = _validate_limit(max_materialize)

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -123,16 +123,18 @@ def apply_canonical_clamps(nd: dict[str, Any], G=None, node=None) -> None:
 
     set_attr(nd, ALIAS_EPI, clamp(epi, eps_min, eps_max))
 
-    def _maybe_set(alias, value, setter, **kwargs):
-        if G is not None and node is not None:
-            setter(G, node, value, **kwargs)
-        else:
-            set_attr(nd, alias, value)
+    vf_val = clamp(vf, vf_min, vf_max)
+    if G is not None and node is not None:
+        set_vf(G, node, vf_val, update_max=False)
+    else:
+        set_attr(nd, ALIAS_VF, vf_val)
 
-    _maybe_set(ALIAS_VF, clamp(vf, vf_min, vf_max), set_vf, update_max=False)
     if theta_wrap:
         new_th = (th + math.pi) % (2 * math.pi) - math.pi
-        _maybe_set(ALIAS_THETA, new_th, set_theta)
+        if G is not None and node is not None:
+            set_theta(G, node, new_th)
+        else:
+            set_attr(nd, ALIAS_THETA, new_th)
 
 
 def validate_canon(G) -> None:

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -167,9 +167,8 @@ def node_set_checksum(
     for digest in _iter_node_digests(node_iterable, presorted=presorted):
         hasher.update(digest)
 
-    hash_hex = hasher.hexdigest()
-    checksum = hash_hex
-    token = hash_hex[:16]
+    checksum = hasher.hexdigest()
+    token = checksum[:16]
     if store:
         # Cache the result using a short token to detect unchanged node sets.
         cached = graph.get("_node_set_checksum_cache")

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -150,15 +150,16 @@ def neighbor_phase_mean_list(
     :func:`_phase_mean_from_iter` helper which uses a running Kahan
     summation for stable accumulation.
     """
-    deg = len(neigh)
-    if np is not None and deg > 0:
-        pairs = np.fromiter(
-            (c for v in neigh for c in (cos_th[v], sin_th[v])),
-            dtype=float,
-            count=deg * 2,
-        ).reshape(deg, 2)
-        mean_cos, mean_sin = pairs.mean(axis=0)
-        return float(np.arctan2(mean_sin, mean_cos))
+    if np is not None:
+        deg = len(neigh)
+        if deg > 0:
+            pairs = np.fromiter(
+                (c for v in neigh for c in (cos_th[v], sin_th[v])),
+                dtype=float,
+                count=deg * 2,
+            ).reshape(deg, 2)
+            mean_cos, mean_sin = pairs.mean(axis=0)
+            return float(np.arctan2(mean_sin, mean_cos))
     return _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), fallback)
 
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -150,15 +150,11 @@ def wbar(G, window: int | None = None) -> float:
             "history is not a mapping; using instantaneous coherence"
         )
         return compute_coherence(G)
-    cs = hist.get("C_steps", [])
+    cs = list(hist.get("C_steps", []))
     if not cs:
         # fallback: coherencia instantánea
         return compute_coherence(G)
-    if not isinstance(cs, (list, tuple)):
-        cs = list(cs)
-    w = validate_window(
-        get_param(G, "WBAR_WINDOW") if window is None else window,
-        positive=True,
-    )
+    w_param = get_param(G, "WBAR_WINDOW") if window is None else window
+    w = validate_window(w_param, positive=True)
     w = min(len(cs), w)
     return float(statistics.fmean(cs[-w:]))

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -4,7 +4,7 @@ Public exports are declared in ``__all__`` for explicit star imports.
 """
 
 from __future__ import annotations
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, Union
 from dataclasses import dataclass
 from collections import deque
 from collections.abc import Callable, Iterable, Sequence
@@ -19,15 +19,12 @@ from .types import Glyph
 from .collections_utils import ensure_collection, MAX_MATERIALIZE_DEFAULT
 from .glyph_history import ensure_history
 
-if TYPE_CHECKING:  # pragma: no cover
-    import networkx as nx  # type: ignore[import-untyped]  # noqa: F401
-
 # Basic types
 Node = Any
 AdvanceFn = Callable[[Any], None]  # normalmente dynamics.step
 
 HandlerFn = Callable[
-    ["nx.Graph", Any, Optional[list[Node]], deque, Optional[AdvanceFn]],
+    ["networkx.Graph", Any, Optional[list[Node]], deque, Optional[AdvanceFn]],
     Optional[list[Node]],
 ]
 

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -12,6 +12,8 @@ from cachetools import LRUCache, cached
 from .constants import DEFAULTS
 from .helpers.cache import get_graph
 
+MASK64 = 0xFFFFFFFFFFFFFFFF
+
 _RNG_LOCK = threading.Lock()
 _CACHE_MAXSIZE = int(DEFAULTS.get("JITTER_CACHE_SIZE", 128))
 
@@ -19,8 +21,8 @@ _CACHE_MAXSIZE = int(DEFAULTS.get("JITTER_CACHE_SIZE", 128))
 def _seed_hash(seed_int: int, key_int: int) -> int:
     seed_bytes = struct.pack(
         ">QQ",
-        seed_int & 0xFFFFFFFFFFFFFFFF,
-        key_int & 0xFFFFFFFFFFFFFFFF,
+        seed_int & MASK64,
+        key_int & MASK64,
     )
     return int.from_bytes(
         hashlib.blake2b(seed_bytes, digest_size=8).digest(), "big"

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -1,7 +1,8 @@
 """Sense calculations."""
 
 from __future__ import annotations
-from typing import Iterable, TypeVar
+from typing import TypeVar
+from collections.abc import Iterable
 import math
 from collections import Counter
 
@@ -72,12 +73,14 @@ def glyph_unit(g: str) -> complex:
     return _resolve_glyph(g, GLYPH_UNITS)
 
 
+MODE_FUNCS = {
+    "Si": lambda nd: clamp01(get_attr(nd, ALIAS_SI, 0.5)),
+    "EPI": lambda nd: max(0.0, get_attr(nd, ALIAS_EPI, 0.0)),
+}
+
+
 def _weight(nd, mode: str) -> float:
-    if mode == "Si":
-        return clamp01(get_attr(nd, ALIAS_SI, 0.5))
-    if mode == "EPI":
-        return max(0.0, get_attr(nd, ALIAS_EPI, 0.0))
-    return 1.0
+    return MODE_FUNCS.get(mode, lambda _: 1.0)(nd)
 
 
 def _node_weight(nd, weight_mode: str) -> tuple[str, float, complex] | None:
@@ -120,10 +123,8 @@ def _sigma_from_iterable(
     number of processed values under the ``"n"`` key.
     """
 
-    try:
-        iterator = iter(values)
-    except TypeError:
-        iterator = iter([values])
+    iterator = values if isinstance(values, Iterable) else [values]
+    iterator = iter(iterator)
 
     cnt = 0
 

--- a/tests/test_make_rng_threadsafe.py
+++ b/tests/test_make_rng_threadsafe.py
@@ -1,5 +1,4 @@
 import threading
-import threading
 import random
 
 from tnfr import rng as rng_mod


### PR DESCRIPTION
## Summary
- remove unused imports and consolidate threading import
- simplify alias helpers and vector setters using partials and validation
- streamline metrics helpers, observers, RNG and sense utilities

## Testing
- `pyflakes src/tnfr/program.py tests/test_make_rng_threadsafe.py src/tnfr/metrics_utils.py src/tnfr/sense.py src/tnfr/helpers/cache.py src/tnfr/collections_utils.py src/tnfr/helpers/numeric.py src/tnfr/dynamics/__init__.py src/tnfr/rng.py src/tnfr/observers.py`
- `pyflakes src/tnfr/alias.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1bbeaf12083219983995d25f6977a