### PR TITLE
Refactor list_mean for manual accumulation

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -37,10 +37,14 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Return the arithmetic mean of ``xs`` or ``default`` if empty."""
-    try:
-        return float(fmean(xs))
-    except (StatisticsError, ValueError, TypeError):
-        return float(default)
+    total = 0.0
+    count = 0
+    for x in xs:
+        total = math.fsum((total, float(x)))
+        count += 1
+    if count:
+        return total / count
+    return float(default)
 
 
 def kahan_sum_nd(values: Iterable[Sequence[float]], dims: int) -> tuple[float, ...]:


### PR DESCRIPTION
## Summary
- Replace list_mean's fmean-based implementation with manual accumulation using math.fsum
- Return the default value when no items are provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e467ad5083218115b36a55c911ba