### PR TITLE
Refactor DNFR cache with dataclass

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -8,6 +8,7 @@ simulations.
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from ..collections_utils import normalize_weights
@@ -25,6 +26,18 @@ from ..alias import (
 )
 from ..metrics_utils import get_trig_cache
 from ..import_utils import get_numpy
+
+
+@dataclass
+class DnfrCache:
+    idx: dict[Any, int]
+    theta: list[float]
+    epi: list[float]
+    vf: list[float]
+    cos_theta: list[float]
+    sin_theta: list[float]
+    degs: dict[Any, float] | None = None
+    checksum: Any | None = None
 
 __all__ = (
     "default_compute_delta_nfr",
@@ -70,16 +83,21 @@ def _configure_dnfr_weights(G) -> dict:
     return weights
 
 
-def _init_dnfr_cache(G, nodes, prev_cache, checksum, dirty):
+def _init_dnfr_cache(
+    G, nodes, prev_cache: DnfrCache | None, checksum, dirty
+):
     """Initialise or reuse cached ΔNFR arrays."""
-    if prev_cache and prev_cache.get("checksum") == checksum and not dirty:
-        idx = prev_cache["idx"]
-        theta = prev_cache["theta"]
-        epi = prev_cache["epi"]
-        vf = prev_cache["vf"]
-        cos_theta = prev_cache["cos_theta"]
-        sin_theta = prev_cache["sin_theta"]
-        return prev_cache, idx, theta, epi, vf, cos_theta, sin_theta, False
+    if prev_cache and prev_cache.checksum == checksum and not dirty:
+        return (
+            prev_cache,
+            prev_cache.idx,
+            prev_cache.theta,
+            prev_cache.epi,
+            prev_cache.vf,
+            prev_cache.cos_theta,
+            prev_cache.sin_theta,
+            False,
+        )
 
     idx = {n: i for i, n in enumerate(nodes)}
     theta = [0.0] * len(nodes)
@@ -87,31 +105,40 @@ def _init_dnfr_cache(G, nodes, prev_cache, checksum, dirty):
     vf = [0.0] * len(nodes)
     cos_theta = [1.0] * len(nodes)
     sin_theta = [0.0] * len(nodes)
-    cache = {
-        "checksum": checksum,
-        "idx": idx,
-        "theta": theta,
-        "epi": epi,
-        "vf": vf,
-        "cos_theta": cos_theta,
-        "sin_theta": sin_theta,
-        "degs": prev_cache.get("degs") if prev_cache else None,
-    }
+    cache = DnfrCache(
+        idx=idx,
+        theta=theta,
+        epi=epi,
+        vf=vf,
+        cos_theta=cos_theta,
+        sin_theta=sin_theta,
+        degs=prev_cache.degs if prev_cache else None,
+        checksum=checksum,
+    )
     G.graph["_dnfr_prep_cache"] = cache
-    return cache, idx, theta, epi, vf, cos_theta, sin_theta, True
+    return (
+        cache,
+        cache.idx,
+        cache.theta,
+        cache.epi,
+        cache.vf,
+        cache.cos_theta,
+        cache.sin_theta,
+        True,
+    )
 
 
-def _refresh_dnfr_vectors(G, nodes, theta, epi, vf, cos_theta, sin_theta):
+def _refresh_dnfr_vectors(G, nodes, cache: DnfrCache):
     """Update cached angle and state vectors for ΔNFR."""
     trig = get_trig_cache(G)
     for i, n in enumerate(nodes):
         nd = G.nodes[n]
         th = get_attr(nd, ALIAS_THETA, 0.0)
-        theta[i] = th
-        epi[i] = get_attr(nd, ALIAS_EPI, 0.0)
-        vf[i] = get_attr(nd, ALIAS_VF, 0.0)
-        cos_theta[i] = trig.cos.get(n, math.cos(th))
-        sin_theta[i] = trig.sin.get(n, math.sin(th))
+        cache.theta[i] = th
+        cache.epi[i] = get_attr(nd, ALIAS_EPI, 0.0)
+        cache.vf[i] = get_attr(nd, ALIAS_VF, 0.0)
+        cache.cos_theta[i] = trig.cos.get(n, math.cos(th))
+        cache.sin_theta[i] = trig.sin.get(n, math.sin(th))
 
 
 def _prepare_dnfr_data(G, *, cache_size: int | None = 128) -> dict:
@@ -123,27 +150,27 @@ def _prepare_dnfr_data(G, *, cache_size: int | None = 128) -> dict:
     use_numpy = get_numpy() is not None and G.graph.get("vectorized_dnfr")
 
     nodes, A = cached_nodes_and_A(G, cache_size=cache_size)
-    cache = G.graph.get("_dnfr_prep_cache")
+    cache: DnfrCache | None = G.graph.get("_dnfr_prep_cache")
     checksum = G.graph.get("_dnfr_nodes_checksum")
     dirty = bool(G.graph.pop("_dnfr_prep_dirty", False))
-    cache, idx, theta, epi, vf, cos_theta, sin_theta, refreshed = (
-        _init_dnfr_cache(G, nodes, cache, checksum, dirty)
+    cache, idx, theta, epi, vf, cos_theta, sin_theta, refreshed = _init_dnfr_cache(
+        G, nodes, cache, checksum, dirty
     )
     if refreshed:
-        _refresh_dnfr_vectors(G, nodes, theta, epi, vf, cos_theta, sin_theta)
+        _refresh_dnfr_vectors(G, nodes, cache)
 
     w_phase = float(weights.get("phase", 0.0))
     w_epi = float(weights.get("epi", 0.0))
     w_vf = float(weights.get("vf", 0.0))
     w_topo = float(weights.get("topo", 0.0))
-    degs = cache.get("degs") if cache else None
+    degs = cache.degs if cache else None
     if w_topo != 0 and (dirty or degs is None):
         degs = dict(G.degree())
-        cache["degs"] = degs
+        cache.degs = degs
     elif w_topo == 0:
         degs = None
         if cache is not None:
-            cache["degs"] = None
+            cache.degs = None
 
     if not use_numpy:
         A = None

--- a/tests/test_dynamics_helpers.py
+++ b/tests/test_dynamics_helpers.py
@@ -21,7 +21,7 @@ def test_init_and_refresh_dnfr_cache(graph_canon):
         G, nodes, None, 1, False
     )
     assert refreshed
-    _refresh_dnfr_vectors(G, nodes, th, epi, vf, cx, sx)
+    _refresh_dnfr_vectors(G, nodes, cache)
     assert th[1] == pytest.approx(0.1)
     cache2, *_rest, refreshed2 = _init_dnfr_cache(G, nodes, cache, 1, False)
     assert not refreshed2


### PR DESCRIPTION
## Summary
- Introduce `DnfrCache` dataclass to hold ΔNFR cache arrays and metadata
- Update cache initialization and refresh helpers to operate on the dataclass
- Adjust ΔNFR data preparation and tests to use the new cache structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1edbd2fe88321b5e90733e1d227e9