### PR TITLE
Refactor callback normalization helper

### DIFF
--- a/tests/test_ensure_callbacks.py
+++ b/tests/test_ensure_callbacks.py
@@ -3,6 +3,7 @@
 from tnfr.callback_utils import (
     _ensure_callbacks,
     _normalize_callback_registry,
+    _normalized_callbacks,
     register_callback,
     CallbackEvent,
 )
@@ -77,3 +78,19 @@ def test_normalize_callback_registry_handles_sequences_and_mappings():
     assert set(res_map.keys()) == {"a", "cb2"}
     assert res_map["a"].func is cb1
     assert res_map["cb2"].func is cb2
+
+
+def test_normalized_callbacks_handles_iterables():
+    def cb1(G, ctx):
+        pass
+
+    def cb2(G, ctx):
+        pass
+
+    entries = (e for e in [("a", cb1), cb2, ("bad", 1), object()])
+
+    res = _normalized_callbacks(entries)
+
+    assert set(res.keys()) == {"a", "cb2"}
+    assert res["a"].func is cb1
+    assert res["cb2"].func is cb2

--- a/tests/test_normalize_event_callbacks.py
+++ b/tests/test_normalize_event_callbacks.py
@@ -21,3 +21,16 @@ def test_normalize_event_callbacks_filters_and_normalizes():
     # Valid event is normalized into a mapping
     _normalize_event_callbacks(cbs, CallbackEvent.BEFORE_STEP.value)
     assert set(cbs[CallbackEvent.BEFORE_STEP.value]) == {"cb"}
+
+
+def test_normalize_event_callbacks_drops_invalid_entries():
+    def cb1(G, ctx):
+        pass
+
+    cbs = {
+        CallbackEvent.BEFORE_STEP.value: [("cb1", cb1), ("bad", 1), object()],
+    }
+
+    _normalize_event_callbacks(cbs, CallbackEvent.BEFORE_STEP.value)
+
+    assert set(cbs[CallbackEvent.BEFORE_STEP.value]) == {"cb1"}


### PR DESCRIPTION
## Summary
- extract `_normalized_callbacks` to unify callback entry normalization
- reuse helper across registry and event normalizers
- expand tests to cover invalid callback entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c498dc43d483219d4267951e3385af