### PR TITLE
Use NumPy variance in phase_sync with fallback tests

### DIFF
--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -69,6 +69,22 @@ def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
     assert ps_np == pytest.approx(ps_py)
 
 
+# NumPy and pure-Python variants should match numerically
+def test_phase_sync_numpy_and_python_consistent(monkeypatch, graph_canon):
+    pytest.importorskip("numpy")
+    G = graph_canon()
+    angles = [0.2, -1.0, 1.5, 2.1]
+    for idx, th in enumerate(angles):
+        G.add_node(idx)
+        set_attr(G.nodes[idx], ALIAS_THETA, th)
+
+    ps_np = phase_sync(G)
+    monkeypatch.setattr("tnfr.import_utils.optional_numpy", lambda logger: None)
+    monkeypatch.setattr("tnfr.helpers.numeric.optional_numpy", lambda logger: None)
+    ps_py = phase_sync(G)
+    assert ps_np == pytest.approx(ps_py)
+
+
 def test_phase_sync_bounds(graph_canon):
     G = graph_canon()
     angles = [0.1, 1.2, -2.5, 3.6]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c66c333bd4832188dc6d17680b181e