### PR TITLE
refactor: remove unused edge weight accessor

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -260,10 +260,6 @@ class NodoTNFR:
     def has_edge(self, other: "NodoTNFR") -> bool:
         return other in self._neighbors
 
-    def edge_weight(self, other: "NodoTNFR") -> float:
-        """Return the edge weight towards ``other`` or ``0.0`` if absent."""
-        return self._neighbors.get(other, 0.0)
-
     def add_edge(
         self,
         other: "NodoTNFR",

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -11,8 +11,8 @@ def test_add_edge_stores_weight():
     a.add_edge(b, weight=2.5)
     assert a.has_edge(b)
     assert b.has_edge(a)
-    assert math.isclose(a.edge_weight(b), 2.5)
-    assert math.isclose(b.edge_weight(a), 2.5)
+    assert math.isclose(a._neighbors[b], 2.5)
+    assert math.isclose(b._neighbors[a], 2.5)
 
 
 def test_add_edge_stores_weight_nx(graph_canon):
@@ -29,7 +29,7 @@ def test_missing_edge_returns_zero():
     a = NodoTNFR()
     b = NodoTNFR()
     assert not a.has_edge(b)
-    assert a.edge_weight(b) == 0.0
+    assert a._neighbors.get(b, 0.0) == 0.0
 
 
 def test_add_edge_preserves_weight_by_default():
@@ -37,8 +37,8 @@ def test_add_edge_preserves_weight_by_default():
     b = NodoTNFR()
     a.add_edge(b, weight=1.0)
     a.add_edge(b, weight=2.0)
-    assert math.isclose(a.edge_weight(b), 1.0)
-    assert math.isclose(b.edge_weight(a), 1.0)
+    assert math.isclose(a._neighbors[b], 1.0)
+    assert math.isclose(b._neighbors[a], 1.0)
 
 
 def test_add_edge_preserves_weight_by_default_nx(graph_canon):
@@ -56,8 +56,8 @@ def test_add_edge_overwrite():
     b = NodoTNFR()
     a.add_edge(b, weight=1.0)
     a.add_edge(b, weight=2.0, overwrite=True)
-    assert math.isclose(a.edge_weight(b), 2.0)
-    assert math.isclose(b.edge_weight(a), 2.0)
+    assert math.isclose(a._neighbors[b], 2.0)
+    assert math.isclose(b._neighbors[a], 2.0)
 
 
 def test_add_edge_overwrite_nx(graph_canon):
@@ -96,8 +96,8 @@ def test_add_edge_rejects_negative_weight_existing_edge():
     a.add_edge(b, weight=1.0)
     with pytest.raises(ValueError):
         a.add_edge(b, weight=-2.0)
-    assert math.isclose(a.edge_weight(b), 1.0)
-    assert math.isclose(b.edge_weight(a), 1.0)
+    assert math.isclose(a._neighbors[b], 1.0)
+    assert math.isclose(b._neighbors[a], 1.0)
 
 
 def test_add_edge_rejects_negative_weight_existing_edge_nx(graph_canon):


### PR DESCRIPTION
## Summary
- remove the unused `edge_weight` method from `NodoTNFR`
- access neighbor weights directly in tests

## Testing
- `ruff check`
- `PYTHONPATH=src pytest tests/test_node_weights.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d71c51288321bac1465d1f6fe316