### PR TITLE
Avoid float coercion in glyph timing metrics

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -163,7 +163,7 @@ def _update_tg_node(n, nd, dt, tg_total, tg_by_node):
     elif g == curr:
         st.run += dt
     else:
-        dur = float(st.run)
+        dur = st.run
         tg_total[curr] += dur
         if tg_by_node is not None:
             tg_by_node[n][curr].append(dur)

--- a/tests/test_update_tg_performance.py
+++ b/tests/test_update_tg_performance.py
@@ -42,7 +42,7 @@ def _update_tg_naive(G, hist, dt, save_by_node):
             st.run += dt
         else:
             prev = st.curr
-            dur = float(st.run)
+            dur = st.run
             tg_total[prev] += dur
             if save_by_node:
                 tg_by_node[n][prev].append(dur)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5dc2b69548321a25a44216270ac05