### PR TITLE
Normalize generator callback entries

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -170,16 +170,23 @@ def _normalize_callback_entry(entry: Any) -> "CallbackSpec | None":
     Supported formats
     -----------------
     * :class:`CallbackSpec` instances (returned unchanged).
-    * Sequences ``(name: str, func: Callable)`` such as lists or tuples.
+    * Sequences ``(name: str, func: Callable)`` such as lists, tuples or other
+      iterables.
     * Bare callables ``func`` whose name is taken from ``func.__name__``.
 
     ``None`` is returned when ``entry`` does not match any of the accepted
-    formats.  The original ``entry`` is never mutated.
+    formats. The original ``entry`` is never mutated. Sequence inputs are
+    converted to ``tuple`` before validation to support generators; the
+    materialization consumes the iterable and failure results in ``None``.
     """
 
     if isinstance(entry, CallbackSpec):
         return entry
     elif is_non_string_sequence(entry):
+        try:
+            entry = tuple(entry)
+        except TypeError:
+            return None
         if len(entry) != 2:
             return None
         name, fn = entry

--- a/tests/test_normalize_callback_entry.py
+++ b/tests/test_normalize_callback_entry.py
@@ -1,0 +1,30 @@
+"""Pruebas de `_normalize_callback_entry` con secuencias."""
+
+from tnfr.callback_utils import _normalize_callback_entry, CallbackSpec
+
+
+def dummy_cb(G, ctx):
+    pass
+
+
+def test_list_entry():
+    entry = ["cb", dummy_cb]
+    assert _normalize_callback_entry(entry) == CallbackSpec("cb", dummy_cb)
+
+
+def test_generator_entry():
+    entry = (x for x in ("cb", dummy_cb))
+    assert _normalize_callback_entry(entry) == CallbackSpec("cb", dummy_cb)
+
+
+def test_iterable_conversion_type_error_returns_none():
+    class BadIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise TypeError("bad iter")
+
+    entry = BadIter()
+    assert _normalize_callback_entry(entry) is None
+


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5dc1cfd2c8321882482a77e448451