### PR TITLE
Configure pytest to include src directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = src
 addopts = -m "not slow"
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
## Summary
- ensure pytest can import project modules by adding src to pythonpath

## Testing
- `pytest -q` *(fails: NameError: name 'singledispatch' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f30a996883218a84553177eb0589