### PR TITLE
fix: add spacing before grammar exports

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -41,6 +41,7 @@ class GrammarContext:
             norms=G.graph.get("_sel_norms") or {},
         )
 
+
 __all__ = (
     "CANON_COMPAT",
     "CANON_FALLBACK",


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c4c4b146e88321aacf9e7017f4dc38