### PR TITLE
Refactor weight normalization into testable helpers

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -157,20 +157,44 @@ def ensure_collection(
         raise ValueError(msg)
     return materialized
 
+def _convert_weights(
+    dict_like: Mapping[str, Any],
+    keys: Iterable[str] | Sequence[str],
+    default: float,
+    *,
+    error_on_conversion: bool,
+) -> tuple[dict[str, float], list[str]]:
+    """Materialize ``keys`` and convert values in ``dict_like`` to ``float``."""
+    keys_list = list(dict.fromkeys(keys))
+    default_float = float(default)
+    weights: dict[str, float] = {}
+    for k in keys_list:
+        ok, val = convert_value(
+            dict_like.get(k, default_float),
+            float,
+            strict=error_on_conversion,
+            key=k,
+            log_level=logging.WARNING,
+        )
+        weights[k] = cast(float, val) if ok else default_float
+    return weights, keys_list
 
-def _process_negative_weights(
+
+def _handle_negative_weights(
     weights: dict[str, float],
-    negatives: dict[str, float],
+    *,
+    error_on_negative: bool,
     warn_once: bool,
-    total: float,
 ) -> float:
-    """Handle negative weights by logging, clamping and adjusting total."""
+    """Clamp negative weights and adjust total according to policy."""
+    negatives = {k: w for k, w in weights.items() if w < 0}
+    from .helpers.numeric import kahan_sum  # local import to avoid circular dependency
+    total = kahan_sum(weights.values())
+    if not negatives:
+        return total
+    if error_on_negative:
+        raise ValueError(NEGATIVE_WEIGHTS_MSG % negatives)
     if warn_once:
-        # ``warn_once`` returns a callable that logs at most once per key.
-        # ``_log_negative_keys_once`` expects a mapping of keys to values so
-        # pass the entire ``negatives`` dict at once.  This ensures each
-        # negative weight is only warned about on its first occurrence across
-        # all calls to :func:`normalize_weights`.
         _log_negative_keys_once(negatives)
     else:
         logger.warning(NEGATIVE_WEIGHTS_MSG, negatives)
@@ -178,6 +202,18 @@ def _process_negative_weights(
         weights[k] = 0.0
         total -= w
     return total
+
+
+def _normalize_non_negative_weights(
+    weights: dict[str, float],
+    keys: Sequence[str],
+    total: float,
+) -> dict[str, float]:
+    """Return weights normalized to sum to 1 or a uniform distribution."""
+    if total <= 0:
+        uniform = 1.0 / len(keys)
+        return {k: uniform for k in keys}
+    return {k: w / total for k, w in weights.items()}
 
 
 def normalize_weights(
@@ -207,32 +243,20 @@ def normalize_weights(
     When ``warn_once`` is ``True`` warnings for a given key are emitted only on
     their first occurrence across calls.
     """
-    keys = list(dict.fromkeys(keys))
-    default_float = float(default)
-    if not keys:
+    weights, keys_list = _convert_weights(
+        dict_like,
+        keys,
+        default,
+        error_on_conversion=error_on_conversion,
+    )
+    if not keys_list:
         return {}
-
-    weights: dict[str, float] = {}
-    for k in keys:
-        ok, val = convert_value(
-            dict_like.get(k, default_float),
-            float,
-            strict=error_on_conversion,
-            key=k,
-            log_level=logging.WARNING,
-        )
-        weights[k] = cast(float, val) if ok else default_float
-    negatives = {k: w for k, w in weights.items() if w < 0}
-    from .helpers.numeric import kahan_sum  # local import to avoid circular dependency
-    total = kahan_sum(weights.values())
-    if negatives:
-        if error_on_negative:
-            raise ValueError(NEGATIVE_WEIGHTS_MSG % negatives)
-        total = _process_negative_weights(weights, negatives, warn_once, total)
-    if total <= 0:
-        uniform = 1.0 / len(keys)
-        return {k: uniform for k in keys}
-    return {k: w / total for k, w in weights.items()}
+    total = _handle_negative_weights(
+        weights,
+        error_on_negative=error_on_negative,
+        warn_once=warn_once,
+    )
+    return _normalize_non_negative_weights(weights, keys_list, total)
 
 
 def normalize_counter(

--- a/tests/test_normalize_weights_helpers.py
+++ b/tests/test_normalize_weights_helpers.py
@@ -1,0 +1,44 @@
+import math
+import pytest
+import tnfr.collections_utils as cu
+
+
+def test_convert_weights_dedup_and_defaults():
+    weights, keys = cu._convert_weights({"a": "1", "c": "bad"}, ["a", "b", "c", "a"], 2.0, error_on_conversion=False)
+    assert keys == ["a", "b", "c"]
+    assert weights == {"a": 1.0, "b": 2.0, "c": 2.0}
+
+
+def test_convert_weights_error_on_conversion():
+    with pytest.raises(ValueError):
+        cu._convert_weights({"a": "bad"}, ["a"], 0.0, error_on_conversion=True)
+
+
+def test_handle_negative_weights_clamps(caplog):
+    cu.clear_warned_negative_keys()
+    weights = {"a": -1.0, "b": 2.0}
+    with caplog.at_level("WARNING"):
+        total = cu._handle_negative_weights(weights, error_on_negative=False, warn_once=False)
+    assert total == 2.0
+    assert weights["a"] == 0.0
+    assert any("Negative weights" in m for m in caplog.messages)
+
+
+def test_handle_negative_weights_raises():
+    with pytest.raises(ValueError):
+        cu._handle_negative_weights({"a": -1.0}, error_on_negative=True, warn_once=True)
+
+
+def test_normalize_non_negative_uniform():
+    weights = {"a": 0.0, "b": 0.0}
+    keys = ["a", "b"]
+    norm = cu._normalize_non_negative_weights(weights, keys, 0.0)
+    assert norm == {"a": 0.5, "b": 0.5}
+
+
+def test_normalize_non_negative_divides():
+    weights = {"a": 1.0, "b": 3.0}
+    keys = ["a", "b"]
+    norm = cu._normalize_non_negative_weights(weights, keys, 4.0)
+    assert math.isclose(norm["a"], 0.25)
+    assert math.isclose(norm["b"], 0.75)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c46aea378c832183c24a97ffb11865