### PR TITLE
refactor: drop json_dumps_str alias

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -36,7 +36,7 @@ from ..helpers.numeric import list_mean
 from ..observers import attach_standard_observer
 from ..logging_utils import get_logger
 from ..types import Glyph
-from ..json_utils import json_dumps_str
+from ..json_utils import json_dumps
 
 from .arguments import _args_to_dict
 from .token_parser import _parse_tokens
@@ -45,7 +45,7 @@ logger = get_logger(__name__)
 
 
 def _save_json(path: str, data: Any) -> None:
-    payload = json_dumps_str(data, ensure_ascii=False, indent=2, default=list)
+    payload = json_dumps(data, ensure_ascii=False, indent=2, default=list)
     safe_write(path, lambda f: f.write(payload))
 
 
@@ -233,5 +233,5 @@ def cmd_metrics(args: argparse.Namespace) -> int:
     if args.save:
         _save_json(args.save, out)
     else:
-        logger.info("%s", json_dumps_str(out))
+        logger.info("%s", json_dumps(out))
     return 0

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -1,8 +1,6 @@
 """JSON serialization helpers.
 
 This module lazily imports :mod:`orjson` on first use of :func:`json_dumps`.
-The :func:`json_dumps_str` helper mirrors :func:`json_dumps` but always returns
-``str`` output.
 """
 
 from __future__ import annotations
@@ -14,7 +12,7 @@ import warnings
 from typing import Any, Callable, Literal, cast, overload
 
 from dataclasses import dataclass
-from functools import lru_cache, partial
+from functools import lru_cache
 from .import_utils import optional_import
 
 _ORJSON_PARAMS_MSG = (
@@ -167,4 +165,3 @@ def json_dumps(
     return _json_dumps_std(obj, params, **kwargs)
 
 
-json_dumps_str = partial(json_dumps, to_bytes=False)

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -10,7 +10,7 @@ from ..glyph_history import ensure_history
 from ..io import safe_write
 from ..constants_glyphs import GLYPHS_CANONICAL
 from .core import glyphogram_series
-from ..json_utils import json_dumps_str
+from ..json_utils import json_dumps
 
 
 def _write_csv(path, headers, rows):
@@ -134,4 +134,4 @@ def export_metrics(G, base_path: str, fmt: str = "csv") -> None:
             "epi_support": epi_supp,
         }
         json_path = base_path + ".json"
-        safe_write(json_path, lambda f: f.write(json_dumps_str(data)))
+        safe_write(json_path, lambda f: f.write(json_dumps(data)))

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -38,6 +38,8 @@ def test_warns_once(monkeypatch, caplog):
     assert len(w) == 1
 
 
-def test_json_dumps_str_matches_json_dumps():
+def test_json_dumps_returns_str_by_default():
     data = {"a": 1, "b": [1, 2, 3]}
-    assert json_utils.json_dumps_str(data) == json_utils.json_dumps(data, to_bytes=False)
+    result = json_utils.json_dumps(data)
+    assert isinstance(result, str)
+    assert result == json_utils.json_dumps(data, to_bytes=False)


### PR DESCRIPTION
## Summary
- remove `json_dumps_str` alias in `json_utils`
- inline `json_dumps` in CLI and metrics modules
- update tests for default string output

## Testing
- `pytest tests/test_json_utils.py::test_json_dumps_returns_str_by_default -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b1622cb083219bc65806fc87ae63