### PR TITLE
Cache missing dependency errors

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -7,11 +7,13 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any, Callable
+from functools import lru_cache
 
 from .import_utils import optional_import
 from .logging_utils import get_logger
 
 
+@lru_cache(maxsize=None)
 def _missing_dependency_error(dep: str) -> type[Exception]:
     """Return a fallback :class:`Exception` when ``dep`` is unavailable."""
 

--- a/tests/test_missing_dependency_error_cache.py
+++ b/tests/test_missing_dependency_error_cache.py
@@ -1,0 +1,11 @@
+from tnfr.io import _missing_dependency_error
+
+
+def test_missing_dependency_error_cached() -> None:
+    cls1 = _missing_dependency_error("fake_dep")
+    cls2 = _missing_dependency_error("fake_dep")
+    assert cls1 is cls2
+    assert issubclass(cls1, Exception)
+    assert cls1.__doc__ == "Fallback error used when fake_dep is missing."
+    cls3 = _missing_dependency_error("other_dep")
+    assert cls3 is not cls1


### PR DESCRIPTION
## Summary
- cache fallback exception classes in `_missing_dependency_error`
- add regression test ensuring repeated calls reuse the same class

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e474215883219351a747957dd32f