### PR TITLE
chore: add spacing before Mapping freeze decorator

### DIFF
--- a/src/tnfr/immutable.py
+++ b/src/tnfr/immutable.py
@@ -87,6 +87,7 @@ for _cls, _tag in (
 ):
     _register_iterable(_cls, _tag)
 
+
 @_freeze.register(Mapping)
 @_check_cycle
 def _freeze_mapping(value: Mapping, seen: set[int] | None = None):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4c4b676108321b7a55ecb2f7392c5