### PR TITLE
refactor: extract callback validation

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -148,6 +148,17 @@ _EDGE_OPS: dict[EdgeStrategy, EdgeOps] = {
 }
 
 
+def _validate_callbacks(exists_cb, set_cb) -> None:
+    """Validate callback pair provided to :func:`add_edge`."""
+
+    if (exists_cb is None) != (set_cb is None):
+        raise ValueError("exists_cb and set_cb must be provided together")
+
+    if exists_cb is not None and set_cb is not None:
+        if not callable(exists_cb) or not callable(set_cb):
+            raise TypeError("exists_cb and set_cb must be callables")
+
+
 def _resolve_edge_ops(graph, strategy, exists_cb, set_cb):
     if exists_cb is not None and set_cb is not None:
         return _CallbackEdgeOps(exists_cb, set_cb)
@@ -185,12 +196,7 @@ def add_edge(
     if weight is None:
         return
 
-    if (exists_cb is None) != (set_cb is None):
-        raise ValueError("exists_cb and set_cb must be provided together")
-
-    if exists_cb is not None and set_cb is not None:
-        if not callable(exists_cb) or not callable(set_cb):
-            raise TypeError("exists_cb and set_cb must be callables")
+    _validate_callbacks(exists_cb, set_cb)
 
     ops = _resolve_edge_ops(graph, strategy, exists_cb, set_cb)
 

--- a/tests/test_add_edge_callbacks.py
+++ b/tests/test_add_edge_callbacks.py
@@ -1,17 +1,28 @@
 """Tests for add_edge callback validation."""
 
 import pytest
-from tnfr.node import add_edge
+from tnfr.node import add_edge, _validate_callbacks
 
 
-def test_add_edge_requires_callback_pair():
+def test_validate_callbacks_requires_callback_pair():
+    with pytest.raises(ValueError):
+        _validate_callbacks(lambda *_: False, None)
+    with pytest.raises(ValueError):
+        _validate_callbacks(None, lambda *_: None)
+
+
+def test_validate_callbacks_requires_callables():
+    with pytest.raises(TypeError):
+        _validate_callbacks(object(), lambda *_: None)
+    with pytest.raises(TypeError):
+        _validate_callbacks(lambda *_: False, object())
+
+
+def test_add_edge_validates_callbacks():
     with pytest.raises(ValueError):
         add_edge({}, 1, 2, 1.0, False, exists_cb=lambda *_: False)
     with pytest.raises(ValueError):
         add_edge({}, 1, 2, 1.0, False, set_cb=lambda *_: None)
-
-
-def test_add_edge_requires_callables():
     with pytest.raises(TypeError):
         add_edge({}, 1, 2, 1.0, False, exists_cb=object(), set_cb=lambda *_: None)
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary
- factor out add_edge callback validation into `_validate_callbacks`
- test helper and ensure `add_edge` delegates to it

## Testing
- `pytest tests/test_add_edge_callbacks.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1feeefa34832194c1ed3f1d8c219a