### PR TITLE
feat: unify neighbor phase mean helper

### DIFF
--- a/tests/test_neighbor_phase_mean_missing_trig.py
+++ b/tests/test_neighbor_phase_mean_missing_trig.py
@@ -20,17 +20,19 @@ def test_neighbor_phase_mean_core_missing_trig():
     )
 
 
-def test_neighbor_phase_mean_list_delegates_core(monkeypatch):
+def test_neighbor_phase_mean_list_delegates_generic(monkeypatch):
     neigh = [1]
     cos_th = {1: 1.0}
     sin_th = {1: 0.0}
     captured = {}
 
-    def fake_core(neigh_arg, cos_map, sin_map, np_arg, fallback):
-        captured["args"] = (neigh_arg, cos_map, sin_map, np_arg, fallback)
+    def fake_generic(neigh_arg, cos_map=None, sin_map=None, np=None, fallback=0.0):
+        captured["args"] = (neigh_arg, cos_map, sin_map, np, fallback)
         return 1.23
 
-    monkeypatch.setattr("tnfr.helpers.numeric._neighbor_phase_mean_core", fake_core)
+    monkeypatch.setattr(
+        "tnfr.helpers.numeric._neighbor_phase_mean_generic", fake_generic
+    )
     result = neighbor_phase_mean_list(neigh, cos_th, sin_th, np=None, fallback=0.0)
     assert result == pytest.approx(1.23)
     assert captured["args"] == (neigh, cos_th, sin_th, None, 0.0)

--- a/tests/test_neighbor_phase_mean_no_graph.py
+++ b/tests/test_neighbor_phase_mean_no_graph.py
@@ -24,7 +24,7 @@ def test_neighbor_phase_mean_requires_graph():
         neighbor_phase_mean(node)
 
 
-def test_neighbor_phase_mean_uses_core(monkeypatch, graph_canon):
+def test_neighbor_phase_mean_uses_generic(monkeypatch, graph_canon):
     ALIAS_THETA = get_aliases("THETA")
     G = graph_canon()
     G.add_edge(1, 2)
@@ -33,11 +33,13 @@ def test_neighbor_phase_mean_uses_core(monkeypatch, graph_canon):
 
     calls = []
 
-    def fake_core(neigh, cos_map, sin_map, np, fallback):
-        calls.append((neigh, cos_map, sin_map, np, fallback))
+    def fake_generic(obj, cos_map=None, sin_map=None, np=None, fallback=0.0):
+        calls.append((obj, cos_map, sin_map, np, fallback))
         return 0.0
 
-    monkeypatch.setattr("tnfr.helpers.numeric._neighbor_phase_mean_core", fake_core)
+    monkeypatch.setattr("tnfr.helpers.numeric._neighbor_phase_mean_generic", fake_generic)
     neighbor_phase_mean(G, 1)
     assert len(calls) == 1
-    assert list(calls[0][0]) == list(G[1])
+    node_arg, cos_map, sin_map, np_arg, fallback = calls[0]
+    assert node_arg.n == 1 and node_arg.G is G
+    assert cos_map is None and sin_map is None and np_arg is None and fallback == 0.0


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c6101bb2348321ac2a6ebcd452295f