### PR TITLE
Cleanup unused locks for unbounded edge cache

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -318,9 +318,10 @@ def _get_edge_cache(
         else:
             locks = graph.get("_edge_version_cache_locks")
             cache = graph.get("_edge_version_cache")
-        if isinstance(cache, dict) and isinstance(locks, dict):
+        if max_entries is None and isinstance(locks, dict):
+            cache_keys = cache.keys() if isinstance(cache, dict) else ()
             for key in list(locks.keys()):
-                if key not in cache:
+                if key not in cache_keys:
                     locks.pop(key, None)
     return cache, locks
 

--- a/tests/test_edge_version_cache_locks.py
+++ b/tests/test_edge_version_cache_locks.py
@@ -7,3 +7,16 @@ def test_edge_version_cache_prunes_locks(graph_canon):
         edge_version_cache(G, str(i), lambda i=i: i, max_entries=2)
     locks = G.graph["_edge_version_cache_locks"]
     assert len(locks) <= 2
+
+
+def test_edge_version_cache_lock_cleanup_unbounded(graph_canon):
+    G = graph_canon()
+    edge_version_cache(G, "a", lambda: 1, max_entries=None)
+    edge_version_cache(G, "b", lambda: 2, max_entries=None)
+    cache = G.graph["_edge_version_cache"]
+    locks = G.graph["_edge_version_cache_locks"]
+    cache.pop("a")
+    assert "a" in locks
+    edge_version_cache(G, "c", lambda: 3, max_entries=None)
+    assert "a" not in locks
+    assert set(locks) == set(cache)


### PR DESCRIPTION
## Summary
- remove leftover locks when edge cache is unbounded
- test lock cleanup for unlimited edge_version_cache

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e466988c8321a90f63b3aa4b45ee