### PR TITLE
Validate steps parameter in sigma_rose

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -345,11 +345,13 @@ def sigma_rose(G, steps: int | None = None) -> dict[str, int]:
     counts = hist.get("sigma_counts", [])
     if not counts:
         return {g: 0 for g in GLYPHS_CANONICAL}
-    rows = (
-        counts
-        if steps is None or steps >= len(counts)
-        else counts[-int(steps) :]  # noqa: E203
-    )
+    if steps is not None:
+        steps = int(steps)
+        if steps < 0:
+            raise ValueError("steps must be non-negative")
+        rows = counts if steps >= len(counts) else counts[-steps:]  # noqa: E203
+    else:
+        rows = counts
     counter = Counter()
     for row in rows:
         for k, v in row.items():

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -11,6 +11,7 @@ from tnfr.sense import (
     _sigma_from_iterable,
     glyph_unit,
     glyph_angle,
+    sigma_rose,
 )
 from tnfr.types import Glyph
 
@@ -103,3 +104,19 @@ def test_unknown_glyph_raises():
         glyph_angle("ZZ")
     with pytest.raises(KeyError):
         glyph_unit("ZZ")
+
+
+def test_sigma_rose_valid_and_invalid_steps(graph_canon):
+    G = graph_canon()
+    G.graph["history"] = {
+        "sigma_counts": [
+            {"t": 0, Glyph.AL.value: 1},
+            {"t": 1, Glyph.AL.value: 2, Glyph.EN.value: 1},
+            {"t": 2, Glyph.EN.value: 3},
+        ]
+    }
+    res = sigma_rose(G, steps=2.0)
+    assert res[Glyph.AL.value] == 2
+    assert res[Glyph.EN.value] == 4
+    with pytest.raises(ValueError):
+        sigma_rose(G, steps=-1)


### PR DESCRIPTION
## Summary
- ensure `sigma_rose` converts `steps` to int and rejects negative values
- exercise valid and invalid `steps` in new tests

## Testing
- `PYTHONPATH=src pytest tests/test_sense.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb114db883219b4201f8028320cb