### PR TITLE
Streamline neighbor phase mean computation

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -155,16 +155,14 @@ def neighbor_phase_mean_list(
     summation for stable accumulation.
     """
     if np is not None:
-        valid_pairs = (
+        pairs = [
             (c, s)
             for v in neigh
             if (c := cos_th.get(v)) is not None
             and (s := sin_th.get(v)) is not None
-        )
-        cos_iter, sin_iter = tee(valid_pairs)
-        cos_arr = np.fromiter((c for c, _ in cos_iter), dtype=float)
-        if cos_arr.size:
-            sin_arr = np.fromiter((s for _, s in sin_iter), dtype=float)
+        ]
+        if pairs:
+            cos_arr, sin_arr = np.column_stack(pairs)
             mean_cos = float(np.mean(cos_arr))
             mean_sin = float(np.mean(sin_arr))
             return float(np.arctan2(mean_sin, mean_cos))


### PR DESCRIPTION
## Summary
- Build cosine/sine pairs once in `neighbor_phase_mean_list`
- Compute mean cosine and sine from single pass using `np.column_stack`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c20bbfc9d883218ad39108333890d2