### PR TITLE
feat: add string iterable option to ensure_collection

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -72,22 +72,29 @@ def ensure_collection(
     *,
     max_materialize: int | None = MAX_MATERIALIZE_DEFAULT,
     error_msg: str | None = None,
+    treat_strings_as_iterables: bool = False,
 ) -> Collection[T]:
     """Return ``it`` as a ``Collection`` materializing if necessary.
 
-    Step 1 detects collections and string-like inputs early. ``max_materialize``
-    limits materialization for non-collection iterables; ``None`` disables the
-    limit. ``error_msg`` customizes the :class:`ValueError` raised when the
-    iterable yields more items than allowed. ``TypeError`` is raised when ``it``
-    is not iterable. The input is consumed at most once and no extra items
-    beyond the limit are stored in memory.
+    Step 1 detects collections and handles string-like inputs (``str``,
+    ``bytes`` and ``bytearray``) specially. By default these are wrapped as a
+    single item tuple so they are not iterated character by character. Pass
+    ``treat_strings_as_iterables=True`` to materialize them like any other
+    iterable. ``max_materialize`` limits materialization for non-collection
+    iterables; ``None`` disables the limit. ``error_msg`` customizes the
+    :class:`ValueError` raised when the iterable yields more items than allowed.
+    ``TypeError`` is raised when ``it`` is not iterable. The input is consumed
+    at most once and no extra items beyond the limit are stored in memory.
     """
 
     # Step 1: detect collections and raw strings/bytes early
-    if isinstance(it, Collection) and not isinstance(it, STRING_TYPES):
-        return it
-    if isinstance(it, STRING_TYPES):
-        return (cast(T, it),)
+    if isinstance(it, Collection):
+        if isinstance(it, STRING_TYPES):
+            if not treat_strings_as_iterables:
+                return (cast(T, it),)
+            # Fall through to materialization when treating as iterable
+        else:
+            return it
 
     # Step 2: validate limit
     limit = _validate_limit(max_materialize)

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -16,6 +16,20 @@ def test_wraps_bytearray():
     assert ensure_collection(arr) == (arr,)
 
 
+def test_string_materialized_when_requested():
+    assert ensure_collection("node", treat_strings_as_iterables=True) == tuple("node")
+
+
+def test_bytes_materialized_when_requested():
+    data = b"node"
+    assert ensure_collection(data, treat_strings_as_iterables=True) == tuple(data)
+
+
+def test_bytearray_materialized_when_requested():
+    arr = bytearray(b"node")
+    assert ensure_collection(arr, treat_strings_as_iterables=True) == tuple(arr)
+
+
 def test_iterable_not_iterator_materialized():
     class CustomIterable:
         def __iter__(self):


### PR DESCRIPTION
## Summary
- document special handling of string-like inputs in `ensure_collection`
- add `treat_strings_as_iterables` option to control how strings are materialized
- cover both behaviors with new tests

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'run_sequence' from 'tnfr')*
- `pytest tests/test_ensure_collection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1fec427c88321b76be4804436331d