### PR TITLE
Refine initialization and error handling across modules

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -10,8 +10,8 @@ from collections.abc import Callable, Mapping, Sequence
 
 import traceback
 from .logging_utils import get_logger
-
 from .constants import DEFAULTS
+
 from .trace import CallbackSpec
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -195,7 +195,7 @@ def invoke_callbacks(
         name, fn = spec.name, spec.func
         try:
             fn(G, ctx)
-        except Exception as e:  # catch all callback errors
+        except (RuntimeError, ValueError, TypeError) as e:  # catch expected callback errors
             logger.exception("callback %r failed for %s: %s", name, event, e)
             if strict:
                 raise
@@ -214,3 +214,8 @@ def invoke_callbacks(
                     "name": name,
                 }
             )
+        except Exception:
+            logger.exception(
+                "callback %r raised unexpected exception for %s", name, event
+            )
+            raise

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1,3 +1,10 @@
+"""ΔNFR (dynamic network field response) utilities and strategies.
+
+This module provides helper functions to configure, cache and apply ΔNFR
+components such as phase, epidemiological state and vortex fields during
+simulations.
+"""
+
 from __future__ import annotations
 
 import math

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -39,7 +39,7 @@ __all__ = [
 
 @lru_cache(maxsize=1)
 def _default_gamma_spec() -> tuple[bytes, str]:
-    dumped = json_dumps(DEFAULT_GAMMA, sort_keys=True)
+    dumped = json_dumps(DEFAULT_GAMMA, sort_keys=True, to_bytes=True)
     hash_ = hashlib.blake2b(dumped, digest_size=16).hexdigest()
     return dumped, hash_
 
@@ -127,7 +127,7 @@ def _cache_gamma_spec(
             _, cur_hash = _default_gamma_spec()
     else:
         if cur_hash is None:
-            dumped = json_dumps(spec, sort_keys=True)
+            dumped = json_dumps(spec, sort_keys=True, to_bytes=True)
             cur_hash = hashlib.blake2b(dumped, digest_size=16).hexdigest()
     if cached is not None and prev_hash == cur_hash:
         return cached

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -371,7 +371,7 @@ def edge_version_cache(
     # Execute builder without holding the lock to avoid blocking other threads.
     try:
         value = builder()
-    except Exception as exc:  # pragma: no cover - logging side effect
+    except (RuntimeError, ValueError) as exc:  # pragma: no cover - logging side effect
         logger.exception("edge_version_cache builder failed for %r: %s", key, exc)
         raise
     else:

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -121,15 +121,16 @@ def json_dumps(
     ensure_ascii: bool = True,
     separators: tuple[str, str] = (",", ":"),
     cls: type[json.JSONEncoder] | None = None,
-    to_bytes: bool = True,
+    to_bytes: bool = False,
     **kwargs: Any,
 ) -> bytes | str:
     """Serialize ``obj`` to JSON using ``orjson`` when available.
 
-    When :mod:`orjson` is used, the ``ensure_ascii``, ``separators``, ``cls``
-    and any additional keyword arguments are ignored because they are not
-    supported by :func:`orjson.dumps`. A warning is emitted only the first time
-    such ignored parameters are detected.
+    Returns a ``str`` by default. Pass ``to_bytes=True`` to obtain a ``bytes``
+    result. When :mod:`orjson` is used, the ``ensure_ascii``, ``separators``,
+    ``cls`` and any additional keyword arguments are ignored because they are
+    not supported by :func:`orjson.dumps`. A warning is emitted only the first
+    time such ignored parameters are detected.
     """
     orjson = _load_orjson()
     if orjson is not None:

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -48,31 +48,34 @@ def preparar_red(
             "PHASE_HISTORY_MAXLEN", METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"]
         )
     )
-    G.graph.setdefault(
-        "history",
+    hist_keys = [
+        "C_steps",
+        "stable_frac",
+        "phase_sync",
+        "kuramoto_R",
+        "sense_sigma_x",
+        "sense_sigma_y",
+        "sense_sigma_mag",
+        "sense_sigma_angle",
+        "iota",
+        "glyph_load_estab",
+        "glyph_load_disr",
+        "Si_mean",
+        "Si_hi_frac",
+        "Si_lo_frac",
+        "W_bar",
+        "phase_kG",
+        "phase_kL",
+    ]
+    history = {k: [] for k in hist_keys}
+    history.update(
         {
-            "C_steps": [],
-            "stable_frac": [],
-            "phase_sync": [],
-            "kuramoto_R": [],
-            "sense_sigma_x": [],
-            "sense_sigma_y": [],
-            "sense_sigma_mag": [],
-            "sense_sigma_angle": [],
-            "iota": [],
-            "glyph_load_estab": [],
-            "glyph_load_disr": [],
-            "Si_mean": [],
-            "Si_hi_frac": [],
-            "Si_lo_frac": [],
-            "W_bar": [],
-            "phase_kG": [],
-            "phase_kL": [],
             "phase_state": deque(maxlen=ph_len),
             "phase_R": deque(maxlen=ph_len),
             "phase_disr": deque(maxlen=ph_len),
-        },
+        }
     )
+    G.graph.setdefault("history", history)
     # REMESH_TAU: alias legado resuelto por ``get_param``
     tau = int(get_param(G, "REMESH_TAU_GLOBAL"))
     maxlen = max(2 * tau + 5, 64)

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -15,7 +15,7 @@ Note on REMESH α (alpha) precedence:
 
 # operators.py — TNFR canónica (ASCII-safe)
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING, Optional
+from typing import Any, TYPE_CHECKING
 import math
 import hashlib
 import heapq
@@ -256,7 +256,7 @@ def _determine_dominant(
     Falls back to ``default_kind`` when neighbours lack ``epi_kind``.
     """
 
-    best_kind: Optional[str] = None
+    best_kind: str | None = None
     best_abs = 0.0
     for v in neigh:
         abs_v = abs(v.EPI)
@@ -553,7 +553,7 @@ _NAME_TO_OP = {
 
 
 def apply_glyph_obj(
-    node: NodoProtocol, glyph: Glyph | str, *, window: Optional[int] = None
+    node: NodoProtocol, glyph: Glyph | str, *, window: int | None = None
 ) -> None:
     """Apply ``glyph`` to an object satisfying :class:`NodoProtocol`."""
 
@@ -587,7 +587,7 @@ def apply_glyph_obj(
 
 
 def apply_glyph(
-    G, n, glyph: Glyph | str, *, window: Optional[int] = None
+    G, n, glyph: Glyph | str, *, window: int | None = None
 ) -> None:
     """Adapter to operate on ``networkx`` graphs."""
     NodoNX = import_nodonx()
@@ -843,11 +843,11 @@ def _community_remesh(
 
 def apply_topological_remesh(
     G,
-    mode: Optional[str] = None,
+    mode: str | None = None,
     *,
-    k: Optional[int] = None,
+    k: int | None = None,
     p_rewire: float = 0.2,
-    seed: Optional[int] = None,
+    seed: int | None = None,
 ) -> None:
     """Approximate topological remeshing.
 
@@ -935,7 +935,7 @@ def _extra_gating_ok(hist, cfg, w_estab):
 
 
 def apply_remesh_if_globally_stable(
-    G, pasos_estables_consecutivos: Optional[int] = None
+    G, pasos_estables_consecutivos: int | None = None
 ) -> None:
     params = [
         (

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -21,7 +21,7 @@ def test_json_dumps_without_orjson(monkeypatch):
     _reset_json_utils(monkeypatch, None)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = json_utils.json_dumps({"a": 1}, ensure_ascii=False)
+        result = json_utils.json_dumps({"a": 1}, ensure_ascii=False, to_bytes=True)
     assert result == b'{"a":1}'
     assert w == []
 


### PR DESCRIPTION
## Summary
- Document ΔNFR utilities module for clarity
- Streamline history initialization and type hints
- Tighten callback and cache error handling and switch `json_dumps` to return strings by default

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd0288f483219e500f8b9fece9a4