### PR TITLE
Log NetworkX callback errors

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -354,6 +354,9 @@ def invoke_callbacks(
             if strict:
                 raise
         except nx.NetworkXError as err:
+            with _CALLBACK_LOCK:
+                _record_callback_error(G, event, ctx, spec, err)
+            # NetworkX errors are unexpected; log and re-raise
             logger.exception(
                 "callback %r raised NetworkXError for %s with ctx=%r",
                 spec.name,

--- a/tests/test_invoke_callbacks.py
+++ b/tests/test_invoke_callbacks.py
@@ -1,5 +1,8 @@
 """Tests for invoke_callbacks context handling."""
 
+import networkx as nx
+import pytest
+
 from tnfr.callback_utils import CallbackEvent, invoke_callbacks, register_callback
 
 
@@ -15,3 +18,23 @@ def test_invoke_callbacks_preserves_context(graph_canon):
     invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
 
     assert ctx["called"] == 1
+
+
+def test_invoke_callbacks_records_networkx_error(graph_canon):
+    G = graph_canon()
+
+    def failing_cb(G, ctx):
+        G.remove_node("missing")
+
+    register_callback(G, CallbackEvent.BEFORE_STEP, failing_cb)
+
+    ctx = {"step": 5}
+    with pytest.raises(nx.NetworkXError):
+        invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
+
+    err_list = G.graph.get("_callback_errors")
+    assert err_list and len(err_list) == 1
+    err = err_list[0]
+    assert err["event"] == CallbackEvent.BEFORE_STEP.value
+    assert err["step"] == 5
+    assert "NetworkXError" in err["error"]


### PR DESCRIPTION
### Qué reorganiza
- [x] Incrementa C(t) o reduce ΔNFR donde corresponde
- [x] Mantiene cierre operatorio y fractalidad operativa

### Evidencias
- [ ] Logs de fase/νf
- [ ] Curvas C(t), Si
- [ ] Casos de bifurcación controlada

### Compatibilidad
- [x] API estable o mapeada
- [x] Seed reproducible

------
https://chatgpt.com/codex/tasks/task_e_68c404c5a4908321bedbc41121194c42