### PR TITLE
Lazily configure root logging

### DIFF
--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -41,14 +41,9 @@ def get_logger(name: str) -> logging.Logger:
     preserved.
     """
 
-    if _LOGGING_CONFIGURED:
-        return logging.getLogger(name)
-
-    with _LOCK:
-        if not _LOGGING_CONFIGURED:
-            _configure_root()
+    if not _LOGGING_CONFIGURED:
+        with _LOCK:
+            if not _LOGGING_CONFIGURED:
+                _configure_root()
     return logging.getLogger(name)
 
-
-# Configure logging at import time.
-_configure_root()


### PR DESCRIPTION
## Summary
- remove eager root logger configuration at import time
- lazily configure the root logger on first `get_logger` call

## Testing
- `PYTHONPATH=src pytest tests/test_structural.py tests/test_topological_remesh.py -vv`
- `PYTHONPATH=src pytest` *(fails: cannot import name 'run_sequence' from 'tnfr')*

------
https://chatgpt.com/codex/tasks/task_e_68c1fa18f2c883219679966cea152c2d