### PR TITLE
refactor: drop _ensure_edge_cache helper

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -293,13 +293,6 @@ def _maybe_init_edge_cache(
     return cache
 
 
-def _ensure_edge_cache(
-    graph: Any, locks: dict, max_entries: int | None
-) -> dict | LRUCache:
-    """Return cache mapping for edge data, initializing when needed."""
-    return _maybe_init_edge_cache(graph, locks, max_entries)
-
-
 def _get_edge_cache(
     graph: Any, max_entries: int | None, *, create: bool = True
 ):


### PR DESCRIPTION
## Summary
- remove obsolete `_ensure_edge_cache`
- directly rely on `_maybe_init_edge_cache` in edge cache retrieval

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1d63993448321985bf6a8bf31b40e