### PR TITLE
refactor: modern typing for locks

### DIFF
--- a/src/tnfr/locking.py
+++ b/src/tnfr/locking.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 import threading
 from contextlib import contextmanager
-from typing import Dict, Iterator
+from collections.abc import Iterator
 
 # Registry of locks by name guarded by ``_REGISTRY_LOCK``.
-_locks: Dict[str, threading.Lock] = {}
+_locks: dict[str, threading.Lock] = {}
 _REGISTRY_LOCK = threading.Lock()
 
 


### PR DESCRIPTION
## Summary
- use collections.abc.Iterator in locking utils
- annotate lock registry with built-in dict

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20a9b547c8321a866eb88f76365ac