### PR TITLE
Prevent treating str/bytes as iterables in sigma

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -124,7 +124,10 @@ def _sigma_from_iterable(
     number of processed values under the ``"n"`` key.
     """
 
-    iterator = values if isinstance(values, Iterable) else [values]
+    if isinstance(values, Iterable) and not isinstance(values, (str, bytes, bytearray)):
+        iterator = values
+    else:
+        iterator = [values]
     np = get_numpy()
     if np is not None:
         arr = np.fromiter((_to_complex(v) for v in iterator), dtype=np.complex128)

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -91,6 +91,16 @@ def test_sigma_from_vectors_rejects_invalid_iterable():
         _sigma_from_vectors("abc")
 
 
+def test_sigma_from_iterable_rejects_str():
+    with pytest.raises(TypeError, match="real or complex"):
+        _sigma_from_iterable("abc")
+
+
+def test_sigma_from_iterable_rejects_bytes():
+    with pytest.raises(TypeError, match="real or complex"):
+        _sigma_from_iterable(b"\x01\x02")
+
+
 def test_sigma_from_iterable_accepts_reals():
     vec = _sigma_from_iterable([1.0, 3.0])
     assert vec["n"] == 2


### PR DESCRIPTION
## Summary
- handle `str`, `bytes` and `bytearray` inputs in `_sigma_from_iterable` as single values
- add unit tests ensuring strings and bytes are rejected

## Testing
- `PYTHONPATH=src pytest tests/test_sense.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb0c57008321a8a741cba684affb