### PR TITLE
Handle zero window in glyph_load

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -124,6 +124,8 @@ def glyph_load(G, window: int | None = None) -> dict:
       otherwise use the deque's maxlen.
     Returns a dict with proportions per glyph and useful aggregates.
     """
+    if window == 0:
+        return {"_count": 0}
     window_int: int | None = None
     if window is not None:
         window_int = validate_window(window, positive=True)

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -147,11 +147,16 @@ def test_wbar_rejects_non_positive_window(graph_canon, w):
         wbar(G, window=w)
 
 
-@pytest.mark.parametrize("w", [0, -1])
+@pytest.mark.parametrize("w", [-1])
 def test_glyph_load_rejects_non_positive_window(graph_canon, w):
     G = graph_canon()
     with pytest.raises(ValueError):
         glyph_load(G, window=w)
+
+
+def test_glyph_load_zero_window(graph_canon):
+    G = graph_canon()
+    assert glyph_load(G, window=0) == {"_count": 0}
 
 
 def test_wbar_uses_default_window(graph_canon):


### PR DESCRIPTION
## Summary
- Avoid processing in `glyph_load` when `window` is zero
- Update observer tests for zero window behavior

## Testing
- `pytest`
- `flake8 src/tnfr/observers.py tests/test_observers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c20bc7266883218a39e5f6ecb6c119