### PR TITLE
refactor: centralize get_attr and add partial wrappers

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -13,13 +13,12 @@ from typing import (
     Callable,
     TypeVar,
     Optional,
-    overload,
     Generic,
     Hashable,
     TYPE_CHECKING,
 )
 
-from functools import lru_cache
+from functools import lru_cache, partial
 
 from .value_utils import _convert_value
 
@@ -29,7 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover
 T = TypeVar("T")
 
 __all__ = (
-    "get_attr_generic",
     "set_attr_generic",
     "get_attr",
     "set_attr",
@@ -202,38 +200,14 @@ class AliasAccessor(Generic[T]):
 _generic_accessor: AliasAccessor[Any] = AliasAccessor()
 
 
-@overload
-def get_attr_generic(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: T,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], T],
-) -> T: ...
-
-
-@overload
-def get_attr_generic(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: None = None,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], T],
-) -> T | None: ...
-
-
-def get_attr_generic(
+def get_attr(
     d: dict[str, Any],
     aliases: Iterable[str],
     default: T | None = None,
     *,
     strict: bool = False,
     log_level: int | None = None,
-    conv: Callable[[Any], T],
+    conv: Callable[[Any], T] = float,
 ) -> T | None:
     """Return the value for the first key in ``aliases`` found in ``d``."""
 
@@ -259,53 +233,6 @@ def set_attr_generic(
     return _generic_accessor.set(d, aliases, value, conv=conv)
 
 
-@overload
-def get_attr(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: float,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], float] | None = None,
-) -> float: ...
-
-
-@overload
-def get_attr(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: None = None,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], float] | None = None,
-) -> float | None: ...
-
-
-def get_attr(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: float | None = None,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], float] | None = None,
-) -> float | None:
-    """Return the value for the first key in ``aliases`` found in ``d``."""
-
-    if conv is None:
-        conv = float
-    return get_attr_generic(
-        d,
-        aliases,
-        default,
-        strict=strict,
-        log_level=log_level,
-        conv=conv,
-    )
-
-
 def set_attr(
     d: dict[str, Any],
     aliases: Iterable[str],
@@ -319,64 +246,8 @@ def set_attr(
     return set_attr_generic(d, aliases, value, conv=conv)
 
 
-@overload
-def get_attr_str(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: str,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], str] | None = None,
-) -> str: ...
-
-
-@overload
-def get_attr_str(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: None = None,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], str] | None = None,
-) -> str | None: ...
-
-
-def get_attr_str(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    default: str | None = None,
-    *,
-    strict: bool = False,
-    log_level: int | None = None,
-    conv: Callable[[Any], str] | None = None,
-) -> str | None:
-    """Return the string value for the first key in ``aliases``."""
-
-    if conv is None:
-        conv = str
-    return get_attr_generic(
-        d,
-        aliases,
-        default,
-        strict=strict,
-        log_level=log_level,
-        conv=conv,
-    )
-
-
-def set_attr_str(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    value: Any,
-    conv: Callable[[Any], str] | None = None,
-) -> str:
-    """Assign ``value`` to the first alias key in ``d`` as ``str``."""
-
-    if conv is None:
-        conv = str
-    return set_attr_generic(d, aliases, value, conv=conv)
+get_attr_str = partial(get_attr, conv=str)
+set_attr_str = partial(set_attr, conv=str)
 
 
 # -------------------------

--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -15,7 +15,7 @@ from ..constants import (
     ALIAS_D2EPI,
 )
 from ..gamma import eval_gamma
-from ..alias import get_attr, set_attr
+from ..alias import get_attr, get_attr_str, set_attr, set_attr_str
 
 __all__ = (
     "prepare_integration_params",
@@ -171,10 +171,10 @@ def update_epi_via_nodal_equation(
 
         for n, (epi, dEPI_dt, d2epi) in updates.items():
             nd = G.nodes[n]
-            epi_kind = get_attr(nd, ALIAS_EPI_KIND, "", conv=str)
+            epi_kind = get_attr_str(nd, ALIAS_EPI_KIND, "")
             set_attr(nd, ALIAS_EPI, epi)
             if epi_kind:
-                set_attr(nd, ALIAS_EPI_KIND, epi_kind, conv=str)
+                set_attr_str(nd, ALIAS_EPI_KIND, epi_kind)
             set_attr(nd, ALIAS_dEPI, dEPI_dt)
             set_attr(nd, ALIAS_D2EPI, d2epi)
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -21,7 +21,9 @@ from .constants import (
 from .glyph_history import push_glyph
 from .alias import (
     get_attr,
+    get_attr_str,
     set_attr,
+    set_attr_str,
     set_vf,
     set_dnfr,
     set_theta,
@@ -309,8 +311,8 @@ class NodoNX(NodoProtocol):
     epi_kind = _nx_attr_property(
         ALIAS_EPI_KIND,
         default="",
-        getter=lambda d, a, default: get_attr(d, a, default, conv=str),
-        setter=lambda d, a, value: set_attr(d, a, value, conv=str),
+        getter=get_attr_str,
+        setter=set_attr_str,
         to_python=str,
         to_storage=str,
     )

--- a/tests/test_get_attr_str_wrapper.py
+++ b/tests/test_get_attr_str_wrapper.py
@@ -1,0 +1,11 @@
+from tnfr.alias import get_attr_str
+
+
+def test_get_attr_str_returns_string():
+    d = {"x": 5}
+    assert get_attr_str(d, ("x",), "") == "5"
+
+
+def test_get_attr_str_default_used():
+    d = {}
+    assert get_attr_str(d, ("x",), "foo") == "foo"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,7 +9,7 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.alias import set_attr
+from tnfr.alias import set_attr, set_attr_str
 from tnfr.io import read_structured_file, StructuredFileError
 from tnfr.config import load_config
 
@@ -58,7 +58,7 @@ def test_validator_sigma_norm(monkeypatch):
 def test_validator_invalid_glyph():
     G = _base_graph()
     n0 = list(G.nodes())[0]
-    set_attr(G.nodes[n0], ALIAS_EPI_KIND, "INVALID", conv=str)
+    set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
     G.nodes[n0]["glyph_history"] = ["INVALID"]
     with pytest.raises(KeyError):
         run_validators(G)


### PR DESCRIPTION
## Summary
- collapse `get_attr` variants into a single function with converter parameter defaulting to `float`
- expose `get_attr_str` and `set_attr_str` as thin `functools.partial` wrappers
- adjust imports and tests to use new wrappers

## Testing
- `pytest` *(fails: ImportError: cannot import name 'apply_topological_remesh')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fee43cec8321a5fd8f2aa327cace