### PR TITLE
Lock AliasAccessor key cache for thread safety

### DIFF
--- a/tests/test_alias_key_cache_threadsafe.py
+++ b/tests/test_alias_key_cache_threadsafe.py
@@ -1,0 +1,22 @@
+"""Pruebas concurrentes de AliasAccessor compartiendo instancia."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from tnfr.alias import AliasAccessor
+
+
+def test_alias_accessor_key_cache_threadsafe():
+    acc = AliasAccessor(int)
+    d: dict[str, int] = {}
+    aliases = ("k", "a")
+
+    def worker(i: int) -> None:
+        for _ in range(100):
+            acc.set(d, aliases, i)
+            val = acc.get(d, aliases)
+            assert isinstance(val, int)
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        list(ex.map(worker, range(16)))
+
+    assert len(acc._key_cache) == 1


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5db9c263883219449489c36c46ed9