### PR TITLE
Avoid redundant node materialization in collect_attr

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -263,15 +263,18 @@ def collect_attr(
 
     if np is not None:
         if nodes is G.nodes:
+            nodes_iter = G.nodes
             size = G.number_of_nodes()
         else:
             try:
                 size = len(nodes)  # type: ignore[arg-type]
+                nodes_iter = nodes
             except TypeError:
-                nodes = list(nodes)
-                size = len(nodes)
+                nodes_list = list(nodes)
+                nodes_iter = nodes_list
+                size = len(nodes_list)
         return np.fromiter(
-            (get_attr(G.nodes[n], aliases, default) for n in nodes),
+            (get_attr(G.nodes[n], aliases, default) for n in nodes_iter),
             float,
             count=size,
         )

--- a/tests/test_collect_attr_generators.py
+++ b/tests/test_collect_attr_generators.py
@@ -1,0 +1,18 @@
+import networkx as nx
+import numpy as np
+
+from tnfr.alias import set_attr, collect_attr
+from tnfr.constants import get_aliases
+
+ALIAS_THETA = get_aliases("THETA")
+
+
+def test_collect_attr_with_generator_numpy():
+    G = nx.path_graph(3)
+    for n in G.nodes:
+        set_attr(G.nodes[n], ALIAS_THETA, float(n))
+
+    nodes_gen = (n for n in G.nodes)
+    result = collect_attr(G, nodes_gen, ALIAS_THETA, 0.0, np=np)
+
+    assert np.array_equal(result, np.array([0.0, 1.0, 2.0], dtype=float))


### PR DESCRIPTION
## Summary
- optimize numpy branch in `collect_attr` by materializing nodes once and using the computed length for `np.fromiter`
- add regression test covering generator-based node iterables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c66c2e3d98832190edc5cc9b6f5f73