### PR TITLE
refactor glyph timing storage to dataclass

### DIFF
--- a/tests/test_update_tg_node.py
+++ b/tests/test_update_tg_node.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from tnfr.metrics.core import _update_tg_node, TgCurr, TgRun
+from tnfr.metrics.core import _update_tg_node, GlyphTiming
 from tnfr.glyph_history import push_glyph
 
 
@@ -18,4 +18,5 @@ def test_update_tg_node_accumulates_and_resets():
     assert tg_total["A"] == 1.0
     assert tg_by_node[1]["A"] == [1.0]
     st = nd["_Tg"]
-    assert st[TgCurr] == "B" and st[TgRun] == 2.0
+    assert isinstance(st, GlyphTiming)
+    assert st.curr == "B" and st.run == 2.0

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -6,7 +6,7 @@ from collections import Counter, defaultdict
 from tnfr.constants import inject_defaults
 from tnfr.glyph_history import last_glyph
 from tnfr.metrics import _update_tg, _tg_state
-from tnfr.metrics.core import LATENT_GLYPH, TgCurr, TgRun
+from tnfr.metrics.core import LATENT_GLYPH
 
 
 def _update_tg_naive(G, hist, dt, save_by_node):
@@ -35,19 +35,19 @@ def _update_tg_naive(G, hist, dt, save_by_node):
         counts[g] += 1
 
         st = _tg_state(nd)
-        if st[TgCurr] is None:
-            st[TgCurr] = g
-            st[TgRun] = dt
-        elif g == st[TgCurr]:
-            st[TgRun] += dt
+        if st.curr is None:
+            st.curr = g
+            st.run = dt
+        elif g == st.curr:
+            st.run += dt
         else:
-            prev = st[TgCurr]
-            dur = float(st[TgRun])
+            prev = st.curr
+            dur = float(st.run)
             tg_total[prev] += dur
             if save_by_node:
                 tg_by_node[n][prev].append(dur)
-            st[TgCurr] = g
-            st[TgRun] = dt
+            st.curr = g
+            st.run = dt
 
     return counts, n_total, n_latent
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c454f3882083218fc7fbacec67167d