### PR TITLE
Refactor edge cache management into EdgeCacheManager

### DIFF
--- a/tests/test_edge_version_cache_limit.py
+++ b/tests/test_edge_version_cache_limit.py
@@ -1,4 +1,4 @@
-from tnfr.helpers.cache import edge_version_cache
+from tnfr.helpers.cache import EdgeCacheManager, edge_version_cache
 
 
 def test_edge_version_cache_limit(graph_canon):
@@ -6,7 +6,7 @@ def test_edge_version_cache_limit(graph_canon):
     edge_version_cache(G, "a", lambda: 1, max_entries=2)
     edge_version_cache(G, "b", lambda: 2, max_entries=2)
     edge_version_cache(G, "c", lambda: 3, max_entries=2)
-    cache = G.graph["_edge_version_cache"]
+    cache, _ = EdgeCacheManager(G.graph).get_cache(2)
     assert "a" not in cache
     assert "b" in cache and "c" in cache
 
@@ -15,7 +15,6 @@ def test_edge_version_cache_lock_cleanup(graph_canon):
     G = graph_canon()
     for i in range(10):
         edge_version_cache(G, str(i), lambda i=i: i, max_entries=2)
-    cache = G.graph["_edge_version_cache"]
-    locks = G.graph["_edge_version_cache_locks"]
+    cache, locks = EdgeCacheManager(G.graph).get_cache(2)
     assert len(cache) <= 2
     assert set(locks) == set(cache)

--- a/tests/test_edge_version_cache_locks.py
+++ b/tests/test_edge_version_cache_locks.py
@@ -1,11 +1,11 @@
-from tnfr.helpers.cache import edge_version_cache
+from tnfr.helpers.cache import EdgeCacheManager, edge_version_cache
 
 
 def test_edge_version_cache_prunes_locks(graph_canon):
     G = graph_canon()
     for i in range(5):
         edge_version_cache(G, str(i), lambda i=i: i, max_entries=2)
-    locks = G.graph["_edge_version_cache_locks"]
+    _, locks = EdgeCacheManager(G.graph).get_cache(2)
     assert len(locks) <= 2
 
 
@@ -13,8 +13,7 @@ def test_edge_version_cache_lock_cleanup_unbounded(graph_canon):
     G = graph_canon()
     edge_version_cache(G, "a", lambda: 1, max_entries=None)
     edge_version_cache(G, "b", lambda: 2, max_entries=None)
-    cache = G.graph["_edge_version_cache"]
-    locks = G.graph["_edge_version_cache_locks"]
+    cache, locks = EdgeCacheManager(G.graph).get_cache(None)
     cache.pop("a")
     assert "a" in locks
     edge_version_cache(G, "c", lambda: 3, max_entries=None)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -7,7 +7,7 @@ import pytest
 from tnfr.constants import inject_defaults, merge_overrides
 from tnfr.dynamics import update_epi_via_nodal_equation
 from tnfr.gamma import eval_gamma, GAMMA_REGISTRY, GammaEntry
-from tnfr.helpers.cache import increment_edge_version
+from tnfr.helpers.cache import EdgeCacheManager, increment_edge_version
 
 
 def test_gamma_linear_integration(graph_canon):
@@ -221,7 +221,7 @@ def test_kuramoto_cache_step_limit(graph_canon):
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     gamma_mod._ensure_kuramoto_cache(G, t=1)
     gamma_mod._ensure_kuramoto_cache(G, t=2)
-    cache = G.graph["_edge_version_cache"]
+    cache, _ = EdgeCacheManager(G.graph).get_cache(2)
     entries = [k for k in cache if isinstance(k, tuple)]
     assert len(entries) == 2
 


### PR DESCRIPTION
## Summary
- encapsulate edge cache creation and lock handling within new EdgeCacheManager class
- update edge_version_cache and invalidate_edge_version_cache to rely on EdgeCacheManager
- adjust tests to interact with EdgeCacheManager

## Testing
- `pytest` *(fails: ImportError: cannot import name 'apply_topological_remesh')*
- `pytest tests/test_edge_version_cache_limit.py tests/test_edge_version_cache_locks.py tests/test_edge_version_cache_disable.py tests/test_edge_version_cache_threadsafe.py tests/test_edge_version_cache_reentrant.py tests/test_gamma.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1fec6b7488321acc5b8fabee12e3c