### PR TITLE
Switch module exports to tuples

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -54,7 +54,7 @@ except PackageNotFoundError:  # pragma: no cover
     else:  # pragma: no cover
         __version__ = "0+unknown"
 
-__all__ = [
+__all__ = (
     "__version__",
     "step",
     "run",
@@ -64,4 +64,4 @@ __all__ = [
     "NodeState",
     "apply_topological_remesh",
     "CallbackSpec",
-]
+)

--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -32,7 +32,7 @@ logger = get_logger(__name__)
 
 T = TypeVar("T")
 
-__all__ = [
+__all__ = (
     "get_attr",
     "set_attr",
     "get_attr_str",
@@ -45,7 +45,7 @@ __all__ = [
     "set_theta",
     "recompute_abs_max",
     "multi_recompute_abs_max",
-]
+)
 
 
 @lru_cache(maxsize=128)

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -17,7 +17,7 @@ from .trace import CallbackSpec
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx  # type: ignore[import-untyped]
 
-__all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
+__all__ = ("CallbackEvent", "register_callback", "invoke_callbacks")
 
 logger = get_logger(__name__)
 

--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -36,7 +36,7 @@ from .. import __version__
 
 logger = get_logger(__name__)
 
-__all__ = [
+__all__ = (
     "main",
     "add_common_args",
     "add_grammar_args",
@@ -55,7 +55,7 @@ __all__ = [
     "_flatten_tokens",
     "_save_json",
     "_args_to_dict",
-]
+)
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/src/tnfr/cli/token_parser.py
+++ b/src/tnfr/cli/token_parser.py
@@ -11,13 +11,13 @@ from ..token_parser import (
     _flatten_tokens as _tp_flatten_tokens,
 )
 
-__all__ = [
+__all__ = (
     "validate_token",
     "_parse_tokens",
     "_flatten_tokens",
     "parse_thol",
     "TOKEN_MAP",
-]
+)
 
 
 def parse_thol(spec: dict[str, Any]) -> Any:

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -35,13 +35,13 @@ def _log_negative_keys_once(negatives: Mapping[str, float]) -> None:
     if new:
         logger.warning(NEGATIVE_WEIGHTS_MSG, new)
 
-__all__ = [
+__all__ = (
     "MAX_MATERIALIZE_DEFAULT",
     "ensure_collection",
     "normalize_weights",
     "normalize_counter",
     "mix_groups",
-]
+)
 
 MAX_MATERIALIZE_DEFAULT: int = 1000
 """Default materialization limit used by :func:`ensure_collection`.

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -11,7 +11,7 @@ from .constants import inject_defaults
 if TYPE_CHECKING:  # pragma: no cover - only for type checkers
     import networkx as nx  # type: ignore[import-untyped]
 
-__all__ = ["load_config", "apply_config"]
+__all__ = ("load_config", "apply_config")
 
 
 def load_config(path: str | Path) -> Mapping[str, Any]:

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -281,7 +281,7 @@ dVF_PRIMARY = ALIAS_dVF[0]
 D2VF_PRIMARY = ALIAS_D2VF[0]
 dSI_PRIMARY = ALIAS_dSI[0]
 
-__all__ = [
+__all__ = (
     "CORE_DEFAULTS",
     "INIT_DEFAULTS",
     "REMESH_DEFAULTS",
@@ -322,4 +322,4 @@ __all__ = [
     "dVF_PRIMARY",
     "D2VF_PRIMARY",
     "dSI_PRIMARY",
-]
+)

--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -79,11 +79,11 @@ ANGLE_MAP: dict[str, float] = {
     Glyph.REMESH.value: 24 * math.pi / 13,
 }
 
-__all__ = [
+__all__ = (
     "GLYPHS_CANONICAL",
     "GLYPHS_CANONICAL_SET",
     "ESTABILIZADORES",
     "DISRUPTIVOS",
     "GLYPH_GROUPS",
     "ANGLE_MAP",
-]
+)

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -74,7 +74,7 @@ from .integrators import (
 
 logger = get_logger(__name__)
 
-__all__ = [
+__all__ = (
     "default_compute_delta_nfr",
     "set_delta_nfr_hook",
     "dnfr_phase_only",
@@ -97,7 +97,7 @@ __all__ = [
     "_refresh_dnfr_vectors",
     "_compute_neighbor_means",
     "_compute_dnfr",
-]
+)
 def _log_clamp(hist, node, attr, value, lo, hi):
     if value < lo or value > hi:
         hist.append({"node": node, "attr": attr, "value": float(value)})

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -26,14 +26,14 @@ from ..alias import (
 from ..metrics_utils import get_trig_cache
 from ..import_utils import get_numpy
 
-__all__ = [
+__all__ = (
     "default_compute_delta_nfr",
     "set_delta_nfr_hook",
     "dnfr_phase_only",
     "dnfr_epi_vf_mixed",
     "dnfr_laplacian",
     "apply_dnfr_field",
-]
+)
 
 
 def _write_dnfr_metadata(

--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -17,11 +17,11 @@ from ..constants import (
 from ..gamma import eval_gamma
 from ..alias import get_attr, set_attr, get_attr_str, set_attr_str
 
-__all__ = [
+__all__ = (
     "prepare_integration_params",
     "update_epi_via_nodal_equation",
     "integrar_epi_euler",
-]
+)
 
 
 def prepare_integration_params(

--- a/src/tnfr/dynamics/sampling.py
+++ b/src/tnfr/dynamics/sampling.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from ..helpers.cache import _cache_node_list
 from ..rng import _rng_for_step, base_seed
 
-__all__ = ["update_node_sample"]
+__all__ = ("update_node_sample",)
 
 
 def update_node_sample(G, *, step: int) -> None:

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 
 DEFAULT_GAMMA: Mapping[str, str] = {"type": "none"}
 
-__all__ = [
+__all__ = (
     "kuramoto_R_psi",
     "gamma_none",
     "gamma_kuramoto_linear",
@@ -34,7 +34,7 @@ __all__ = [
     "GammaEntry",
     "GAMMA_REGISTRY",
     "eval_gamma",
-]
+)
 
 
 @lru_cache(maxsize=1)

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from .constants import get_param
 from .collections_utils import ensure_collection
 
-__all__ = [
+__all__ = (
     "HistoryDict",
     "IncrementDict",
     "push_glyph",
@@ -22,7 +22,7 @@ __all__ = [
     "last_glyph",
     "count_glyphs",
     "validate_window",
-]
+)
 
 
 def validate_window(window: int, *, positive: bool = False) -> int:

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -16,13 +16,13 @@ from .glyph_history import recent_glyph
 from .types import Glyph
 from .operators import apply_glyph  # avoid repeated import inside functions
 
-__all__ = [
+__all__ = (
     "CANON_COMPAT",
     "CANON_FALLBACK",
     "enforce_canonical_grammar",
     "on_applied_glyph",
     "apply_glyph_with_grammar",
-]
+)
 
 # -------------------------
 # Per-node grammar state

--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Any
 
-__all__ = ["mark_dnfr_prep_dirty"]
+__all__ = ("mark_dnfr_prep_dirty",)
 
 
 def mark_dnfr_prep_dirty(G: Any) -> None:

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -40,7 +40,7 @@ from .cache import (
     increment_edge_version,
 )
 
-__all__ = [
+__all__ = (
     "MAX_MATERIALIZE_DEFAULT",
     "ensure_collection",
     "clamp",
@@ -71,4 +71,4 @@ __all__ = [
     "get_graph",
     "get_graph_mapping",
     "mark_dnfr_prep_dirty",
-]
+)

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -36,7 +36,7 @@ EDGE_VERSION_CACHE_KEYS = (
 )
 
 
-__all__ = [
+__all__ = (
     "get_graph",
     "get_graph_mapping",
     "node_set_checksum",
@@ -49,7 +49,7 @@ __all__ = [
     "cached_nodes_and_A",
     "invalidate_edge_version_cache",
     "increment_edge_version",
-]
+)
 
 
 def get_graph(obj: Any) -> Any:

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -11,7 +11,7 @@ import math
 from ..import_utils import get_numpy, import_nodonx
 from ..alias import get_attr
 
-__all__ = [
+__all__ = (
     "clamp",
     "clamp01",
     "list_mean",
@@ -22,7 +22,7 @@ __all__ = [
     "neighbor_mean",
     "neighbor_phase_mean",
     "neighbor_phase_mean_list",
-]
+)
 
 
 def clamp(x: float, a: float, b: float) -> float:

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -17,13 +17,13 @@ import threading
 import time
 from .logging_utils import get_logger
 
-__all__ = [
+__all__ = (
     "optional_import",
     "get_numpy",
     "import_nodonx",
     "prune_failed_imports",
     "clear_optional_import_cache",
-]
+)
 
 
 logger = get_logger(__name__)

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -11,7 +11,7 @@ from .rng import make_rng
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx  # type: ignore[import-untyped]
 
-__all__ = ["init_node_attrs"]
+__all__ = ("init_node_attrs",)
 
 
 def _init_phase(

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -173,10 +173,10 @@ def safe_write(
             tmp_path.unlink(missing_ok=True)
 
 
-__all__ = [
+__all__ = (
     "read_structured_file",
     "safe_write",
     "StructuredFileError",
     "TOMLDecodeError",
     "YAMLError",
-]
+)

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from .import_utils import optional_import
 
-__all__ = ["json_dumps", "json_dumps_str"]
+__all__ = ("json_dumps", "json_dumps_str")
 
 _ignored_param_warned = False
 _warn_lock = threading.Lock()

--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -11,7 +11,7 @@ import threading
 
 _LOCK = threading.Lock()
 
-__all__ = ["get_logger"]
+__all__ = ("get_logger",)
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -32,7 +32,7 @@ from .diagnosis import (
 )
 from .export import export_metrics
 
-__all__ = [
+__all__ = (
     "register_metrics_callbacks",
     "Tg_global",
     "Tg_by_node",
@@ -55,4 +55,4 @@ __all__ = [
     "register_diagnosis_callbacks",
     "dissonance_events",
     "export_metrics",
-]
+)

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -39,7 +39,7 @@ class GraphLike(Protocol):
     def __iter__(self) -> Iterable[Any]: ...
 
 
-__all__ = [
+__all__ = (
     "TrigCache",
     "compute_dnfr_accel_max",
     "compute_coherence",
@@ -49,7 +49,7 @@ __all__ = [
     "compute_Si_node",
     "compute_Si",
     "min_max_range",
-]
+)
 
 
 @dataclass(slots=True)

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -34,7 +34,7 @@ from .operators import apply_glyph_obj
 
 T = TypeVar("T")
 
-__all__ = ["NodoTNFR", "NodoNX", "NodoProtocol", "EdgeStrategy"]
+__all__ = ("NodoTNFR", "NodoNX", "NodoProtocol", "EdgeStrategy")
 
 
 def _nx_attr_property(

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -18,7 +18,7 @@ from .logging_utils import get_logger
 from .import_utils import get_numpy
 
 
-__all__ = [
+__all__ = (
     "attach_standard_observer",
     "std_before",
     "std_after",
@@ -27,7 +27,7 @@ __all__ = [
     "kuramoto_order",
     "glyph_load",
     "wbar",
-]
+)
 
 
 logger = get_logger(__name__)

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx  # type: ignore[import-untyped]
 
 # API de alto nivel
-__all__ = ["preparar_red", "step", "run"]
+__all__ = ("preparar_red", "step", "run")
 
 
 def preparar_red(

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -62,7 +62,7 @@ _JITTER_LOCK = threading.Lock()
 if TYPE_CHECKING:
     from .node import NodoProtocol
 
-__all__ = [
+__all__ = (
     "clear_rng_cache",
     "random_jitter",
     "get_glyph_factors",
@@ -71,7 +71,7 @@ __all__ = [
     "apply_network_remesh",
     "apply_topological_remesh",
     "apply_remesh_if_globally_stable",
-]
+)
 
 
 def _node_offset(G, n) -> int:

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -9,12 +9,12 @@ ARRANQUE_BASICO = seq(Glyph.AL, Glyph.EN)
 CIERRE_BASICO = seq(Glyph.RA, Glyph.SHA)
 NUCLEO_VAL_UM = seq(Glyph.VAL, Glyph.UM)
 
-__all__ = [
+__all__ = (
     "ARRANQUE_BASICO",
     "CIERRE_BASICO",
     "NUCLEO_VAL_UM",
     "get_preset",
-]
+)
 
 
 _PRESETS = {

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -44,7 +44,7 @@ def get_step_fn() -> AdvanceFn:
     return step_impl
 
 
-__all__ = [
+__all__ = (
     "WAIT",
     "TARGET",
     "THOL",
@@ -59,7 +59,7 @@ __all__ = [
     "wait",
     "play",
     "basic_canonical_example",
-]
+)
 
 # ---------------------
 # DSL constructs

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -97,10 +97,10 @@ def set_cache_maxsize(size: int) -> None:
         _RNG_CACHE, _seed_hash_cached = _make_cache(new_size)
 
 
-__all__ = [
+__all__ = (
     "make_rng",
     "set_cache_maxsize",
     "base_seed",
     "cache_enabled",
     "clear_rng_cache",
-]
+)

--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -8,7 +8,7 @@ from .initialization import init_node_attrs
 
 VALID_TOPOLOGIES = ("ring", "complete", "erdos")
 
-__all__ = ["build_graph"]
+__all__ = ("build_graph",)
 
 
 def build_graph(

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -16,12 +16,12 @@ from .metrics_utils import compute_dnfr_accel_max
 
 HYSTERESIS_GLYPHS: set[str] = {"IL", "OZ", "ZHIR", "THOL", "NAV", "RA"}
 
-__all__ = [
+__all__ = (
     "_selector_thresholds",
     "_norms_para_selector",
     "_calc_selector_score",
     "_apply_selector_hysteresis",
-]
+)
 
 
 def _selector_thresholds(G: "nx.Graph") -> dict:

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -32,7 +32,7 @@ GLYPH_UNITS: dict[str, complex] = {
     g: complex(math.cos(a), math.sin(a)) for g, a in ANGLE_MAP.items()
 }
 
-__all__ = [
+__all__ = (
     "GLYPH_UNITS",
     "glyph_angle",
     "glyph_unit",
@@ -43,7 +43,7 @@ __all__ = [
     "register_sigma_callback",
     "sigma_series",
     "sigma_rose",
-]
+)
 
 # -------------------------
 # Utilidades básicas

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -111,11 +111,11 @@ OPERADORES = operador_factory(
 )
 
 # Exposición dinámica de clases concretas en el espacio global
-__all__ = ["create_nfr", "Operador", "OPERADORES"]
+__all__ = ("create_nfr", "Operador", "OPERADORES")
 for _cls in OPERADORES.values():
     globals()[_cls.__name__] = _cls
-    __all__.append(_cls.__name__)
-__all__ += ["validate_sequence", "run_sequence"]
+    __all__ += (_cls.__name__,)
+__all__ += ("validate_sequence", "run_sequence")
 # ---------------------------------------------------------------------------
 # 3) Motor de secuencias + validador sintáctico
 # ---------------------------------------------------------------------------

--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 from collections import deque
 from collections.abc import Sequence
 
-__all__ = ["_flatten_tokens", "validate_token", "_parse_tokens"]
+__all__ = ("_flatten_tokens", "validate_token", "_parse_tokens")
 
 
 def _flatten_tokens(obj: Any):

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -50,13 +50,13 @@ def _sigma_fallback(
 
 
 # Public exports for this module
-__all__ = [
+__all__ = (
     "CallbackSpec",
     "register_trace",
     "_callback_names",
     "gamma_field",
     "grammar_field",
-]
+)
 
 # -------------------------
 # Helpers

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-__all__ = ["NodeState", "Glyph"]
+__all__ = ("NodeState", "Glyph")
 
 
 @dataclass(slots=True)

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -11,7 +11,7 @@ from .glyph_history import last_glyph
 from .sense import sigma_vector_from_graph
 from .constants_glyphs import GLYPHS_CANONICAL_SET
 
-__all__ = ["run_validators"]
+__all__ = ("run_validators",)
 
 
 def _require_attr(data, alias, node, name):

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -10,7 +10,7 @@ T = TypeVar("T")
 
 logger = get_logger(__name__)
 
-__all__ = ["_convert_value"]
+__all__ = ("_convert_value",)
 
 
 def _convert_value(


### PR DESCRIPTION
## Summary
- replace `__all__` lists with tuples throughout the codebase
- adjust dynamic export assembly in `structural.py`

## Testing
- `PYTHONPATH=src python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e477c2e08321b9cc5c9f7f142e6b