### PR TITLE
Align exported alias setters

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -34,24 +34,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 T = TypeVar("T")
 
-__all__ = (
-    "set_attr_generic",
-    "get_attr",
-    "collect_attr",
-    "set_attr",
-    "get_attr_str",
-    "set_attr_str",
-    "set_attr_and_cache",
-    "set_attr_with_max",
-    "set_scalar",
-    "SCALAR_SETTERS",
-    "set_vf",
-    "set_dnfr",
-    "set_theta",
-    "recompute_abs_max",
-    "multi_recompute_abs_max",
-)
-
 
 def _convert_default(
     default: Any,
@@ -487,3 +469,20 @@ for _name, _spec in SCALAR_SETTERS.items():
     globals()[f"set_{_name}"] = _make_scalar_setter(_name, _spec)
 
 del _name, _spec, _make_scalar_setter
+
+
+__all__ = [
+    "set_attr_generic",
+    "get_attr",
+    "collect_attr",
+    "set_attr",
+    "get_attr_str",
+    "set_attr_str",
+    "set_attr_and_cache",
+    "set_attr_with_max",
+    "set_scalar",
+    "SCALAR_SETTERS",
+    *[f"set_{name}" for name in SCALAR_SETTERS],
+    "recompute_abs_max",
+    "multi_recompute_abs_max",
+]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c701009fc08321a9c2d399bf736acf