### PR TITLE
Simplify callbacks_field condition

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -255,9 +255,7 @@ def callbacks_field(G: Any) -> TraceMetadata:
         return {}
     out: dict[str, list[str] | None] = {}
     for phase, cb_map in cb.items():
-        if isinstance(cb_map, Mapping):
-            out[phase] = _callback_names(cb_map)
-        elif is_non_string_sequence(cb_map):
+        if isinstance(cb_map, Mapping) or is_non_string_sequence(cb_map):
             out[phase] = _callback_names(cb_map)
         else:
             out[phase] = None


### PR DESCRIPTION
## Summary
- simplify callbacks_field to handle mappings and sequences in one branch

## Testing
- `flake8 src/tnfr/trace.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c2430e088321a1e2200b095aaace