### PR TITLE
Avoid materializing string histories before collection check

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -44,13 +44,12 @@ def validate_window(window: int, *, positive: bool = False) -> int:
 
 def _normalize_history_input(hist: Any) -> Iterable[Any]:
     """Normalise ``hist`` to an iterable excluding strings/bytes."""
-    try:
-        seq = ensure_collection(hist, max_materialize=None)
-    except TypeError:
-        return ()
     if isinstance(hist, (str, bytes, bytearray)):
         return ()
-    return seq
+    try:
+        return ensure_collection(hist, max_materialize=None)
+    except TypeError:
+        return ()
 
 
 def _ensure_glyph_history(


### PR DESCRIPTION
## Summary
- Check for string and byte inputs in `glyph_history._normalize_history_input` before calling `ensure_collection`
- Simplify normalization to skip unnecessary materialization

## Testing
- `ruff check`
- `PYTHONPATH=src pytest tests/test_history.py tests/test_push_glyph.py tests/test_recent_glyph.py tests/test_history_maxlen.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1dadc962083218db07faba98f8d12