### PR TITLE
Expose topological remeshing operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ npm install
 * `gradient(state) → ΔNFR`: local demand for reorganization (high = risk of collapse/bifurcation).
 * `sense_index(traj) → Si`: proxy for **structural sense** (capacity to generate shared coherence) combining **νf**, phase, and topology.
 
+## Topological remeshing
+
+Use ``apply_topological_remesh`` to reorganize connectivity based on nodal
+EPI similarity while preserving graph connectivity. Modes:
+
+- ``"knn"`` – connect each node to its ``k`` nearest neighbours (with optional
+  rewiring).
+- ``"mst"`` – retain only a minimum spanning tree.
+- ``"community"`` – collapse modular communities and reconnect them by
+  similarity.
+
+All modes ensure connectivity by adding a base MST.
+
 ---
 
 ## History configuration

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -17,6 +17,7 @@ from .dynamics import step, run
 from .ontosim import preparar_red
 from .structural import create_nfr
 from .types import NodeState
+from .operators import apply_topological_remesh
 
 # re-exported for tests
 from .trace import CallbackSpec  # noqa: F401
@@ -60,5 +61,6 @@ __all__ = [
     "preparar_red",
     "create_nfr",
     "NodeState",
+    "apply_topological_remesh",
     "CallbackSpec",
 ]

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -4,8 +4,8 @@ This module implements:
 - The 13 glyphs as smooth local operators.
 - A dispatcher ``apply_glyph`` that maps the glyph name (with typographic
   apostrophe) to its function.
-- Network remeshing: ``apply_network_remesh`` and
-  ``apply_remesh_if_globally_stable``.
+- Network remeshing: ``apply_network_remesh``,
+  ``apply_topological_remesh`` and ``apply_remesh_if_globally_stable``.
 
 Note on REMESH α (alpha) precedence:
 1) ``G.graph["GLYPH_FACTORS"]["REMESH_alpha"]``
@@ -66,6 +66,7 @@ __all__ = [
     "apply_glyph_obj",
     "apply_glyph",
     "apply_network_remesh",
+    "apply_topological_remesh",
     "apply_remesh_if_globally_stable",
 ]
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -11,6 +11,7 @@ def test_public_exports():
         "create_nfr",
         "NodeState",
         "CallbackSpec",
+        "apply_topological_remesh",
     }
     assert set(tnfr.__all__) == expected
 
@@ -25,5 +26,5 @@ def test_basic_flow():
     assert isinstance(tnfr.NodeState(), tnfr.NodeState)
 
 
-def test_removed_name():
-    assert not hasattr(tnfr, "apply_topological_remesh")
+def test_topological_remesh_exported():
+    assert hasattr(tnfr, "apply_topological_remesh")

--- a/tests/test_topological_remesh.py
+++ b/tests/test_topological_remesh.py
@@ -1,9 +1,8 @@
 """Pruebas de remeshing topológico."""
-
 import networkx as nx
 
 from tnfr.constants import inject_defaults
-from tnfr.operators import apply_topological_remesh
+from tnfr import apply_topological_remesh
 
 
 def _graph_with_epi(graph_canon, n=6):


### PR DESCRIPTION
## Summary
- expose `apply_topological_remesh` as part of the public API
- document topological remeshing modes in README
- test that `apply_topological_remesh` is exported

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d7b8e5e48321b3f33cc530380b6f