### PR TITLE
Prefix internal orjson cache helper

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -5,7 +5,7 @@ The fast serializer is brought in through
 ``tnfr.import_utils.cached_import``; its cache and failure registry can be
 reset using ``cached_import.cache_clear()`` and
 :func:`tnfr.import_utils.prune_failed_imports` or the local
-:func:`clear_orjson_cache` helper.
+:func:`_clear_orjson_cache` helper.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ def _format_ignored_params(combo: frozenset[str]) -> str:
     return "{" + ", ".join(map(repr, sorted(combo))) + "}"
 
 
-def clear_orjson_cache() -> None:
+def _clear_orjson_cache() -> None:
     """Clear cached :mod:`orjson` module and warning state."""
     _warn_orjson_params_once.clear()
     cache_clear = getattr(cached_import, "cache_clear", None)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -19,7 +19,7 @@ def test_lazy_orjson_import(monkeypatch):
         return FakeOrjson()
 
     monkeypatch.setattr(json_utils, "cached_import", fake_cached_import)
-    json_utils.clear_orjson_cache()
+    json_utils._clear_orjson_cache()
 
     assert calls["n"] == 0
     json_utils.json_dumps({})
@@ -32,7 +32,7 @@ def test_warns_once(monkeypatch, caplog):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda *a, **k: FakeOrjson()
     )
-    json_utils.clear_orjson_cache()
+    json_utils._clear_orjson_cache()
 
     with caplog.at_level(logging.WARNING):
         for _ in range(2):
@@ -45,7 +45,7 @@ def test_warns_once_per_unique_combo(monkeypatch, caplog):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda *a, **k: FakeOrjson()
     )
-    json_utils.clear_orjson_cache()
+    json_utils._clear_orjson_cache()
 
     with caplog.at_level(logging.WARNING):
         json_utils.json_dumps({}, ensure_ascii=False)

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -18,14 +18,14 @@ def _reset_json_utils(monkeypatch, module):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda name, attr=None, **kwargs: module
     )
-    json_utils.clear_orjson_cache()
+    json_utils._clear_orjson_cache()
     import_utils.prune_failed_imports()
     with import_utils._WARNED_STATE.lock:
         import_utils._WARNED_STATE.clear()
 
 
 def test_json_dumps_without_orjson(monkeypatch, caplog):
-    json_utils.clear_orjson_cache()
+    json_utils._clear_orjson_cache()
     import_utils.prune_failed_imports()
     with import_utils._WARNED_STATE.lock:
         import_utils._WARNED_STATE.clear()

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -7,7 +7,7 @@ from tnfr import json_utils
 
 
 def test_stable_json_dict_order_deterministic():
-    json_utils.clear_orjson_cache()
+    json_utils._clear_orjson_cache()
     json_utils._orjson = None
     obj = {"b": 1, "a": 2}
     res1 = stable_json(obj)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c7171456b083219797e367da102189