### PR TITLE
refactor: narrow get_graph_mapping return type

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -58,7 +58,7 @@ def get_graph(obj: Any) -> Any:
 
 def get_graph_mapping(
     G: Any, key: str, warn_msg: str
-) -> dict[str, Any] | None:
+) -> Mapping[str, Any] | None:
     """Return an immutable view of ``G.graph[key]`` if it is a mapping.
 
     The mapping is wrapped in :class:`types.MappingProxyType` to prevent


### PR DESCRIPTION
## Summary
- refine `get_graph_mapping` return type to `Mapping[str, Any]`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c33a71e6048321ba2517687cee7f09