### PR TITLE
Refactor callback registration and deduplication

### DIFF
--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -41,6 +41,19 @@ def test_register_callback_replaces_existing(graph_canon):
     }
 
 
+def test_register_callback_same_callable_dedupes(graph_canon):
+    G = graph_canon()
+
+    def cb(G, ctx):
+        pass
+
+    register_callback(G, CallbackEvent.BEFORE_STEP, cb)
+    register_callback(G, CallbackEvent.BEFORE_STEP, cb)
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == {
+        "cb": CallbackSpec("cb", cb)
+    }
+
+
 def test_register_callback_rejects_tuple(graph_canon):
     G = graph_canon()
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c6101723b483218f6e49cb8c9698c8