### PR TITLE
Accept numpy integers in validate_window

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -7,6 +7,7 @@ from collections import deque, Counter
 from itertools import islice
 import heapq
 from collections.abc import Iterable
+import numbers
 
 from .constants import get_param
 from .collections_utils import ensure_collection
@@ -37,7 +38,7 @@ def validate_window(window: int, *, positive: bool = False) -> int:
     Negative values always raise :class:`ValueError`.
     """
 
-    if isinstance(window, bool) or not isinstance(window, int):
+    if isinstance(window, bool) or not isinstance(window, numbers.Integral):
         raise TypeError("'window' must be an integer")
     if window < 0 or (positive and window == 0):
         kind = "positive" if positive else "non-negative"

--- a/tests/test_validate_window.py
+++ b/tests/test_validate_window.py
@@ -1,6 +1,7 @@
 """Tests for validate_window parameter handling."""
 
 import pytest
+import numpy as np
 
 from tnfr.glyph_history import validate_window
 
@@ -9,3 +10,8 @@ from tnfr.glyph_history import validate_window
 def test_validate_window_rejects_bool(value):
     with pytest.raises(TypeError):
         validate_window(value)
+
+
+@pytest.mark.parametrize("value", [np.int32(0), np.int64(3)])
+def test_validate_window_accepts_numpy_int(value):
+    assert validate_window(value) == int(value)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c43e3a00908321bbaa215314189255