### PR TITLE
docs: add test instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ For optional JavaScript tooling, install the Node.js dependencies:
 npm install
 ```
 
+## Tests
+
+```bash
+python -m pip install -e .
+python -m pytest
+```
+
+The repository ships with a `pytest.ini` that adds the `src` directory to
+`PYTHONPATH`, so tests can import the package without extra configuration.
+
+Test dependencies such as `networkx`, `cachetools` and `numpy` are required; if
+they are not already installed, fetch them together with `pytest`:
+
+```bash
+python -m pip install networkx cachetools numpy pytest
+```
+
 ---
 
 ## Why TNFR (in 60 seconds)


### PR DESCRIPTION
## Summary
- document how to run the test suite
- note pytest.ini PYTHONPATH config and optional test dependencies

## Testing
- `python -m pytest` *(fails: ImportError: cannot import name 'apply_topological_remesh')*

------
https://chatgpt.com/codex/tasks/task_e_68c1fce5bbc0832197995c7956de1786