### PR TITLE
Document constants and remove unused EPI_MAX_GLOBAL

### DIFF
--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -21,12 +21,17 @@ SELECTOR_THRESHOLD_DEFAULTS: Mapping[str, float] = MappingProxyType(
 
 @dataclass(frozen=True)
 class CoreDefaults:
+    """Default parameters for the core engine.
+
+    The fields are exported via :data:`CORE_DEFAULTS` and may therefore appear
+    unused to static analysis tools such as Vulture.
+    """
+
     DT: float = 1.0
     INTEGRATOR_METHOD: str = "euler"
     DT_MIN: float = 0.1
     EPI_MIN: float = -1.0
     EPI_MAX: float = 1.0
-    EPI_MAX_GLOBAL: float = 1.0
     VF_MIN: float = 0.0
     VF_MAX: float = 1.0
     THETA_WRAP: bool = True
@@ -121,6 +126,12 @@ class CoreDefaults:
 
 @dataclass(frozen=True)
 class RemeshDefaults:
+    """Default parameters for the remeshing subsystem.
+
+    As with :class:`CoreDefaults`, the fields are exported via
+    :data:`REMESH_DEFAULTS` and may look unused to static analysers.
+    """
+
     EPS_DNFR_STABLE: float = 1e-3
     EPS_DEPI_STABLE: float = 1e-3
     FRACTION_STABLE_REMESH: float = 0.80

--- a/src/tnfr/constants/init.py
+++ b/src/tnfr/constants/init.py
@@ -8,6 +8,12 @@ import math
 
 @dataclass(frozen=True)
 class InitDefaults:
+    """Default parameters for node initialisation.
+
+    The fields are collected into :data:`INIT_DEFAULTS` and may therefore
+    appear unused to tools like Vulture.
+    """
+
     INIT_RANDOM_PHASE: bool = True
     INIT_THETA_MIN: float = -math.pi
     INIT_THETA_MAX: float = math.pi

--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -9,6 +9,12 @@ from types import MappingProxyType
 
 @dataclass(frozen=True)
 class MetricDefaults:
+    """Default parameters for metric computation.
+
+    The fields are gathered into :data:`METRIC_DEFAULTS` and exposed through
+    read-only views below, so they may appear unused to static analysis tools.
+    """
+
     PHASE_HISTORY_MAXLEN: int = 50
     STOP_EARLY: dict[str, Any] = field(
         default_factory=lambda: {


### PR DESCRIPTION
## Summary
- clarify that default constant dataclasses are consumed via mapping dictionaries
- drop unused `EPI_MAX_GLOBAL` constant from core defaults

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1d19b33cc8321b02473f3b78cfd61