### PR TITLE
Refactor weight normalization helper into unified _prepare_weights

### DIFF
--- a/tests/test_normalize_weights_helpers.py
+++ b/tests/test_normalize_weights_helpers.py
@@ -3,42 +3,47 @@ import pytest
 import tnfr.collections_utils as cu
 
 
-def test_convert_weights_dedup_and_defaults():
-    weights, keys = cu._convert_weights({"a": "1", "c": "bad"}, ["a", "b", "c", "a"], 2.0, error_on_conversion=False)
+def test_prepare_weights_dedup_and_defaults():
+    weights, keys, total = cu._prepare_weights(
+        {"a": "1", "c": "bad"}, ["a", "b", "c", "a"], 2.0,
+        error_on_conversion=False,
+        error_on_negative=False,
+        warn_once=False,
+    )
     assert keys == ["a", "b", "c"]
     assert weights == {"a": 1.0, "b": 2.0, "c": 2.0}
+    assert math.isclose(total, 5.0)
 
 
-def test_convert_weights_error_on_conversion():
+def test_prepare_weights_error_on_conversion():
     with pytest.raises(ValueError):
-        cu._convert_weights({"a": "bad"}, ["a"], 0.0, error_on_conversion=True)
+        cu._prepare_weights(
+            {"a": "bad"}, ["a"], 0.0,
+            error_on_conversion=True,
+            error_on_negative=False,
+            warn_once=False,
+        )
 
 
-def test_handle_negative_weights_clamps(caplog):
+def test_prepare_weights_clamps_negatives(caplog):
     cu.clear_warned_negative_keys()
-    weights = {"a": -1.0, "b": 2.0}
-    with caplog.at_level("WARNING"):
-        total = cu._handle_negative_weights(weights, error_on_negative=False, warn_once=False)
-    assert total == 2.0
-    assert weights["a"] == 0.0
+    weights, keys, total = cu._prepare_weights(
+        {"a": -1.0, "b": 2.0}, ["a", "b"], 0.0,
+        error_on_conversion=False,
+        error_on_negative=False,
+        warn_once=False,
+    )
     assert any("Negative weights" in m for m in caplog.messages)
+    assert weights == {"a": 0.0, "b": 2.0}
+    assert keys == ["a", "b"]
+    assert total == 2.0
 
 
-def test_handle_negative_weights_raises():
+def test_prepare_weights_raises_on_negative():
     with pytest.raises(ValueError):
-        cu._handle_negative_weights({"a": -1.0}, error_on_negative=True, warn_once=True)
-
-
-def test_normalize_non_negative_uniform():
-    weights = {"a": 0.0, "b": 0.0}
-    keys = ["a", "b"]
-    norm = cu._normalize_non_negative_weights(weights, keys, 0.0)
-    assert norm == {"a": 0.5, "b": 0.5}
-
-
-def test_normalize_non_negative_divides():
-    weights = {"a": 1.0, "b": 3.0}
-    keys = ["a", "b"]
-    norm = cu._normalize_non_negative_weights(weights, keys, 4.0)
-    assert math.isclose(norm["a"], 0.25)
-    assert math.isclose(norm["b"], 0.75)
+        cu._prepare_weights(
+            {"a": -1.0}, ["a"], 0.0,
+            error_on_conversion=False,
+            error_on_negative=True,
+            warn_once=True,
+        )


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c5d98de16483219b52a066a13eacc8