### PR TITLE
Ensure immutability of helper structures

### DIFF
--- a/tests/test_is_immutable.py
+++ b/tests/test_is_immutable.py
@@ -8,6 +8,8 @@ import pytest
 
 from tnfr.immutable import (
     _IMMUTABLE_CACHE,
+    _IMMUTABLE_TAG_DISPATCH,
+    IMMUTABLE_SIMPLE,
     _is_immutable,
     _is_immutable_inner,
 )
@@ -143,3 +145,12 @@ def test_is_immutable_cache_auto_cleanup():
 
     # the weak cache should have removed the entry
     assert obj_id not in {id(k) for k in _IMMUTABLE_CACHE.keys()}
+
+
+def test_internal_constants_are_immutable():
+    assert isinstance(IMMUTABLE_SIMPLE, frozenset)
+    assert isinstance(_IMMUTABLE_TAG_DISPATCH, MappingProxyType)
+    with pytest.raises(TypeError):
+        _IMMUTABLE_TAG_DISPATCH["new"] = lambda v: False  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        IMMUTABLE_SIMPLE.add(int)  # type: ignore[attr-defined]


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4bc21e0188321804f127275a90c54