### PR TITLE
refactor: hoist emit map

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -29,6 +29,15 @@ __all__ = (
 
 logger = get_logger(__name__)
 
+EMIT_MAP: dict[str, tuple] = {
+    "warn": (lambda m: warnings.warn(m, RuntimeWarning, stacklevel=2),),
+    "log": (logger.warning,),
+    "both": (
+        lambda m: warnings.warn(m, RuntimeWarning, stacklevel=2),
+        logger.warning,
+    ),
+}
+
 _FAILED_IMPORT_LIMIT = 128  # keep only this many recent failures
 _FAILED_IMPORT_MAX_AGE = 3600.0  # seconds
 _FAILED_IMPORT_PRUNE_INTERVAL = 60.0  # seconds between automatic prunes
@@ -111,16 +120,7 @@ def _warn_failure(
     if not first:
         logger.debug(msg)
         return
-
-    emit_map = {
-        "warn": (lambda m: warnings.warn(m, RuntimeWarning, stacklevel=2),),
-        "log": (logger.warning,),
-        "both": (
-            lambda m: warnings.warn(m, RuntimeWarning, stacklevel=2),
-            logger.warning,
-        ),
-    }
-    for fn in emit_map[emit]:
+    for fn in EMIT_MAP[emit]:
         fn(msg)
 
 

--- a/tests/test_warn_failure_emit.py
+++ b/tests/test_warn_failure_emit.py
@@ -39,3 +39,25 @@ def test_warn_failure_both(caplog):
         assert len(w) == 1
         assert len(caplog.records) == 1
         assert "mod_both" in caplog.records[0].message
+
+
+def test_warn_failure_uses_emit_map():
+    from tnfr import import_utils
+
+    called: list[str] = []
+
+    def fake_warn(msg: str) -> None:
+        called.append(msg)
+
+    _clear_warned()
+    original = import_utils.EMIT_MAP["warn"]
+    import_utils.EMIT_MAP["warn"] = (fake_warn,)
+    try:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _warn_failure("mod_emit_map", None, ImportError("boom"))
+        assert not w
+        assert called == ["Failed to import module 'mod_emit_map': boom"]
+    finally:
+        import_utils.EMIT_MAP["warn"] = original
+        _clear_warned()


### PR DESCRIPTION
## Summary
- hoist emit mapping to module scope
- reuse global emit mapping in `_warn_failure`
- cover emit map usage with additional tests

## Testing
- `pytest tests/test_warn_failure_emit.py tests/test_warn_failure_threadsafe.py tests/test_warned_modules_prune.py tests/test_import_utils.py tests/test_optional_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2c179cc4883218de8bf6106b71f8d