### PR TITLE
Use shared sentinel for alias resolution

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -45,6 +45,9 @@ __all__ = (
     "multi_recompute_abs_max",
 )
 
+# Sentinel object used internally when resolving aliases
+SENTINEL = object()
+
 def _convert_default(
     default: Any,
     conv: Callable[[Any], T],
@@ -76,8 +79,6 @@ def _alias_resolve(
     log_level: int | None = None,
 ) -> Optional[T]:
     """Resolve the first matching key in ``aliases`` from ``d``."""
-
-    sentinel = object()
     value = next(
         (
             v
@@ -94,9 +95,9 @@ def _alias_resolve(
             ]
             if ok
         ),
-        sentinel,
+        SENTINEL,
     )
-    if value is not sentinel:
+    if value is not SENTINEL:
         return value
     if default is not None:
         ok, value = _convert_default(


### PR DESCRIPTION
## Summary
- Define a module-level sentinel constant for alias resolution
- Use global SENTINEL within `_alias_resolve`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'run_sequence' from 'tnfr')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fa2462248321b20651243f1bc8b2