### PR TITLE
refactor: simplify window validation

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -26,7 +26,7 @@ __all__ = (
 
 
 def validate_window(window: int, *, positive: bool = False) -> int:
-    """Validate and coerce ``window`` to an ``int``.
+    """Validate ``window`` as an ``int`` and return it.
 
     Non-integer values raise :class:`TypeError`. When ``positive`` is ``True``
     the value must be strictly greater than zero; otherwise it may be zero.
@@ -35,11 +35,10 @@ def validate_window(window: int, *, positive: bool = False) -> int:
 
     if not isinstance(window, int):
         raise TypeError("'window' must be an integer")
-    window_int = int(window)
-    if window_int < 0 or (positive and window_int == 0):
+    if window < 0 or (positive and window == 0):
         kind = "positive" if positive else "non-negative"
         raise ValueError(f"'window'={window} must be {kind}")
-    return window_int
+    return int(window)
 
 
 def _normalize_history_input(hist: Any) -> Iterable[Any]:


### PR DESCRIPTION
## Summary
- simplify window validation by removing redundant casting
- update docstring to clarify int return value

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c20ba1e32c832192f3f58347a41356