### PR TITLE
Require explicit step function in advance

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -27,7 +27,7 @@ Node = Any
 AdvanceFn = Callable[[Any], None]  # normalmente dynamics.step
 
 HandlerFn = Callable[
-    [nx.Graph, Any, Optional[list[Node]], deque, Optional[AdvanceFn]],
+    [nx.Graph, Any, Optional[list[Node]], deque, AdvanceFn],
     Optional[list[Node]],
 ]
 
@@ -143,9 +143,7 @@ def _apply_glyph_to_targets(
     apply_glyph_with_grammar(G, nodes_iter, g, w)
 
 
-def _advance(G, step_fn: Optional[AdvanceFn] = None):
-    if step_fn is None:
-        step_fn = get_step_fn()
+def _advance(G, step_fn: AdvanceFn):
     step_fn(G)
 
 
@@ -303,7 +301,7 @@ def _advance_and_record(
     G,
     trace: deque,
     label: OpTag,
-    step_fn: Optional[AdvanceFn],
+    step_fn: AdvanceFn,
     *,
     times: int = 1,
     **data,
@@ -313,7 +311,9 @@ def _advance_and_record(
     _record_trace(trace, G, label, **data)
 
 
-def _handle_target(G, payload: TARGET, _curr_target, trace: deque, _step_fn):
+def _handle_target(
+    G, payload: TARGET, _curr_target, trace: deque, _step_fn: AdvanceFn
+):
     """Handle a ``TARGET`` token and return the active node set.
 
     Notes
@@ -334,7 +334,7 @@ def _handle_target(G, payload: TARGET, _curr_target, trace: deque, _step_fn):
 
 
 def _handle_wait(
-    G, steps: int, curr_target, trace: deque, step_fn: Optional[AdvanceFn]
+    G, steps: int, curr_target, trace: deque, step_fn: AdvanceFn
 ):
     _advance_and_record(G, trace, OpTag.WAIT, step_fn, times=steps, k=steps)
     return curr_target
@@ -345,7 +345,7 @@ def _handle_glyph(
     g: str,
     curr_target,
     trace: deque,
-    step_fn: Optional[AdvanceFn],
+    step_fn: AdvanceFn,
     label: OpTag = OpTag.GLYPH,
 ):
     _apply_glyph_to_targets(G, g, curr_target)
@@ -354,7 +354,7 @@ def _handle_glyph(
 
 
 def _handle_thol(
-    G, g, curr_target, trace: deque, step_fn: Optional[AdvanceFn]
+    G, g, curr_target, trace: deque, step_fn: AdvanceFn
 ):
     return _handle_glyph(
         G, g or Glyph.THOL.value, curr_target, trace, step_fn, label=OpTag.THOL

--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -17,9 +17,11 @@ def test_advance_caches_step(monkeypatch, graph_canon):
 
     monkeypatch.setattr(dyn, "step", first_step)
     program.get_step_fn.cache_clear()
-    _advance(G)
+    step_fn = program.get_step_fn()
+    _advance(G, step_fn)
     monkeypatch.setattr(dyn, "step", second_step)
-    _advance(G)
+    step_fn = program.get_step_fn()
+    _advance(G, step_fn)
     assert calls == [1, 1]
     program.get_step_fn.cache_clear()
 
@@ -42,7 +44,7 @@ def test_advance_thread_safe(monkeypatch, graph_canon):
 
     def worker():
         barrier.wait()
-        _advance(G)
+        _advance(G, program.get_step_fn())
 
     threads = [threading.Thread(target=worker) for _ in range(5)]
     for t in threads:
@@ -51,7 +53,7 @@ def test_advance_thread_safe(monkeypatch, graph_canon):
         t.join()
 
     monkeypatch.setattr(dyn, "step", second_step)
-    _advance(G)
+    _advance(G, program.get_step_fn())
 
     assert calls == [1] * 6
     program.get_step_fn.cache_clear()


### PR DESCRIPTION
## Summary
- require step function to be passed explicitly to internal advance routine
- ensure play forwards the step function to all handlers
- adapt caching tests to pass explicit step function

## Testing
- `pytest tests/test_program.py tests/test_program_step_cache.py`
- `pytest` *(fails: ImportError: cannot import name 'apply_topological_remesh')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fa0fe9f88321a05a70add99a5b44