### PR TITLE
Refactor performance tests into standalone benchmarks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 79
 ignore = F821,F841,E501,W503,E704
+exclude = benchmarks/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 *.log
 .DS_Store
 Thumbs.db
+.benchmarks/

--- a/benchmarks/cached_abs_max.py
+++ b/benchmarks/cached_abs_max.py
@@ -1,6 +1,7 @@
+"""Benchmark for set_attr_with_max vs recompute_abs_max."""
+
 import time
 import networkx as nx
-import pytest
 
 from tnfr.alias import set_attr_with_max, set_attr, recompute_abs_max
 from tnfr.constants import get_aliases
@@ -8,8 +9,8 @@ from tnfr.constants import get_aliases
 ALIAS_VF = get_aliases("VF")
 
 
-@pytest.mark.slow
-def test_cached_abs_max_update_performance():
+def run():
+    """Run the benchmark and print the elapsed times."""
     G_opt = nx.gnp_random_graph(500, 0.1, seed=1)
     G_naive = G_opt.copy()
 
@@ -32,4 +33,8 @@ def test_cached_abs_max_update_performance():
         recompute_abs_max(G_naive, ALIAS_VF, key="_vfmax")
     t_naive = time.perf_counter() - start
 
-    assert t_opt <= t_naive
+    print(f"cached update: {t_opt:.6f}s, naive: {t_naive:.6f}s")
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/collect_attr.py
+++ b/benchmarks/collect_attr.py
@@ -1,7 +1,8 @@
+"""Benchmark for collect_attr performance."""
+
 import time
 import networkx as nx
 import numpy as np
-import pytest
 
 from tnfr.alias import set_attr, collect_attr
 from tnfr.constants import get_aliases
@@ -16,8 +17,8 @@ def _naive_collect(G):
     )
 
 
-@pytest.mark.slow
-def test_collect_attr_performance():
+def run():
+    """Run the benchmark and print the elapsed times."""
     G = nx.gnp_random_graph(300, 0.1, seed=1)
     for n in G.nodes:
         set_attr(G.nodes[n], ALIAS_THETA, 0.0)
@@ -32,4 +33,8 @@ def test_collect_attr_performance():
         _naive_collect(G)
     t_naive = time.perf_counter() - start
 
-    assert t_opt <= t_naive
+    print(f"optimized: {t_opt:.6f}s, naive: {t_naive:.6f}s")
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/ensure_history_trim.py
+++ b/benchmarks/ensure_history_trim.py
@@ -1,13 +1,15 @@
+"""Benchmark for ensure_history trim performance."""
+
 import time
-import pytest
 
 from tnfr.glyph_history import HistoryDict, ensure_history
 from tnfr.constants import inject_defaults
+import networkx as nx
 
 
-@pytest.mark.slow
-def test_ensure_history_trim_performance(graph_canon):
-    G = graph_canon()
+def run():
+    """Run the benchmark and print the elapsed times."""
+    G = nx.Graph()
     inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 1000
     G.graph["HISTORY_COMPACT_EVERY"] = 100
@@ -24,4 +26,8 @@ def test_ensure_history_trim_performance(graph_canon):
         hist2.pop_least_used()
     t_loop = time.perf_counter() - start
 
-    assert t_bulk <= t_loop
+    print(f"bulk: {t_bulk:.6f}s, manual loop: {t_loop:.6f}s")
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/history_increment.py
+++ b/benchmarks/history_increment.py
@@ -1,12 +1,13 @@
+"""Benchmark for HistoryDict.increment performance."""
+
 import time
 from collections import Counter
-import pytest
 
 from tnfr.glyph_history import HistoryDict
 
 
-@pytest.mark.slow
-def test_increment_performance():
+def run():
+    """Run the benchmark and print the elapsed times."""
     n = 5000
     hist = HistoryDict()
     start = time.perf_counter()
@@ -20,4 +21,8 @@ def test_increment_performance():
         counter[f"k{i}"] += 1
     t_counter = time.perf_counter() - start
 
-    assert t_hist <= t_counter * 10
+    print(f"HistoryDict: {t_hist:.6f}s, Counter: {t_counter:.6f}s")
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/neighbor_phase_mean.py
+++ b/benchmarks/neighbor_phase_mean.py
@@ -1,9 +1,8 @@
 """Benchmark for neighbor_phase_mean performance."""
 
-import time
 import math
+import time
 import networkx as nx
-import pytest
 
 from tnfr.helpers.numeric import neighbor_phase_mean
 from tnfr.constants import get_aliases
@@ -27,9 +26,8 @@ def _naive_neighbor_phase_mean(G, n):
     return math.atan2(y, x)
 
 
-@pytest.mark.slow
-def test_neighbor_phase_mean_performance():
-    """Optimised neighbour mean should be faster than naive version."""
+def run():
+    """Run the benchmark and print the elapsed times."""
     G = nx.gnp_random_graph(200, 0.2, seed=1)
     for n in G.nodes:
         G.nodes[n][ALIAS_THETA] = 0.0
@@ -45,5 +43,8 @@ def test_neighbor_phase_mean_performance():
         for n in G.nodes:
             _naive_neighbor_phase_mean(G, n)
     t_naive = time.perf_counter() - start
+    print(f"optimized: {t_opt:.6f}s, naive: {t_naive:.6f}s")
 
-    assert t_opt <= t_naive
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/prepare_dnfr_data.py
+++ b/benchmarks/prepare_dnfr_data.py
@@ -1,6 +1,7 @@
+"""Benchmark for _prepare_dnfr_data performance."""
+
 import time
 import networkx as nx
-import pytest
 
 from tnfr.constants import get_aliases
 from tnfr.dynamics import _prepare_dnfr_data
@@ -20,8 +21,8 @@ def _naive_prepare(G):
     return theta, epi, vf
 
 
-@pytest.mark.slow
-def test_prepare_dnfr_data_performance():
+def run():
+    """Run the benchmark and print the elapsed times."""
     G = nx.gnp_random_graph(300, 0.1, seed=1)
     for n in G.nodes:
         set_attr(G.nodes[n], ALIAS_THETA, 0.0)
@@ -38,4 +39,8 @@ def test_prepare_dnfr_data_performance():
         _naive_prepare(G)
     t_naive = time.perf_counter() - start
 
-    assert t_opt <= t_naive
+    print(f"optimized: {t_opt:.6f}s, naive: {t_naive:.6f}s")
+
+
+if __name__ == "__main__":
+    run()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 pythonpath = src
-addopts = -m "not slow"
+addopts = -m "not slow" --ignore=benchmarks
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -42,5 +42,4 @@ def supports_add_edge(graph: Any) -> bool:
     bool
         ``True`` when ``graph`` implements ``add_edge``; ``False`` otherwise.
     """
-
     return hasattr(graph, "add_edge")


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c7b2e291a08321a888666371bc5ed3