### PR TITLE
feat: restrict cache helper exports

### DIFF
--- a/src/tnfr/dynamics/sampling.py
+++ b/src/tnfr/dynamics/sampling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..helpers.cache import _cache_node_list
+from ..helpers.cache import cached_node_list
 from ..rng import _rng_for_step, base_seed
 
 __all__ = ("update_node_sample",)
@@ -20,7 +20,7 @@ def update_node_sample(G, *, step: int) -> None:
     """
     graph = G.graph
     limit = int(graph.get("UM_CANDIDATE_COUNT", 0))
-    nodes = _cache_node_list(G)
+    nodes = cached_node_list(G)
     current_n = len(nodes)
     if limit <= 0 or current_n < 50 or limit >= current_n:
         graph["_node_sample"] = nodes

--- a/src/tnfr/helpers/cache.py
+++ b/src/tnfr/helpers/cache.py
@@ -44,10 +44,8 @@ __all__ = (
     "get_graph",
     "get_graph_mapping",
     "node_set_checksum",
-    "_stable_json",
-    "_node_repr_digest",
-    "_node_repr",
-    "_cache_node_list",
+    "stable_json",
+    "cached_node_list",
     "ensure_node_index_map",
     "ensure_node_offset_map",
     "edge_version_cache",
@@ -90,6 +88,11 @@ def _stable_json(obj: Any) -> str:
         ensure_ascii=False,
         to_bytes=False,
     )
+
+
+def stable_json(obj: Any) -> str:
+    """Public wrapper returning a stable JSON string for ``obj``."""
+    return _stable_json(obj)
 
 
 @lru_cache(maxsize=1024)
@@ -300,6 +303,11 @@ def _cache_node_list(G: nx.Graph) -> tuple[Any, ...]:
         if sort_nodes and sorted_nodes is None and cache is not None:
             cache.sorted_nodes = tuple(sorted(nodes, key=_node_repr))
     return nodes
+
+
+def cached_node_list(G: nx.Graph) -> tuple[Any, ...]:
+    """Public wrapper returning the cached node tuple for ``G``."""
+    return _cache_node_list(G)
 
 
 def _ensure_node_map(G, *, attrs: tuple[str, ...], sort: bool = False) -> dict[Any, int]:

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -19,7 +19,7 @@ from .helpers.numeric import (
     neighbor_phase_mean_list,
     kahan_sum2d,
 )
-from .helpers.cache import edge_version_cache, _stable_json
+from .helpers.cache import edge_version_cache, stable_json
 from .import_utils import optional_numpy
 from .logging import get_module_logger
 
@@ -253,7 +253,7 @@ def _cache_weights(G: GraphLike) -> tuple[float, float, float]:
     merely prepares the data stored in ``G.graph`` when invoked.
     """
     w = merge_graph_weights(G, "SI_WEIGHTS")
-    cfg_key = _stable_json(w)
+    cfg_key = stable_json(w)
 
     def builder() -> tuple[float, float, float]:
         weights = normalize_weights(w, ("alpha", "beta", "gamma"), default=0.0)

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -7,7 +7,7 @@ from tnfr.helpers.cache import (
     increment_edge_version,
     edge_version_update,
     ensure_node_offset_map,
-    _cache_node_list,
+    cached_node_list,
     ensure_node_index_map,
     _ensure_node_map,
 )
@@ -93,21 +93,21 @@ def test_node_maps_order(graph_canon):
 def test_cache_node_list_updates_on_dirty(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    nodes1 = _cache_node_list(G)
-    nodes2 = _cache_node_list(G)
+    nodes1 = cached_node_list(G)
+    nodes2 = cached_node_list(G)
     assert nodes1 is nodes2
     G.graph["_node_list_dirty"] = True
-    nodes3 = _cache_node_list(G)
+    nodes3 = cached_node_list(G)
     assert nodes3 is not nodes1
 
 
 def test_cache_node_list_invalidate_on_node_replacement(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    nodes1 = _cache_node_list(G)
+    nodes1 = cached_node_list(G)
     G.remove_node(0)
     G.add_node(2)
-    nodes2 = _cache_node_list(G)
+    nodes2 = cached_node_list(G)
     assert nodes2 is not nodes1
     assert set(nodes2) == {1, 2}
 
@@ -115,10 +115,10 @@ def test_cache_node_list_invalidate_on_node_replacement(graph_canon):
 def test_cache_node_list_cache_updated_on_node_set_change(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
-    nodes1 = _cache_node_list(G)
+    nodes1 = cached_node_list(G)
     cache1 = G.graph["_node_list_cache"]
     G.add_node(2)
-    nodes2 = _cache_node_list(G)
+    nodes2 = cached_node_list(G)
     cache2 = G.graph["_node_list_cache"]
     assert nodes2 is not nodes1
     assert cache2 is not cache1

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from tnfr.helpers.cache import (
     NODE_SET_CHECKSUM_KEY,
     node_set_checksum,
-    _stable_json,
+    stable_json,
     increment_edge_version,
     _node_repr,
     _hash_node,
@@ -31,7 +31,7 @@ def _reference_checksum(G):
     hasher = hashlib.blake2b(digest_size=16)
     for n in nodes:
         d = hashlib.blake2b(
-            _stable_json(n).encode("utf-8"), digest_size=16
+            stable_json(n).encode("utf-8"), digest_size=16
         ).digest()
         hasher.update(d)
     return hasher.hexdigest()

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from tnfr.helpers.cache import _stable_json
+from tnfr.helpers.cache import stable_json
 from tnfr import json_utils
 
 
@@ -10,8 +10,8 @@ def test_stable_json_dict_order_deterministic():
     json_utils.clear_orjson_cache()
     json_utils._orjson = None
     obj = {"b": 1, "a": 2}
-    res1 = _stable_json(obj)
-    res2 = _stable_json(obj)
+    res1 = stable_json(obj)
+    res2 = stable_json(obj)
     assert res1 == res2
     assert json.loads(res1) == {"a": 2, "b": 1}
 
@@ -20,4 +20,4 @@ def test_stable_json_warns_with_orjson():
     if json_utils._orjson is None:
         pytest.skip("orjson not installed")
     with pytest.warns(UserWarning, match="ignored when using orjson"):
-        _stable_json({"a": 1})
+        stable_json({"a": 1})


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c5f17249388321b8bacb4d356d5f50