### PR TITLE
Expose json_dumps_str helper

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -1,6 +1,8 @@
 """JSON serialization helpers.
 
 This module lazily imports :mod:`orjson` on first use of :func:`json_dumps`.
+The :func:`json_dumps_str` helper mirrors :func:`json_dumps` but always returns
+``str`` output.
 """
 
 from __future__ import annotations
@@ -26,6 +28,8 @@ _ORJSON_PARAMS_MSG = (
     "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson"
 )
 _warned_orjson_params = False
+
+__all__ = ("json_dumps", "json_dumps_str")
 @lru_cache(maxsize=1)
 def _load_orjson() -> Any | None:
     """Lazily import :mod:`orjson` once."""


### PR DESCRIPTION
## Summary
- mention json_dumps_str helper in json_utils module docstring
- export json_dumps_str via __all__

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20bcd6d2c83218a646797c112e2c4