### PR TITLE
Remove unused tee import from numeric helper

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 from collections.abc import Iterable, Sequence
 from statistics import fmean, StatisticsError, pvariance
-from itertools import chain, tee
+from itertools import chain
 import math
 
 from ..import_utils import get_numpy, import_nodonx


### PR DESCRIPTION
## Summary
- drop unused tee import from itertools in numeric helper

## Testing
- `flake8 src/tnfr/helpers/numeric.py`


------
https://chatgpt.com/codex/tasks/task_e_68c27dc484308321b7c6f321b33f2f86