### PR TITLE
Refactor grammar arg dest creation

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -18,14 +18,22 @@ GRAMMAR_ARG_SPECS = specs(
     ("--glyph.hysteresis_window", {"type": int}),
 )
 
+def _with_dest_and_default(arg_specs):
+    """Return ``specs`` adding a ``dest`` and ``default`` for each option.
 
-GRAMMAR_ARG_SPECS_WITH_DEST = [
-    (
-        opt,
-        {**kwargs, "dest": opt.lstrip("-").replace(".", "_"), "default": None},
-    )
-    for opt, kwargs in GRAMMAR_ARG_SPECS
-]
+    The ``dest`` is derived from the option string by stripping leading dashes
+    and replacing dots with underscores so that nested CLI options can be
+    accessed as regular attributes. All options default to ``None`` to allow
+    ``_args_to_dict`` to filter them out when not provided.
+    """
+
+    return [
+        (
+            opt,
+            {**kwargs, "dest": opt.lstrip("-").replace(".", "_"), "default": None},
+        )
+        for opt, kwargs in arg_specs
+    ]
 
 
 # Especificaciones para opciones relacionadas con el histórico
@@ -108,7 +116,7 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
 def add_grammar_args(parser: argparse.ArgumentParser) -> None:
     """Add grammar and glyph hysteresis options."""
     group = parser.add_argument_group("Grammar")
-    add_arg_specs(group, GRAMMAR_ARG_SPECS_WITH_DEST)
+    add_arg_specs(group, _with_dest_and_default(GRAMMAR_ARG_SPECS))
 
 
 def add_grammar_selector_args(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -9,6 +9,7 @@ from tnfr.cli import (
     _build_graph_from_args,
     _args_to_dict,
 )
+from tnfr.cli.arguments import GRAMMAR_ARG_SPECS
 from tnfr.constants import METRIC_DEFAULTS
 from tnfr.io import read_structured_file
 from tnfr import __version__
@@ -98,3 +99,12 @@ def test_args_to_dict_filters_none_values():
     args = parser.parse_args(["--grammar.enabled"])
     result = _args_to_dict(args, "grammar_")
     assert result == {"enabled": True}
+
+
+def test_grammar_args_dest_and_default():
+    parser = argparse.ArgumentParser()
+    add_grammar_args(parser)
+    for opt, _ in GRAMMAR_ARG_SPECS:
+        action = next(a for a in parser._actions if opt in a.option_strings)
+        assert action.dest == opt.lstrip("-").replace(".", "_")
+        assert action.default is None


### PR DESCRIPTION
## Summary
- compute `dest` and `default` for grammar CLI options dynamically
- test grammar CLI arguments keep expected `dest` and default values

## Testing
- `pytest` *(fails: ImportError: cannot import name 'run_sequence' from 'tnfr')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f7797d6483219f037c0a7cf6fd3d