### PR TITLE
Delegate abs max recomputation through cache-aware helper

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -385,14 +385,22 @@ def set_attr_str(
 
 
 def recompute_abs_max(
-    G: "networkx.Graph", aliases: tuple[str, ...]
+    G: "networkx.Graph", aliases: tuple[str, ...], *, key: str | None = None
 ) -> tuple[float, Hashable | None]:
-    """Recalculate and return ``(max_val, node)`` for ``aliases`` in ``G``."""
+    """Recalculate absolute maximum for ``aliases`` in ``G``.
+
+    When ``key`` is provided, the graph caches ``G.graph[key]`` and
+    ``G.graph[f"{key}_node"]`` are updated with the new maximum value and the
+    node where it occurs.
+    """
     node, max_val = max(
         ((n, abs(get_attr(G.nodes[n], aliases, 0.0))) for n in G.nodes()),
         key=lambda x: x[1],
         default=(None, 0.0),
     )
+    if key is not None:
+        G.graph[key] = max_val
+        G.graph[f"{key}_node"] = node
     return max_val, node
 
 
@@ -436,9 +444,7 @@ def _update_cached_abs_max(
         G.graph[key] = val
         G.graph[node_key] = n
     elif cur_node == n and val < cur:
-        max_val, max_node = recompute_abs_max(G, aliases)
-        G.graph[key] = max_val
-        G.graph[node_key] = max_node
+        recompute_abs_max(G, aliases, key=key)
 
 
 def set_attr_and_cache(
@@ -450,7 +456,11 @@ def set_attr_and_cache(
     cache: str | None = None,
     extra: Callable[["networkx.Graph", Hashable, float], None] | None = None,
 ) -> float:
-    """Assign ``value`` to node ``n`` and update caches if requested."""
+    """Assign ``value`` to node ``n`` and update caches if requested.
+
+    Cache updates are performed via :func:`recompute_abs_max` when the
+    existing maximum becomes invalid.
+    """
 
     val = set_attr(G.nodes[n], aliases, value)
     if cache is not None:
@@ -468,7 +478,10 @@ def set_attr_with_max(
     *,
     cache: str,
 ) -> None:
-    """Assign ``value`` to node ``n`` and update the global maximum."""
+    """Assign ``value`` to node ``n`` and update the global maximum.
+
+    This is a convenience wrapper around :func:`set_attr_and_cache`.
+    """
     set_attr_and_cache(G, n, aliases, value, cache=cache)
 
 

--- a/tests/test_cached_abs_max_performance.py
+++ b/tests/test_cached_abs_max_performance.py
@@ -1,0 +1,33 @@
+import time
+import networkx as nx
+import pytest
+
+from tnfr.alias import set_attr_with_max, set_attr, recompute_abs_max
+from tnfr.constants import ALIAS_VF
+
+
+@pytest.mark.slow
+def test_cached_abs_max_update_performance():
+    G_opt = nx.gnp_random_graph(500, 0.1, seed=1)
+    G_naive = G_opt.copy()
+
+    for n in G_opt.nodes:
+        set_attr_with_max(G_opt, n, ALIAS_VF, 0.0, cache="_vfmax")
+        set_attr(G_naive.nodes[n], ALIAS_VF, 0.0)
+    recompute_abs_max(G_naive, ALIAS_VF, key="_vfmax")
+
+    nodes = list(G_opt.nodes)
+    values = [float(i) for i in range(len(nodes))]
+
+    start = time.perf_counter()
+    for n, v in zip(nodes, values):
+        set_attr_with_max(G_opt, n, ALIAS_VF, v, cache="_vfmax")
+    t_opt = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for n, v in zip(nodes, values):
+        set_attr(G_naive.nodes[n], ALIAS_VF, v)
+        recompute_abs_max(G_naive, ALIAS_VF, key="_vfmax")
+    t_naive = time.perf_counter() - start
+
+    assert t_opt <= t_naive


### PR DESCRIPTION
## Summary
- allow `recompute_abs_max` to optionally refresh graph-level caches
- update `_update_cached_abs_max` and helpers to use the cache-aware recomputation
- add performance test covering cached vs naive maximum updates

## Testing
- `pytest` *(fails: cannot import name 'run_sequence' / 'apply_topological_remesh')*
- `pytest tests/test_cached_abs_max_performance.py -m slow -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ff0552548321bd90e4bdbba26de1