### PR TITLE
Refactor THOL flattening and natural token order

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -4,15 +4,21 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from .collections_utils import flatten_structure
+from .collections_utils import is_non_string_sequence
 
 __all__ = ("_flatten_tokens", "validate_token", "_parse_tokens")
 
 
 def _flatten_tokens(obj: Any):
-    """Yield each token in order."""
+    """Yield each token in order preserving natural sequence."""
 
-    yield from flatten_structure(obj)
+    stack = [obj]
+    while stack:
+        item = stack.pop()
+        if is_non_string_sequence(item):
+            stack.extend(reversed(item))
+        else:
+            yield item
 
 
 def validate_token(

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -230,13 +230,13 @@ def test_flatten_thol_multiple_repeats():
     stack = deque()
     _flatten_thol(THOL(body=[Glyph.AL, Glyph.RA], repeat=3), stack)
     assert list(stack) == [
-        Glyph.RA,
-        Glyph.AL,
-        Glyph.RA,
-        Glyph.AL,
-        Glyph.RA,
-        Glyph.AL,
         THOL_SENTINEL,
+        Glyph.AL,
+        Glyph.RA,
+        Glyph.AL,
+        Glyph.RA,
+        Glyph.AL,
+        Glyph.RA,
     ]
 
 


### PR DESCRIPTION
## Summary
- Refactor `_flatten_thol` to build THOL bodies iteratively in natural order with closing glyphs appended after repetitions
- Preserve sequence order when parsing tokens by reworking `_flatten_tokens`
- Adjust tests for new THOL stacking order

## Testing
- `pytest tests/test_program.py -q`
- `pytest tests/test_cli_flatten_tokens.py tests/test_parse_tokens_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f0107ee483219e56220b809a0fba