### PR TITLE
feat: add typed warn_once helper

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -24,22 +24,12 @@ _ORJSON_PARAMS_MSG = (
 
 # Track combinations of parameters for which a warning has already been emitted.
 logger = get_module_logger(__name__)
-_log_orjson_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
+_warn_orjson_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
 
 
 def _format_ignored_params(combo: frozenset[str]) -> str:
     """Return a stable representation for ignored parameter combinations."""
     return "{" + ", ".join(map(repr, sorted(combo))) + "}"
-
-
-def _warn_orjson_params_once(combo: frozenset[str]) -> None:
-    """Warn once per unique combination of ignored parameters."""
-    _log_orjson_params_once({combo: _format_ignored_params(combo)})
-
-
-_warn_orjson_params_once.clear = _log_orjson_params_once.clear  # type: ignore[attr-defined]
-
-
 def clear_orjson_cache() -> None:
     """Clear cached :mod:`orjson` module and warning state."""
     _warn_orjson_params_once.clear()
@@ -118,7 +108,8 @@ def _json_dumps_orjson(
     if kwargs:
         ignored.extend(kwargs)
     if ignored:
-        _warn_orjson_params_once(frozenset(ignored))
+        combo = frozenset(ignored)
+        _warn_orjson_params_once({combo: _format_ignored_params(combo)})
 
     option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
     data = orjson.dumps(obj, option=option, default=params.default)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c5f49087a48321b11cf87262348caa