### PR TITLE
Refactor optional import tests to cached_import

### DIFF
--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -1,56 +1,28 @@
-import sys
-import sys
-import sys
-import sys
+import importlib
 import sys
 import types
-import importlib
 
 import pytest
-from tnfr.import_utils import (
-    clear_optional_import_cache as _clear_optional_import_cache,
-    optional_import as _optional_import,
-    cached_import,
-)
+from tnfr.import_utils import cached_import, optional_import, prune_failed_imports
 
 
-def optional_import(*args, **kwargs):
-    with pytest.warns(DeprecationWarning):
-        return _optional_import(*args, **kwargs)
-
-
-def clear_optional_import_cache(*args, **kwargs):
-    with pytest.warns(DeprecationWarning):
-        return _clear_optional_import_cache(*args, **kwargs)
-
-
-def test_optional_import_success_and_failure(monkeypatch):
-    clear_optional_import_cache()
-    fallback = object()
-    # module missing -> fallback returned
-    assert optional_import("fake_mod", fallback) is fallback
-    # insert fake module
-    fake_mod = types.ModuleType("fake_mod")
-    monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
-    # cached failure still returns fallback
-    assert optional_import("fake_mod", fallback) is fallback
-    # clearing cache allows successful import
-    clear_optional_import_cache()
-    assert optional_import("fake_mod") is fake_mod
+def reset() -> None:
+    cached_import.cache_clear()
+    prune_failed_imports()
 
 
 def test_cached_import_attribute_and_fallback(monkeypatch):
-    clear_optional_import_cache()
+    reset()
     fake_mod = types.SimpleNamespace(value=5)
     monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
     assert cached_import("fake_mod", attr="value") == 5
-    clear_optional_import_cache()
+    reset()
     monkeypatch.delitem(sys.modules, "fake_mod")
     assert cached_import("fake_mod", attr="value", fallback=1) == 1
 
 
 def test_cached_import_uses_cache(monkeypatch):
-    clear_optional_import_cache()
+    reset()
     calls = {"n": 0}
 
     def fake_import(name):
@@ -61,3 +33,15 @@ def test_cached_import_uses_cache(monkeypatch):
     cached_import("fake_mod")
     cached_import("fake_mod")
     assert calls["n"] == 1
+
+
+def test_optional_import_wrapper(monkeypatch):
+    reset()
+    fallback = object()
+    with pytest.warns(DeprecationWarning):
+        assert optional_import("fake_mod", fallback) is fallback
+    fake_mod = types.ModuleType("fake_mod")
+    monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
+    reset()
+    with pytest.warns(DeprecationWarning):
+        assert optional_import("fake_mod") is fake_mod


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c56b5c0fb083218827305c7821b358