### PR TITLE
refactor: centralize string type tuple

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -15,6 +15,8 @@ T = TypeVar("T")
 
 logger = get_logger(__name__)
 
+STRING_TYPES = (str, bytes, bytearray)
+
 NEGATIVE_WEIGHTS_MSG = "Negative weights detected: %s"
 
 # Track keys that have already triggered a negative weight warning
@@ -79,9 +81,9 @@ def ensure_collection(
     """
 
     # Step 1: detect collections and raw strings/bytes early
-    if isinstance(it, Collection) and not isinstance(it, (str, bytes, bytearray)):
+    if isinstance(it, Collection) and not isinstance(it, STRING_TYPES):
         return it
-    if isinstance(it, (str, bytes, bytearray)):
+    if isinstance(it, STRING_TYPES):
         return (cast(T, it),)
 
     # Step 2: validate limit


### PR DESCRIPTION
## Summary
- define `STRING_TYPES` constant for common string-like classes
- reuse `STRING_TYPES` in `ensure_collection`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1edb760c883218bc220fc035bad0d