### PR TITLE
Fix ignored parameters tracking in json utils

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -61,12 +61,12 @@ def _json_dumps_orjson(
     **kwargs: Any,
 ) -> bytes | str:
     """Serialize using :mod:`orjson` and warn about unsupported parameters."""
-    mapping = {
-        params.ensure_ascii is not True: "ensure_ascii",
-        params.separators != (",", ":"): "separators",
-        params.cls is not None: "cls",
-    }
-    ignored = [name for cond, name in mapping.items() if cond]
+    checks = [
+        (params.ensure_ascii is not True, "ensure_ascii"),
+        (params.separators != (",", ":"), "separators"),
+        (params.cls is not None, "cls"),
+    ]
+    ignored = [name for cond, name in checks if cond]
     if kwargs:
         ignored.extend(kwargs)
     if ignored:


### PR DESCRIPTION
## Summary
- replace boolean-key dict with explicit list of checks in `_json_dumps_orjson`
- build `ignored` list safely and preserve warnings

## Testing
- `pytest` *(fails: tests/test_cache_helpers.py::test_cached_nodes_and_A_returns_none_without_numpy, tests/test_cache_helpers.py::test_cached_nodes_and_A_requires_numpy, tests/test_cli_history.py::test_cli_run_save_history, tests/test_cli_history.py::test_cli_run_save_and_export_metrics, tests/test_cli_history.py::test_cli_sequence_save_history, tests/test_dnfr_precompute.py::test_strategies_share_precomputed_data, tests/test_dynamics_vectorized.py::test_default_compute_delta_nfr_paths[False], tests/test_json_utils.py::test_warns_once, tests/test_json_utils_extra.py::test_json_dumps_with_orjson_warns)`

------
https://chatgpt.com/codex/tasks/task_e_68c2ace284dc8321af6693f3ccc6ee2e