### PR TITLE
Limit public API exports to stable symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ inspected with ``tnfr.callback_utils.get_callback_error_limit``.
 
 ## Topological remeshing
 
-Use ``apply_topological_remesh`` to reorganize connectivity based on nodal
-EPI similarity while preserving graph connectivity. Modes:
+Use ``tnfr.operators.apply_topological_remesh`` (``from tnfr.operators import apply_topological_remesh``)
+to reorganize connectivity based on nodal EPI similarity while preserving
+graph connectivity. Modes:
 
 - ``"knn"`` – connect each node to its ``k`` nearest neighbours (with optional
   rewiring).
@@ -177,6 +178,8 @@ https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-teoria-de-la-natur
 
 * Removed deprecated alias `sigma_vector_global`; use `sigma_vector_from_graph` instead.
 * Cleaned up `tnfr.program.__all__` to exclude private helpers.
+* Stopped re-exporting ``CallbackSpec`` and ``apply_topological_remesh`` at the
+  package root; import them via ``tnfr.trace`` and ``tnfr.operators``.
 
 ---
 

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -13,8 +13,6 @@ example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or
 
 from __future__ import annotations
 
-# re-exported for tests
-from .trace import CallbackSpec  # noqa: F401
 from .import_utils import optional_import
 from .ontosim import preparar_red
 from .types import NodeState
@@ -48,13 +46,6 @@ else:
     _HAS_RUN_SEQUENCE = True
 
 
-_HAS_APPLY_TOPOLOGICAL_REMESH = False
-try:  # pragma: no cover - exercised in import tests
-    from .operators import apply_topological_remesh
-except ImportError as exc:  # pragma: no cover - no missing deps in CI
-    apply_topological_remesh = _missing_dependency("apply_topological_remesh", exc)
-else:
-    _HAS_APPLY_TOPOLOGICAL_REMESH = True
 
 _metadata = optional_import("importlib.metadata")
 if _metadata is None:  # pragma: no cover
@@ -96,10 +87,7 @@ __all__ = [
     "preparar_red",
     "create_nfr",
     "NodeState",
-    "CallbackSpec",
 ]
 
 if _HAS_RUN_SEQUENCE:
     __all__.append("run_sequence")
-if _HAS_APPLY_TOPOLOGICAL_REMESH:
-    __all__.append("apply_topological_remesh")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -10,12 +10,9 @@ def test_public_exports():
         "preparar_red",
         "create_nfr",
         "NodeState",
-        "CallbackSpec",
     }
     if getattr(tnfr, "_HAS_RUN_SEQUENCE", False):
         expected.add("run_sequence")
-    if getattr(tnfr, "_HAS_APPLY_TOPOLOGICAL_REMESH", False):
-        expected.add("apply_topological_remesh")
     assert set(tnfr.__all__) == expected
 
 
@@ -29,5 +26,5 @@ def test_basic_flow():
     assert isinstance(tnfr.NodeState(), tnfr.NodeState)
 
 
-def test_topological_remesh_exported():
-    assert hasattr(tnfr, "apply_topological_remesh")
+def test_topological_remesh_not_exported():
+    assert not hasattr(tnfr, "apply_topological_remesh")

--- a/tests/test_topological_remesh.py
+++ b/tests/test_topological_remesh.py
@@ -2,7 +2,7 @@
 import networkx as nx
 
 from tnfr.constants import inject_defaults
-from tnfr import apply_topological_remesh
+from tnfr.operators import apply_topological_remesh
 from tnfr.glyph_history import ensure_history
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4bf48443083219f1f261a14296be5