### PR TITLE
Use helper for non-string Sequence checks

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING, TypedDict
 from enum import Enum
 from collections import defaultdict, deque
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping
 
 import traceback
 from .logging_utils import get_logger
 from .constants import DEFAULTS
 
 from .trace import CallbackSpec
+from .collections_utils import is_non_string_sequence
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx  # type: ignore[import-untyped]
@@ -91,7 +92,7 @@ def _normalize_event_callbacks(cbs: CallbackRegistry, event: str) -> None:
     cb_map = cbs[event]
     if isinstance(cb_map, Mapping):
         entries = cb_map.values()
-    elif isinstance(cb_map, Sequence) and not isinstance(cb_map, (str, bytes)):
+    elif is_non_string_sequence(cb_map):
         entries = cb_map
     else:
         entries = []
@@ -125,7 +126,7 @@ def _normalize_callback_entry(entry: Any) -> "CallbackSpec | None":
 
     if isinstance(entry, CallbackSpec):
         return entry
-    elif isinstance(entry, Sequence) and not isinstance(entry, str):
+    elif is_non_string_sequence(entry):
         if len(entry) != 2:
             return None
         name, fn = entry

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -31,9 +31,14 @@ def clear_warned_negative_keys() -> None:
     _log_negative_keys_once.clear()
 
 
+def is_non_string_sequence(obj: Any) -> bool:
+    """Return ``True`` if ``obj`` is a ``Sequence`` but not string-like."""
+    return isinstance(obj, Sequence) and not isinstance(obj, STRING_TYPES)
+
 
 __all__ = (
     "MAX_MATERIALIZE_DEFAULT",
+    "is_non_string_sequence",
     "ensure_collection",
     "normalize_weights",
     "normalize_counter",

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -19,7 +19,11 @@ from .constants import get_param
 from .grammar import apply_glyph_with_grammar
 from .constants_glyphs import GLYPHS_CANONICAL_SET
 from .types import Glyph
-from .collections_utils import ensure_collection, MAX_MATERIALIZE_DEFAULT
+from .collections_utils import (
+    ensure_collection,
+    MAX_MATERIALIZE_DEFAULT,
+    is_non_string_sequence,
+)
 from .glyph_history import ensure_history
 
 # Basic types
@@ -324,7 +328,7 @@ def _handle_target(
     """
     nodes_src = G.nodes() if payload.nodes is None else payload.nodes
     nodes = ensure_collection(nodes_src, max_materialize=None)
-    curr_target = nodes if isinstance(nodes, Sequence) else tuple(nodes)
+    curr_target = nodes if is_non_string_sequence(nodes) else tuple(nodes)
     _record_trace(trace, G, OpTag.TARGET, n=len(curr_target))
     return curr_target
 

--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 from collections import deque
-from collections.abc import Sequence
+
+from .collections_utils import is_non_string_sequence
 
 __all__ = ("_flatten_tokens", "validate_token", "_parse_tokens")
 
@@ -15,7 +16,7 @@ def _flatten_tokens(obj: Any):
     stack = deque([obj])
     while stack:
         item = stack.pop()
-        if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+        if is_non_string_sequence(item):
             # ``extendleft`` pushes items in reverse order, preserving
             # LIFO semantics without creating an intermediate reversed list
             stack.extendleft(item)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -8,12 +8,13 @@ structures as immutable snapshots.
 from __future__ import annotations
 
 from typing import Any, Callable, Optional, Protocol, NamedTuple, TypedDict, cast
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping
 
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
 from .import_utils import optional_import
 from .helpers.cache import get_graph_mapping
+from .collections_utils import is_non_string_sequence
 
 
 class _KuramotoFn(Protocol):
@@ -227,9 +228,7 @@ def callbacks_field(G):
     for phase, cb_map in cb.items():
         if isinstance(cb_map, Mapping):
             out[phase] = _callback_names(cb_map)
-        elif isinstance(cb_map, Sequence) and not isinstance(
-            cb_map, (str, bytes)
-        ):
+        elif is_non_string_sequence(cb_map):
             out[phase] = _callback_names(cb_map)
         else:
             out[phase] = None


### PR DESCRIPTION
## Summary
- add `is_non_string_sequence` helper to centralize sequence checks
- refactor token parser, callback utils, program selector, and tracing to use the helper

## Testing
- `python -m flake8 src/tnfr/collections_utils.py src/tnfr/token_parser.py src/tnfr/callback_utils.py src/tnfr/trace.py src/tnfr/selector.py src/tnfr/program.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c217a826c4832194070b8e9e2fc1ff