### PR TITLE
refactor: drop unused remesh constants import

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -12,7 +12,6 @@ from ..grammar import enforce_canonical_grammar, on_applied_glyph
 from ..types import Glyph
 from ..constants import (
     DEFAULTS,
-    REMESH_DEFAULTS,
     METRIC_DEFAULTS,
     ALIAS_VF,
     ALIAS_THETA,


### PR DESCRIPTION
## Summary
- remove REMESH_DEFAULTS from dynamics constants imports to silence pyflakes warning

## Testing
- `pyflakes src/tnfr/dynamics/__init__.py`
- `pytest -q` *(fails: ImportError: cannot import name 'MAX_MATERIALIZE_DEFAULT' from partially initialized module 'tnfr.collections_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68c4177b88b48321938f50471583ff3a