### PR TITLE
Fix spacing before _empty_sigma in sense

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -111,7 +111,6 @@ def _to_complex(val: complex | float | int) -> complex:
     raise TypeError("values must be an iterable of real or complex numbers")
 
 
-
 def _empty_sigma(fallback_angle: float) -> dict[str, float]:
     """Return an empty σ-vector with ``fallback_angle``.
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c4c4eec3608321b6cb11b160fa0ecd