### PR TITLE
refactor: reorder ensure_collection checks

### DIFF
--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -2,6 +2,11 @@ import pytest
 from tnfr.collections_utils import ensure_collection
 
 
+def test_existing_collection_returned_as_is():
+    items = [0, 1, 2]
+    assert ensure_collection(items) is items
+
+
 def test_wraps_string():
     assert ensure_collection("node") == ("node",)
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c48738f890832182bc3a240c7c6130