### PR TITLE
Streamline trig cache generation

### DIFF
--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -1,3 +1,5 @@
+import math
+
 from tnfr.constants import get_aliases
 from tnfr.metrics_utils import compute_Si
 from tnfr.alias import set_attr
@@ -12,6 +14,12 @@ def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
     class DummyNP:
         def fromiter(self, iterable, dtype=float, count=-1):
             return list(iterable)
+
+        def cos(self, arr):
+            return [math.cos(x) for x in arr]
+
+        def sin(self, arr):
+            return [math.sin(x) for x in arr]
 
     sentinel = DummyNP()
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c5b4e5874c832194213ecab92de277