### PR TITLE
Remove redundant immutability helpers

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -100,13 +100,6 @@ _FREEZE_DISPATCH: dict[type, Callable[[Any, set[int]], Any]] = {
 }
 
 
-def _all_immutable(iterable) -> bool:
-    return all(_is_immutable(v) for v in iterable)
-
-
-_IMMUTABLE_TAG_DISPATCH: dict[str, Callable[[Any], bool]] = {}
-
-
 def _freeze(value: Any, seen: set[int] | None = None):
     if seen is None:
         seen = set()


### PR DESCRIPTION
## Summary
- remove duplicate `_all_immutable` definition and placeholder `_IMMUTABLE_TAG_DISPATCH`
- keep consolidated immutability checks with dispatch table

## Testing
- `pytest` *(fails: ImportError: cannot import name 'apply_topological_remesh' from 'tnfr')*

------
https://chatgpt.com/codex/tasks/task_e_68c1f7610c548321aaef1365236f05c6