### PR TITLE
refactor: reuse early-stop config in run

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -640,14 +640,16 @@ def run(
     steps_int = int(steps)
     if steps_int < 0:
         raise ValueError("'steps' must be non-negative")
+    stop_cfg = get_graph_param(G, "STOP_EARLY", dict)
+    history = None
+    if stop_cfg and stop_cfg.get("enabled", False):
+        w = int(stop_cfg.get("window", 25))
+        frac = float(stop_cfg.get("fraction", 0.90))
+        history = G.graph.setdefault("history", {"stable_frac": []})
     for _ in range(steps_int):
         step(G, dt=dt, use_Si=use_Si, apply_glyphs=apply_glyphs)
         # Early-stop opcional
-        stop_cfg = get_graph_param(G, "STOP_EARLY", dict)
-        if stop_cfg and stop_cfg.get("enabled", False):
-            w = int(stop_cfg.get("window", 25))
-            frac = float(stop_cfg.get("fraction", 0.90))
-            hist = G.graph.setdefault("history", {"stable_frac": []})
-            series = hist.get("stable_frac", [])
+        if history is not None:
+            series = history.get("stable_frac", [])
             if len(series) >= w and all(v >= frac for v in series[-w:]):
                 break


### PR DESCRIPTION
### Qué reorganiza
- [ ] Incrementa C(t) o reduce ΔNFR donde corresponde
- [x] Mantiene cierre operatorio y fractalidad operativa

### Evidencias
- [ ] Logs de fase/νf
- [ ] Curvas C(t), Si
- [ ] Casos de bifurcación controlada

### Compatibilidad
- [x] API estable o mapeada
- [x] Seed reproducible

Refactoriza `run` para precalcular la configuración de parada temprana y el historial fuera del bucle principal y reutilizarlos dentro del ciclo.

------
https://chatgpt.com/codex/tasks/task_e_68c3f12dcb1c8321969f80a09ef4f5bd