### PR TITLE
Add configurable cached_import utility and refactor optional imports

### DIFF
--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,7 +1,12 @@
 import sys
 import types
+import importlib
 
-from tnfr.import_utils import clear_optional_import_cache, optional_import
+from tnfr.import_utils import (
+    clear_optional_import_cache,
+    optional_import,
+    cached_import,
+)
 
 
 def test_optional_import_success_and_failure(monkeypatch):
@@ -17,3 +22,27 @@ def test_optional_import_success_and_failure(monkeypatch):
     # clearing cache allows successful import
     clear_optional_import_cache()
     assert optional_import("fake_mod") is fake_mod
+
+
+def test_cached_import_attribute_and_fallback(monkeypatch):
+    clear_optional_import_cache()
+    fake_mod = types.SimpleNamespace(value=5)
+    monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
+    assert cached_import("fake_mod", attr="value") == 5
+    clear_optional_import_cache()
+    monkeypatch.delitem(sys.modules, "fake_mod")
+    assert cached_import("fake_mod", attr="value", fallback=1) == 1
+
+
+def test_cached_import_uses_cache(monkeypatch):
+    clear_optional_import_cache()
+    calls = {"n": 0}
+
+    def fake_import(name):
+        calls["n"] += 1
+        return types.SimpleNamespace()
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    cached_import("fake_mod")
+    cached_import("fake_mod")
+    assert calls["n"] == 1


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5544fe3288321b613787c887f01d8