### PR TITLE
Remove unused cached_import from edge cache

### DIFF
--- a/src/tnfr/helpers/edge_cache.py
+++ b/src/tnfr/helpers/edge_cache.py
@@ -10,7 +10,7 @@ from cachetools import LRUCache
 import networkx as nx  # type: ignore[import-untyped]
 
 from ..graph_utils import mark_dnfr_prep_dirty
-from ..import_utils import optional_numpy, cached_import  # noqa: F401 - used in tests
+from ..import_utils import optional_numpy
 from ..logging_utils import get_logger
 from .node_cache import get_graph, node_set_checksum, clear_node_repr_cache
 

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -130,9 +130,6 @@ def test_cache_node_list_cache_updated_on_node_set_change(graph_canon):
 
 def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
     monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
-    monkeypatch.setattr(
-        "tnfr.helpers.edge_cache.cached_import", import_utils.cached_import
-    )
     G = graph_canon()
     G.add_edge(0, 1)
     nodes, A = cached_nodes_and_A(G)
@@ -142,9 +139,6 @@ def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon)
 
 def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
     monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
-    monkeypatch.setattr(
-        "tnfr.helpers.edge_cache.cached_import", import_utils.cached_import
-    )
     G = graph_canon()
     G.add_edge(0, 1)
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c70d5a2b7c83219471d31663d137e3