### PR TITLE
Reuse run_program in metrics and honor zero steps

### DIFF
--- a/tests/test_run_program_zero_steps.py
+++ b/tests/test_run_program_zero_steps.py
@@ -1,0 +1,31 @@
+from argparse import Namespace
+from tnfr.cli.execution import run_program
+from tnfr.glyph_history import ensure_history
+
+
+def test_run_program_respects_zero_steps():
+    args = Namespace(
+        nodes=3,
+        topology="ring",
+        seed=1,
+        p=None,
+        config=None,
+        dt=None,
+        integrator=None,
+        remesh_mode=None,
+        glyph_hysteresis_window=None,
+        grammar_canon=True,
+        selector="basic",
+        gamma_type=None,
+        gamma_beta=None,
+        gamma_R0=None,
+        observer=False,
+        save_history=None,
+        export_history_base=None,
+        export_format="json",
+        steps=0,
+    )
+    G = run_program(None, None, args)
+    hist = ensure_history(G)
+    assert len(hist.get("C_steps", [])) == 1
+


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c67388a13c832193783c24ec3181ae