### PR TITLE
Allow configuring jitter cache size

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,26 @@ has fewer than **50 nodes**, in which case all nodes are included.
 ### Jitter RNG cache
 
 `random_jitter` uses an LRU cache of `random.Random` instances keyed by `(seed, node)`.
-`JITTER_CACHE_SIZE` controls the maximum number of cached generators (default: `256`); 
-when the limit is exceeded the least‑recently used entry is discarded. Increase it for 
+`JITTER_CACHE_SIZE` controls the maximum number of cached generators (default: `256`);
+when the limit is exceeded the least‑recently used entry is discarded. Increase it for
 large graphs or heavy jitter usage, or lower it to save memory.
+
+To adjust the number of cached jitter sequences used for deterministic noise,
+configure `JITTER_MANAGER` before calling `setup`:
+
+```python
+from tnfr.operators import JITTER_MANAGER
+
+# Resize cache to keep only 512 entries
+JITTER_MANAGER.max_entries = 512
+JITTER_MANAGER.setup(force=True)
+
+# or in a single call
+JITTER_MANAGER.setup(max_entries=512)
+```
+
+`setup` preserves the current size unless a new `max_entries` value is supplied.
+Custom sizes persist across subsequent `setup` calls.
 
 ### Edge version tracking
 

--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -75,9 +75,24 @@ class JitterCacheManager:
     def lock(self):
         return self.cache.lock
 
-    def setup(self, force: bool = False) -> None:
-        """Ensure jitter cache matches the configured size."""
-        self.cache.max_entries = _JITTER_MAX_ENTRIES
+    @property
+    def max_entries(self) -> int:
+        """Return the maximum number of cached jitter entries."""
+        return self.cache.max_entries
+
+    @max_entries.setter
+    def max_entries(self, value: int) -> None:
+        """Set the maximum number of cached jitter entries."""
+        self.cache.max_entries = value
+
+    def setup(self, force: bool = False, max_entries: int | None = None) -> None:
+        """Ensure jitter cache matches the configured size.
+
+        ``max_entries`` may be provided to explicitly resize the cache.
+        When omitted the existing ``cache.max_entries`` is preserved.
+        """
+        if max_entries is not None:
+            self.cache.max_entries = max_entries
         self.cache.setup(force)
 
     def clear(self) -> None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -97,10 +97,9 @@ def test_rng_cache_disabled_with_size_zero(graph_canon):
     set_cache_maxsize(DEFAULTS["JITTER_CACHE_SIZE"])
 
 
-def test_jitter_seq_purges_old_entries(monkeypatch):
+def test_jitter_seq_purges_old_entries():
     JITTER_MANAGER.clear()
-    monkeypatch.setattr(operators, "_JITTER_MAX_ENTRIES", 4)
-    operators.JITTER_MANAGER.setup(force=True)
+    operators.JITTER_MANAGER.setup(force=True, max_entries=4)
     graph = SimpleNamespace(graph={})
     nodes = [SimpleNamespace(G=graph) for _ in range(5)]
     first_key = (0, id(nodes[0]))
@@ -108,6 +107,23 @@ def test_jitter_seq_purges_old_entries(monkeypatch):
         random_jitter(n, 0.1)
     assert len(operators.JITTER_MANAGER.seq) == 4
     assert first_key not in operators.JITTER_MANAGER.seq
+
+
+def test_jitter_manager_respects_custom_max_entries():
+    JITTER_MANAGER.clear()
+    operators.JITTER_MANAGER.max_entries = 8
+    operators.JITTER_MANAGER.setup(force=True)
+    assert operators.JITTER_MANAGER.settings["max_entries"] == 8
+    operators.JITTER_MANAGER.setup()
+    assert operators.JITTER_MANAGER.settings["max_entries"] == 8
+
+
+def test_jitter_manager_setup_override_size():
+    JITTER_MANAGER.clear()
+    operators.JITTER_MANAGER.setup(force=True, max_entries=5)
+    assert operators.JITTER_MANAGER.settings["max_entries"] == 5
+    operators.JITTER_MANAGER.setup(max_entries=7)
+    assert operators.JITTER_MANAGER.settings["max_entries"] == 7
 
 
 def test_um_candidate_subset_proximity(graph_canon):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5937e12a4832196c2416abbdb86f5