### PR TITLE
refactor: optimize numeric helpers and callbacks

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -190,10 +190,7 @@ def invoke_callbacks(
     )
     if ctx is None:
         ctx = {}
-    err_list = G.graph.get("_callback_errors")
-    if not isinstance(err_list, deque) or err_list.maxlen != _CALLBACK_ERROR_LIMIT:
-        err_list = deque(maxlen=_CALLBACK_ERROR_LIMIT)
-        G.graph["_callback_errors"] = err_list
+    err_list: deque | None = None
     for spec in cbs.values():
         name, fn = spec.name, spec.func
         try:
@@ -202,6 +199,11 @@ def invoke_callbacks(
             logger.exception("callback %r failed for %s: %s", name, event, e)
             if strict:
                 raise
+            if err_list is None:
+                err_list = G.graph.get("_callback_errors")
+                if not isinstance(err_list, deque) or err_list.maxlen != _CALLBACK_ERROR_LIMIT:
+                    err_list = deque(maxlen=_CALLBACK_ERROR_LIMIT)
+                    G.graph["_callback_errors"] = err_list
             err_list.append(
                 {
                     "event": event,

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -135,12 +135,10 @@ def neighbor_phase_mean_list(
     if np is not None:
         deg = len(neigh)
         if deg > 0:
-            pairs = np.fromiter(
-                (c for v in neigh for c in (cos_th[v], sin_th[v])),
-                dtype=float,
-                count=deg * 2,
-            ).reshape(deg, 2)
-            mean_cos, mean_sin = pairs.mean(axis=0)
+            cos_arr = np.fromiter((cos_th[v] for v in neigh), dtype=float, count=deg)
+            sin_arr = np.fromiter((sin_th[v] for v in neigh), dtype=float, count=deg)
+            mean_cos = float(np.mean(cos_arr))
+            mean_sin = float(np.mean(sin_arr))
             return float(np.arctan2(mean_sin, mean_cos))
     return _phase_mean_from_iter(((cos_th[v], sin_th[v]) for v in neigh), fallback)
 

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -48,9 +48,6 @@ def _sigma_fallback(
     return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 
-sigma_vector_from_graph: _SigmaVectorFn = optional_import(
-    "tnfr.sense.sigma_vector_from_graph", fallback=_sigma_fallback
-)
 
 # Public exports for this module
 __all__ = [
@@ -228,6 +225,9 @@ def kuramoto_field(G):
 
 
 def sigma_field(G):
+    sigma_vector_from_graph: _SigmaVectorFn = optional_import(
+        "tnfr.sense.sigma_vector_from_graph", fallback=_sigma_fallback
+    )
     sv = sigma_vector_from_graph(G)
     return {
         "sigma": {


### PR DESCRIPTION
## Summary
- defer sigma vector import to runtime to avoid circular trace-sense import
- vectorize coherence and trig cache helpers and streamline numeric phase mean
- lazily allocate callback error buffer
- handle neighbor phase means for arbitrary node IDs

## Testing
- `PYTHONPATH=src pytest tests/test_import_utils.py::test_optional_import_success_and_failure -q`
- `PYTHONPATH=src pytest tests/test_trig_cache_reuse.py::test_trig_cache_reuse_between_modules -q`
- `PYTHONPATH=src pytest tests/test_neighbor_phase_mean_no_graph.py -q`
- `PYTHONPATH=src pytest tests/test_callback_errors_limit.py -q`
- `PYTHONPATH=src pytest tests/test_register_callback.py -q`
- `PYTHONPATH=src pytest tests/test_invoke_callbacks.py -q`
- `PYTHONPATH=src pytest tests/test_compute_coherence.py -q`
- `PYTHONPATH=src pytest tests/test_sense.py -q`
- `PYTHONPATH=src pytest tests/test_compute_Si_numpy_usage.py -q`
- `PYTHONPATH=src pytest tests/test_si_helpers.py -q`
- `PYTHONPATH=src pytest tests/test_neighbor_phase_mean_performance.py -q -m slow`


------
https://chatgpt.com/codex/tasks/task_e_68c1c85475c08321b0fd9c51a8d169a0