### PR TITLE
Refine numpy usage in adjacency cache

### DIFF
--- a/src/tnfr/helpers/edge_cache.py
+++ b/src/tnfr/helpers/edge_cache.py
@@ -249,19 +249,19 @@ def cached_nodes_and_A(
     checksum = node_set_checksum(G, nodes_list, store=False)
     key = f"_dnfr_{len(nodes_list)}_{checksum}"
     G.graph["_dnfr_nodes_checksum"] = checksum
-    np = optional_numpy(logger)
-    if np is None:
-        if require_numpy:
-            raise RuntimeError("NumPy is required for adjacency caching")
-        return edge_version_cache(
-            G, key, lambda: (nodes_list, None), max_entries=cache_size
-        )
-
     def builder() -> tuple[list[int], Any]:
+        np = optional_numpy(logger)
+        if np is None:
+            return nodes_list, None
         A = nx.to_numpy_array(G, nodelist=nodes_list, weight=None, dtype=float)
         return nodes_list, A
 
-    return edge_version_cache(G, key, builder, max_entries=cache_size)
+    nodes, A = edge_version_cache(G, key, builder, max_entries=cache_size)
+
+    if require_numpy and A is None:
+        raise RuntimeError("NumPy is required for adjacency caching")
+
+    return nodes, A
 
 
 def _reset_edge_caches(graph: Any, G: Any) -> None:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c6738b9fd08321a8a5496a9f704a32