### PR TITLE
Handle missing trig data in neighbor phase mean

### DIFF
--- a/tests/test_neighbor_phase_mean_missing_trig.py
+++ b/tests/test_neighbor_phase_mean_missing_trig.py
@@ -1,0 +1,15 @@
+import math
+import pytest
+
+from tnfr.helpers.numeric import neighbor_phase_mean_list
+
+
+def test_neighbor_phase_mean_list_missing_trig():
+    neigh = [1, 2, 3]
+    cos_th = {1: 1.0, 2: 0.0}
+    sin_th = {1: 0.0, 2: 1.0}
+
+    angle = neighbor_phase_mean_list(neigh, cos_th, sin_th, fallback=0.5)
+    assert angle == pytest.approx(math.pi / 4)
+
+    assert neighbor_phase_mean_list([3], cos_th, sin_th, fallback=0.5) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- ignore missing trig data when averaging neighbour phases
- ensure fallback is used when all neighbours lack trig values
- test neighbor phase mean with absent trig entries

## Testing
- `PYTHONPATH=src pytest tests/test_neighbor_phase_mean_missing_trig.py tests/test_trig_cache_reuse.py tests/test_neighbor_phase_mean_no_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e2503c788321b59cc9ce473ca55e