### PR TITLE
Use kahan_sum2d for coherence accumulation

### DIFF
--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -22,6 +22,7 @@ from .helpers.numeric import (
     clamp01,
     angle_diff,
     neighbor_phase_mean_list,
+    kahan_sum2d,
 )
 from .helpers.cache import edge_version_cache
 from .import_utils import get_numpy
@@ -95,30 +96,23 @@ def compute_coherence(
     if use_np:
         dnfr_arr = np.empty(count, dtype=float)
         depi_arr = np.empty(count, dtype=float)
-    else:
-        dnfr_sum = dnfr_c = 0.0
-        depi_sum = depi_c = 0.0
-
-    for idx, (_, nd) in enumerate(G.nodes(data=True)):
-        dnfr = abs(get_attr(nd, ALIAS_DNFR, 0.0))
-        depi = abs(get_attr(nd, ALIAS_dEPI, 0.0))
-        if use_np:
+        for idx, (_, nd) in enumerate(G.nodes(data=True)):
+            dnfr = abs(get_attr(nd, ALIAS_DNFR, 0.0))
+            depi = abs(get_attr(nd, ALIAS_dEPI, 0.0))
             dnfr_arr[idx] = dnfr
             depi_arr[idx] = depi
-        else:
-            y = dnfr - dnfr_c
-            t = dnfr_sum + y
-            dnfr_c = (t - dnfr_sum) - y
-            dnfr_sum = t
-            y = depi - depi_c
-            t = depi_sum + y
-            depi_c = (t - depi_sum) - y
-            depi_sum = t
-
-    if use_np:
         dnfr_mean = float(np.mean(dnfr_arr))
         depi_mean = float(np.mean(depi_arr))
     else:
+        dnfr_sum, depi_sum = kahan_sum2d(
+            (
+                (
+                    abs(get_attr(nd, ALIAS_DNFR, 0.0)),
+                    abs(get_attr(nd, ALIAS_dEPI, 0.0)),
+                )
+                for _, nd in G.nodes(data=True)
+            )
+        )
         dnfr_mean = dnfr_sum / count
         depi_mean = depi_sum / count
 


### PR DESCRIPTION
## Summary
- use kahan_sum2d for numerically stable dnfr/depi accumulation when numpy isn't available

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1edbed4788321bcbd84b3c0fd1d3e