### PR TITLE
feat: allow external edge cache manager reuse

### DIFF
--- a/src/tnfr/helpers/edge_cache.py
+++ b/src/tnfr/helpers/edge_cache.py
@@ -195,6 +195,7 @@ def edge_version_cache(
     builder: Callable[[], T],
     *,
     max_entries: int | None = 128,
+    manager: EdgeCacheManager | None = None,
 ) -> T:
     """Return cached ``builder`` output tied to the edge version of ``G``."""
 
@@ -206,7 +207,15 @@ def edge_version_cache(
         return builder()
 
     graph = get_graph(G)
-    cache, locks = EdgeCacheManager(graph).get_cache(max_entries)
+    if manager is None:
+        manager = graph.get("_edge_cache_manager")  # type: ignore[assignment]
+        if not isinstance(manager, EdgeCacheManager) or manager.graph is not graph:
+            manager = EdgeCacheManager(graph)
+            graph["_edge_cache_manager"] = manager
+    else:
+        graph["_edge_cache_manager"] = manager
+
+    cache, locks = manager.get_cache(max_entries)
     edge_version = int(graph.get("_edge_version", 0))
     lock = locks[key]
 

--- a/tests/test_edge_version_cache_manager.py
+++ b/tests/test_edge_version_cache_manager.py
@@ -1,0 +1,17 @@
+from tnfr.helpers.edge_cache import EdgeCacheManager, edge_version_cache
+
+
+def test_edge_version_cache_stores_manager(graph_canon):
+    G = graph_canon()
+    edge_version_cache(G, "a", lambda: 1)
+    manager = G.graph.get("_edge_cache_manager")
+    assert isinstance(manager, EdgeCacheManager)
+    edge_version_cache(G, "b", lambda: 2)
+    assert G.graph.get("_edge_cache_manager") is manager
+
+
+def test_edge_version_cache_accepts_manager(graph_canon):
+    G = graph_canon()
+    manager = EdgeCacheManager(G.graph)
+    edge_version_cache(G, "a", lambda: 1, manager=manager)
+    assert G.graph.get("_edge_cache_manager") is manager


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c6738472c08321a173959634df3eb0