### PR TITLE
Clear RNG cache on cache size changes

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -111,6 +111,7 @@ def set_cache_maxsize(size: int) -> None:
     """Update RNG cache maximum size.
 
     ``size`` must be a non-negative integer; ``0`` disables caching.
+    Changing the cache size resets any cached seed hashes.
     If caching is disabled, ``clear_rng_cache`` has no effect.
     """
 
@@ -119,6 +120,8 @@ def set_cache_maxsize(size: int) -> None:
     if new_size < 0:
         raise ValueError("size must be non-negative")
     with _RNG_LOCK:
+        if _CACHE_MAXSIZE > 0:
+            _seed_hash_cached.cache_clear()
         _CACHE_MAXSIZE = new_size
         _seed_hash_cached = _make_cache(new_size)
 

--- a/tests/test_rng_base_seed.py
+++ b/tests/test_rng_base_seed.py
@@ -21,3 +21,21 @@ def test_cache_clear_no_fail_when_cache_disabled():
         assert clear_rng_cache() is None
     finally:
         set_cache_maxsize(old_size)
+
+
+def test_set_cache_maxsize_resets_cache():
+    import tnfr.rng as rng_module
+
+    old_size = rng_module._CACHE_MAXSIZE
+    try:
+        set_cache_maxsize(2)
+        # populate cache and keep a reference to the underlying cache object
+        rng_module._seed_hash_cached(1, 1)
+        cache = rng_module._seed_hash_cached.cache
+        assert cache.currsize == 1
+
+        set_cache_maxsize(3)
+        # old cache should be cleared when size changes
+        assert cache.currsize == 0
+    finally:
+        set_cache_maxsize(old_size)


### PR DESCRIPTION
## Summary
- clear RNG cache before rebuilding when cache size is changed
- document cache reset behaviour in `set_cache_maxsize`
- test that changing cache size resets existing cache

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c21f90c98c8321a4abc42887f7efc7