### PR TITLE
Fix normalization logging and improve JSON utilities

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -119,8 +119,12 @@ def _process_negative_weights(
 ) -> float:
     """Handle negative weights by logging, clamping and adjusting total."""
     if warn_once:
-        for k, v in negatives.items():
-            log_warn_once(f"negative_weight:{k}", NEGATIVE_WEIGHTS_MSG % {k: v})
+        # ``warn_once`` returns a callable that logs at most once per key.
+        # ``_log_negative_keys_once`` expects a mapping of keys to values so
+        # pass the entire ``negatives`` dict at once.  This ensures each
+        # negative weight is only warned about on its first occurrence across
+        # all calls to :func:`normalize_weights`.
+        _log_negative_keys_once(negatives)
     else:
         logger.warning(NEGATIVE_WEIGHTS_MSG, negatives)
     for k, w in negatives.items():

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -86,7 +86,10 @@ def cache_enabled(G: Any | None = None) -> bool:
     When ``G`` is provided, the cache size is synchronised with
     ``JITTER_CACHE_SIZE`` stored in ``G``.
     """
-    if G is not None:
+    # Only synchronise the cache size with ``G`` when caching is enabled.  This
+    # preserves explicit calls to :func:`set_cache_maxsize(0)` which are used in
+    # tests to temporarily disable caching regardless of graph defaults.
+    if _CACHE_MAXSIZE > 0 and G is not None:
         size = get_cache_maxsize(G)
         if size != _CACHE_MAXSIZE:
             set_cache_maxsize(size)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -2,6 +2,7 @@ import logging
 
 import tnfr.json_utils as json_utils
 import tnfr.logging_utils as logging_utils
+import warnings
 
 
 class FakeOrjson:

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -1,4 +1,4 @@
-import logging
+import warnings
 from dataclasses import is_dataclass
 
 import tnfr.json_utils as json_utils
@@ -15,6 +15,8 @@ class DummyOrjson:
 
 def _reset_json_utils(monkeypatch, module):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: module)
+    json_utils._load_orjson.cache_clear()
+    json_utils._warned_orjson_params = False
 
 
 def test_json_dumps_without_orjson(monkeypatch, caplog):

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -2,6 +2,7 @@
 
 import math
 import pytest
+import tnfr.collections_utils as cu
 from tnfr.collections_utils import normalize_weights
 import tnfr.logging_utils as logging_utils
 


### PR DESCRIPTION
## Summary
- ensure negative weight warnings are logged only once
- avoid resetting RNG cache when explicitly disabled
- log orjson parameter warnings once and expose required test helpers
- fix tests to import required modules and reset caches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20753ebcc83218fb93a2bd3ae055a