### PR TITLE
Remove unused threading import from RNG module

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import random
 import hashlib
 import struct
-import threading
 from typing import Any, Callable
 
 


### PR DESCRIPTION
## Summary
- drop unused `threading` import from `rng` utilities

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c20a994f808321a1d660cdfce9c957