### PR TITLE
Allow cached_import to use caller-provided lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ from tnfr import cached_import
 np = cached_import("numpy")
 safe_load = cached_import("yaml", "safe_load")
 
+# provide a shared cache with an explicit lock
+from cachetools import TTLCache
+import threading
+
+cache = TTLCache(32, 60)
+lock = threading.Lock()
+cached_import("numpy", cache=cache, lock=lock)
+
 # clear the cache (e.g. after installing a dependency at runtime)
 cached_import.cache_clear()
 ```


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5dc3e709c8321bfeb57cee08497cc