### PR TITLE
Refactor jitter cache initialization to avoid per-call size check

### DIFF
--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -101,6 +101,7 @@ def test_rng_cache_disabled_with_size_zero(graph_canon):
 def test_jitter_seq_purges_old_entries(monkeypatch):
     clear_rng_cache()
     monkeypatch.setattr(operators, "_JITTER_MAX_ENTRIES", 4)
+    operators.setup_jitter_cache(force=True)
     graph = SimpleNamespace(graph={})
     nodes = [SimpleNamespace(G=graph) for _ in range(5)]
     first_key = (0, id(nodes[0]))


### PR DESCRIPTION
## Summary
- centralize jitter cache sizing in new `setup_jitter_cache` and run at import
- reset jitter sequence cache only when cache settings change
- adjust tests to configure cache using setup function

## Testing
- `pytest tests/test_operators.py::test_jitter_seq_purges_old_entries -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2daa6dbb0832195114d57796dd7ea