### PR TITLE
chore: remove unused test imports

### DIFF
--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -3,8 +3,6 @@
 from dataclasses import dataclass
 from types import MappingProxyType
 
-import pytest
-
 from tnfr.immutable import _freeze
 
 

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,7 +1,4 @@
-import logging
-
 import tnfr.json_utils as json_utils
-import tnfr.logging_utils as logging_utils
 import warnings
 
 

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -2,7 +2,6 @@ import warnings
 from dataclasses import is_dataclass
 
 import tnfr.json_utils as json_utils
-import tnfr.logging_utils as logging_utils
 
 
 class DummyOrjson:
@@ -22,7 +21,7 @@ def _reset_json_utils(monkeypatch, module):
 def test_json_dumps_without_orjson(monkeypatch, caplog):
     _reset_json_utils(monkeypatch, None)
 
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True):
 
         result = json_utils.json_dumps({"a": 1}, ensure_ascii=False, to_bytes=True)
     assert result == b'{"a":1}'
@@ -32,7 +31,7 @@ def test_json_dumps_without_orjson(monkeypatch, caplog):
 def test_json_dumps_with_orjson_warns(monkeypatch, caplog):
     _reset_json_utils(monkeypatch, DummyOrjson())
 
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True):
         warnings.filterwarnings("once", message=".*ignored when using orjson")
 
         json_utils.json_dumps({"a": 1}, ensure_ascii=False)

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -4,7 +4,6 @@ import math
 import pytest
 import tnfr.collections_utils as cu
 from tnfr.collections_utils import normalize_weights
-import tnfr.logging_utils as logging_utils
 
 
 def test_normalize_weights_warns_on_negative_value(caplog):


### PR DESCRIPTION
## Summary
- remove unused logging imports and variables in json_utils tests
- drop unused imports reported by pyflakes in normalize weights and freeze tests

## Testing
- `pyflakes tests`
- `pytest tests/test_json_utils.py tests/test_json_utils_extra.py tests/test_normalize_weights.py tests/test_freeze.py`


------
https://chatgpt.com/codex/tasks/task_e_68c20bca2d54832185c8fc2e90ba5f4d