### PR TITLE
refactor: use extendleft for LIFO stack

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -16,7 +16,9 @@ def _flatten_tokens(obj: Any):
     while stack:
         item = stack.pop()
         if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
-            stack.extend(reversed(item))
+            # ``extendleft`` pushes items in reverse order, preserving
+            # LIFO semantics without creating an intermediate reversed list
+            stack.extendleft(item)
         else:
             yield item
 


### PR DESCRIPTION
## Summary
- use `extendleft` in token parser to avoid building reversed lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1edbe17548321a7f8fcc6722ce103