### PR TITLE
refactor: obtain NumPy locally

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -11,9 +11,6 @@ import math
 from ..import_utils import get_numpy, import_nodonx
 from ..alias import get_attr
 
-
-np = get_numpy()
-
 __all__ = (
     "clamp",
     "clamp01",
@@ -49,6 +46,7 @@ def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
 
 def list_pvariance(xs: Iterable[float], default: float = 0.0) -> float:
     """Return the population variance of ``xs`` or ``default`` if empty."""
+    np = get_numpy()
     if np is not None:
         arr = np.fromiter(xs, dtype=float)
         return float(np.var(arr)) if arr.size else float(default)
@@ -109,6 +107,7 @@ def neighbor_mean(
 def _neighbor_phase_mean(node, trig) -> float:
     """Internal helper delegating to :func:`neighbor_phase_mean_list`."""
     fallback = trig.theta.get(node.n, 0.0)
+    np = get_numpy()
     neigh = node.G[node.n]
     return neighbor_phase_mean_list(
         neigh, trig.cos, trig.sin, np=np, fallback=fallback
@@ -144,7 +143,7 @@ def neighbor_phase_mean_list(
     neigh: Sequence[Any],
     cos_th: dict[Any, float],
     sin_th: dict[Any, float],
-    np=np,
+    np=None,
     fallback: float = 0.0,
 ) -> float:
     """Return circular mean of neighbour phases from cosine/sine mappings.
@@ -155,6 +154,9 @@ def neighbor_phase_mean_list(
     using the pure-Python :func:`_phase_mean_from_iter` helper which uses a
     running Kahan summation for stable accumulation.
     """
+    if np is None:
+        np = get_numpy()
+
     if np is not None:
         pairs = [
             (c, s)

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -21,9 +21,6 @@ from .gamma import kuramoto_R_psi
 from .logging_utils import get_logger
 from .import_utils import get_numpy
 
-
-np = get_numpy()
-
 __all__ = (
     "attach_standard_observer",
     "std_before",
@@ -88,6 +85,7 @@ def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
         return 1.0
     _, psi = _get_R_psi(G, R, psi)
 
+    np = get_numpy()
     if np is not None:
         th = np.fromiter(
             (

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -18,7 +18,7 @@ def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
         captured.append(np)
         return 0.0
 
-    monkeypatch.setattr("tnfr.metrics_utils.np", sentinel)
+    monkeypatch.setattr("tnfr.metrics_utils.get_numpy", lambda: sentinel)
     monkeypatch.setattr(
         "tnfr.metrics_utils.neighbor_phase_mean_list",
         fake_neighbor_phase_mean_list,

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -51,7 +51,7 @@ def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
         set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     ps_np = phase_sync(G)
-    monkeypatch.setattr("tnfr.observers.np", None)
+    monkeypatch.setattr("tnfr.observers.get_numpy", lambda: None)
     ps_py = phase_sync(G)
     assert ps_np == pytest.approx(ps_py)
 


### PR DESCRIPTION
## Summary
- lazily import NumPy within phase synchronization and metrics helpers
- handle absence of NumPy across observers, helpers, and metrics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c32f42ce5c83219aed139bb0faf815