### PR TITLE
Refactor list_mean to use fmean

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -37,14 +37,10 @@ def clamp01(x: float) -> float:
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Return the arithmetic mean of ``xs`` or ``default`` if empty."""
-    total = 0.0
-    count = 0
-    for x in xs:
-        total = math.fsum((total, float(x)))
-        count += 1
-    if count:
-        return total / count
-    return float(default)
+    try:
+        return fmean(xs)
+    except StatisticsError:
+        return float(default)
 
 
 def kahan_sum_nd(values: Iterable[Sequence[float]], dims: int) -> tuple[float, ...]:


### PR DESCRIPTION
## Summary
- simplify `list_mean` to rely on `statistics.fmean`
- return provided default when iterable is empty

## Testing
- `pytest` *(fails: NameError: name 'count' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e8b501dc832194abec5797a7de28