### PR TITLE
Ensure closure token terminates structural sequences

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -166,9 +166,9 @@ def _has_tramo_intermedio(nombres: list[str], start: int) -> bool:
 
 
 def _has_cierre(nombres: list[str]) -> bool:
-    """Check if the sequence ends with a valid closure token."""
+    """Check if the last token is a valid closure token."""
 
-    return any(n in _CIERRE_VALIDO for n in nombres[-2:])
+    return bool(nombres) and nombres[-1] in _CIERRE_VALIDO
 
 
 def _thol_blocks_closed(nombres: list[str]) -> bool:
@@ -192,7 +192,7 @@ def _validate_logical_coherence(nombres: list[str]) -> tuple[bool, str]:
     if not _has_tramo_intermedio(nombres, i_coh + 1):
         return False, "missing tension/coupling/resonance segment"
     if not _has_cierre(nombres):
-        return False, "missing closure (silence/transition/recursion)"
+        return False, "sequence must end with silence/transition/recursion"
     if not _thol_blocks_closed(nombres):
         return False, "THOL block without closure"
     return True, "ok"

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -74,3 +74,16 @@ def test_thol_closed_by_silencio():
     names = [op.name for op in ops]
     ok, msg = validate_sequence(names)
     assert ok, msg
+
+
+def test_sequence_rejects_trailing_tokens():
+    names = [
+        "emision",
+        "recepcion",
+        "coherencia",
+        "resonancia",
+        "silencio",
+        "emision",
+    ]
+    ok, msg = validate_sequence(names)
+    assert not ok


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5920108948321af26756a977cc9f8