### PR TITLE
Add helper for merging and normalizing graph weights

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -33,10 +33,13 @@ from ..alias import (
     set_theta,
     multi_recompute_abs_max,
 )
-from ..metrics_utils import compute_Si, compute_dnfr_accel_max, merge_graph_weights
+from ..metrics_utils import (
+    compute_Si,
+    compute_dnfr_accel_max,
+    merge_and_normalize_weights,
+)
 from ..callback_utils import invoke_callbacks
 from ..glyph_history import recent_glyph, ensure_history, append_metric
-from ..collections_utils import normalize_weights
 from ..selector import (
     _selector_thresholds,
     _norms_para_selector,
@@ -400,8 +403,9 @@ def _selector_base_choice(Si, dnfr, accel, thr):
 
 def _configure_selector_weights(G) -> dict:
     """Normalise and store selector weights in ``G.graph``."""
-    w = merge_graph_weights(G, "SELECTOR_WEIGHTS")
-    weights = normalize_weights(w, ("w_si", "w_dnfr", "w_accel"))
+    weights = merge_and_normalize_weights(
+        G, "SELECTOR_WEIGHTS", ("w_si", "w_dnfr", "w_accel")
+    )
     G.graph["_selector_weights"] = weights
     return weights
 

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -24,7 +24,7 @@ from ..alias import (
     get_attr,
     set_dnfr,
 )
-from ..metrics_utils import get_trig_cache, merge_graph_weights
+from ..metrics_utils import get_trig_cache, merge_and_normalize_weights
 from ..import_utils import get_numpy
 
 ALIAS_THETA = get_aliases("THETA")
@@ -84,8 +84,9 @@ def _configure_dnfr_weights(G) -> dict:
     dictionary of normalised components reused at each simulation step
     without recomputing the mix.
     """
-    w = merge_graph_weights(G, "DNFR_WEIGHTS")
-    weights = normalize_weights(w, ("phase", "epi", "vf", "topo"), default=0.0)
+    weights = merge_and_normalize_weights(
+        G, "DNFR_WEIGHTS", ("phase", "epi", "vf", "topo"), default=0.0
+    )
     G.graph["_dnfr_weights"] = weights
     return weights
 

--- a/tests/test_merge_and_normalize_weights.py
+++ b/tests/test_merge_and_normalize_weights.py
@@ -1,0 +1,14 @@
+import pytest
+
+from tnfr.metrics_utils import merge_and_normalize_weights
+
+
+def test_merge_and_normalize_weights(graph_canon):
+    G = graph_canon()
+    G.graph["DNFR_WEIGHTS"] = {"phase": 2, "epi": 1, "vf": 1, "topo": 0}
+    weights = merge_and_normalize_weights(
+        G, "DNFR_WEIGHTS", ("phase", "epi", "vf", "topo"), default=0.0
+    )
+    assert weights == pytest.approx(
+        {"phase": 0.5, "epi": 0.25, "vf": 0.25, "topo": 0.0}
+    )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4b32c23c48321910eecb61be723a5