### PR TITLE
refactor: drop set_attr wrapper

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -241,21 +241,11 @@ def set_attr_generic(
     return _generic_accessor.set(d, aliases, value, conv=conv)
 
 
-def set_attr(
-    d: dict[str, Any],
-    aliases: Iterable[str],
-    value: Any,
-    conv: Callable[[Any], float] | None = None,
-) -> float:
-    """Assign ``value`` to the first alias key found in ``d``."""
-
-    if conv is None:
-        conv = float
-    return set_attr_generic(d, aliases, value, conv=conv)
+set_attr = partial(set_attr_generic, conv=float)
 
 
 get_attr_str = partial(get_attr, conv=str)
-set_attr_str = partial(set_attr, conv=str)
+set_attr_str = partial(set_attr_generic, conv=str)
 
 
 # -------------------------

--- a/tests/test_set_attr_error.py
+++ b/tests/test_set_attr_error.py
@@ -1,10 +1,10 @@
-"""Pruebas de ``set_attr`` para conversiones nulas."""
+"""Pruebas de ``set_attr_generic`` para conversiones nulas."""
 
-from tnfr.alias import set_attr
+from tnfr.alias import set_attr_generic
 
 
 def test_set_attr_allows_none_conversion():
-    """``set_attr`` debe permitir valores ``None``."""
+    """``set_attr_generic`` debe permitir valores ``None``."""
     d = {}
-    set_attr(d, ("x",), 123, conv=lambda v: None)
+    set_attr_generic(d, ("x",), 123, conv=lambda v: None)
     assert "x" in d and d["x"] is None


### PR DESCRIPTION
## Summary
- expose `set_attr_generic` as the core setter and derive `set_attr` as a `functools.partial` with `float` conversion
- adjust `set_attr_str` and test coverage for new interface

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c22f69c6e083218bad88450948490d