### PR TITLE
feat: incrementally prune history heap

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -201,13 +201,18 @@ class HistoryDict(dict):
         target = len(self._counts) + self._compact_every
         if len(self._heap) <= target:
             return
-        self._heap = [
-            (cnt, key)
-            for cnt, key in self._heap
-            if self._counts.get(key) == cnt
-        ]
-        heapq.heapify(self._heap)
-        self._heap_index = {k: i for i, (cnt, k) in enumerate(self._heap)}
+        removed = False
+        temp: list[tuple[int, str]] = []
+        while len(self._heap) + len(temp) > target:
+            cnt, key = heapq.heappop(self._heap)
+            if self._counts.get(key) == cnt:
+                temp.append((cnt, key))
+            else:
+                removed = True
+        for item in temp:
+            heapq.heappush(self._heap, item)
+        if removed:
+            self._rebuild_index()
 
     def _pop_heap_key(self) -> str:
         """Pop and return the key with the smallest count from the heap."""

--- a/tests/test_history_heap_index.py
+++ b/tests/test_history_heap_index.py
@@ -52,3 +52,14 @@ def test_prune_heap_keeps_index_consistent():
     for k, idx in hist._heap_index.items():
         assert hist._heap[idx][1] == k
 
+
+def test_prune_heap_prunes_in_place():
+    hist = HistoryDict({f"k{i}": [] for i in range(3)}, compact_every=1)
+    original_heap = id(hist._heap)
+    for _ in range(5):
+        hist.get_increment("k0")
+    assert id(hist._heap) == original_heap
+    assert len(hist._heap) <= len(hist._counts) + hist._compact_every
+    for k, idx in hist._heap_index.items():
+        assert hist._heap[idx][1] == k
+


### PR DESCRIPTION
## Summary
- Remove outdated heap entries incrementally instead of rebuilding the heap
- Update heap index after pruning only when necessary
- Add unit test ensuring heap pruning occurs in place

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb0d2d0c832180a7278101db0d5c