### PR TITLE
Use np.fromiter for attribute collection and add benchmark

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -254,11 +254,19 @@ def collect_attr(
     """
 
     if np is not None:
-        nodes_list = list(nodes)
-        arr = np.empty(len(nodes_list), dtype=float)
-        for idx, n in enumerate(nodes_list):
-            arr[idx] = get_attr(G.nodes[n], aliases, default)
-        return arr
+        if nodes is G.nodes:
+            size = G.number_of_nodes()
+        else:
+            try:
+                size = len(nodes)  # type: ignore[arg-type]
+            except TypeError:
+                nodes = list(nodes)
+                size = len(nodes)
+        return np.fromiter(
+            (get_attr(G.nodes[n], aliases, default) for n in nodes),
+            float,
+            count=size,
+        )
     return [get_attr(G.nodes[n], aliases, default) for n in nodes]
 
 

--- a/tests/test_collect_attr_performance.py
+++ b/tests/test_collect_attr_performance.py
@@ -1,0 +1,35 @@
+import time
+import networkx as nx
+import numpy as np
+import pytest
+
+from tnfr.alias import set_attr, collect_attr
+from tnfr.constants import get_aliases
+
+ALIAS_THETA = get_aliases("THETA")
+
+
+def _naive_collect(G):
+    return np.array(
+        [collect_attr(G, [n], ALIAS_THETA, 0.0, np=np)[0] for n in G.nodes],
+        dtype=float,
+    )
+
+
+@pytest.mark.slow
+def test_collect_attr_performance():
+    G = nx.gnp_random_graph(300, 0.1, seed=1)
+    for n in G.nodes:
+        set_attr(G.nodes[n], ALIAS_THETA, 0.0)
+
+    start = time.perf_counter()
+    for _ in range(5):
+        collect_attr(G, G.nodes, ALIAS_THETA, 0.0, np=np)
+    t_opt = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(5):
+        _naive_collect(G)
+    t_naive = time.perf_counter() - start
+
+    assert t_opt <= t_naive


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5dc3ec8748321848690d482d03792