### PR TITLE
Unify logger helpers via logging_utils

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Mapping, Iterable
 
 import traceback
 import threading
-from .logging import get_module_logger
+from .logging_utils import get_logger
 from .constants import DEFAULTS
 from .locking import get_lock
 
@@ -35,7 +35,7 @@ __all__ = (
     "CallbackError",
 )
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 _CALLBACK_LOCK = get_lock("callbacks")
 

--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -30,10 +30,10 @@ from .execution import (
     _load_sequence,
     _save_json,
 )
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 from .. import __version__
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = (
     "main",

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -34,14 +34,14 @@ from ..io import read_structured_file, safe_write
 from ..glyph_history import ensure_history
 from ..helpers.numeric import list_mean
 from ..observers import attach_standard_observer
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 from ..types import Glyph
 from ..json_utils import json_dumps
 
 from .arguments import _args_to_dict
 from .token_parser import _parse_tokens
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _save_json(path: str, data: Any) -> None:

--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -8,14 +8,14 @@ from collections.abc import Collection, Iterable, Mapping, Sequence
 from itertools import islice
 from typing import Any, Callable, Iterator, TypeVar, cast
 
-from .logging import get_module_logger
+from .logging_utils import get_logger
 from .logging_utils import warn_once
 from .value_utils import convert_value
 from .helpers.numeric import kahan_sum
 
 T = TypeVar("T")
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 STRING_TYPES = (str, bytes, bytearray)
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -49,7 +49,7 @@ from ..selector import (
     _apply_selector_hysteresis,
 )
 
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 
 from .sampling import update_node_sample as _update_node_sample
 from .dnfr import (
@@ -79,7 +79,7 @@ ALIAS_SI = get_aliases("SI")
 ALIAS_D2EPI = get_aliases("D2EPI")
 ALIAS_DSI = get_aliases("DSI")
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = (
     "default_compute_delta_nfr",

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -26,9 +26,9 @@ from ..alias import (
 )
 from ..metrics_utils import compute_theta_trig, merge_and_normalize_weights
 from ..import_utils import optional_numpy
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -17,12 +17,12 @@ from .helpers import (
     get_graph_mapping,
 )
 from .json_utils import json_dumps
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
 ALIAS_THETA = get_aliases("THETA")
 
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_GAMMA: Mapping[str, str] = {"type": "none"}
 

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -10,9 +10,9 @@ import numbers
 
 from .constants import get_param
 from .collections_utils import ensure_collection
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = (
     "HistoryDict",

--- a/src/tnfr/helpers/edge_cache.py
+++ b/src/tnfr/helpers/edge_cache.py
@@ -11,13 +11,13 @@ import networkx as nx  # type: ignore[import-untyped]
 
 from ..graph_utils import mark_dnfr_prep_dirty
 from ..import_utils import optional_numpy, cached_import  # noqa: F401 - used in tests
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 from .node_cache import get_graph, node_set_checksum, clear_node_repr_cache
 
 T = TypeVar("T")
 U = TypeVar("U")
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 # Keys of cache entries dependent on the edge version. Any change to the edge
 # set requires these to be dropped to avoid stale data.

--- a/src/tnfr/helpers/node_cache.py
+++ b/src/tnfr/helpers/node_cache.py
@@ -10,9 +10,9 @@ from typing import Any, Iterable, Mapping
 import networkx as nx  # type: ignore[import-untyped]
 
 from ..json_utils import json_dumps
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 # Key used to store the node set checksum in a graph's ``graph`` attribute.
 NODE_SET_CHECKSUM_KEY = "_node_set_checksum_cache"

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -10,9 +10,9 @@ import math
 
 from ..import_utils import cached_import, optional_numpy
 from ..alias import get_attr
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = (
     "clamp",

--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from cachetools import TTLCache
 import threading
 import time
-from .logging import get_module_logger
+from .logging_utils import get_logger
 from .locking import get_lock
 
 __all__ = (
@@ -29,7 +29,7 @@ __all__ = (
 )
 
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _emit_warn(message: str) -> None:

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, IO
 from functools import lru_cache
 
 from .import_utils import cached_import
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
 
 @lru_cache(maxsize=None)
@@ -132,7 +132,7 @@ def read_structured_file(path: Path) -> Any:
         raise StructuredFileError(path, e) from e
 
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _write_to_fd(fd: IO[Any], write: Callable[[Any], Any], *, sync: bool = False) -> None:

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Literal, overload
 
 from dataclasses import dataclass
 from .import_utils import cached_import
-from .logging import get_module_logger
+from .logging_utils import get_logger
 from .logging_utils import warn_once
 
 _ORJSON_PARAMS_MSG = (
@@ -24,7 +24,7 @@ _ORJSON_PARAMS_MSG = (
 )
 
 # Track combinations of parameters for which a warning has already been emitted.
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 _warn_orjson_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
 
 

--- a/src/tnfr/logging.py
+++ b/src/tnfr/logging.py
@@ -1,22 +1,6 @@
-"""Simplified logging helpers for TNFR modules.
-
-Provides :func:`get_module_logger` which mirrors the default configuration
-used by :mod:`tnfr.logging_utils` without importing the heavier module.
-This keeps compatibility with existing logging setups while avoiding
-additional dependencies when only a plain logger is required.
-"""
-
+"""Compatibility wrapper for deprecated tnfr.logging module."""
 from __future__ import annotations
 
-import logging
-
-from .logging_base import _configure_root
+from .logging_utils import get_logger as get_module_logger
 
 __all__ = ["get_module_logger"]
-
-
-def get_module_logger(name: str) -> logging.Logger:
-    """Return a module-specific logger configured with TNFR defaults."""
-
-    _configure_root()
-    return logging.getLogger(name)

--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -1,7 +1,9 @@
 """Logging utilities for TNFR.
 
-Provides a helper to obtain module-specific loggers with a
-consistent configuration across the project.
+Centralises creation of module-specific loggers so that all TNFR
+modules share a consistent configuration.  ``get_module_logger`` is
+retained as a lightweight alias to ``get_logger`` for backwards
+compatibility.
 """
 
 from __future__ import annotations
@@ -14,13 +16,18 @@ from collections import deque
 
 from .logging_base import _configure_root
 
-__all__ = ("get_logger", "WarnOnce", "warn_once")
+__all__ = ("get_logger", "get_module_logger", "WarnOnce", "warn_once")
 
 
 def get_logger(name: str) -> logging.Logger:
     """Return a module-specific logger."""
     _configure_root()
     return logging.getLogger(name)
+
+
+# Backwards compatibility --------------------------------------------------
+
+get_module_logger = get_logger
 
 
 class WarnOnce:

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -19,9 +19,9 @@ from ..helpers.numeric import clamp01, _norm01, _similarity_abs
 from ..helpers import ensure_node_index_map
 from ..metrics_utils import get_trig_cache, min_max_range, compute_theta_trig
 from ..import_utils import optional_numpy
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")

--- a/src/tnfr/metrics/coherence_updates.py
+++ b/src/tnfr/metrics/coherence_updates.py
@@ -8,7 +8,7 @@ from typing import Any
 from ..alias import get_attr, set_attr
 from ..constants import get_aliases, get_param
 from ..glyph_history import append_metric
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 from ..metrics_utils import compute_coherence
 from ..observers import glyph_load, kuramoto_order, phase_sync
 from ..sense import sigma_vector
@@ -21,7 +21,7 @@ ALIAS_VF = get_aliases("VF")
 ALIAS_DVF = get_aliases("DVF")
 ALIAS_D2VF = get_aliases("D2VF")
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = [
     "_update_coherence",

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..callback_utils import register_callback
 from ..constants import get_param
 from ..glyph_history import append_metric, ensure_history
-from ..logging import get_module_logger
+from ..logging_utils import get_logger
 from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks
 from .coherence_updates import (
@@ -38,7 +38,7 @@ from .reporting import (
     latency_series,
 )
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = [
     "LATENT_GLYPH",

--- a/src/tnfr/metrics_utils.py
+++ b/src/tnfr/metrics_utils.py
@@ -21,9 +21,9 @@ from .helpers.numeric import (
 )
 from .helpers import edge_version_cache, stable_json
 from .import_utils import optional_numpy
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 NP = optional_numpy(logger)
 
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -18,7 +18,7 @@ from .glyph_history import (
 from .collections_utils import normalize_counter, mix_groups
 from .constants_glyphs import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
 ALIAS_THETA = get_aliases("THETA")
 
@@ -35,7 +35,7 @@ __all__ = (
 )
 
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 
 # -------------------------

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -24,13 +24,13 @@ from .constants_glyphs import (
     ANGLE_MAP,
     GLYPHS_CANONICAL,
 )
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
 # -------------------------
 # Canon: orden circular de glyphs y ángulos
 # -------------------------
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 NP = optional_numpy(logger)
 
 GLYPH_UNITS: dict[str, complex] = {

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, TypeVar
 import logging
-from .logging import get_module_logger
+from .logging_utils import get_logger
 
 T = TypeVar("T")
 
-logger = get_module_logger(__name__)
+logger = get_logger(__name__)
 
 __all__ = ("convert_value",)
 

--- a/tests/test_logging_module.py
+++ b/tests/test_logging_module.py
@@ -1,25 +1,25 @@
 import importlib
 import logging
 
-import tnfr.logging as tnfr_logging
+import tnfr.logging_utils as logging_utils
 import tnfr.logging_base as logging_base
 
 
-def reload_logging():
-    global tnfr_logging
+def reload_logging_utils():
+    global logging_utils
     importlib.reload(logging_base)
-    tnfr_logging = importlib.reload(tnfr_logging)
-    return tnfr_logging
+    logging_utils = importlib.reload(logging_utils)
+    return logging_utils
 
 
-def test_get_module_logger_configures_root_once():
+def test_get_logger_configures_root_once():
     root = logging.getLogger()
     root.handlers.clear()
     root.setLevel(logging.NOTSET)
-    reload_logging()
-    tnfr_logging.get_module_logger("test")
+    reload_logging_utils()
+    logging_utils.get_logger("test")
     assert len(root.handlers) == 1
     assert root.level == logging.INFO
     assert root.handlers[0].formatter is not None
-    tnfr_logging.get_module_logger("again")
+    logging_utils.get_logger("again")
     assert len(root.handlers) == 1


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c685a560a4832190fa2deec3cf6cd0