### PR TITLE
refactor: isolate orjson cache helper for tests

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -4,8 +4,7 @@ This module lazily imports :mod:`orjson` on first use of :func:`json_dumps`.
 The fast serializer is brought in through
 ``tnfr.import_utils.cached_import``; its cache and failure registry can be
 reset using ``cached_import.cache_clear()`` and
-:func:`tnfr.import_utils.prune_failed_imports` or the local
-:func:`_clear_orjson_cache` helper.
+:func:`tnfr.import_utils.prune_failed_imports`.
 """
 
 from __future__ import annotations
@@ -31,14 +30,6 @@ _warn_orjson_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
 def _format_ignored_params(combo: frozenset[str]) -> str:
     """Return a stable representation for ignored parameter combinations."""
     return "{" + ", ".join(map(repr, sorted(combo))) + "}"
-
-
-def _clear_orjson_cache() -> None:
-    """Clear cached :mod:`orjson` module and warning state."""
-    _warn_orjson_params_once.clear()
-    cache_clear = getattr(cached_import, "cache_clear", None)
-    if cache_clear:
-        cache_clear()
 
 
 @dataclass(slots=True, frozen=True)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,6 +1,7 @@
 import logging
 
 import tnfr.json_utils as json_utils
+from .utils import clear_orjson_cache
 
 
 class FakeOrjson:
@@ -19,7 +20,7 @@ def test_lazy_orjson_import(monkeypatch):
         return FakeOrjson()
 
     monkeypatch.setattr(json_utils, "cached_import", fake_cached_import)
-    json_utils._clear_orjson_cache()
+    clear_orjson_cache()
 
     assert calls["n"] == 0
     json_utils.json_dumps({})
@@ -32,7 +33,7 @@ def test_warns_once(monkeypatch, caplog):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda *a, **k: FakeOrjson()
     )
-    json_utils._clear_orjson_cache()
+    clear_orjson_cache()
 
     with caplog.at_level(logging.WARNING):
         for _ in range(2):
@@ -45,7 +46,7 @@ def test_warns_once_per_unique_combo(monkeypatch, caplog):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda *a, **k: FakeOrjson()
     )
-    json_utils._clear_orjson_cache()
+    clear_orjson_cache()
 
     with caplog.at_level(logging.WARNING):
         json_utils.json_dumps({}, ensure_ascii=False)

--- a/tests/test_json_utils_extra.py
+++ b/tests/test_json_utils_extra.py
@@ -1,9 +1,9 @@
-import importlib
 import logging
 from dataclasses import is_dataclass
 
 import tnfr.json_utils as json_utils
 import tnfr.import_utils as import_utils
+from .utils import clear_orjson_cache
 
 
 class DummyOrjson:
@@ -18,14 +18,14 @@ def _reset_json_utils(monkeypatch, module):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda name, attr=None, **kwargs: module
     )
-    json_utils._clear_orjson_cache()
+    clear_orjson_cache()
     import_utils.prune_failed_imports()
     with import_utils._WARNED_STATE.lock:
         import_utils._WARNED_STATE.clear()
 
 
 def test_json_dumps_without_orjson(monkeypatch, caplog):
-    json_utils._clear_orjson_cache()
+    clear_orjson_cache()
     import_utils.prune_failed_imports()
     with import_utils._WARNED_STATE.lock:
         import_utils._WARNED_STATE.clear()

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -1,14 +1,14 @@
+import importlib
 import json
 
 import pytest
 
 from tnfr.helpers.node_cache import stable_json
-from tnfr import json_utils
+from .utils import clear_orjson_cache
 
 
 def test_stable_json_dict_order_deterministic():
-    json_utils._clear_orjson_cache()
-    json_utils._orjson = None
+    clear_orjson_cache()
     obj = {"b": 1, "a": 2}
     res1 = stable_json(obj)
     res2 = stable_json(obj)
@@ -17,7 +17,8 @@ def test_stable_json_dict_order_deterministic():
 
 
 def test_stable_json_warns_with_orjson():
-    if json_utils._orjson is None:
+    if importlib.util.find_spec("orjson") is None:
         pytest.skip("orjson not installed")
+    clear_orjson_cache()
     with pytest.warns(UserWarning, match="ignored when using orjson"):
         stable_json({"a": 1})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import networkx as nx
 from tnfr.constants import inject_defaults
+import tnfr.json_utils as json_utils
 
 
 def build_graph(n, graph_canon=None):
@@ -8,3 +9,11 @@ def build_graph(n, graph_canon=None):
     for i in range(n):
         G.add_node(i, **{"θ": 0.0, "EPI": 0.0})
     return G
+
+
+def clear_orjson_cache() -> None:
+    """Clear cached :mod:`orjson` module and warning state."""
+    json_utils._warn_orjson_params_once.clear()
+    cache_clear = getattr(json_utils.cached_import, "cache_clear", None)
+    if cache_clear:
+        cache_clear()


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c72801dd7083218ee7005f64e30b75