### PR TITLE
Remove unused cast import

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -9,7 +9,7 @@ import json
 import threading
 import warnings
 
-from typing import Any, Callable, Literal, cast, overload
+from typing import Any, Callable, Literal, overload
 
 from dataclasses import dataclass
 from functools import lru_cache


### PR DESCRIPTION
## Summary
- streamline json utilities by removing unused cast import

## Testing
- `python -m flake8 src/tnfr/json_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c41ba844988321813c0633e2182943