### PR TITLE
Log discarded glyph history inputs

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -10,6 +10,9 @@ from collections.abc import Iterable
 
 from .constants import get_param
 from .collections_utils import ensure_collection
+from .logging_utils import get_logger
+
+logger = get_logger(__name__)
 
 __all__ = (
     "HistoryDict",
@@ -49,6 +52,7 @@ def _normalize_history_input(hist: Any) -> Iterable[Any]:
     try:
         return ensure_collection(hist, max_materialize=None)
     except TypeError:
+        logger.debug("Discarding non-iterable glyph history value %r", hist)
         return ()
 
 


### PR DESCRIPTION
## Summary
- add module logger to glyph_history
- log discarded non-iterable glyph history inputs

## Testing
- `pytest tests/test_history.py tests/test_recent_glyph.py tests/test_push_glyph.py`


------
https://chatgpt.com/codex/tasks/task_e_68c33a705c448321947e78c57955a3c6