### PR TITLE
Lazy initialize logging configuration

### DIFF
--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -35,14 +35,10 @@ def _configure_root() -> None:
     _LOGGING_CONFIGURED = True
 
 
-_configure_root()
-
-
 def get_logger(name: str) -> logging.Logger:
     """Return a module-specific logger."""
-
+    _configure_root()
     return logging.getLogger(name)
-
 
 
 def warn_once(
@@ -76,4 +72,3 @@ def warn_once(
 
     _log.clear = _seen.clear  # type: ignore[attr-defined]
     return _log
-


### PR DESCRIPTION
## Summary
- configure root logger lazily on first `get_logger` call

## Testing
- `flake8 src/tnfr/logging_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c27f0795f0832180676da51bb94b72