### PR TITLE
Serialize access to callback error limit

### DIFF
--- a/tests/test_callback_errors_limit.py
+++ b/tests/test_callback_errors_limit.py
@@ -6,7 +6,6 @@ from tnfr.callback_utils import (
     CallbackEvent,
     invoke_callbacks,
     register_callback,
-    set_callback_error_limit,
 )
 
 
@@ -20,7 +19,8 @@ def test_callback_error_list_resets_limit(graph_canon):
     original = deque(maxlen=None)
     G.graph["_callback_errors"] = original
 
-    prev = set_callback_error_limit(7)
+    prev = cb_utils.get_callback_error_limit()
+    cb_utils.set_callback_error_limit(7)
     try:
         invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
         err_list = G.graph.get("_callback_errors")
@@ -28,4 +28,4 @@ def test_callback_error_list_resets_limit(graph_canon):
         assert err_list.maxlen == cb_utils.get_callback_error_limit() == 7
         assert len(err_list) == 1
     finally:
-        set_callback_error_limit(prev)
+        cb_utils.set_callback_error_limit(prev)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c5bcaae7108321b7a13057f1130a1f