### PR TITLE
Prevent cycles in flatten_structure traversal

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -58,14 +58,20 @@ def flatten_structure(
     """
 
     stack = deque([obj])
+    seen: set[int] = set()
     while stack:
         item = stack.pop()
+        item_id = id(item)
+        if item_id in seen:
+            continue
         if expand is not None:
             replacement = expand(item)
             if replacement is not None:
+                seen.add(item_id)
                 stack.extendleft(replacement)
                 continue
         if is_non_string_sequence(item):
+            seen.add(item_id)
             stack.extendleft(item)
         else:
             yield item


### PR DESCRIPTION
## Summary
- avoid infinite recursion in `flatten_structure` by tracking seen objects

## Testing
- `pytest tests/test_flatten_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2daab1ce08321860b026928fe15c0