### PR TITLE
Rename derivative alias constants and update usage

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -123,11 +123,11 @@ ALIAS_DNFR = ("ΔNFR", "delta_nfr", "dnfr")
 ALIAS_EPI = ("EPI", "psi", "PSI", "value")
 ALIAS_EPI_KIND = ("EPI_kind", "epi_kind", "source_glyph")
 ALIAS_SI = ("Si", "sense_index", "S_i", "sense", "meaning_index")
-ALIAS_dEPI = ("dEPI_dt", "dpsi_dt", "dEPI", "velocity")
+ALIAS_DEPI = ("dEPI_dt", "dpsi_dt", "dEPI", "velocity")
 ALIAS_D2EPI = ("d2EPI_dt2", "d2psi_dt2", "d2EPI", "accel")
-ALIAS_dVF = ("dνf_dt", "dvf_dt", "dnu_dt", "dvf")
+ALIAS_DVF = ("dνf_dt", "dvf_dt", "dnu_dt", "dvf")
 ALIAS_D2VF = ("d2νf_dt2", "d2vf_dt2", "d2nu_dt2", "B")
-ALIAS_dSI = ("δSi", "delta_Si", "dSi")
+ALIAS_DSI = ("δSi", "delta_Si", "dSi")
 
 VF_PRIMARY = ALIAS_VF[0]
 THETA_PRIMARY = ALIAS_THETA[0]
@@ -135,11 +135,11 @@ DNFR_PRIMARY = ALIAS_DNFR[0]
 EPI_PRIMARY = ALIAS_EPI[0]
 EPI_KIND_PRIMARY = ALIAS_EPI_KIND[0]
 SI_PRIMARY = ALIAS_SI[0]
-dEPI_PRIMARY = ALIAS_dEPI[0]
+dEPI_PRIMARY = ALIAS_DEPI[0]
 D2EPI_PRIMARY = ALIAS_D2EPI[0]
-dVF_PRIMARY = ALIAS_dVF[0]
+dVF_PRIMARY = ALIAS_DVF[0]
 D2VF_PRIMARY = ALIAS_D2VF[0]
-dSI_PRIMARY = ALIAS_dSI[0]
+dSI_PRIMARY = ALIAS_DSI[0]
 
 __all__ = (
     "CORE_DEFAULTS",
@@ -166,11 +166,11 @@ __all__ = (
     "ALIAS_EPI",
     "ALIAS_EPI_KIND",
     "ALIAS_SI",
-    "ALIAS_dEPI",
+    "ALIAS_DEPI",
     "ALIAS_D2EPI",
-    "ALIAS_dVF",
+    "ALIAS_DVF",
     "ALIAS_D2VF",
-    "ALIAS_dSI",
+    "ALIAS_DSI",
     "VF_PRIMARY",
     "THETA_PRIMARY",
     "DNFR_PRIMARY",
@@ -183,3 +183,24 @@ __all__ = (
     "D2VF_PRIMARY",
     "dSI_PRIMARY",
 )
+
+# Deprecated names ---------------------------------------------------------
+# Keep legacy lowercase derivative aliases for backwards compatibility.
+# Accessing them triggers a ``DeprecationWarning`` pointing to the new
+# uppercase variants.
+_DEPRECATED_ALIASES = {
+    "ALIAS_dEPI": "ALIAS_DEPI",
+    "ALIAS_dVF": "ALIAS_DVF",
+    "ALIAS_dSI": "ALIAS_DSI",
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        warnings.warn(
+            f"'{name}' is deprecated; use '{_DEPRECATED_ALIASES[name]}'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED_ALIASES[name]]
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -20,7 +20,7 @@ from ..constants import (
     ALIAS_EPI,
     ALIAS_SI,
     ALIAS_D2EPI,
-    ALIAS_dSI,
+    ALIAS_DSI,
     get_param,
 )
 from ..observers import glyph_load, kuramoto_order
@@ -420,7 +420,7 @@ def _compute_selector_score(G, nd, Si, dnfr, accel, cand):
     score = _calc_selector_score(Si, dnfr, accel, W)
     hist_prev = nd.get("glyph_history")
     if hist_prev and hist_prev[-1] == cand:
-        delta_si = get_attr(nd, ALIAS_dSI, 0.0)
+        delta_si = get_attr(nd, ALIAS_DSI, 0.0)
         h = ensure_history(G)
         sig = h.get("sense_sigma_mag", [])
         delta_sigma = sig[-1] - sig[-2] if len(sig) >= 2 else 0.0

--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -9,7 +9,7 @@ from ..constants import (
     DEFAULTS,
     ALIAS_VF,
     ALIAS_DNFR,
-    ALIAS_dEPI,
+    ALIAS_DEPI,
     ALIAS_EPI,
     ALIAS_EPI_KIND,
     ALIAS_D2EPI,
@@ -175,7 +175,7 @@ def update_epi_via_nodal_equation(
             set_attr(nd, ALIAS_EPI, epi)
             if epi_kind:
                 set_attr_str(nd, ALIAS_EPI_KIND, epi_kind)
-            set_attr(nd, ALIAS_dEPI, dEPI_dt)
+            set_attr(nd, ALIAS_DEPI, dEPI_dt)
             set_attr(nd, ALIAS_D2EPI, d2epi)
 
         t_local += dt_step
@@ -197,6 +197,6 @@ def _node_state(nd: dict[str, Any]) -> tuple[float, float, float, float]:
 
     vf = get_attr(nd, ALIAS_VF, 0.0)
     dnfr = get_attr(nd, ALIAS_DNFR, 0.0)
-    dEPI_dt_prev = get_attr(nd, ALIAS_dEPI, 0.0)
+    dEPI_dt_prev = get_attr(nd, ALIAS_DEPI, 0.0)
     epi_i = get_attr(nd, ALIAS_EPI, 0.0)
     return vf, dnfr, dEPI_dt_prev, epi_i

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -13,11 +13,11 @@ import math
 from ..constants import (
     ALIAS_EPI,
     ALIAS_DNFR,
-    ALIAS_dEPI,
+    ALIAS_DEPI,
     ALIAS_SI,
-    ALIAS_dSI,
+    ALIAS_DSI,
     ALIAS_VF,
-    ALIAS_dVF,
+    ALIAS_DVF,
     ALIAS_D2VF,
     get_param,
 )
@@ -259,7 +259,7 @@ def _track_stability(G, hist, dt, eps_dnfr, eps_depi):
     for _, nd in G.nodes(data=True):
         if (
             abs(get_attr(nd, ALIAS_DNFR, 0.0)) <= eps_dnfr
-            and abs(get_attr(nd, ALIAS_dEPI, 0.0)) <= eps_depi
+            and abs(get_attr(nd, ALIAS_DEPI, 0.0)) <= eps_depi
         ):
             stables += 1
 
@@ -267,7 +267,7 @@ def _track_stability(G, hist, dt, eps_dnfr, eps_depi):
         Si_prev = nd.get("_prev_Si", Si_curr)
         dSi = Si_curr - Si_prev
         nd["_prev_Si"] = Si_curr
-        set_attr(nd, ALIAS_dSI, dSi)
+        set_attr(nd, ALIAS_DSI, dSi)
         delta_si_sum += dSi
         delta_si_count += 1
 
@@ -278,7 +278,7 @@ def _track_stability(G, hist, dt, eps_dnfr, eps_depi):
         B = (dvf_dt - dvf_prev) / dt
         nd["_prev_vf"] = vf_curr
         nd["_prev_dvf"] = dvf_dt
-        set_attr(nd, ALIAS_dVF, dvf_dt)
+        set_attr(nd, ALIAS_DVF, dvf_dt)
         set_attr(nd, ALIAS_D2VF, B)
         B_sum += B
         B_count += 1

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -11,7 +11,7 @@ from .constants import (
     DEFAULTS,
     ALIAS_DNFR,
     ALIAS_D2EPI,
-    ALIAS_dEPI,
+    ALIAS_DEPI,
     ALIAS_VF,
     ALIAS_THETA,
     ALIAS_SI,
@@ -98,7 +98,7 @@ def compute_coherence(
         depi_arr = np.empty(count, dtype=float)
         for idx, (_, nd) in enumerate(G.nodes(data=True)):
             dnfr = abs(get_attr(nd, ALIAS_DNFR, 0.0))
-            depi = abs(get_attr(nd, ALIAS_dEPI, 0.0))
+            depi = abs(get_attr(nd, ALIAS_DEPI, 0.0))
             dnfr_arr[idx] = dnfr
             depi_arr[idx] = depi
         dnfr_mean = float(np.mean(dnfr_arr))
@@ -108,7 +108,7 @@ def compute_coherence(
             (
                 (
                     abs(get_attr(nd, ALIAS_DNFR, 0.0)),
-                    abs(get_attr(nd, ALIAS_dEPI, 0.0)),
+                    abs(get_attr(nd, ALIAS_DEPI, 0.0)),
                 )
                 for _, nd in G.nodes(data=True)
             )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -7,7 +7,7 @@ from tnfr.constants import (
     inject_defaults,
     ALIAS_EPI,
     ALIAS_DNFR,
-    ALIAS_dEPI,
+    ALIAS_DEPI,
     ALIAS_SI,
     ALIAS_VF,
 )
@@ -37,7 +37,7 @@ def test_track_stability_updates_hist(graph_canon):
 
     # Node 0: stable
     set_attr(G.nodes[0], ALIAS_DNFR, 0.0)
-    set_attr(G.nodes[0], ALIAS_dEPI, 0.0)
+    set_attr(G.nodes[0], ALIAS_DEPI, 0.0)
     set_attr(G.nodes[0], ALIAS_SI, 2.0)
     G.nodes[0]["_prev_Si"] = 1.0
     set_attr(G.nodes[0], ALIAS_VF, 1.0)
@@ -46,7 +46,7 @@ def test_track_stability_updates_hist(graph_canon):
 
     # Node 1: unstable
     set_attr(G.nodes[1], ALIAS_DNFR, 10.0)
-    set_attr(G.nodes[1], ALIAS_dEPI, 10.0)
+    set_attr(G.nodes[1], ALIAS_DEPI, 10.0)
     set_attr(G.nodes[1], ALIAS_SI, 3.0)
     G.nodes[1]["_prev_Si"] = 1.0
     set_attr(G.nodes[1], ALIAS_VF, 1.0)


### PR DESCRIPTION
## Summary
- Rename derivative alias constants (`ALIAS_DEPI`, `ALIAS_DVF`, `ALIAS_DSI`)
- Add module-level deprecation warnings for legacy names
- Update all imports, references, and tests to use the new constants

## Testing
- `pytest tests/test_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2419cf9b08321bde86821fb3e3e4a