### PR TITLE
refactor: unify attribute access with generic helpers

### DIFF
--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -15,7 +15,7 @@ from ..constants import (
     ALIAS_D2EPI,
 )
 from ..gamma import eval_gamma
-from ..alias import get_attr, set_attr, get_attr_str, set_attr_str
+from ..alias import get_attr, set_attr
 
 __all__ = (
     "prepare_integration_params",
@@ -171,10 +171,10 @@ def update_epi_via_nodal_equation(
 
         for n, (epi, dEPI_dt, d2epi) in updates.items():
             nd = G.nodes[n]
-            epi_kind = get_attr_str(nd, ALIAS_EPI_KIND, "")
+            epi_kind = get_attr(nd, ALIAS_EPI_KIND, "", conv=str)
             set_attr(nd, ALIAS_EPI, epi)
             if epi_kind:
-                set_attr_str(nd, ALIAS_EPI_KIND, epi_kind)
+                set_attr(nd, ALIAS_EPI_KIND, epi_kind, conv=str)
             set_attr(nd, ALIAS_dEPI, dEPI_dt)
             set_attr(nd, ALIAS_D2EPI, d2epi)
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -21,9 +21,7 @@ from .constants import (
 from .glyph_history import push_glyph
 from .alias import (
     get_attr,
-    get_attr_str,
     set_attr,
-    set_attr_str,
     set_vf,
     set_dnfr,
     set_theta,
@@ -311,8 +309,8 @@ class NodoNX(NodoProtocol):
     epi_kind = _nx_attr_property(
         ALIAS_EPI_KIND,
         default="",
-        getter=get_attr_str,
-        setter=set_attr_str,
+        getter=lambda d, a, default: get_attr(d, a, default, conv=str),
+        setter=lambda d, a, value: set_attr(d, a, value, conv=str),
         to_python=str,
         to_storage=str,
     )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,7 +9,7 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.alias import set_attr_str, set_attr
+from tnfr.alias import set_attr
 from tnfr.io import read_structured_file, StructuredFileError
 from tnfr.config import load_config
 
@@ -58,7 +58,7 @@ def test_validator_sigma_norm(monkeypatch):
 def test_validator_invalid_glyph():
     G = _base_graph()
     n0 = list(G.nodes())[0]
-    set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
+    set_attr(G.nodes[n0], ALIAS_EPI_KIND, "INVALID", conv=str)
     G.nodes[n0]["glyph_history"] = ["INVALID"]
     with pytest.raises(KeyError):
         run_validators(G)


### PR DESCRIPTION
## Summary
- add generic `get_attr_generic`/`set_attr_generic` helpers
- rewrite attribute helpers to use generic converters
- update call sites to use unified helpers for string attributes

## Testing
- `pytest`
- `pytest tests/test_get_attr_default.py tests/test_get_attr_strict.py tests/test_alias_cache.py tests/test_validators.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1f76e9dbc8321b9b7cdae8655fc00