### PR TITLE
feat: add error_on_conversion to weight normalization

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -181,6 +181,7 @@ def normalize_weights(
     *,
     error_on_negative: bool = False,
     warn_once: bool = True,
+    error_on_conversion: bool = False,
 ) -> dict[str, float]:
     """Normalize ``keys`` in ``dict_like`` so their sum is 1.
 
@@ -190,9 +191,15 @@ def normalize_weights(
     Negative weights are handled according to ``error_on_negative``. When
     ``True`` a :class:`ValueError` is raised. Otherwise negatives are logged,
     replaced with ``0`` and the remaining weights are renormalized. If all
-    weights are non-positive a uniform distribution is returned. When
-    ``warn_once`` is ``True`` warnings for a given key are emitted only on their
-    first occurrence across calls.
+    weights are non-positive a uniform distribution is returned.
+
+    Conversion errors are controlled separately by ``error_on_conversion``. When
+    ``True`` any :class:`TypeError` or :class:`ValueError` while converting a
+    value to ``float`` is propagated. Otherwise the error is logged and the
+    ``default`` value is used.
+
+    When ``warn_once`` is ``True`` warnings for a given key are emitted only on
+    their first occurrence across calls.
     """
     keys = list(dict.fromkeys(keys))
     default_float = float(default)
@@ -204,7 +211,7 @@ def normalize_weights(
         try:
             return float(val)
         except (TypeError, ValueError) as exc:
-            if error_on_negative:
+            if error_on_conversion:
                 raise
             logger.warning("Could not convert value for %r: %s", key, exc)
             return default_float

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -64,7 +64,16 @@ def test_normalize_weights_warn_once(caplog):
 def test_normalize_weights_raises_on_non_numeric_value():
     weights = {"a": "not-a-number", "b": 2.0}
     with pytest.raises(ValueError):
-        normalize_weights(weights, ("a", "b"), error_on_negative=True)
+        normalize_weights(weights, ("a", "b"), error_on_conversion=True)
+
+
+def test_normalize_weights_error_on_negative_does_not_raise_conversion(caplog):
+    """error_on_negative should not affect conversion errors."""
+    weights = {"a": "not-a-number", "b": 2.0}
+    with caplog.at_level("WARNING"):
+        norm = normalize_weights(weights, ("a", "b"), error_on_negative=True, default=1.0)
+    assert any("Could not convert" in m for m in caplog.messages)
+    assert math.isclose(math.fsum(norm.values()), 1.0)
 
 
 def test_normalize_weights_high_precision():


### PR DESCRIPTION
## Summary
- allow normalize_weights to raise on conversion errors via new `error_on_conversion` flag
- keep negative weight handling separate from conversion errors
- update tests for new parameter and add coverage

## Testing
- `pytest tests/test_normalize_weights.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2bde6b3d88321ac24d25938e0b64e