### PR TITLE
Use warn_once for orjson parameter warnings

### DIFF
--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,5 +1,6 @@
+import logging
+
 import tnfr.json_utils as json_utils
-import warnings
 
 
 class FakeOrjson:
@@ -31,11 +32,11 @@ def test_warns_once(monkeypatch, caplog):
     monkeypatch.setattr(json_utils, "optional_import", lambda name: FakeOrjson())
     json_utils.clear_orjson_cache()
 
-    with warnings.catch_warnings(record=True) as w:
+    with caplog.at_level(logging.WARNING):
         for _ in range(2):
             json_utils.json_dumps({}, ensure_ascii=False)
 
-    assert len(w) == 1
+    assert sum("ignored" in r.message for r in caplog.records) == 1
 
 
 def test_json_dumps_returns_str_by_default():

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -1,4 +1,4 @@
-import warnings
+import logging
 from dataclasses import is_dataclass
 
 import tnfr.json_utils as json_utils
@@ -20,21 +20,19 @@ def _reset_json_utils(monkeypatch, module):
 def test_json_dumps_without_orjson(monkeypatch, caplog):
     _reset_json_utils(monkeypatch, None)
 
-    with warnings.catch_warnings(record=True):
-
+    with caplog.at_level(logging.WARNING):
         result = json_utils.json_dumps({"a": 1}, ensure_ascii=False, to_bytes=True)
     assert result == b'{"a":1}'
     assert caplog.records == []
 
 
-def test_json_dumps_with_orjson_warns(monkeypatch):
+def test_json_dumps_with_orjson_warns(monkeypatch, caplog):
     _reset_json_utils(monkeypatch, DummyOrjson())
 
-    with warnings.catch_warnings(record=True) as w:
-
+    with caplog.at_level(logging.WARNING):
         json_utils.json_dumps({"a": 1}, ensure_ascii=False)
         json_utils.json_dumps({"a": 1}, ensure_ascii=False)
-    assert sum("ignored" in str(r.message) for r in w) == 1
+    assert sum("ignored" in r.message for r in caplog.records) == 1
 
 
 def test_params_passed_to_std(monkeypatch):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c4ac01f5b88321ac6c9cc77d4cec74