### PR TITLE
Add module-level logging configuration flag

### DIFF
--- a/tests/test_logging_threadsafe.py
+++ b/tests/test_logging_threadsafe.py
@@ -1,16 +1,17 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
 
-from tnfr.logging_utils import get_logger
+import tnfr.logging_utils as logging_utils
 
 
 def _worker():
-    get_logger("test_logger")
+    logging_utils.get_logger("test_logger")
 
 
 def test_get_logger_threadsafe():
     root = logging.getLogger()
     root.handlers.clear()
+    logging_utils._LOGGING_CONFIGURED = False
     with ThreadPoolExecutor(max_workers=32) as ex:
         list(ex.map(lambda _: _worker(), range(64)))
     assert len(root.handlers) == 1
@@ -20,7 +21,8 @@ def test_get_logger_preserves_existing_level():
     root = logging.getLogger()
     root.handlers.clear()
     root.setLevel(logging.ERROR)
-    get_logger("test_logger")
+    logging_utils._LOGGING_CONFIGURED = False
+    logging_utils.get_logger("test_logger")
     assert root.level == logging.ERROR
     root.setLevel(logging.WARNING)
 
@@ -29,6 +31,7 @@ def test_get_logger_sets_level_when_notset():
     root = logging.getLogger()
     root.handlers.clear()
     root.setLevel(logging.NOTSET)
-    get_logger("test_logger")
+    logging_utils._LOGGING_CONFIGURED = False
+    logging_utils.get_logger("test_logger")
     assert root.level == logging.INFO
     root.setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- configure root logger once via new `_LOGGING_CONFIGURED` flag
- skip locking and reconfiguration in `get_logger` after initial setup
- adjust logging tests to reset flag when checking configuration behavior

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e471f9ec83218e641bd7b2049a8e