### PR TITLE
Use cached_import to simulate NumPy presence in tests

### DIFF
--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,5 +1,6 @@
 import pytest
 
+import tnfr.import_utils as import_utils
 from tnfr import dynamics
 from tnfr.helpers.cache import (
     cached_nodes_and_A,
@@ -126,8 +127,9 @@ def test_cache_node_list_cache_updated_on_node_set_change(graph_canon):
 
 
 def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
+    monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
     monkeypatch.setattr(
-        "tnfr.helpers.cache.cached_import", lambda *a, **k: None
+        "tnfr.helpers.cache.cached_import", import_utils.cached_import
     )
     G = graph_canon()
     G.add_edge(0, 1)
@@ -137,8 +139,9 @@ def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon)
 
 
 def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
+    monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
     monkeypatch.setattr(
-        "tnfr.helpers.cache.cached_import", lambda *a, **k: None
+        "tnfr.helpers.cache.cached_import", import_utils.cached_import
     )
     G = graph_canon()
     G.add_edge(0, 1)

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -1,6 +1,7 @@
 from tnfr.constants import get_aliases
 from tnfr.metrics_utils import compute_Si
 from tnfr.alias import set_attr
+import tnfr.import_utils as import_utils
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_VF = get_aliases("VF")
@@ -23,8 +24,12 @@ def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
         return 0.0
 
     monkeypatch.setattr(
-        "tnfr.metrics_utils.cached_import",
+        import_utils,
+        "cached_import",
         lambda module, attr=None, **kwargs: sentinel if module == "numpy" else None,
+    )
+    monkeypatch.setattr(
+        "tnfr.metrics_utils.cached_import", import_utils.cached_import
     )
     monkeypatch.setattr(
         "tnfr.metrics_utils.neighbor_phase_mean_list",

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -5,6 +5,8 @@ import statistics as st
 from collections import deque
 import pytest
 
+import tnfr.import_utils as import_utils
+
 from tnfr.constants import get_aliases
 from tnfr.observers import phase_sync, kuramoto_order, glyph_load, wbar
 from tnfr.gamma import kuramoto_R_psi
@@ -53,8 +55,9 @@ def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
         set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     ps_np = phase_sync(G)
+    monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
     monkeypatch.setattr(
-        "tnfr.helpers.numeric.cached_import", lambda *a, **k: None
+        "tnfr.helpers.numeric.cached_import", import_utils.cached_import
     )
     ps_py = phase_sync(G)
     assert ps_np == pytest.approx(ps_py)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c570a654a48321a281285e64c0bca4