### PR TITLE
Remove obsolete _flatten_thol helper

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -242,18 +242,6 @@ class THOLEvaluator:
         raise StopIteration
 
 
-def _flatten_thol(
-    item: THOL,
-    stack: deque[Any],
-    *,
-    max_materialize: int | None = MAX_MATERIALIZE_DEFAULT,
-) -> None:
-    """Expand a ``THOL`` block onto ``stack`` para su procesamiento."""
-
-    for token in THOLEvaluator(item, max_materialize=max_materialize):
-        stack.append(token)
-
-
 def _flatten_target(
     item: TARGET,
     ops: list[tuple[OpTag, Any]],

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -226,7 +226,7 @@ def test_thol_repeat_lt_one_raises():
         list(THOLEvaluator(THOL(body=[], repeat=0)))
 
 
-def test_flatten_thol_multiple_repeats():
+def test_thol_evaluator_multiple_repeats():
     tokens = list(THOLEvaluator(THOL(body=[Glyph.AL, Glyph.RA], repeat=3)))
     assert tokens == [
         THOL_SENTINEL,
@@ -239,7 +239,7 @@ def test_flatten_thol_multiple_repeats():
     ]
 
 
-def test_flatten_thol_body_limit_error_message():
+def test_thol_evaluator_body_limit_error_message():
     body = (Glyph.AL for _ in range(5))
     with pytest.raises(
         ValueError, match="THOL body exceeds max_materialize=3"


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c6ebde834483218ebbe550b27eee38