### PR TITLE
Accept Mapping in normalize_weights and test immutable mappings

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -208,7 +208,7 @@ def _prepare_weights(
 
 
 def normalize_weights(
-    dict_like: dict[str, Any],
+    dict_like: Mapping[str, Any],
     keys: Iterable[str] | Sequence[str],
     default: float = 0.0,
     *,
@@ -216,7 +216,7 @@ def normalize_weights(
     warn_once: bool = True,
     error_on_conversion: bool = False,
 ) -> dict[str, float]:
-    """Normalize ``keys`` in ``dict_like`` so their sum is 1.
+    """Normalize ``keys`` in mapping ``dict_like`` so their sum is 1.
 
     ``keys`` may be any iterable of strings and is materialized once while
     collapsing repeated entries preserving their first occurrence.

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -1,6 +1,8 @@
 """Tests for normalize_weights helper."""
 
 import math
+from types import MappingProxyType
+
 import pytest
 import tnfr.collections_utils as cu
 from tnfr.collections_utils import normalize_weights
@@ -95,3 +97,9 @@ def test_normalize_weights_deduplicates_keys():
     expected = {"a": 0.5, "b": 0.5}
     assert norm_dup == norm_unique
     assert norm_dup == pytest.approx(expected)
+
+
+def test_normalize_weights_accepts_mapping_proxy():
+    weights = MappingProxyType({"a": 1.0, "b": 2.0})
+    norm = normalize_weights(weights, weights.keys())
+    assert norm == pytest.approx({"a": 1 / 3, "b": 2 / 3})


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c5dc101e5083218a792e2fb45f3e9e