### PR TITLE
refactor: streamline import cache pruning

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -68,10 +68,14 @@ class _ImportState:
     def prune(self, now: float | None = None) -> None:
         now = time.monotonic() if now is None else now
         expiry = now - self.max_age
-        while self.failed and next(iter(self.failed.values())) < expiry:
-            self.failed.popitem(last=False)
-        while len(self.failed) > self.limit:
-            self.failed.popitem(last=False)
+        failed = self.failed
+        while failed:
+            key, timestamp = next(iter(failed.items()))
+            if timestamp >= expiry:
+                break
+            failed.pop(key)
+        while len(failed) > self.limit:
+            failed.popitem(last=False)
 
     def record(self, item: str) -> None:
         now = time.monotonic()


### PR DESCRIPTION
## Summary
- simplify failed-import pruning by extracting key/value in one step

## Testing
- `pytest tests/test_import_utils.py tests/test_warned_modules_prune.py tests/test_warn_failure_threadsafe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c33a74a8308321abbef2b981da25f6