### PR TITLE
Centralize neighbor phase mean logic

### DIFF
--- a/tests/test_neighbor_phase_mean_missing_trig.py
+++ b/tests/test_neighbor_phase_mean_missing_trig.py
@@ -1,15 +1,36 @@
 import math
 import pytest
 
-from tnfr.helpers.numeric import neighbor_phase_mean_list
+from tnfr.helpers.numeric import (
+    neighbor_phase_mean_list,
+    _neighbor_phase_mean_core,
+)
 
 
-def test_neighbor_phase_mean_list_missing_trig():
+def test_neighbor_phase_mean_core_missing_trig():
     neigh = [1, 2, 3]
     cos_th = {1: 1.0, 2: 0.0}
     sin_th = {1: 0.0, 2: 1.0}
 
-    angle = neighbor_phase_mean_list(neigh, cos_th, sin_th, fallback=0.5)
+    angle = _neighbor_phase_mean_core(neigh, cos_th, sin_th, np=None, fallback=0.5)
     assert angle == pytest.approx(math.pi / 4)
 
-    assert neighbor_phase_mean_list([3], cos_th, sin_th, fallback=0.5) == pytest.approx(0.5)
+    assert _neighbor_phase_mean_core([3], cos_th, sin_th, np=None, fallback=0.5) == pytest.approx(
+        0.5
+    )
+
+
+def test_neighbor_phase_mean_list_delegates_core(monkeypatch):
+    neigh = [1]
+    cos_th = {1: 1.0}
+    sin_th = {1: 0.0}
+    captured = {}
+
+    def fake_core(neigh_arg, cos_map, sin_map, np_arg, fallback):
+        captured["args"] = (neigh_arg, cos_map, sin_map, np_arg, fallback)
+        return 1.23
+
+    monkeypatch.setattr("tnfr.helpers.numeric._neighbor_phase_mean_core", fake_core)
+    result = neighbor_phase_mean_list(neigh, cos_th, sin_th, np=None, fallback=0.0)
+    assert result == pytest.approx(1.23)
+    assert captured["args"] == (neigh, cos_th, sin_th, None, 0.0)

--- a/tests/test_neighbor_phase_mean_no_graph.py
+++ b/tests/test_neighbor_phase_mean_no_graph.py
@@ -1,6 +1,8 @@
 import pytest
 
 from tnfr.helpers.numeric import neighbor_phase_mean
+from tnfr.constants import get_aliases
+from tnfr.alias import set_attr
 
 
 class DummyNeighbor:
@@ -20,3 +22,22 @@ def test_neighbor_phase_mean_requires_graph():
     node = DummyNode()
     with pytest.raises(TypeError):
         neighbor_phase_mean(node)
+
+
+def test_neighbor_phase_mean_uses_core(monkeypatch, graph_canon):
+    ALIAS_THETA = get_aliases("THETA")
+    G = graph_canon()
+    G.add_edge(1, 2)
+    for n in G.nodes:
+        set_attr(G.nodes[n], ALIAS_THETA, 0.0)
+
+    calls = []
+
+    def fake_core(neigh, cos_map, sin_map, np, fallback):
+        calls.append((neigh, cos_map, sin_map, np, fallback))
+        return 0.0
+
+    monkeypatch.setattr("tnfr.helpers.numeric._neighbor_phase_mean_core", fake_core)
+    neighbor_phase_mean(G, 1)
+    assert len(calls) == 1
+    assert list(calls[0][0]) == list(G[1])


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c54a7112f08321b7ee2977fcddbfa8