### PR TITLE
Expose run_sequence via public API

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -7,7 +7,7 @@ example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or
 
 - ``step`` and ``run`` in :mod:`tnfr.dynamics`
 - ``preparar_red`` in :mod:`tnfr.ontosim`
-- ``create_nfr`` in :mod:`tnfr.structural`
+- ``create_nfr`` and ``run_sequence`` in :mod:`tnfr.structural`
 - ``NodeState`` in :mod:`tnfr.types`
 """
 
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from .dynamics import step, run
 from .ontosim import preparar_red
-from .structural import create_nfr
+from .structural import create_nfr, run_sequence
 from .types import NodeState
 from .operators import apply_topological_remesh
 
@@ -60,6 +60,7 @@ __all__ = [
     "run",
     "preparar_red",
     "create_nfr",
+    "run_sequence",
     "NodeState",
     "apply_topological_remesh",
     "CallbackSpec",

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -2,6 +2,7 @@
 
 import networkx as nx
 
+from tnfr import run_sequence
 from tnfr.structural import (
     create_nfr,
     Emision,
@@ -11,7 +12,6 @@ from tnfr.structural import (
     Silencio,
     Autoorganizacion,
     validate_sequence,
-    run_sequence,
 )
 from tnfr.constants import EPI_PRIMARY
 


### PR DESCRIPTION
## Summary
- Export `run_sequence` from top-level package
- Cover `run_sequence` via public API in tests

## Testing
- `/usr/local/bin/pytest tests/test_structural.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1d910aaa483218a5950a4dc4d101b