### PR TITLE
feat: flatten arbitrary iterables

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -33,8 +33,8 @@ def clear_warned_negative_keys() -> None:
 
 
 def is_non_string_sequence(obj: Any) -> bool:
-    """Return ``True`` if ``obj`` is a ``Sequence`` but not string-like."""
-    return isinstance(obj, Sequence) and not isinstance(obj, STRING_TYPES)
+    """Return ``True`` if ``obj`` is an ``Iterable`` but not string-like or a mapping."""
+    return isinstance(obj, Iterable) and not isinstance(obj, (*STRING_TYPES, Mapping))
 
 
 def flatten_structure(
@@ -42,12 +42,16 @@ def flatten_structure(
     *,
     expand: Callable[[Any], Iterable[Any] | None] | None = None,
 ) -> Iterator[Any]:
-    """Yield leaf items from ``obj`` preserving order.
+    """Yield leaf items from ``obj``.
+
+    The order of yielded items follows the order of the input iterable when it
+    is defined. For unordered iterables like :class:`set` the resulting order is
+    arbitrary. Mappings are treated as atomic items and not expanded.
 
     Parameters
     ----------
     obj:
-        Object that may contain nested sequences.
+        Object that may contain nested iterables.
     expand:
         Optional callable returning a replacement iterable for ``item``. When
         it returns ``None`` the ``item`` is processed normally.

--- a/tests/test_flatten_structure.py
+++ b/tests/test_flatten_structure.py
@@ -1,0 +1,15 @@
+from tnfr.collections_utils import flatten_structure
+
+
+def test_flatten_structure_set():
+    items = {1, 2, 3}
+    assert set(flatten_structure(items)) == items
+
+
+def _simple_gen():
+    for i in range(3):
+        yield i
+
+
+def test_flatten_structure_generator():
+    assert list(flatten_structure(_simple_gen())) == [0, 1, 2]


### PR DESCRIPTION
## Summary
- generalize `flatten_structure` to accept any non-string iterable
- clarify ordering behavior and skip expansion of mappings
- add tests for sets and generator inputs

## Testing
- `pytest tests/test_flatten_structure.py tests/test_cli_sanity.py::test_cli_sequence_file -q`
- `pytest tests/test_program.py tests/test_trace.py tests/test_selector_utils.py tests/test_selector_norms.py tests/test_invoke_callbacks.py tests/test_register_callback.py tests/test_callback_errors_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b8e0e6008321b5705e5b45c20247