### PR TITLE
feat: make token parsing lazy

### DIFF
--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 from .collections_utils import flatten_structure
 
@@ -40,8 +40,8 @@ def validate_token(
 
 def _parse_tokens(
     obj: Any, token_map: dict[str, Callable[[Any], Any]]
-) -> list[Any]:
-    return [
-        validate_token(tok, pos, token_map)
-        for pos, tok in enumerate(flatten_structure(obj), start=1)
-    ]
+) -> Iterator[Any]:
+    """Yield validated tokens from ``obj`` lazily."""
+
+    for pos, tok in enumerate(flatten_structure(obj), start=1):
+        yield validate_token(tok, pos, token_map)

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -9,7 +9,7 @@ from tnfr.cli import _parse_tokens, TOKEN_MAP
 
 def test_parse_tokens_value_error_context():
     with pytest.raises(ValueError) as exc:
-        _parse_tokens([{"WAIT": "x"}])
+        list(_parse_tokens([{"WAIT": "x"}]))
     msg = str(exc.value)
     assert msg.endswith("(pos 1, token {'WAIT': 'x'})")
     assert isinstance(exc.value.__cause__, ValueError)
@@ -21,7 +21,7 @@ def test_parse_tokens_key_error_context(monkeypatch):
 
     monkeypatch.setitem(TOKEN_MAP, "RAISE", raiser)
     with pytest.raises(ValueError) as exc:
-        _parse_tokens([{"RAISE": {}}])
+        list(_parse_tokens([{"RAISE": {}}]))
     msg = str(exc.value)
     assert msg.endswith("(pos 1, token {'RAISE': {}})")
     assert isinstance(exc.value.__cause__, KeyError)
@@ -33,7 +33,7 @@ def test_parse_tokens_type_error_context(monkeypatch):
 
     monkeypatch.setitem(TOKEN_MAP, "RAISE_TYPE", raiser)
     with pytest.raises(ValueError) as exc:
-        _parse_tokens([{"RAISE_TYPE": {}}])
+        list(_parse_tokens([{"RAISE_TYPE": {}}]))
     msg = str(exc.value)
     assert msg.endswith("(pos 1, token {'RAISE_TYPE': {}})")
     assert isinstance(exc.value.__cause__, TypeError)
@@ -41,7 +41,7 @@ def test_parse_tokens_type_error_context(monkeypatch):
 
 def test_thol_invalid_close():
     with pytest.raises(ValueError) as exc:
-        _parse_tokens([{"THOL": {"close": "XYZ"}}])
+        list(_parse_tokens([{"THOL": {"close": "XYZ"}}]))
     msg = str(exc.value)
     assert "XYZ" in msg
     assert "Glyph" in msg
@@ -72,7 +72,7 @@ def test_parse_tokens_error_format_unified(monkeypatch):
 
     for tokens, start in cases:
         with pytest.raises(ValueError) as exc:
-            _parse_tokens(tokens)
+            list(_parse_tokens(tokens))
         msg = str(exc.value)
         assert msg.startswith(start)
         expected_end = (

--- a/tests/test_parse_tokens_lazy.py
+++ b/tests/test_parse_tokens_lazy.py
@@ -1,0 +1,19 @@
+"""Pruebas de evaluación lazy en _parse_tokens."""
+
+from __future__ import annotations
+
+import pytest
+
+from tnfr.cli import _parse_tokens
+
+
+def test_parse_tokens_lazy_evaluation():
+    it = _parse_tokens([{"WAIT": "x"}])
+    assert iter(it) is it
+    with pytest.raises(ValueError):
+        next(it)
+
+
+def test_parse_tokens_large_input():
+    grande = ({"WAIT": 1} for _ in range(10000))
+    assert sum(1 for _ in _parse_tokens(grande)) == 10000


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c66c365fa48321af235db7a30363bc