### PR TITLE
Use kahan_sum for group aggregations

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -192,7 +192,7 @@ def mix_groups(
     out: dict[str, float] = dict(dist)
     out.update(
         {
-            f"{prefix}{label}": sum(dist.get(k, 0.0) for k in keys)
+            f"{prefix}{label}": kahan_sum(dist.get(k, 0.0) for k in keys)
             for label, keys in groups.items()
         }
     )


### PR DESCRIPTION
## Summary
- use numerically stable `kahan_sum` when aggregating grouped values

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1e47730bc83218dc284d2ef72b593