### PR TITLE
Avoid history allocation on zero-window glyph checks

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -93,15 +93,16 @@ def push_glyph(nd: dict[str, Any], glyph: str, window: int) -> None:
 def recent_glyph(nd: dict[str, Any], glyph: str, window: int) -> bool:
     """Return ``True`` if ``glyph`` appeared in last ``window`` emissions.
 
-    ``window`` is validated once and reused when ensuring the history deque,
-    avoiding redundant validation. A ``window`` of zero returns ``False``.
-    Negative values raise :class:`ValueError`.
+    ``window`` is validated once. A ``window`` of zero returns ``False`` and
+    leaves ``nd`` unchanged. For positive windows the history deque is ensured
+    exactly once via :func:`ensure_history_deque`. Negative values raise
+    :class:`ValueError`.
     """
 
     v_window = validate_window(window)
-    hist = ensure_history_deque(nd, v_window)
     if v_window == 0:
         return False
+    hist = ensure_history_deque(nd, v_window)
     gl = str(glyph)
     return gl in hist
 

--- a/tests/test_recent_glyph.py
+++ b/tests/test_recent_glyph.py
@@ -26,10 +26,10 @@ def test_recent_glyph_window_zero():
     assert not recent_glyph(nd, "B", window=0)
 
 
-def test_recent_glyph_window_zero_creates_empty_history():
+def test_recent_glyph_window_zero_does_not_create_history():
     nd = {}
     assert not recent_glyph(nd, "B", window=0)
-    assert list(nd["glyph_history"]) == []
+    assert "glyph_history" not in nd
 
 
 def test_recent_glyph_window_negative():


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c421eddae883218902ad481e71f1a2