### PR TITLE
Refactor import failure caching with TTLCache

### DIFF
--- a/tests/test_warned_modules_prune.py
+++ b/tests/test_warned_modules_prune.py
@@ -18,7 +18,7 @@ def test_warned_modules_pruning(monkeypatch):
         _warn_failure("mod", None, ImportError("boom"))
     with _WARNED_LOCK:
         assert "mod" in _WARNED_MODULES
-        _WARNED_MODULES["mod"] = time.monotonic() - (_FAILED_IMPORT_MAX_AGE + 1)
+        _WARNED_MODULES.expire(time.monotonic() + (_FAILED_IMPORT_MAX_AGE + 1))
     monkeypatch.setattr(import_utils._IMPORT_STATE, "last_prune", 0.0)
     monkeypatch.setattr(import_utils, "_FAILED_IMPORT_PRUNE_INTERVAL", 0.0)
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4a4b7890c8321b44b71aa041fc50b