### PR TITLE
refactor: extract import warning emit helpers

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -29,13 +29,27 @@ __all__ = (
 
 logger = get_logger(__name__)
 
+
+def _emit_warn(message: str) -> None:
+    """Emit a warning preserving caller context."""
+    warnings.warn(message, RuntimeWarning, stacklevel=2)
+
+
+def _emit_log(message: str) -> None:
+    """Log a warning message using the module logger."""
+    logger.warning(message)
+
+
+def _emit_both(message: str) -> None:
+    """Emit a warning and log it."""
+    warnings.warn(message, RuntimeWarning, stacklevel=2)
+    logger.warning(message)
+
+
 EMIT_MAP: dict[str, tuple] = {
-    "warn": (lambda m: warnings.warn(m, RuntimeWarning, stacklevel=2),),
-    "log": (logger.warning,),
-    "both": (
-        lambda m: warnings.warn(m, RuntimeWarning, stacklevel=2),
-        logger.warning,
-    ),
+    "warn": (_emit_warn,),
+    "log": (_emit_log,),
+    "both": (_emit_both,),
 }
 
 _FAILED_IMPORT_LIMIT = 128  # keep only this many recent failures


### PR DESCRIPTION
## Summary
- add dedicated helpers for warning and logging
- use new helpers in `EMIT_MAP`

## Testing
- `pytest tests/test_import_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c330f9736483219da1b7a14ee5b7bf