### PR TITLE
Use ensure_history helper

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -31,6 +31,7 @@ from ..scenarios import build_graph
 from ..presets import get_preset
 from ..config import apply_config
 from ..io import read_structured_file, safe_write
+from ..glyph_history import ensure_history
 from ..helpers.numeric import list_mean
 from ..observers import attach_standard_observer
 from ..logging_utils import get_logger
@@ -58,7 +59,7 @@ def _attach_callbacks(G: "nx.Graph") -> None:
 
 def _persist_history(G: "nx.Graph", args: argparse.Namespace) -> None:
     if args.save_history or args.export_history_base:
-        history = G.graph.get("history", {})
+        history = ensure_history(G)
         if args.save_history:
             _save_json(args.save_history, history)
         if args.export_history_base:
@@ -162,7 +163,7 @@ def run_program(
 def _log_run_summaries(G: "nx.Graph", args: argparse.Namespace) -> None:
     cfg_coh = G.graph.get("COHERENCE", METRIC_DEFAULTS["COHERENCE"])
     cfg_diag = G.graph.get("DIAGNOSIS", METRIC_DEFAULTS["DIAGNOSIS"])
-    hist = G.graph.get("history", {})
+    hist = ensure_history(G)
 
     if cfg_coh.get("enabled", True):
         Wstats = hist.get(cfg_coh.get("stats_history_key", "W_stats"), [])

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -421,7 +421,7 @@ def _compute_selector_score(G, nd, Si, dnfr, accel, cand):
     hist_prev = nd.get("glyph_history")
     if hist_prev and hist_prev[-1] == cand:
         delta_si = get_attr(nd, ALIAS_dSI, 0.0)
-        h = G.graph.get("history", {})
+        h = ensure_history(G)
         sig = h.get("sense_sigma_mag", [])
         delta_sigma = sig[-1] - sig[-2] if len(sig) >= 2 else 0.0
         if delta_si <= 0.0 and delta_sigma <= 0.0:
@@ -600,7 +600,7 @@ def _run_validators(G) -> None:
 
 
 def _run_after_callbacks(G, *, step_idx: int) -> None:
-    h = G.graph.get("history", {})
+    h = ensure_history(G)
     ctx = {"step": step_idx}
     metric_pairs = [
         ("C", "C_steps"),

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 from functools import partial
 import statistics
-from collections.abc import Mapping
 
 from .constants import ALIAS_THETA, get_param
 from .alias import get_attr
@@ -141,16 +140,10 @@ def glyph_load(G, window: int | None = None) -> dict:
 def wbar(G, window: int | None = None) -> float:
     """Return W̄ = mean of ``C(t)`` over a recent window.
 
-    The function expects ``G.graph['history']`` to be a mapping containing the
-    ``"C_steps"`` sequence. If the history is missing or malformed, the
-    instantaneous coherence is computed instead.
+    Uses :func:`ensure_history` to obtain ``G.graph['history']`` and falls back
+    to the instantaneous coherence when ``"C_steps"`` is missing or empty.
     """
-    hist = G.graph.get("history")
-    if not isinstance(hist, Mapping):
-        logger.warning(
-            "history is not a mapping; using instantaneous coherence"
-        )
-        return compute_coherence(G)
+    hist = ensure_history(G)
     cs = list(hist.get("C_steps", []))
     if not cs:
         # fallback: coherencia instantánea

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -709,7 +709,7 @@ def apply_network_remesh(G) -> None:
     }
 
     # Snapshot opcional de métricas recientes
-    h = G.graph.get("history", {})
+    h = ensure_history(G)
     if h:
         if h.get("stable_frac"):
             meta["stable_frac_last"] = h["stable_frac"][-1]

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -337,7 +337,7 @@ def register_sigma_callback(G) -> None:
 def sigma_series(G, key: str | None = None) -> dict[str, list[float]]:
     cfg = _sigma_cfg(G)
     key = key or cfg.get("history_key", "sigma_global")
-    hist = G.graph.get("history", {})
+    hist = ensure_history(G)
     xs = hist.get(key, [])
     if not xs:
         return {"t": [], "angle": [], "mag": []}
@@ -350,7 +350,7 @@ def sigma_series(G, key: str | None = None) -> dict[str, list[float]]:
 
 def sigma_rose(G, steps: int | None = None) -> dict[str, int]:
     """Histogram of glyphs in the last ``steps`` steps (or all)."""
-    hist = G.graph.get("history", {})
+    hist = ensure_history(G)
     counts = hist.get("sigma_counts", [])
     if not counts:
         return {g: 0 for g in GLYPHS_CANONICAL}

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tnfr.metrics import _metrics_step
-from tnfr.glyph_history import push_glyph
+from tnfr.glyph_history import push_glyph, ensure_history
 
 
 def test_phase_sync_and_kuramoto_recorded(graph_canon):
@@ -11,7 +11,7 @@ def test_phase_sync_and_kuramoto_recorded(graph_canon):
     G.add_node(1, theta=0.0)
     G.add_node(2, theta=0.0)
     _metrics_step(G)
-    hist = G.graph.get("history", {})
+    hist = ensure_history(G)
     assert hist["phase_sync"][-1] == pytest.approx(1.0)
     assert "kuramoto_R" in hist
     assert hist["kuramoto_R"][-1] == pytest.approx(1.0)

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -4,7 +4,7 @@ from tnfr.constants import inject_defaults
 from tnfr.dynamics import step
 from tnfr.metrics import register_metrics_callbacks
 from tnfr.gamma import GAMMA_REGISTRY
-from tnfr.glyph_history import HistoryDict
+from tnfr.glyph_history import HistoryDict, ensure_history
 
 
 def test_history_delta_si_and_B(graph_canon):
@@ -14,7 +14,7 @@ def test_history_delta_si_and_B(graph_canon):
     register_metrics_callbacks(G)
     step(G, apply_glyphs=False)
     step(G, apply_glyphs=False)
-    hist = G.graph.get("history", {})
+    hist = ensure_history(G)
     assert "delta_Si" in hist and len(hist["delta_Si"]) >= 2
     assert "B" in hist and len(hist["B"]) >= 2
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -10,6 +10,7 @@ from tnfr.dynamics import step
 from tnfr.metrics import register_metrics_callbacks, _metrics_step
 from tnfr.operators import apply_glyph, apply_remesh_if_globally_stable
 from tnfr.types import Glyph
+from tnfr.glyph_history import ensure_history
 
 
 @pytest.fixture
@@ -86,15 +87,15 @@ def test_remesh_cooldown_if_present(G_small):
     )
 
     apply_remesh_if_globally_stable(G_small)
-    events = list(G_small.graph.get("history", {}).get("remesh_events", []))
+    events = list(ensure_history(G_small).get("remesh_events", []))
     assert len(events) == 1
 
     sf.append(1.0)
     apply_remesh_if_globally_stable(G_small)
-    events2 = list(G_small.graph.get("history", {}).get("remesh_events", []))
+    events2 = list(ensure_history(G_small).get("remesh_events", []))
     assert len(events2) == 1
 
     sf.extend([1.0] * int(cooldown))
     apply_remesh_if_globally_stable(G_small)
-    events3 = list(G_small.graph.get("history", {}).get("remesh_events", []))
+    events3 = list(ensure_history(G_small).get("remesh_events", []))
     assert len(events3) == 2

--- a/tests/test_topological_remesh.py
+++ b/tests/test_topological_remesh.py
@@ -3,6 +3,7 @@ import networkx as nx
 
 from tnfr.constants import inject_defaults
 from tnfr import apply_topological_remesh
+from tnfr.glyph_history import ensure_history
 
 
 def _graph_with_epi(graph_canon, n=6):
@@ -34,7 +35,7 @@ def test_remesh_community_reduces_nodes_and_preserves_connectivity(
     apply_topological_remesh(G, mode="community")
     assert nx.is_connected(G)
     assert G.number_of_nodes() < 6
-    ev = G.graph.get("history", {}).get("remesh_events", [])
+    ev = ensure_history(G).get("remesh_events", [])
     assert ev and ev[-1].get("mode") == "community"
 
 


### PR DESCRIPTION
## Summary
- use ensure_history instead of manual G.graph.get('history') checks
- drop wbar warning branch and rely on helper to manage history
- update tests for ensure_history-based behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2225275ec8321b4684c123602a4bd