### PR TITLE
Refactor phase_sync variance calculation with reusable helper

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 from collections.abc import Iterable, Sequence
-from statistics import fmean, StatisticsError
+from statistics import fmean, StatisticsError, pvariance
 from itertools import chain
 import math
 
@@ -15,6 +15,7 @@ __all__ = (
     "clamp",
     "clamp01",
     "list_mean",
+    "list_pvariance",
     "kahan_sum_nd",
     "kahan_sum",
     "kahan_sum2d",
@@ -39,6 +40,18 @@ def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
     """Return the arithmetic mean of ``xs`` or ``default`` if empty."""
     try:
         return fmean(xs)
+    except StatisticsError:
+        return float(default)
+
+
+def list_pvariance(xs: Iterable[float], default: float = 0.0) -> float:
+    """Return the population variance of ``xs`` or ``default`` if empty."""
+    np = get_numpy()
+    if np is not None:
+        arr = np.fromiter(xs, dtype=float)
+        return float(np.var(arr)) if arr.size else float(default)
+    try:
+        return pvariance(xs)
     except StatisticsError:
         return float(default)
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -42,6 +42,20 @@ def test_phase_observers_match_manual_calculation(graph_canon):
     assert math.isclose(R_again, R)
 
 
+def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
+    pytest.importorskip("numpy")
+    G = graph_canon()
+    angles = [0.1, -2.0, 2.5, 3.0]
+    for idx, th in enumerate(angles):
+        G.add_node(idx)
+        set_attr(G.nodes[idx], ALIAS_THETA, th)
+
+    ps_np = phase_sync(G)
+    monkeypatch.setattr("tnfr.observers.get_numpy", lambda: None)
+    ps_py = phase_sync(G)
+    assert ps_np == pytest.approx(ps_py)
+
+
 def test_phase_sync_bounds(graph_canon):
     G = graph_canon()
     angles = [0.1, 1.2, -2.5, 3.6]


### PR DESCRIPTION
## Summary
- add `list_pvariance` helper that uses NumPy when available and `statistics.pvariance` otherwise
- simplify `phase_sync` by replacing inline Welford algorithm with new variance utility
- test phase synchronization produces identical results with and without NumPy

## Testing
- `pytest tests/test_observers.py::test_phase_sync_equivalent_with_without_numpy -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb109cac8321bc79d810afc1e2ce