### PR TITLE
Remove deprecated tnfr.logging module

### DIFF
--- a/src/tnfr/logging.py
+++ b/src/tnfr/logging.py
@@ -1,6 +1,0 @@
-"""Compatibility wrapper for deprecated tnfr.logging module."""
-from __future__ import annotations
-
-from .logging_utils import get_logger as get_module_logger
-
-__all__ = ["get_module_logger"]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c72e484428832194d96b3de60d20cd