### PR TITLE
Refactor JSON dumps parameter handling

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -10,6 +10,7 @@ import warnings
 import threading
 from typing import Any, Callable, overload, Literal
 
+from dataclasses import dataclass
 from functools import lru_cache
 from .import_utils import optional_import
 
@@ -25,23 +26,27 @@ def _load_orjson() -> Any | None:
     return optional_import("orjson")
 
 
+@dataclass
+class JsonDumpsParams:
+    sort_keys: bool
+    default: Callable[[Any], Any] | None
+    ensure_ascii: bool
+    separators: tuple[str, str]
+    cls: type[json.JSONEncoder] | None
+    to_bytes: bool
+
+
 def _json_dumps_orjson(
     orjson: Any,
     obj: Any,
-    *,
-    sort_keys: bool,
-    default: Callable[[Any], Any] | None,
-    ensure_ascii: bool,
-    separators: tuple[str, str],
-    cls: type[json.JSONEncoder] | None,
-    to_bytes: bool,
+    params: JsonDumpsParams,
     **kwargs: Any,
 ) -> bytes | str:
     """Serialize using :mod:`orjson` and warn about unsupported parameters."""
     if (
-        ensure_ascii is not True
-        or separators != (",", ":")
-        or cls is not None
+        params.ensure_ascii is not True
+        or params.separators != (",", ":")
+        or params.cls is not None
         or kwargs
     ):
         global _ignored_param_warned
@@ -54,33 +59,27 @@ def _json_dumps_orjson(
                     stacklevel=3,
                 )
                 _ignored_param_warned = True
-    option = orjson.OPT_SORT_KEYS if sort_keys else 0
-    data = orjson.dumps(obj, option=option, default=default)
-    return data if to_bytes else data.decode("utf-8")
+    option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
+    data = orjson.dumps(obj, option=option, default=params.default)
+    return data if params.to_bytes else data.decode("utf-8")
 
 
 def _json_dumps_std(
     obj: Any,
-    *,
-    sort_keys: bool,
-    default: Callable[[Any], Any] | None,
-    ensure_ascii: bool,
-    separators: tuple[str, str],
-    cls: type[json.JSONEncoder] | None,
-    to_bytes: bool,
+    params: JsonDumpsParams,
     **kwargs: Any,
 ) -> bytes | str:
     """Serialize using the standard library :func:`json.dumps`."""
     result = json.dumps(
         obj,
-        sort_keys=sort_keys,
-        ensure_ascii=ensure_ascii,
-        separators=separators,
-        cls=cls,
-        default=default,
+        sort_keys=params.sort_keys,
+        ensure_ascii=params.ensure_ascii,
+        separators=params.separators,
+        cls=params.cls,
+        default=params.default,
         **kwargs,
     )
-    return result if not to_bytes else result.encode("utf-8")
+    return result if not params.to_bytes else result.encode("utf-8")
 
 
 @overload
@@ -132,29 +131,18 @@ def json_dumps(
     not supported by :func:`orjson.dumps`. A warning is emitted only the first
     time such ignored parameters are detected.
     """
-    orjson = _load_orjson()
-    if orjson is not None:
-        return _json_dumps_orjson(
-            orjson,
-            obj,
-            sort_keys=sort_keys,
-            default=default,
-            ensure_ascii=ensure_ascii,
-            separators=separators,
-            cls=cls,
-            to_bytes=to_bytes,
-            **kwargs,
-        )
-    return _json_dumps_std(
-        obj,
+    params = JsonDumpsParams(
         sort_keys=sort_keys,
         default=default,
         ensure_ascii=ensure_ascii,
         separators=separators,
         cls=cls,
         to_bytes=to_bytes,
-        **kwargs,
     )
+    orjson = _load_orjson()
+    if orjson is not None:
+        return _json_dumps_orjson(orjson, obj, params, **kwargs)
+    return _json_dumps_std(obj, params, **kwargs)
 
 
 def json_dumps_str(obj: Any, **kwargs: Any) -> str:

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -1,4 +1,5 @@
 import warnings
+from dataclasses import is_dataclass
 
 import tnfr.json_utils as json_utils
 
@@ -33,3 +34,31 @@ def test_json_dumps_with_orjson_warns(monkeypatch):
         json_utils.json_dumps({"a": 1}, ensure_ascii=False)
     assert len(w) == 1
     assert "ignored" in str(w[0].message)
+
+
+def test_params_passed_to_std(monkeypatch):
+    _reset_json_utils(monkeypatch, None)
+
+    captured = {}
+
+    def fake_std(obj, params, **kwargs):
+        captured["params"] = params
+        return b"{}"
+
+    monkeypatch.setattr(json_utils, "_json_dumps_std", fake_std)
+    json_utils.json_dumps({"a": 1})
+    assert is_dataclass(captured["params"])
+
+
+def test_params_passed_to_orjson(monkeypatch):
+    _reset_json_utils(monkeypatch, DummyOrjson())
+
+    captured = {}
+
+    def fake_orjson(orjson_mod, obj, params, **kwargs):
+        captured["params"] = params
+        return b"{}"
+
+    monkeypatch.setattr(json_utils, "_json_dumps_orjson", fake_orjson)
+    json_utils.json_dumps({"a": 1})
+    assert is_dataclass(captured["params"])


### PR DESCRIPTION
## Summary
- centralize JSON dump options in new `JsonDumpsParams` dataclass
- update serializers to accept the params structure
- add tests ensuring params are passed for orjson and stdlib paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e028511c8321a4aa81a268463b9a