### PR TITLE
test: patch numpy via module attribute

### DIFF
--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -117,7 +117,7 @@ def test_cache_node_list_cache_updated_on_node_set_change(graph_canon):
 
 
 def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
-    monkeypatch.setattr("tnfr.helpers.cache.get_numpy", lambda: None)
+    monkeypatch.setattr("tnfr.helpers.cache.np", None, raising=False)
     G = graph_canon()
     G.add_edge(0, 1)
     nodes, A = cached_nodes_and_A(G)
@@ -126,7 +126,7 @@ def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon)
 
 
 def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
-    monkeypatch.setattr("tnfr.helpers.cache.get_numpy", lambda: None)
+    monkeypatch.setattr("tnfr.helpers.cache.np", None, raising=False)
     G = graph_canon()
     G.add_edge(0, 1)
     with pytest.raises(RuntimeError):

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -3,19 +3,12 @@ from tnfr.metrics_utils import compute_Si
 from tnfr.alias import set_attr
 
 
-def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch, graph_canon):
-    calls = 0
-
+def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
     class DummyNP:
         def fromiter(self, iterable, dtype=float, count=-1):
             return list(iterable)
 
     sentinel = DummyNP()
-
-    def fake_get_numpy():
-        nonlocal calls
-        calls += 1
-        return sentinel
 
     captured = []
 
@@ -25,7 +18,7 @@ def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch, graph_canon
         captured.append(np)
         return 0.0
 
-    monkeypatch.setattr("tnfr.metrics_utils.get_numpy", fake_get_numpy)
+    monkeypatch.setattr("tnfr.metrics_utils.np", sentinel)
     monkeypatch.setattr(
         "tnfr.metrics_utils.neighbor_phase_mean_list",
         fake_neighbor_phase_mean_list,
@@ -40,5 +33,4 @@ def test_compute_Si_calls_get_numpy_once_and_propagates(monkeypatch, graph_canon
 
     compute_Si(G, inplace=False)
 
-    assert calls == 1
     assert captured == [sentinel] * G.number_of_nodes()

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -51,7 +51,7 @@ def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
         set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     ps_np = phase_sync(G)
-    monkeypatch.setattr("tnfr.observers.get_numpy", lambda: None)
+    monkeypatch.setattr("tnfr.observers.np", None)
     ps_py = phase_sync(G)
     assert ps_np == pytest.approx(ps_py)
 


### PR DESCRIPTION
## Summary
- update tests to monkeypatch module-level `np` instead of `get_numpy`
- ensure observers and cache helpers emulate missing NumPy via `np` attribute
- simplify compute_Si test by dropping call count assertion

## Testing
- `pytest tests/test_compute_Si_numpy_usage.py tests/test_observers.py tests/test_cache_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2a8838c708321af147505ee35fcce