### PR TITLE
feat(trace): add dynamic field registry

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -56,7 +56,7 @@ def _json_dumps_orjson(
         or kwargs
     ):
 
-        warnings.warn(_ORJSON_PARAMS_MSG, UserWarning, stacklevel=3)
+        warnings.warn(_ORJSON_PARAMS_MSG, UserWarning, stacklevel=2)
 
     option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
     data = orjson.dumps(obj, option=option, default=params.default)

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -4,6 +4,7 @@ import pytest
 
 from tnfr.trace import (
     register_trace,
+    register_trace_field,
     _callback_names,
     gamma_field,
     grammar_field,
@@ -58,6 +59,22 @@ def test_trace_sigma_no_glyphs(graph_canon):
         "mag": 0.0,
         "angle": 0.0,
     }
+
+
+def test_register_trace_field_dynamic(graph_canon):
+    from tnfr import trace as trace_mod
+
+    def foo_field(G):
+        return {"foo": 42}
+
+    trace_mod.register_trace_field("before", "foo", foo_field)
+    G = graph_canon()
+    G.graph["TRACE"] = {"capture": ["foo"]}
+    register_trace(G)
+    invoke_callbacks(G, "before_step")
+    meta = G.graph["history"]["trace_meta"][0]
+    assert meta["foo"] == 42
+    trace_mod._TRACE_FIELDS["before"].pop("foo", None)
 
 
 def test_callback_names_spec():


### PR DESCRIPTION
## Summary
- add `register_trace_field` API and registry for trace snapshot fields
- pre-register existing before/after fields and iterate registry in `register_trace`
- fix orjson warning stacklevel so ignored-parameter warning only emits once

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2110028c483218f0daa19afff70ca