### PR TITLE
Add tests for WarnOnce cache clearing

### DIFF
--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -58,9 +58,18 @@ def test_normalize_weights_warn_once(caplog):
         normalize_weights(weights, ("x",))
     assert any("Negative weights" in m for m in caplog.messages)
     caplog.clear()
+
+    # second call with same key should not warn
     with caplog.at_level("WARNING"):
         normalize_weights(weights, ("x",))
     assert not any("Negative weights" in m for m in caplog.messages)
+
+    # clearing cache should allow warning again
+    cu.clear_warned_negative_keys()
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        normalize_weights(weights, ("x",))
+    assert any("Negative weights" in m for m in caplog.messages)
 
 
 def test_normalize_weights_raises_on_non_numeric_value():

--- a/tests/test_warn_once_limit.py
+++ b/tests/test_warn_once_limit.py
@@ -18,3 +18,18 @@ def test_warn_once_lru_limit(caplog):
         "{'c': 4}",
         "{'a': 5}",
     ]
+
+
+def test_warn_once_clear(caplog):
+    logger = logging.getLogger("warn_once_clear")
+    warn = warn_once(logger, "%s")
+    with caplog.at_level(logging.WARNING):
+        warn({"a": 1})
+        warn({"a": 2})  # ignored
+    assert [r.message for r in caplog.records] == ["{'a': 1}"]
+
+    warn.clear()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        warn({"a": 3})
+    assert [r.message for r in caplog.records] == ["{'a': 3}"]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c6e4b66d74832192b68a08d2cc9b77