### PR TITLE
style: ensure two blank lines before top-level functions

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -50,6 +50,7 @@ SENTINEL = object()
 # Module-level lock to guard alias cache operations
 _alias_cache_lock = Lock()
 
+
 def _convert_default(
     default: Any,
     conv: Callable[[Any], T],
@@ -70,6 +71,7 @@ def _convert_default(
         key="default",
         log_level=log_level,
     )
+
 
 def _alias_resolve(
     d: dict[str, Any],


### PR DESCRIPTION
## Summary
- ensure _convert_default and _alias_resolve are separated by two blank lines
- keep top-level helpers spaced consistently

## Testing
- `flake8 src/tnfr/alias.py`

------
https://chatgpt.com/codex/tasks/task_e_68c27d363a7c8321ba8d2e891e761355