### PR TITLE
refactor: centralize weight merging utility

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -39,7 +39,7 @@ from ..alias import (
     set_theta,
     multi_recompute_abs_max,
 )
-from ..metrics_utils import compute_Si, compute_dnfr_accel_max
+from ..metrics_utils import compute_Si, compute_dnfr_accel_max, merge_graph_weights
 from ..callback_utils import invoke_callbacks
 from ..glyph_history import recent_glyph, ensure_history, append_metric
 from ..collections_utils import normalize_weights
@@ -406,7 +406,7 @@ def _selector_base_choice(Si, dnfr, accel, thr):
 
 def _configure_selector_weights(G) -> dict:
     """Normalise and store selector weights in ``G.graph``."""
-    w = {**DEFAULTS["SELECTOR_WEIGHTS"], **G.graph.get("SELECTOR_WEIGHTS", {})}
+    w = merge_graph_weights(G, "SELECTOR_WEIGHTS")
     weights = normalize_weights(w, ("w_si", "w_dnfr", "w_accel"))
     G.graph["_selector_weights"] = weights
     return weights

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -24,7 +24,7 @@ from ..alias import (
     get_attr,
     set_dnfr,
 )
-from ..metrics_utils import get_trig_cache
+from ..metrics_utils import get_trig_cache, merge_graph_weights
 from ..import_utils import get_numpy
 
 
@@ -78,7 +78,7 @@ def _configure_dnfr_weights(G) -> dict:
     dictionary of normalised components reused at each simulation step
     without recomputing the mix.
     """
-    w = {**DEFAULTS["DNFR_WEIGHTS"], **get_param(G, "DNFR_WEIGHTS")}
+    w = merge_graph_weights(G, "DNFR_WEIGHTS")
     weights = normalize_weights(w, ("phase", "epi", "vf", "topo"), default=0.0)
     G.graph["_dnfr_weights"] = weights
     return weights

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -45,6 +45,7 @@ __all__ = (
     "compute_dnfr_accel_max",
     "compute_coherence",
     "ensure_neighbors_map",
+    "merge_graph_weights",
     "get_Si_weights",
     "get_trig_cache",
     "compute_Si_node",
@@ -129,9 +130,15 @@ def ensure_neighbors_map(G: GraphLike) -> Mapping[Any, Sequence[Any]]:
     return edge_version_cache(G, "_neighbors", builder)
 
 
+def merge_graph_weights(G: GraphLike, key: str) -> dict[str, float]:
+    """Merge default weights for ``key`` with any graph overrides."""
+
+    return {**DEFAULTS[key], **G.graph.get(key, {})}
+
+
 def get_Si_weights(G: GraphLike) -> tuple[float, float, float]:
     """Obtain and normalise weights for the sense index."""
-    w = {**DEFAULTS["SI_WEIGHTS"], **G.graph.get("SI_WEIGHTS", {})}
+    w = merge_graph_weights(G, "SI_WEIGHTS")
     weights = normalize_weights(w, ("alpha", "beta", "gamma"), default=0.0)
     alpha = weights["alpha"]
     beta = weights["beta"]


### PR DESCRIPTION
## Summary
- add `merge_graph_weights` helper for combining graph overrides with defaults
- refactor selector, Si, and ΔNFR weight setup to use the shared helper

## Testing
- `pytest -q` *(fails: tests/test_json_utils.py::test_warns_once, tests/test_json_utils_extra.py::test_json_dumps_with_orjson_warns)*

------
https://chatgpt.com/codex/tasks/task_e_68c28b1c096c832195acd3243950d400