### PR TITLE
Use within_range helper for tolerant range validation

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -13,6 +13,7 @@ from ..alias import get_attr
 __all__ = (
     "clamp",
     "clamp01",
+    "within_range",
     "list_mean",
     "list_pvariance",
     "kahan_sum_nd",
@@ -33,6 +34,16 @@ def clamp(x: float, a: float, b: float) -> float:
 def clamp01(x: float) -> float:
     """Clamp ``x`` to the ``[0,1]`` interval."""
     return clamp(float(x), 0.0, 1.0)
+
+
+def within_range(val: float, lower: float, upper: float, tol: float = 1e-9) -> bool:
+    """Return ``True`` if ``val`` lies in ``[lower, upper]`` within ``tol``.
+
+    The comparison uses absolute differences instead of :func:`math.isclose`.
+    """
+
+    v = float(val)
+    return lower <= v <= upper or abs(v - lower) <= tol or abs(v - upper) <= tol
 
 
 def _norm01(x: float, lo: float, hi: float) -> float:

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-import math
 import sys
 
 from .constants import get_aliases, get_param
 from .alias import get_attr
 from .glyph_history import last_glyph
 from .sense import sigma_vector_from_graph
+from .helpers.numeric import within_range
+from .constants_glyphs import GLYPHS_CANONICAL_SET
 
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")
-from .constants_glyphs import GLYPHS_CANONICAL_SET
 
 __all__ = ("run_validators",)
 
@@ -40,12 +40,8 @@ def _out_of_range_msg(name, node, val):
     return f"{name} out of range in node {node}: {val}"
 
 
-def _check_range(val, lower, upper, name, node):
-    if not (
-        lower <= val <= upper
-        or math.isclose(val, lower)
-        or math.isclose(val, upper)
-    ):
+def _check_range(val, lower, upper, name, node, tol: float = 1e-9):
+    if not within_range(val, lower, upper, tol):
         raise ValueError(_out_of_range_msg(name, node, val))
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -46,6 +46,23 @@ def test_validator_vf_range():
         run_validators(G)
 
 
+def test_validator_epi_range_tolerance():
+    G = _base_graph()
+    n0 = list(G.nodes())[0]
+    epi_min = float(G.graph["EPI_MIN"])
+    set_attr(G.nodes[n0], ALIAS_EPI, epi_min - 5e-10)
+    run_validators(G)
+
+
+def test_validator_epi_range_below_tolerance():
+    G = _base_graph()
+    n0 = list(G.nodes())[0]
+    epi_min = float(G.graph["EPI_MIN"])
+    set_attr(G.nodes[n0], ALIAS_EPI, epi_min - 2e-9)
+    with pytest.raises(ValueError):
+        run_validators(G)
+
+
 def test_validator_sigma_norm(monkeypatch):
     G = _base_graph()
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c46fb4b8388321840f876dfc7c7b39