### PR TITLE
Normalize glyph history inputs for simpler deque creation

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -44,15 +44,15 @@ def validate_window(window: int, *, positive: bool = False) -> int:
     return int(window)
 
 
-def _normalize_history_input(hist: Any) -> Iterable[Any]:
-    """Normalise ``hist`` to an iterable excluding strings/bytes."""
+def _normalize_history_input(hist: Any) -> list[Any]:
+    """Normalise ``hist`` to a list excluding strings/bytes."""
     if isinstance(hist, (str, bytes, bytearray)):
-        return ()
+        return []
     try:
-        return ensure_collection(hist, max_materialize=None)
+        return list(ensure_collection(hist, max_materialize=None))
     except TypeError:
         logger.debug("Discarding non-iterable glyph history value %r", hist)
-        return ()
+        return []
 
 
 def _ensure_history(
@@ -65,8 +65,7 @@ def _ensure_history(
         return v_window, None
     hist = nd.get("glyph_history")
     if not isinstance(hist, deque) or hist.maxlen != v_window:
-        seq = _normalize_history_input(hist)
-        hist = deque(seq, maxlen=v_window)
+        hist = deque(_normalize_history_input(hist), maxlen=v_window)
         nd["glyph_history"] = hist
     return v_window, hist
 

--- a/tests/test_normalize_history_input.py
+++ b/tests/test_normalize_history_input.py
@@ -1,0 +1,16 @@
+from collections import deque
+
+from tnfr.glyph_history import _normalize_history_input, _ensure_history
+
+
+def test_normalize_history_input_filters_and_lists():
+    assert _normalize_history_input('abc') == []
+    assert _normalize_history_input(['a', 'b']) == ['a', 'b']
+
+
+def test_ensure_history_uses_normalized_list():
+    nd: dict[str, object] = {'glyph_history': 'abc'}
+    w, hist = _ensure_history(nd, 2)
+    assert w == 2
+    assert isinstance(hist, deque)
+    assert list(hist) == []


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c6f4dd2e388321b78b1ce264326460