### PR TITLE
Use shared lock in cached_import for external caches

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -178,9 +178,9 @@ def cached_import(
         Mapping used to store cached results. When ``None`` the internal
         process-wide cache is used.
     lock:
-        Optional :class:`threading.Lock` guarding ``cache``. Providing a lock
-        avoids creating a new one on every call when supplying a custom
-        ``cache``.
+        Optional :class:`threading.Lock` guarding ``cache``. When using an
+        external cache, passing a lock is recommended to avoid repeated
+        creations. If omitted, the shared ``_CACHE_LOCK`` is used.
     ttl:
         Time-to-live for entries when using the internal cache.
     emit:
@@ -199,7 +199,7 @@ def cached_import(
                     )
         cache = _IMPORT_CACHE
     elif lock is None:
-        lock = threading.Lock()
+        lock = _CACHE_LOCK
 
     with lock:
         try:

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -61,6 +61,23 @@ def test_cached_import_uses_provided_lock(monkeypatch):
     assert calls["lock"] == 0
 
 
+def test_cached_import_uses_shared_lock_when_missing(monkeypatch):
+    reset()
+    calls = {"lock": 0}
+    orig_lock = import_utils.threading.Lock
+
+    def fake_lock():
+        calls["lock"] += 1
+        return orig_lock()
+
+    monkeypatch.setattr(import_utils.threading, "Lock", fake_lock)
+    cache = TTLCache(16, 1)
+    fake_mod = types.ModuleType("fake_mod")
+    monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
+    cached_import("fake_mod", cache=cache)
+    assert calls["lock"] == 0
+
+
 def test_cache_clear_and_prune_reset_all(monkeypatch):
     reset()
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c66c3150808321ab3723a96ef2c697