### PR TITLE
Refactor node initialization parameter handling

### DIFF
--- a/src/tnfr/constants/init.py
+++ b/src/tnfr/constants/init.py
@@ -23,6 +23,9 @@ class InitDefaults:
     INIT_VF_MEAN: float = 0.5
     INIT_VF_STD: float = 0.15
     INIT_VF_CLAMP_TO_LIMITS: bool = True
+    INIT_SI_MIN: float = 0.4
+    INIT_SI_MAX: float = 0.7
+    INIT_EPI_VALUE: float = 0.0
 
 
 INIT_DEFAULTS = asdict(InitDefaults())


### PR DESCRIPTION
## Summary
- Gather all initialization parameters once via `get_graph_param`
- Avoid repeated type conversions in `_init_vf` and `_init_si_epi`
- Add defaults for `INIT_SI_MIN`, `INIT_SI_MAX`, and `INIT_EPI_VALUE`

## Testing
- `pytest` *(fails: test_compute_Si_calls_get_numpy_once_and_propagates, test_warns_once, test_json_dumps_with_orjson_warns)*

------
https://chatgpt.com/codex/tasks/task_e_68c29ee575348321a3ae2ddeed50b678