### PR TITLE
Use min() for selecting least-used glyph

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -198,7 +198,7 @@ class HistoryDict(dict):
     def pop_least_used(self) -> Any:
         """Remove and return the value with the smallest usage count."""
         while self._counts:
-            key, _ = self._counts.most_common()[-1]
+            key = min(self._counts, key=self._counts.get)
             self._counts.pop(key, None)
             if key in self:
                 return super().pop(key)

--- a/tests/test_history_least_used.py
+++ b/tests/test_history_least_used.py
@@ -15,7 +15,7 @@ def test_pop_least_used_discards_minimum_count():
     for i in range(30):
         hist.get_increment(f"k{i % 3}")
     hist.get_increment("k0")
-    expected = hist._counts.most_common()[-1][0]
+    expected = min(hist._counts, key=hist._counts.get)
     hist.pop_least_used()
     assert expected not in hist
     assert expected not in hist._counts


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c6f4d1dd888321b0833bbdab31297e