### PR TITLE
Expose clear_orjson_cache helper

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -53,7 +53,14 @@ def _cache_clear_and_reset() -> None:
     _orig_cache_clear()
 
 
-cast(Any, _load_orjson).cache_clear = _cache_clear_and_reset  # type: ignore[attr-defined]
+def clear_orjson_cache() -> None:
+    """Clear cached :mod:`orjson` module and warning state.
+
+    This is a thin wrapper around the internal reset routine used in tests to
+    drop the optional import cache and reset the set of ignored-parameter
+    warnings.
+    """
+    _cache_clear_and_reset()
 
 
 @dataclass(slots=True)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -18,7 +18,7 @@ def test_lazy_orjson_import(monkeypatch):
         return FakeOrjson()
 
     monkeypatch.setattr(json_utils, "optional_import", fake_optional_import)
-    json_utils._load_orjson.cache_clear()
+    json_utils.clear_orjson_cache()
 
     assert calls["n"] == 0
     json_utils.json_dumps({})
@@ -29,7 +29,7 @@ def test_lazy_orjson_import(monkeypatch):
 
 def test_warns_once(monkeypatch, caplog):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: FakeOrjson())
-    json_utils._load_orjson.cache_clear()
+    json_utils.clear_orjson_cache()
 
     with warnings.catch_warnings(record=True) as w:
         for _ in range(2):

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -14,7 +14,7 @@ class DummyOrjson:
 
 def _reset_json_utils(monkeypatch, module):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: module)
-    json_utils._load_orjson.cache_clear()
+    json_utils.clear_orjson_cache()
 
 
 def test_json_dumps_without_orjson(monkeypatch, caplog):

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -7,7 +7,7 @@ from tnfr import json_utils
 
 
 def test_stable_json_dict_order_deterministic():
-    json_utils._load_orjson.cache_clear()
+    json_utils.clear_orjson_cache()
     json_utils._orjson = None
     obj = {"b": 1, "a": 2}
     res1 = _stable_json(obj)


### PR DESCRIPTION
## Summary
- add public `clear_orjson_cache` that resets cached optional `orjson` state
- adjust tests to use the new helper instead of touching internal cache methods

## Testing
- `pytest tests/test_json_utils.py tests/test_json_utils_extra.py tests/test_stable_json.py` *(fails: ImportError: cannot import name 'MAX_MATERIALIZE_DEFAULT')*


------
https://chatgpt.com/codex/tasks/task_e_68c40f2fe67c83219fa90a6c9a2958ea