### PR TITLE
Scope JSON warnings locally

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -18,10 +18,6 @@ from dataclasses import dataclass
 from functools import lru_cache, partial
 from .import_utils import optional_import
 
-warnings.filterwarnings(
-    "once", message=".*ignored when using orjson", category=UserWarning
-)
-
 _ORJSON_PARAMS_MSG = (
     "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson"
 )
@@ -72,7 +68,11 @@ def _json_dumps_orjson(
             _warned_orjson_params = True
 
     option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
-    data = orjson.dumps(obj, option=option, default=params.default)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "once", message=".*ignored when using orjson", category=UserWarning
+        )
+        data = orjson.dumps(obj, option=option, default=params.default)
     return data if params.to_bytes else data.decode("utf-8")
 
 


### PR DESCRIPTION
## Summary
- remove module-level `warnings.filterwarnings` to avoid global side effects
- wrap `orjson.dumps` in `warnings.catch_warnings` so filtering applies only to serialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2193e726c832194a33e15d5740cc6