### PR TITLE
Simplify jitter seed caching with setdefault

### DIFF
--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -196,10 +196,7 @@ def random_jitter(
     cache = _get_jitter_cache(node, manager)
 
     cache_key = (seed_root, scope_id)
-    seed = cache.get(cache_key)
-    if seed is None:
-        seed = seed_hash(seed_root, scope_id)
-        cache[cache_key] = seed
+    seed = cache.setdefault(cache_key, seed_hash(seed_root, scope_id))
     seq = 0
     if cache_enabled(node.G):
         with manager.lock:


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c6738657dc8321a2d6a7946ed991a8