### PR TITLE
Optimize node checksum hashing

### DIFF
--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -86,7 +86,8 @@ def test_node_repr_cache_cleared_on_increment(graph_canon):
 
 def test_hash_node_cache_cleared_on_increment(graph_canon):
     nxG = graph_canon()
-    _hash_node(("foo", 1))
+    obj = ("foo", 1)
+    _hash_node(obj, _node_repr(obj))
     assert _hash_node.cache_info().currsize > 0
     increment_edge_version(nxG)
     assert _hash_node.cache_info().currsize == 0
@@ -94,7 +95,6 @@ def test_hash_node_cache_cleared_on_increment(graph_canon):
 
 def test_hash_node_matches_manual():
     obj = ("a", 1)
-    manual = hashlib.blake2b(
-        _node_repr(obj).encode("utf-8"), digest_size=16
-    ).digest()
-    assert _hash_node(obj) == manual
+    obj_repr = _node_repr(obj)
+    manual = hashlib.blake2b(obj_repr.encode("utf-8"), digest_size=16).digest()
+    assert _hash_node(obj, obj_repr) == manual

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,6 +9,7 @@ def test_public_exports():
         "run",
         "preparar_red",
         "create_nfr",
+        "run_sequence",
         "NodeState",
         "CallbackSpec",
         "apply_topological_remesh",


### PR DESCRIPTION
## Summary
- Allow `_hash_node` to take an optional precomputed representation
- Sort `(repr, node)` pairs in `_iter_node_digests` and pass representations to `_hash_node`
- Adjust checksum and public API tests for the new hashing signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1de5b03ac8321b85c8a352e1a5fca