### PR TITLE
Refine helpers and streamline error handling

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -133,9 +133,8 @@ def normalize_weights(
 ) -> dict[str, float]:
     """Normalize ``keys`` in ``dict_like`` so their sum is 1.
 
-    ``keys`` may be any iterable of strings. Sequences and other collections
-    are used directly while non-collection iterables are materialized.
-    Repeated keys are automatically collapsed preserving their first occurrence.
+    ``keys`` may be any iterable of strings and is materialized once while
+    collapsing repeated entries preserving their first occurrence.
 
     Negative weights are handled according to ``error_on_negative``. When
     ``True`` a :class:`ValueError` is raised. Otherwise negatives are logged,
@@ -144,8 +143,6 @@ def normalize_weights(
     ``warn_once`` is ``True`` warnings for a given key are emitted only on their
     first occurrence across calls.
     """
-    if not isinstance(keys, Collection):
-        keys = list(keys)
     keys = list(dict.fromkeys(keys))
     default_float = float(default)
     if not keys:

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -1,3 +1,5 @@
+"""Helper utilities for caching graph-related data and computations."""
+
 from __future__ import annotations
 
 import hashlib

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -12,28 +12,30 @@ from .import_utils import optional_import
 from .logging_utils import get_logger
 
 
+def _missing_dependency_error(dep: str) -> type[Exception]:
+    """Return a fallback :class:`Exception` when ``dep`` is unavailable."""
+
+    class _MissingDependencyError(Exception):
+        pass
+
+    _MissingDependencyError.__doc__ = f"Fallback error used when {dep} is missing."
+    return _MissingDependencyError
+
+
 tomllib = optional_import("tomllib") or optional_import("tomli")
 if tomllib is not None:
     TOMLDecodeError = getattr(tomllib, "TOMLDecodeError", Exception)
     has_toml = True
 else:  # pragma: no cover - depende de tomllib/tomli
     has_toml = False
-
-    class TOMLDecodeError(Exception):
-        """Fallback error used when tomllib/tomli is missing."""
-
-        pass
+    TOMLDecodeError = _missing_dependency_error("tomllib/tomli")
 
 
 yaml = optional_import("yaml")
 if yaml is not None:
     YAMLError = getattr(yaml, "YAMLError", Exception)
 else:  # pragma: no cover - depende de pyyaml
-
-    class YAMLError(Exception):
-        """Fallback error used when pyyaml is missing."""
-
-        pass
+    YAMLError = _missing_dependency_error("pyyaml")
 
 
 def _missing_dependency(name: str) -> Callable[[str], Any]:

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -159,10 +159,10 @@ def _resolve_edge_ops(graph, strategy, exists_cb, set_cb):
             if hasattr(graph, "add_edge")
             else EdgeStrategy.TNFR
         )
-    try:
-        return _EDGE_OPS[strategy]
-    except KeyError as e:
-        raise ValueError("Unknown edge strategy") from e
+    ops = _EDGE_OPS.get(strategy)
+    if ops is None:
+        raise ValueError("Unknown edge strategy")
+    return ops
 
 
 def add_edge(


### PR DESCRIPTION
## Summary
- document caching and numeric helper modules
- streamline phase mean computation using `kahan_sum2d`
- simplify weight normalization and edge ops lookup
- centralize fallback error classes for optional dependencies

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1c56d123883219d82a711a6f8e5e8