### PR TITLE
feat: add callback error limit accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ instantiate ad-hoc locks directly when they are not shared.
 
 Callback errors are stored in a ring buffer attached to the graph.  The
 buffer retains at most the last 100 errors by default, but the limit can be
-adjusted at runtime via ``tnfr.callback_utils.set_callback_error_limit``.
+adjusted at runtime via ``tnfr.callback_utils.set_callback_error_limit`` and
+inspected with ``tnfr.callback_utils.get_callback_error_limit``.
 
 ---
 

--- a/tests/test_callback_errors_limit.py
+++ b/tests/test_callback_errors_limit.py
@@ -25,7 +25,7 @@ def test_callback_error_list_resets_limit(graph_canon):
         invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
         err_list = G.graph.get("_callback_errors")
         assert err_list is not original
-        assert err_list.maxlen == cb_utils._CALLBACK_ERROR_LIMIT == 7
+        assert err_list.maxlen == cb_utils.get_callback_error_limit() == 7
         assert len(err_list) == 1
     finally:
         set_callback_error_limit(prev)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4a1e1b7688321806538b82030290e