### PR TITLE
Reject boolean windows in validate_window

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -35,7 +35,7 @@ def validate_window(window: int, *, positive: bool = False) -> int:
     Negative values always raise :class:`ValueError`.
     """
 
-    if not isinstance(window, int):
+    if isinstance(window, bool) or not isinstance(window, int):
         raise TypeError("'window' must be an integer")
     if window < 0 or (positive and window == 0):
         kind = "positive" if positive else "non-negative"

--- a/tests/test_validate_window.py
+++ b/tests/test_validate_window.py
@@ -1,0 +1,11 @@
+"""Tests for validate_window parameter handling."""
+
+import pytest
+
+from tnfr.glyph_history import validate_window
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_validate_window_rejects_bool(value):
+    with pytest.raises(TypeError):
+        validate_window(value)


### PR DESCRIPTION
## Summary
- ensure `validate_window` treats booleans as invalid by explicitly excluding `bool`
- add tests verifying `True` and `False` raise `TypeError`

## Testing
- `pytest tests/test_validate_window.py tests/test_push_glyph.py tests/test_recent_glyph.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2b472b1b4832183b846871c898da4