### PR TITLE
Remove legacy cosine/sine accumulator wrapper

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -196,13 +196,6 @@ def accumulate_cos_sin(
     return sum_cos + comp_cos, sum_sin + comp_sin, processed
 
 
-def _accumulate_cos_sin(
-    it: Iterable[tuple[float, float] | None],
-) -> tuple[float, float, bool]:
-    """Legacy wrapper for :func:`accumulate_cos_sin`."""
-    return accumulate_cos_sin(it)
-
-
 def _phase_mean_from_iter(
     it: Iterable[tuple[float, float] | None], fallback: float
 ) -> float:

--- a/tests/test_accumulate_cos_sin.py
+++ b/tests/test_accumulate_cos_sin.py
@@ -16,3 +16,10 @@ def test_accumulate_cos_sin_handles_empty_iterable():
     assert processed is False
     assert sum_cos == pytest.approx(0.0)
     assert sum_sin == pytest.approx(0.0)
+
+
+def test_accumulate_cos_sin_wrapper_removed():
+    import tnfr.helpers.numeric as numeric
+
+    with pytest.raises(AttributeError):
+        getattr(numeric, "_accumulate_cos_sin")


### PR DESCRIPTION
Removed obsolete `_accumulate_cos_sin` wrapper so callers use `accumulate_cos_sin` directly.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c4c4fcbf3c8321aa79e3591e4e9e31