### PR TITLE
Simplify RNG seed hash retrieval

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -47,8 +47,6 @@ def _seed_hash_for(seed_int: int, key_int: int) -> int:
     Uses the cached hash when caching is enabled.
     """
 
-    if _CACHE_MAXSIZE <= 0:
-        return seed_hash(seed_int, key_int)
     return _seed_hash_cached(seed_int, key_int)
 
 


### PR DESCRIPTION
## Summary
- streamline `_seed_hash_for` by directly using `_seed_hash_cached`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3cb0c07d88321a27f0f2a4417eff2