### PR TITLE
Use weak references for named locks and test cleanup

### DIFF
--- a/src/tnfr/locking.py
+++ b/src/tnfr/locking.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 import threading
 from contextlib import contextmanager
 from collections.abc import Iterator
+from weakref import WeakValueDictionary
 
 # Registry of locks by name guarded by ``_REGISTRY_LOCK``.
-_locks: dict[str, threading.Lock] = {}
+# Using ``WeakValueDictionary`` ensures that once a lock is no longer
+# referenced elsewhere, it is removed from the registry automatically,
+# keeping the catalogue aligned with active coherence nodes.
+_locks: WeakValueDictionary[str, threading.Lock] = WeakValueDictionary()
 _REGISTRY_LOCK = threading.Lock()
 
 
@@ -29,7 +33,7 @@ def get_lock(name: str) -> threading.Lock:
         if lock is None:
             lock = threading.Lock()
             _locks[name] = lock
-        return lock
+    return lock
 
 
 @contextmanager

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,25 @@
+"""Tests for the named lock registry using weak references."""
+
+import gc
+import uuid
+
+from tnfr import locking
+
+
+def test_lock_registry_shrinks_after_release():
+    """Locks without external references disappear from the registry."""
+    # Generate a unique lock name to avoid collisions with other tests.
+    name = f"lock-{uuid.uuid4()}"
+    start = len(locking._locks)
+
+    lock = locking.get_lock(name)
+    assert len(locking._locks) == start + 1
+
+    # Remove the strong reference and force garbage collection so the
+    # ``WeakValueDictionary`` drops the entry.
+    del lock
+    gc.collect()
+
+    assert len(locking._locks) == start
+    assert name not in locking._locks
+


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c542a959fc8321bc85a82cf1052da9