### PR TITLE
feat: make RNG cache size dynamic

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -144,7 +144,7 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))
     epi_val = float(G.graph.get("INIT_EPI_VALUE", 0.0))
 
-    rng_template = make_rng(seed, -1)
+    rng_template = make_rng(seed, -1, G)
     rng = random.Random()
     rng.setstate(rng_template.getstate())
     for _, nd in G.nodes(data=True):

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -189,14 +189,14 @@ def random_jitter(node: NodoProtocol, amplitude: float) -> float:
         seed = seed_hash(seed_root, scope_id)
         cache[cache_key] = seed
     seq = 0
-    if cache_enabled():
+    if cache_enabled(node.G):
         with _JITTER_LOCK:
             seq = _JITTER_SEQ.get(cache_key, 0)
             _JITTER_SEQ[cache_key] = seq + 1
             _JITTER_SEQ.move_to_end(cache_key)
             if len(_JITTER_SEQ) > _JITTER_MAX_ENTRIES:
                 _JITTER_SEQ.popitem(last=False)
-    rng = make_rng(seed, seed_key + seq)
+    rng = make_rng(seed, seed_key + seq, node.G)
     return rng.uniform(-amplitude, amplitude)
 
 
@@ -370,7 +370,7 @@ def _um_select_candidates(
     ``candidates`` may be a large or lazy iterable. This function consumes
     it incrementally to avoid loading every element into memory.
     """
-    rng = make_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset())
+    rng = make_rng(int(node.graph.get("RANDOM_SEED", 0)), node.offset(), node.G)
 
     if limit <= 0:
         # No limit requested; fully materialize the iterable.
@@ -867,7 +867,7 @@ def apply_topological_remesh(
     if n_before <= 1:
         return
     base_seed = 0 if seed is None else int(seed)
-    rnd = make_rng(base_seed, -2)
+    rnd = make_rng(base_seed, -2, G)
     rnd.seed(base_seed)
 
     if mode is None:

--- a/tests/test_make_rng.py
+++ b/tests/test_make_rng.py
@@ -1,7 +1,10 @@
 import random
 import hashlib
 import struct
-from tnfr.rng import make_rng, clear_rng_cache
+import networkx as nx
+
+from tnfr import rng as rng_mod
+from tnfr.rng import make_rng, clear_rng_cache, cache_enabled
 
 
 def _derive_seed(seed: int, key: int) -> int:
@@ -30,3 +33,21 @@ def test_make_rng_reproducible_sequence():
 
     assert seq1 == exp
     assert seq2 == exp
+
+
+def test_cache_size_updates_from_graph():
+    G = nx.Graph()
+
+    # Initial state uses default size
+    cache_enabled(G)
+    default_size = rng_mod.DEFAULTS["JITTER_CACHE_SIZE"]
+    assert rng_mod._CACHE_MAXSIZE == default_size
+
+    G.graph["JITTER_CACHE_SIZE"] = 0
+    cache_enabled(G)
+    assert rng_mod._CACHE_MAXSIZE == 0
+
+    G.graph["JITTER_CACHE_SIZE"] = 3
+    make_rng(1, 2, G)
+    assert rng_mod._CACHE_MAXSIZE == 3
+


### PR DESCRIPTION
## Summary
- allow RNG cache size to follow `JITTER_CACHE_SIZE` from graph parameters
- use dynamic cache size in RNG creation and cache checks
- add regression test for dynamic cache sizing

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'run_sequence' from 'tnfr')*
- `pytest tests/test_make_rng.py tests/test_make_rng_threadsafe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1fedd971c8321ab0d326e52fc027f