### PR TITLE
refactor: centralize Kuramoto gamma builders

### DIFF
--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -183,6 +183,24 @@ def gamma_none(G, node, t, cfg: dict[str, Any]) -> float:
     return 0.0
 
 
+def _gamma_kuramoto(
+    G,
+    node,
+    cfg: Mapping[str, Any],
+    builder: Callable[..., float],
+    **defaults: float,
+) -> float:
+    """Helper for Kuramoto-based Γ functions.
+
+    ``builder`` receives ``(θ_i, R, ψ, *params)`` where ``params`` are
+    extracted from ``cfg`` according to ``defaults``.
+    """
+
+    params = _gamma_params(cfg, **defaults)
+    th_i, R, psi = _kuramoto_common(G, node, cfg)
+    return builder(th_i, R, psi, *params)
+
+
 def gamma_kuramoto_linear(G, node, t, cfg: dict[str, Any]) -> float:
     """Linear Kuramoto coupling for Γi(R).
 
@@ -194,17 +212,20 @@ def gamma_kuramoto_linear(G, node, t, cfg: dict[str, Any]) -> float:
     Use: reinforces integration when the network already shows phase
     coherence (R>R0).
     """
-    beta, R0 = _gamma_params(cfg, beta=0.0, R0=0.0)
-    th_i, R, psi = _kuramoto_common(G, node, cfg)
-    return beta * (R - R0) * math.cos(th_i - psi)
+
+    def builder(th_i, R, psi, beta, R0):
+        return beta * (R - R0) * math.cos(th_i - psi)
+
+    return _gamma_kuramoto(G, node, cfg, builder, beta=0.0, R0=0.0)
 
 
 def gamma_kuramoto_bandpass(G, node, t, cfg: dict[str, Any]) -> float:
     """Γ = β · R(1-R) · sign(cos(θ_i - ψ))"""
-    (beta,) = _gamma_params(cfg, beta=0.0)
-    th_i, R, psi = _kuramoto_common(G, node, cfg)
-    sgn = 1.0 if math.cos(th_i - psi) >= 0.0 else -1.0
-    return beta * R * (1.0 - R) * sgn
+    def builder(th_i, R, psi, beta):
+        sgn = 1.0 if math.cos(th_i - psi) >= 0.0 else -1.0
+        return beta * R * (1.0 - R) * sgn
+
+    return _gamma_kuramoto(G, node, cfg, builder, beta=0.0)
 
 
 def gamma_kuramoto_tanh(G, node, t, cfg: dict[str, Any]) -> float:
@@ -215,9 +236,10 @@ def gamma_kuramoto_tanh(G, node, t, cfg: dict[str, Any]) -> float:
       - k: tanh slope (how fast it saturates)
       - R0: activation threshold
     """
-    beta, k, R0 = _gamma_params(cfg, beta=0.0, k=1.0, R0=0.0)
-    th_i, R, psi = _kuramoto_common(G, node, cfg)
-    return beta * math.tanh(k * (R - R0)) * math.cos(th_i - psi)
+    def builder(th_i, R, psi, beta, k, R0):
+        return beta * math.tanh(k * (R - R0)) * math.cos(th_i - psi)
+
+    return _gamma_kuramoto(G, node, cfg, builder, beta=0.0, k=1.0, R0=0.0)
 
 
 def gamma_harmonic(G, node, t, cfg: dict[str, Any]) -> float:


### PR DESCRIPTION
## Summary
- add internal helper to build Kuramoto-based gamma functions
- rewrite Kuramoto gamma variants to use shared helper

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'run_sequence' from 'tnfr')*
- `pytest tests/test_history_series.py::test_gamma_kuramoto_tanh_registry -q`
- `flake8` *(fails: style issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f767cc088321adc864dc04b48184