### PR TITLE
Remove broad exception handling in thread tests

### DIFF
--- a/tests/test_make_rng_threadsafe.py
+++ b/tests/test_make_rng_threadsafe.py
@@ -12,18 +12,13 @@ def test_make_rng_thread_safety(monkeypatch):
     clear_rng_cache()
 
     results = []
-    errors = []
     lock = threading.Lock()
 
     def worker():
-        try:
-            rng = make_rng(123, 456)
-            seq = [rng.random() for _ in range(3)]
-            with lock:
-                results.append(seq)
-        except Exception as e:  # pragma: no cover - should not happen
-            with lock:
-                errors.append(e)
+        rng = make_rng(123, 456)
+        seq = [rng.random() for _ in range(3)]
+        with lock:
+            results.append(seq)
 
     threads = [threading.Thread(target=worker) for _ in range(20)]
     for t in threads:
@@ -31,7 +26,7 @@ def test_make_rng_thread_safety(monkeypatch):
     for t in threads:
         t.join()
 
-    assert not errors
+    assert len(results) == 20
     assert all(seq == results[0] for seq in results)
 
 

--- a/tests/test_rng_for_step.py
+++ b/tests/test_rng_for_step.py
@@ -26,18 +26,13 @@ def test_rng_for_step_thread_independence():
     clear_rng_cache()
 
     results = []
-    errors = []
     lock = threading.Lock()
 
     def worker():
-        try:
-            rng = _rng_for_step(123, 5)
-            seq = [rng.random() for _ in range(3)]
-            with lock:
-                results.append(seq)
-        except Exception as e:  # pragma: no cover - should not happen
-            with lock:
-                errors.append(e)
+        rng = _rng_for_step(123, 5)
+        seq = [rng.random() for _ in range(3)]
+        with lock:
+            results.append(seq)
 
     threads = [threading.Thread(target=worker) for _ in range(20)]
     for t in threads:
@@ -45,5 +40,5 @@ def test_rng_for_step_thread_independence():
     for t in threads:
         t.join()
 
-    assert not errors
+    assert len(results) == 20
     assert all(seq == results[0] for seq in results)

--- a/tests/test_warn_failure_threadsafe.py
+++ b/tests/test_warn_failure_threadsafe.py
@@ -16,17 +16,10 @@ def test_warn_failure_thread_safety(monkeypatch):
         _IMPORT_STATE.clear()
         _IMPORT_STATE.last_prune = 0.0
 
-    errors: list[Exception] = []
-    lock = threading.Lock()
-
     def worker() -> None:
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                _warn_failure("mod", None, ImportError("boom"))
-        except Exception as e:  # pragma: no cover - should not happen
-            with lock:
-                errors.append(e)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _warn_failure("mod", None, ImportError("boom"))
 
     threads = [threading.Thread(target=worker) for _ in range(32)]
     for t in threads:
@@ -34,7 +27,6 @@ def test_warn_failure_thread_safety(monkeypatch):
     for t in threads:
         t.join()
 
-    assert not errors
     with _WARNED_LOCK:
         assert len(_WARNED_MODULES) == 1 and "mod" in _WARNED_MODULES
     assert _IMPORT_STATE.last_prune > 0.0


### PR DESCRIPTION
## Summary
- ensure thread-based RNG tests fail on unexpected errors by removing catch-all handlers
- simplify warning failure concurrency test to let errors propagate

## Testing
- `pytest tests/test_rng_for_step.py tests/test_make_rng_threadsafe.py tests/test_warn_failure_threadsafe.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3d095638883219f4070a0e9bdb996