### PR TITLE
refactor: centralize node checksum cache key

### DIFF
--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -24,6 +24,9 @@ T = TypeVar("T")
 
 logger = get_logger(__name__)
 
+# Key used to store the node set checksum in a graph's ``graph`` attribute.
+NODE_SET_CHECKSUM_KEY = "_node_set_checksum_cache"
+
 # Keys of cache entries dependent on the edge version.  Any change to the edge
 # set requires these to be dropped to avoid stale data.
 EDGE_VERSION_CACHE_KEYS = (
@@ -148,7 +151,7 @@ def node_set_checksum(
     Nodes are serialised using :func:`_node_repr`. The helper
     :func:`_iter_node_digests` yields their digests in a deterministic order,
     handling the ``presorted`` and unsorted cases. When ``store`` is ``True``
-    the final checksum is cached under ``"_node_set_checksum_cache"`` to avoid
+    the final checksum is cached under ``NODE_SET_CHECKSUM_KEY`` to avoid
     recomputation for unchanged graphs.
     """
     graph = get_graph(G)
@@ -165,10 +168,10 @@ def node_set_checksum(
     token = checksum[:16]
     if store:
         # Cache the result using a short token to detect unchanged node sets.
-        cached = graph.get("_node_set_checksum_cache")
+        cached = graph.get(NODE_SET_CHECKSUM_KEY)
         if cached and cached[0] == token:
             return cached[1]
-        graph["_node_set_checksum_cache"] = (token, checksum)
+        graph[NODE_SET_CHECKSUM_KEY] = (token, checksum)
     return checksum
 
 

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -2,6 +2,7 @@ import hashlib
 import timeit
 
 from tnfr.helpers.cache import (
+    NODE_SET_CHECKSUM_KEY,
     node_set_checksum,
     _stable_json,
     increment_edge_version,
@@ -63,14 +64,14 @@ def test_node_set_checksum_no_store_does_not_cache(graph_canon):
     G = graph_canon()
     G.add_nodes_from([1, 2])
     node_set_checksum(G, store=False)
-    assert "_node_set_checksum_cache" not in G.graph
+    assert NODE_SET_CHECKSUM_KEY not in G.graph
 
 
 def test_node_set_checksum_cache_token_is_prefix(graph_canon):
     G = graph_canon()
     G.add_nodes_from([1, 2])
     checksum = node_set_checksum(G)
-    token, stored_checksum = G.graph["_node_set_checksum_cache"]
+    token, stored_checksum = G.graph[NODE_SET_CHECKSUM_KEY]
     assert stored_checksum == checksum
     assert token == checksum[:16]
     assert len(token) == 16


### PR DESCRIPTION
## Summary
- define constant for node set checksum cache key
- replace hard-coded "_node_set_checksum_cache" uses with constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c33975466083219fb04c08b0f98378