### PR TITLE
Validate iterables before materialisation

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -133,23 +133,24 @@ def ensure_collection(
     # Step 2: validate limit
     limit = _validate_limit(max_materialize)
 
+    # Step 2.5: ensure input is iterable
+    if not isinstance(it, Iterable):
+        raise TypeError(f"{it!r} is not iterable")
+
     # Step 3: materialize up to ``limit`` items using ``islice`` only once
-    try:
-        if limit is None:
-            return tuple(it)
-        if limit == 0:
-            return ()
-        materialized = tuple(islice(it, limit + 1))
-        if len(materialized) > limit:
-            examples = ", ".join(repr(x) for x in materialized[:3])
-            msg = error_msg or (
-                f"Iterable produced {len(materialized)} items, "
-                f"exceeds limit {limit}; first items: [{examples}]"
-            )
-            raise ValueError(msg)
-        return materialized
-    except TypeError as exc:
-        raise TypeError(f"{it!r} is not iterable") from exc
+    if limit is None:
+        return tuple(it)
+    if limit == 0:
+        return ()
+    materialized = tuple(islice(it, limit + 1))
+    if len(materialized) > limit:
+        examples = ", ".join(repr(x) for x in materialized[:3])
+        msg = error_msg or (
+            f"Iterable produced {len(materialized)} items, "
+            f"exceeds limit {limit}; first items: [{examples}]"
+        )
+        raise ValueError(msg)
+    return materialized
 
 
 def _process_negative_weights(


### PR DESCRIPTION
## Summary
- ensure `ensure_collection` explicitly checks input is iterable
- simplify materialization flow by removing broad TypeError handling

## Testing
- `pytest -q` *(failed: KeyboardInterrupt after tests completed; 258 passed, 5 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c2daa797b88321bfa8b9f7692e7781