### PR TITLE
feat: refine optional import cache handling

### DIFF
--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,3 +1,5 @@
+"""Validate caching and clearing behaviour of optional imports."""
+
 import sys
 import types
 import importlib

--- a/tests/test_optional_import.py
+++ b/tests/test_optional_import.py
@@ -1,3 +1,5 @@
+"""Exercise optional import helpers backed by TTL caches."""
+
 import types
 import importlib
 import logging
@@ -94,7 +96,7 @@ def test_record_prunes_expired_entries(monkeypatch):
             "failed",
             TTLCache(state.limit, 10, timer=lambda: import_utils.time.monotonic()),
         )
-    times = iter([0.0, 11.0])
+    times = iter([0.0, 11.0, 11.0])
     monkeypatch.setattr(import_utils.time, "monotonic", lambda: next(times))
     with state.lock:
         state.record("old")


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c55f1beb7c832190d8aea334c136a6