### PR TITLE
Ensure KNN remeshing rewires edges and adds tests

### DIFF
--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -159,16 +159,24 @@ def _mst_edges_from_epi(nx, nodes, epi):
 
 
 def _knn_edges(nodes, epi, k_val, p_rewire, rnd):
-    """Edges linking each node to its k nearest neighbours in EPI."""
+    """Edges linking each node to its ``k`` nearest neighbours in EPI."""
     new_edges = set()
+    node_set = set(nodes)
     for u in nodes:
         epi_u = epi[u]
-        for _, v in heapq.nsmallest(
-            k_val,
-            ((abs(epi_u - epi[v]), v) for v in nodes if v != u),
-        ):
+        neighbours = [
+            v
+            for _, v in heapq.nsmallest(
+                k_val,
+                ((abs(epi_u - epi[v]), v) for v in nodes if v != u),
+            )
+        ]
+        for v in neighbours:
             if rnd.random() < p_rewire:
-                new_edges.add(tuple(sorted((u, v))))
+                choices = list(node_set - {u, v})
+                if choices:
+                    v = rnd.choice(choices)
+            new_edges.add(tuple(sorted((u, v))))
     return new_edges
 
 

--- a/tests/test_knn_edges.py
+++ b/tests/test_knn_edges.py
@@ -1,0 +1,32 @@
+import random
+
+from tnfr.operators.remesh import _knn_edges
+
+
+def _setup():
+    nodes = list(range(5))
+    epi = {i: float(i) for i in nodes}
+    return nodes, epi
+
+
+def test_knn_edges_connects_nearest_neighbours():
+    nodes, epi = _setup()
+    rnd = random.Random(0)
+    edges = _knn_edges(nodes, epi, k_val=2, p_rewire=0.0, rnd=rnd)
+    expected = {
+        (0, 1),
+        (0, 2),
+        (1, 2),
+        (2, 3),
+        (2, 4),
+        (3, 4),
+    }
+    assert edges == expected
+
+
+def test_knn_edges_rewire_preserves_edge_count():
+    nodes, epi = _setup()
+    edges_base = _knn_edges(nodes, epi, k_val=2, p_rewire=0.0, rnd=random.Random(0))
+    edges_rewired = _knn_edges(nodes, epi, k_val=2, p_rewire=1.0, rnd=random.Random(1))
+    assert len(edges_rewired) == len(edges_base)
+    assert edges_rewired != edges_base


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c59270c3c48321867791dd2c8aecc0