### PR TITLE
refactor: privatize distance threshold helper

### DIFF
--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -73,7 +73,7 @@ def _calc_selector_score(
     )
 
 
-def dist_to_threshold(value: float, hi: float, lo: float) -> float:
+def _dist_to_threshold(value: float, hi: float, lo: float) -> float:
     """Return distance from ``value`` to nearest of ``hi`` or ``lo``."""
     return min(abs(value - hi), abs(value - lo))
 
@@ -88,9 +88,9 @@ def _apply_selector_hysteresis(
 ) -> str | None:
     """Apply hysteresis, returning the previous glyph when close to
     thresholds."""
-    d_si = dist_to_threshold(Si, thr["si_hi"], thr["si_lo"])
-    d_dn = dist_to_threshold(dnfr, thr["dnfr_hi"], thr["dnfr_lo"])
-    d_ac = dist_to_threshold(accel, thr["accel_hi"], thr["accel_lo"])
+    d_si = _dist_to_threshold(Si, thr["si_hi"], thr["si_lo"])
+    d_dn = _dist_to_threshold(dnfr, thr["dnfr_hi"], thr["dnfr_lo"])
+    d_ac = _dist_to_threshold(accel, thr["accel_hi"], thr["accel_lo"])
     certeza = min(d_si, d_dn, d_ac)
     if certeza < margin:
         hist = nd.get("glyph_history")


### PR DESCRIPTION
## Summary
- rename `dist_to_threshold` to `_dist_to_threshold`
- adjust `_apply_selector_hysteresis` to call the renamed helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20a9a7c90832190e491e5c836e30e