### PR TITLE
Add count parameter to phase_sync np.fromiter

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -98,6 +98,7 @@ def phase_sync(G, R: float | None = None, psi: float | None = None) -> float:
                 for _, data in G.nodes(data=True)
             ),
             dtype=float,
+            count=G.number_of_nodes(),
         )
         diff = (th - psi + np.pi) % (2 * np.pi) - np.pi
         var = float(np.var(diff)) if diff.size else 0.0


### PR DESCRIPTION
## Summary
- ensure numpy fromiter receives node count in phase_sync

## Testing
- `pytest tests/test_observers.py::test_phase_sync_bounds -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c33a70f8608321bd33f4846df909c5