### PR TITLE
chore: remove unused imports from coherence metric

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Sequence
 
@@ -13,9 +12,9 @@ from ..constants import (
 )
 from ..callback_utils import register_callback
 from ..glyph_history import ensure_history, append_metric
-from ..alias import get_attr, collect_attr
+from ..alias import collect_attr
 from ..collections_utils import normalize_weights
-from ..helpers.numeric import clamp01, _norm01, _similarity_abs
+from ..helpers.numeric import clamp01
 from ..helpers import ensure_node_index_map
 from ..metrics_utils import get_trig_cache, min_max_range, compute_theta_trig
 from ..import_utils import optional_numpy


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c71101b6108321b8afa0ad8d143ee2