### PR TITLE
Add docstring checks for selector utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "remix vite:build",
-    "test": "pytest"
+    "test": "scripts/run_tests.sh"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 numpy = ["numpy>=1.24"]
 yaml = ["pyyaml>=6.0"]
 orjson = ["orjson>=3"]
+test = ["pytest>=7", "pydocstyle>=6"]
 
 [project.scripts]
 tnfr = "tnfr.cli:main"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 export PYTHONPATH="$PWD/src"
+pydocstyle src/tnfr/selector.py src/tnfr/value_utils.py src/tnfr/graph_utils.py
 python -m pytest "$@"

--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -1,4 +1,7 @@
-"""Utilities for graph-level bookkeeping."""
+"""Utilities for graph-level bookkeeping.
+
+Currently includes helpers to invalidate cached ΔNFR preparation data.
+"""
 
 from __future__ import annotations
 from typing import Any
@@ -7,13 +10,19 @@ __all__ = ("mark_dnfr_prep_dirty",)
 
 
 def mark_dnfr_prep_dirty(G: Any) -> None:
-    """Mark cached ΔNFR preparation data as stale for ``G``.
+    """Flag ΔNFR preparation data as stale.
 
-    This sets a flag in ``G.graph`` so that subsequent calls to
-    :func:`_prepare_dnfr_data` know that node attributes or topology have
-    changed and cached arrays need to be refreshed.
+    Parameters
+    ----------
+    G : Any
+        Graph-like object whose ``graph`` attribute will receive the
+        ``"_dnfr_prep_dirty"`` flag.
+
+    Returns
+    -------
+    None
+        This function mutates ``G`` in place.
     """
-
     from .helpers.cache import get_graph
 
     graph = get_graph(G)

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -1,4 +1,8 @@
-"""Glyph selection."""
+"""Utilities to select glyphs based on structural metrics.
+
+This module normalises thresholds, computes selection scores and applies
+hysteresis when assigning glyphs to nodes.
+"""
 
 from __future__ import annotations
 
@@ -29,9 +33,16 @@ __all__ = (
 def _sorted_items(mapping: Mapping[str, float]) -> tuple[tuple[str, float], ...]:
     """Return mapping items sorted by key.
 
-    Provides a stable, hashable representation for memoisation.
-    """
+    Parameters
+    ----------
+    mapping : Mapping[str, float]
+        Mapping whose items will be sorted.
 
+    Returns
+    -------
+    tuple[tuple[str, float], ...]
+        Key-sorted items providing a hashable representation for memoisation.
+    """
     return tuple(sorted(mapping.items()))
 
 
@@ -41,13 +52,22 @@ def _build_selector_thresholds(
     thr_sel_items: tuple[tuple[str, float], ...],
     thr_def_items: tuple[tuple[str, float], ...],
 ) -> dict[str, float]:
-    """Construct threshold dict once per graph.
+    """Construct selector thresholds for a graph.
 
-    Parameters are hashable representations of the selector and legacy
-    thresholds, enabling memoisation via ``lru_cache``. The returned dictionary
-    is reused for subsequent calls with the same arguments.
+    Parameters
+    ----------
+    graph_id : int
+        Identifier of the graph used to seed the cache.
+    thr_sel_items : tuple[tuple[str, float], ...]
+        Selector threshold items as ``(key, value)`` pairs.
+    thr_def_items : tuple[tuple[str, float], ...]
+        Legacy threshold items used as fallbacks.
+
+    Returns
+    -------
+    dict[str, float]
+        Normalised thresholds combining selector and legacy values.
     """
-
     thr_sel = dict(thr_sel_items)
     thr_def = dict(thr_def_items)
 
@@ -71,13 +91,18 @@ def _build_selector_thresholds(
 
 
 def _selector_thresholds(G: "nx.Graph") -> dict[str, float]:
-    """Return normalised hi/lo thresholds for Si, ΔNFR and acceleration.
+    """Return normalised thresholds for Si, ΔNFR and acceleration.
 
-    Combines ``SELECTOR_THRESHOLDS`` with legacy ``GLYPH_THRESHOLDS`` for Si
-    cutoffs. All values are clamped to ``[0, 1]``. Results are memoised so that
-    each graph builds the thresholds only once.
+    Parameters
+    ----------
+    G : nx.Graph
+        Graph whose configuration stores selector thresholds.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary with clamped hi/lo thresholds, memoised per graph.
     """
-
     sel_defaults = DEFAULTS.get("SELECTOR_THRESHOLDS", {})
     thr_sel = {**sel_defaults, **G.graph.get("SELECTOR_THRESHOLDS", {})}
     glyph_defaults = DEFAULTS.get("GLYPH_THRESHOLDS", {})
@@ -89,8 +114,19 @@ def _selector_thresholds(G: "nx.Graph") -> dict[str, float]:
 
 
 def _norms_para_selector(G: "nx.Graph") -> dict:
-    """Compute and store maxima in ``G.graph`` to normalise |ΔNFR| and
-    |d²EPI/dt²|."""
+    """Compute and cache norms for ΔNFR and acceleration.
+
+    Parameters
+    ----------
+    G : nx.Graph
+        Graph for which to compute maxima. Results are stored in ``G.graph``
+        under ``"_sel_norms"``.
+
+    Returns
+    -------
+    dict
+        Mapping with normalisation maxima for ``dnfr`` and ``accel``.
+    """
     norms = compute_dnfr_accel_max(G)
     G.graph["_sel_norms"] = norms
     return norms
@@ -99,7 +135,24 @@ def _norms_para_selector(G: "nx.Graph") -> dict:
 def _calc_selector_score(
     Si: float, dnfr: float, accel: float, weights: dict[str, float]
 ) -> float:
-    """Compute a weighted score assuming normalised weights."""
+    """Compute weighted selector score.
+
+    Parameters
+    ----------
+    Si : float
+        Normalised sense index.
+    dnfr : float
+        Normalised absolute ΔNFR value.
+    accel : float
+        Normalised acceleration (|d²EPI/dt²|).
+    weights : dict[str, float]
+        Normalised weights for ``"w_si"``, ``"w_dnfr"`` and ``"w_accel"``.
+
+    Returns
+    -------
+    float
+        Final weighted score.
+    """
     return (
         weights["w_si"] * Si
         + weights["w_dnfr"] * (1.0 - dnfr)
@@ -115,8 +168,28 @@ def _apply_selector_hysteresis(
     thr: dict[str, float],
     margin: float,
 ) -> str | None:
-    """Apply hysteresis, returning the previous glyph when close to
-    thresholds."""
+    """Apply hysteresis when values are near thresholds.
+
+    Parameters
+    ----------
+    nd : dict[str, Any]
+        Node attribute dictionary containing glyph history.
+    Si : float
+        Normalised sense index.
+    dnfr : float
+        Normalised absolute ΔNFR value.
+    accel : float
+        Normalised acceleration.
+    thr : dict[str, float]
+        Thresholds returned by :func:`_selector_thresholds`.
+    margin : float
+        Distance from thresholds below which the previous glyph is reused.
+
+    Returns
+    -------
+    str or None
+        Previous glyph if hysteresis applies, otherwise ``None``.
+    """
     # Batch extraction reduces dictionary lookups inside loops.
     si_hi, si_lo, dnfr_hi, dnfr_lo, accel_hi, accel_lo = itemgetter(
         "si_hi", "si_lo", "dnfr_hi", "dnfr_lo", "accel_hi", "accel_lo"

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -1,4 +1,7 @@
-"""Conversion helpers with logging for value normalization."""
+"""Conversion helpers with logging for value normalisation.
+
+Wraps conversion callables to standardise error handling and logging.
+"""
 
 from __future__ import annotations
 
@@ -21,11 +24,27 @@ def convert_value(
     key: str | None = None,
     log_level: int | None = None,
 ) -> tuple[bool, T | None]:
-    """Attempt to convert ``value`` using ``conv`` with error handling.
+    """Attempt to convert a value and report failures.
 
-    ``log_level`` controls the logging level when conversion fails in lax
-    mode. Defaults to ``logging.DEBUG``. If ``strict`` is ``True`` the
-    exception is raised and no log is emitted.
+    Parameters
+    ----------
+    value : Any
+        Input value to convert.
+    conv : Callable[[Any], T]
+        Callable performing the conversion.
+    strict : bool, optional
+        Raise exceptions directly instead of logging them. Defaults to ``False``.
+    key : str, optional
+        Name associated with the value for logging context.
+    log_level : int, optional
+        Logging level used when reporting failures. Defaults to
+        ``logging.DEBUG``.
+
+    Returns
+    -------
+    tuple[bool, T | None]
+        ``(True, result)`` on success or ``(False, None)`` when conversion
+        fails.
     """
     try:
         return True, conv(value)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c54be585fc8321b3e776f6cee5dca5