### PR TITLE
refactor: centralize node presence check

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -67,6 +67,11 @@ def attach_standard_observer(G):
     return G
 
 
+def _ensure_nodes(G) -> bool:
+    """Return ``True`` when the graph has nodes."""
+    return bool(G.number_of_nodes())
+
+
 def _get_R_psi(
     G, R: float | None = None, psi: float | None = None
 ) -> tuple[float, float]:
@@ -81,7 +86,7 @@ def _get_R_psi(
 
 
 def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
-    if not G.number_of_nodes():
+    if not _ensure_nodes(G):
         return 1.0
     _, psi = _get_R_psi(G, R, psi)
 
@@ -110,7 +115,7 @@ def kuramoto_order(
     G, R: float | None = None, psi: float | None = None
 ) -> float:
     """R in [0,1], 1 means perfectly aligned phases."""
-    if not G.number_of_nodes():
+    if not _ensure_nodes(G):
         return 1.0
     R, _ = _get_R_psi(G, R, psi)
     return float(R)


### PR DESCRIPTION
## Summary
- add private `_ensure_nodes` helper for empty graph checks
- reuse `_ensure_nodes` in `phase_sync` and `kuramoto_order`
- keep `_get_R_psi` for shared R/psi computation

## Testing
- `pytest tests/test_observers.py tests/test_history.py tests/test_edge_cases.py tests/test_coherence_cache.py tests/test_local_phase_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c330f1f9748321baaf9bd0dad8c022