### PR TITLE
Graceful handling for optional dependencies in public API

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -133,6 +133,8 @@ class AliasAccessor(Generic[T]):
     ) -> None:
         self._conv = conv
         self._default = default
+        # expose cache for testing and manual control
+        self._alias_cache = _alias_cache
 
     def _prepare(
         self,

--- a/tests/test_get_attr_default.py
+++ b/tests/test_get_attr_default.py
@@ -11,6 +11,7 @@ import pytest
 # Import ``AliasAccessor`` without triggering package-level side effects.
 pkg = types.ModuleType("tnfr")
 pkg.__path__ = [str(Path(__file__).resolve().parents[1] / "src" / "tnfr")]
+_real_tnfr = sys.modules.pop("tnfr", None)
 sys.modules["tnfr"] = pkg
 spec = importlib.util.spec_from_file_location(
     "tnfr.alias", Path(__file__).resolve().parents[1] / "src" / "tnfr" / "alias.py"
@@ -18,6 +19,10 @@ spec = importlib.util.spec_from_file_location(
 alias = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(alias)  # type: ignore[union-attr]
 AliasAccessor = alias.AliasAccessor
+if _real_tnfr is not None:
+    sys.modules["tnfr"] = _real_tnfr
+else:  # pragma: no cover
+    sys.modules.pop("tnfr", None)
 
 
 def test_get_attr_default_none_returns_none():

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,11 +9,13 @@ def test_public_exports():
         "run",
         "preparar_red",
         "create_nfr",
-        "run_sequence",
         "NodeState",
         "CallbackSpec",
-        "apply_topological_remesh",
     }
+    if getattr(tnfr, "_HAS_RUN_SEQUENCE", False):
+        expected.add("run_sequence")
+    if getattr(tnfr, "_HAS_APPLY_TOPOLOGICAL_REMESH", False):
+        expected.add("apply_topological_remesh")
     assert set(tnfr.__all__) == expected
 
 


### PR DESCRIPTION
## Summary
- Guard structural, dynamics and operators imports so missing optional deps don't break package import
- Only export `run_sequence` and `apply_topological_remesh` when their dependencies are present
- Restore real package during alias tests and adjust public API tests for conditional exports

## Testing
- `pytest -q tests/test_public_api.py tests/test_structural.py tests/test_topological_remesh.py tests/test_get_attr_default.py tests/test_alias_cache.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c20115b9f88321a403595f1113f617