### PR TITLE
feat: make callback error limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ instantiate ad-hoc locks directly when they are not shared.
 
 ---
 
+## Callback error handling
+
+Callback errors are stored in a ring buffer attached to the graph.  The
+buffer retains at most the last 100 errors by default, but the limit can be
+adjusted at runtime via ``tnfr.callback_utils.set_callback_error_limit``.
+
+---
+
 ## Why TNFR (in 60 seconds)
 
 * **From objects to coherences:** you model **processes** that hold, not fixed entities.

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -17,7 +17,12 @@ from .trace import CallbackSpec
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx  # type: ignore[import-untyped]
 
-__all__ = ("CallbackEvent", "register_callback", "invoke_callbacks")
+__all__ = (
+    "CallbackEvent",
+    "register_callback",
+    "invoke_callbacks",
+    "set_callback_error_limit",
+)
 
 logger = get_logger(__name__)
 
@@ -32,7 +37,9 @@ class CallbackEvent(str, Enum):
 
 _CALLBACK_EVENTS: set[str] = {e.value for e in CallbackEvent}
 
-_CALLBACK_ERROR_LIMIT = 100  # keep only this many recent callback errors
+# Default number of recent callback errors to retain.
+# Use ``set_callback_error_limit`` to adjust.
+_CALLBACK_ERROR_LIMIT = 100
 
 Callback = Callable[["nx.Graph", dict[str, Any]], None]
 CallbackRegistry = dict[str, dict[str, "CallbackSpec"]]
@@ -127,7 +134,11 @@ def _record_callback_error(
     spec: CallbackSpec,
     err: Exception,
 ) -> None:
-    """Log and store a callback error for later inspection."""
+    """Log and store a callback error for later inspection.
+
+    The number of stored errors is bounded by the limit configured via
+    :func:`set_callback_error_limit`.
+    """
 
     logger.exception("callback %r failed for %s: %s", spec.name, event, err)
     err_list = G.graph.get("_callback_errors")
@@ -147,6 +158,28 @@ def _record_callback_error(
             "name": spec.name,
         }
     )
+
+
+def set_callback_error_limit(limit: int) -> int:
+    """Set the maximum number of callback errors retained.
+
+    Parameters
+    ----------
+    limit:
+        Maximum number of recent callback errors to keep. Must be ``>= 1``.
+
+    Returns
+    -------
+    int
+        The previous limit.
+    """
+
+    if limit < 1:
+        raise ValueError("limit must be positive")
+    global _CALLBACK_ERROR_LIMIT
+    previous = _CALLBACK_ERROR_LIMIT
+    _CALLBACK_ERROR_LIMIT = int(limit)
+    return previous
 
 
 def register_callback(

--- a/tests/test_callback_errors_limit.py
+++ b/tests/test_callback_errors_limit.py
@@ -1,10 +1,12 @@
 from collections import deque
 
+import tnfr.callback_utils as cb_utils
+
 from tnfr.callback_utils import (
     CallbackEvent,
     invoke_callbacks,
     register_callback,
-    _CALLBACK_ERROR_LIMIT,
+    set_callback_error_limit,
 )
 
 
@@ -18,10 +20,13 @@ def test_callback_error_list_resets_limit(graph_canon):
     original = deque(maxlen=None)
     G.graph["_callback_errors"] = original
 
-    invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
-
-    err_list = G.graph.get("_callback_errors")
-    assert err_list is not original
-    assert err_list.maxlen == _CALLBACK_ERROR_LIMIT
-    assert len(err_list) == 1
+    prev = set_callback_error_limit(7)
+    try:
+        invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
+        err_list = G.graph.get("_callback_errors")
+        assert err_list is not original
+        assert err_list.maxlen == cb_utils._CALLBACK_ERROR_LIMIT == 7
+        assert len(err_list) == 1
+    finally:
+        set_callback_error_limit(prev)
 


### PR DESCRIPTION
## Summary
- allow adjusting the callback error retention limit via `set_callback_error_limit`
- document callback error ring buffer and new setter
- cover configurable limit with tests

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c20bccf3208321a0b6c801fee09b1f