### PR TITLE
refactor: centralize theta iteration for trig cache

### DIFF
--- a/tests/test_compute_theta_trig.py
+++ b/tests/test_compute_theta_trig.py
@@ -1,0 +1,22 @@
+import pytest
+import numpy as np
+
+from tnfr.metrics_utils import _compute_trig_python, compute_theta_trig
+
+
+def test_compute_theta_trig_numpy_matches_python():
+    pairs = [
+        ("a", {"theta": 0.1}),
+        ("b", {"theta": -2.3}),
+        ("c", 1.7),
+    ]
+
+    trig_py = _compute_trig_python(pairs)
+    trig_np = compute_theta_trig(pairs, np=np)
+
+    assert trig_py.theta.keys() == trig_np.theta.keys()
+    for n in trig_py.theta:
+        assert trig_py.theta[n] == pytest.approx(trig_np.theta[n])
+        assert trig_py.cos[n] == pytest.approx(trig_np.cos[n])
+        assert trig_py.sin[n] == pytest.approx(trig_np.sin[n])
+


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c60bf4cf7c8321ac574e0dc94dc833