### PR TITLE
Use isinstance for window validation

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -33,9 +33,9 @@ def validate_window(window: int, *, positive: bool = False) -> int:
     Negative values always raise :class:`ValueError`.
     """
 
-    window_int = int(window)
-    if window_int != window:
+    if not isinstance(window, int):
         raise TypeError("'window' must be an integer")
+    window_int = int(window)
     if window_int < 0 or (positive and window_int == 0):
         kind = "positive" if positive else "non-negative"
         raise ValueError(f"'window'={window} must be {kind}")


### PR DESCRIPTION
## Summary
- use `isinstance(window, int)` before coercing to ensure strict integer validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1edc20e00832193877300a0788cd3