### PR TITLE
Use slots in NodeCache dataclass

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -121,7 +121,7 @@ def _iter_node_digests(
             yield _hash_node(node, repr_)
 
 
-@dataclass
+@dataclass(slots=True)
 class NodeCache:
     """Container for cached node data."""
 


### PR DESCRIPTION
## Summary
- optimize NodeCache by enabling dataclass slots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2419b8fd48321b9fffe345325bed0