### PR TITLE
Handle token subclasses in flatten

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -228,12 +228,12 @@ def _flatten_glyph(
     ops.append((OpTag.GLYPH, g))
 
 
-_TOKEN_DISPATCH: dict[type, Callable[[Any, list[tuple[OpTag, Any]]], None]] = {
-    TARGET: _flatten_target,
-    WAIT: _flatten_wait,
-    Glyph: _flatten_glyph,
-    str: _flatten_glyph,
-}
+_TOKEN_DISPATCH: list[tuple[type, Callable[[Any, list[tuple[OpTag, Any]]], None]]] = [
+    (TARGET, _flatten_target),
+    (WAIT, _flatten_wait),
+    (Glyph, _flatten_glyph),
+    (str, _flatten_glyph),
+]
 
 
 def _flatten(
@@ -268,10 +268,12 @@ def _flatten(
         if item is THOL_SENTINEL:
             ops.append((OpTag.THOL, Glyph.THOL.value))
             continue
-        handler = _TOKEN_DISPATCH.get(type(item))
-        if handler is None:
+        for cls, handler in _TOKEN_DISPATCH:
+            if isinstance(item, cls):
+                handler(item, ops)
+                break
+        else:
             raise TypeError(f"Unsupported token: {item!r}")
-        handler(item, ops)
     return ops
 
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -57,6 +57,15 @@ def test_flatten_wait_sanitizes_steps():
     assert ops == [(OpTag.WAIT, 1), (OpTag.WAIT, 2)]
 
 
+def test_flatten_accepts_wait_subclass():
+    class CustomWait(WAIT):
+        pass
+
+    program = seq(CustomWait(3))
+    ops = _flatten(program)
+    assert ops == [(OpTag.WAIT, 3)]
+
+
 def test_play_handles_deeply_nested_blocks(graph_canon):
     G = graph_canon()
     G.add_node(1)


### PR DESCRIPTION
## Summary
- Iterate over token handlers using `isinstance` to support subclasses
- Add regression test covering subclass of `WAIT`

## Testing
- `pytest tests/test_program.py::test_flatten_accepts_wait_subclass -q`


------
https://chatgpt.com/codex/tasks/task_e_68c21db0eeb48321ad019fb7bec5cb92