### PR TITLE
Use slots in JsonDumpsParams

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -26,7 +26,7 @@ def _load_orjson() -> Any | None:
     return optional_import("orjson")
 
 
-@dataclass
+@dataclass(slots=True)
 class JsonDumpsParams:
     sort_keys: bool
     default: Callable[[Any], Any] | None


### PR DESCRIPTION
## Summary
- declare JsonDumpsParams with dataclass slots to prevent dynamic attributes

## Testing
- `pytest tests/test_json_utils.py tests/test_json_utils_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1e46abfdc83219ef3ec87845925ce