### PR TITLE
refactor: remove deprecated get_rng alias

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -56,9 +56,6 @@ def make_rng(seed: int, key: int) -> random.Random:
     key_int = int(key)
     return random.Random(_seed_hash_for(seed_int, key_int))
 
-# Backwards compatibility alias
-get_rng = make_rng
-
 
 def clear_rng_cache() -> None:
     """Clear cached seed hashes."""


### PR DESCRIPTION
## Summary
- remove obsolete get_rng alias

## Testing
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68c1da4545f88321a4f5556e94f50f3b