### PR TITLE
Remove redundant node hash helper

### DIFF
--- a/src/tnfr/helpers/node_cache.py
+++ b/src/tnfr/helpers/node_cache.py
@@ -89,12 +89,6 @@ def _node_repr(n: Any) -> str:
     """Stable representation for node hashing and sorting."""
     return _node_repr_digest(n)[0]
 
-
-def _hash_node(obj: Any) -> bytes:
-    """Return a stable digest for ``obj`` used in node checksums."""
-    return _node_repr_digest(obj)[1]
-
-
 def _iter_node_digests(
     nodes: Iterable[Any], *, presorted: bool
 ) -> Iterable[bytes]:

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -7,7 +7,6 @@ from tnfr.helpers.node_cache import (
     node_set_checksum,
     stable_json,
     _node_repr,
-    _hash_node,
     _node_repr_digest,
 )
 from tnfr.helpers.edge_cache import increment_edge_version
@@ -95,11 +94,3 @@ def test_node_cache_cleared_on_increment(graph_canon):
     assert _node_repr_digest.cache_info().currsize > 0
     increment_edge_version(nxG)
     assert _node_repr_digest.cache_info().currsize == 0
-
-
-def test_hash_node_matches_manual():
-    obj = ("a", 1)
-    obj_repr = _node_repr(obj)
-    manual = hashlib.blake2b(obj_repr.encode("utf-8"), digest_size=16).digest()
-    assert _hash_node(obj) == manual
-    assert _node_repr_digest(obj)[1] == manual


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c717094f348321a37c803f98af7d79