### PR TITLE
Handle optional import fallbacks with cached_import

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -32,7 +32,9 @@ def _missing_dependency_error(dep: str) -> type[Exception]:
     return _MissingDependencyError
 
 
-tomllib = cached_import("tomllib") or cached_import("tomli")
+tomllib = cached_import("tomllib", emit="log") or cached_import(
+    "tomli", emit="log"
+)
 if tomllib is not None:
     TOMLDecodeError = getattr(tomllib, "TOMLDecodeError", Exception)
     has_toml = True
@@ -41,7 +43,7 @@ else:  # pragma: no cover - depende de tomllib/tomli
     TOMLDecodeError = _missing_dependency_error("tomllib/tomli")
 
 
-yaml = cached_import("yaml")
+yaml = cached_import("yaml", emit="log")
 if yaml is not None:
     YAMLError = getattr(yaml, "YAMLError", Exception)
 else:  # pragma: no cover - depende de pyyaml

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -175,7 +175,7 @@ def json_dumps(
             cls=cls,
             to_bytes=to_bytes,
         )
-    orjson = cached_import("orjson")
+    orjson = cached_import("orjson", emit="log")
     if orjson is not None:
         return _json_dumps_orjson(orjson, obj, params, **kwargs)
     return _json_dumps_std(obj, params, **kwargs)


### PR DESCRIPTION
### What it reorganizes
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c57e19a0b08321bb92387a57d2accf