### PR TITLE
refactor: migrate optional import tests to cached_import

### DIFF
--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -10,6 +10,7 @@ from tnfr.helpers.cache import (
     ensure_node_index_map,
     _ensure_node_map,
 )
+from tnfr.import_utils import clear_optional_import_cache
 
 
 def test_edge_version_update_scopes_mutations(graph_canon):
@@ -126,6 +127,7 @@ def test_cache_node_list_cache_updated_on_node_set_change(graph_canon):
 
 
 def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
+    clear_optional_import_cache()
     monkeypatch.setattr("tnfr.helpers.cache.get_numpy", lambda: None)
     G = graph_canon()
     G.add_edge(0, 1)
@@ -135,6 +137,7 @@ def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon)
 
 
 def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
+    clear_optional_import_cache()
     monkeypatch.setattr("tnfr.helpers.cache.get_numpy", lambda: None)
     G = graph_canon()
     G.add_edge(0, 1)

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -1,6 +1,7 @@
 from tnfr.constants import get_aliases
 from tnfr.metrics_utils import compute_Si
 from tnfr.alias import set_attr
+from tnfr.import_utils import clear_optional_import_cache
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_VF = get_aliases("VF")
@@ -22,6 +23,7 @@ def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
         captured.append(np)
         return 0.0
 
+    clear_optional_import_cache()
     monkeypatch.setattr("tnfr.metrics_utils.get_numpy", lambda: sentinel)
     monkeypatch.setattr(
         "tnfr.metrics_utils.neighbor_phase_mean_list",

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -4,24 +4,23 @@ import importlib
 
 from tnfr.import_utils import (
     clear_optional_import_cache,
-    optional_import,
     cached_import,
 )
 
 
-def test_optional_import_success_and_failure(monkeypatch):
+def test_cached_import_success_and_failure(monkeypatch):
     clear_optional_import_cache()
     fallback = object()
     # module missing -> fallback returned
-    assert optional_import("fake_mod", fallback) is fallback
+    assert cached_import("fake_mod", fallback=fallback) is fallback
     # insert fake module
     fake_mod = types.ModuleType("fake_mod")
     monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
     # cached failure still returns fallback
-    assert optional_import("fake_mod", fallback) is fallback
+    assert cached_import("fake_mod", fallback=fallback) is fallback
     # clearing cache allows successful import
     clear_optional_import_cache()
-    assert optional_import("fake_mod") is fake_mod
+    assert cached_import("fake_mod") is fake_mod
 
 
 def test_cached_import_attribute_and_fallback(monkeypatch):

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -14,6 +14,7 @@ from tnfr.helpers.numeric import angle_diff
 from tnfr.alias import set_attr
 from tnfr.callback_utils import CallbackEvent
 from tnfr.observers import attach_standard_observer
+from tnfr.import_utils import clear_optional_import_cache
 
 ALIAS_THETA = get_aliases("THETA")
 
@@ -46,6 +47,7 @@ def test_phase_observers_match_manual_calculation(graph_canon):
 
 def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
     pytest.importorskip("numpy")
+    clear_optional_import_cache()
     G = graph_canon()
     angles = [0.1, -2.0, 2.5, 3.0]
     for idx, th in enumerate(angles):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c55919044c83218a66c1523da3478a