### PR TITLE
Enable slots for all dataclasses

### DIFF
--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -19,7 +19,7 @@ SELECTOR_THRESHOLD_DEFAULTS: Mapping[str, float] = MappingProxyType(
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CoreDefaults:
     """Default parameters for the core engine.
 
@@ -124,7 +124,7 @@ class CoreDefaults:
     HISTORY_COMPACT_EVERY: int = 100
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RemeshDefaults:
     """Default parameters for the remeshing subsystem.
 

--- a/src/tnfr/constants/init.py
+++ b/src/tnfr/constants/init.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, asdict
 import math
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class InitDefaults:
     """Default parameters for node initialisation.
 

--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -7,7 +7,7 @@ from typing import Any
 from types import MappingProxyType
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MetricDefaults:
     """Default parameters for metric computation.
 

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -26,7 +26,7 @@ def _load_orjson() -> Any | None:
     return optional_import("orjson")
 
 
-@dataclass
+@dataclass(slots=True)
 class JsonDumpsParams:
     sort_keys: bool
     default: Callable[[Any], Any] | None

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -113,7 +113,7 @@ class EdgeOps(Protocol):
     def set(self, graph, n1, n2, w: float) -> None: ...
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class NXEdgeOps:
     def exists(self, graph, n1, n2):
         return graph.has_edge(n1, n2)
@@ -122,7 +122,7 @@ class NXEdgeOps:
         graph.add_edge(n1, n2, weight=w)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TNFREdgeOps:
     def exists(self, graph, n1, n2):
         return n2 in n1._neighbors
@@ -132,7 +132,7 @@ class TNFREdgeOps:
         n2._neighbors[n1] = w
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _CallbackEdgeOps:
     exists_cb: Callable
     set_cb: Callable

--- a/tests/test_is_immutable.py
+++ b/tests/test_is_immutable.py
@@ -56,7 +56,7 @@ def test_is_immutable_inner_handles_bytearray_tag():
     assert not _is_immutable_inner(frozen)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FrozenDC:
     x: int
     y: int
@@ -66,7 +66,7 @@ def test_is_immutable_frozen_dataclass():
     assert _is_immutable(FrozenDC(1, 2))
 
 
-@dataclass
+@dataclass(slots=True)
 class MutableDC:
     items: list[int]
 


### PR DESCRIPTION
## Summary
- add `slots=True` to every dataclass in the codebase
- verify default constant dictionaries generated via `asdict`
- update related tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e46e3ecc8321b3880277a9ab27e5