### PR TITLE
refactor: centralize CallbackSpec import

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -13,6 +13,9 @@ example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or
 
 from __future__ import annotations
 
+# re-exported for tests
+from .trace import CallbackSpec  # noqa: F401
+from .import_utils import optional_import
 from .ontosim import preparar_red
 from .types import NodeState
 
@@ -52,10 +55,6 @@ except Exception as exc:  # pragma: no cover - no missing deps in CI
     apply_topological_remesh = _missing_dependency("apply_topological_remesh", exc)
 else:
     _HAS_APPLY_TOPOLOGICAL_REMESH = True
-
-# re-exported for tests
-from .trace import CallbackSpec  # noqa: F401
-from .import_utils import optional_import
 
 _metadata = optional_import("importlib.metadata")
 if _metadata is None:  # pragma: no cover


### PR DESCRIPTION
## Summary
- move CallbackSpec and optional_import to top import section in __init__

## Testing
- `flake8 src/tnfr/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c27ca9408c8321a615154c1b95db93