### PR TITLE
Expose seed hash helper and reuse in operators

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -19,7 +19,6 @@ from typing import Any, TYPE_CHECKING
 import math
 import hashlib
 import heapq
-import struct
 import threading
 from operator import ge, le
 from functools import cache
@@ -46,6 +45,7 @@ from .rng import (
     base_seed,
     cache_enabled,
     clear_rng_cache as _clear_rng_cache,
+    seed_hash,
 )
 from .callback_utils import invoke_callbacks
 from .glyph_history import append_metric, ensure_history, current_step_idx
@@ -186,14 +186,7 @@ def random_jitter(node: NodoProtocol, amplitude: float) -> float:
     cache_key = (seed_root, scope_id)
     seed = cache.get(cache_key)
     if seed is None:
-        seed_bytes = struct.pack(
-            ">QQ",
-            seed_root & 0xFFFFFFFFFFFFFFFF,
-            scope_id & 0xFFFFFFFFFFFFFFFF,
-        )
-        seed = int.from_bytes(
-            hashlib.blake2b(seed_bytes, digest_size=8).digest(), "little"
-        )
+        seed = seed_hash(seed_root, scope_id)
         cache[cache_key] = seed
     seq = 0
     if cache_enabled():

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -18,7 +18,8 @@ _RNG_LOCK = threading.Lock()
 _CACHE_MAXSIZE = int(DEFAULTS.get("JITTER_CACHE_SIZE", 128))
 
 
-def _seed_hash(seed_int: int, key_int: int) -> int:
+def seed_hash(seed_int: int, key_int: int) -> int:
+    """Return a 64-bit hash derived from ``seed_int`` and ``key_int``."""
     seed_bytes = struct.pack(
         ">QQ",
         seed_int & MASK64,
@@ -32,8 +33,8 @@ def _seed_hash(seed_int: int, key_int: int) -> int:
 def _make_cache(size: int) -> Tuple[MutableMapping[tuple[int, int], int], Callable[[int, int], int]]:
     if size > 0:
         cache = LRUCache(maxsize=max(1, size))
-        return cache, cached(cache=cache, lock=_RNG_LOCK)(_seed_hash)
-    return {}, _seed_hash
+        return cache, cached(cache=cache, lock=_RNG_LOCK)(seed_hash)
+    return {}, seed_hash
 
 
 _RNG_CACHE, _seed_hash_cached = _make_cache(_CACHE_MAXSIZE)
@@ -46,7 +47,7 @@ def _seed_hash_for(seed_int: int, key_int: int) -> int:
     """
 
     if _CACHE_MAXSIZE <= 0:
-        return _seed_hash(seed_int, key_int)
+        return seed_hash(seed_int, key_int)
     return _seed_hash_cached(seed_int, key_int)
 
 
@@ -98,6 +99,7 @@ def set_cache_maxsize(size: int) -> None:
 
 
 __all__ = (
+    "seed_hash",
     "make_rng",
     "set_cache_maxsize",
     "base_seed",


### PR DESCRIPTION
## Summary
- expose `seed_hash` helper in `rng` for shared seed derivation
- use `seed_hash` in `operators.random_jitter` instead of local hashing
- adjust imports and keep deterministic RNG behavior

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb0f1354832184d38e321e773655