### PR TITLE
Refactor json_dumps params construction

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -13,7 +13,7 @@ import json
 
 from typing import Any, Callable, Literal, overload
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from .import_utils import cached_import
 from .logging_utils import get_logger
 from .logging_utils import warn_once
@@ -52,38 +52,6 @@ DEFAULT_PARAMS = JsonDumpsParams(
     )
 
 
-def _make_params(
-    *,
-    sort_keys: bool = False,
-    default: Callable[[Any], Any] | None = None,
-    ensure_ascii: bool = True,
-    separators: tuple[str, str] = (",", ":"),
-    cls: type[json.JSONEncoder] | None = None,
-    to_bytes: bool = False,
-) -> JsonDumpsParams:
-    """Return a :class:`JsonDumpsParams` applying defaults.
-
-    The function reuses ``DEFAULT_PARAMS`` when all options match the
-    canonical defaults so downstream serializers can rely on identity
-    comparisons to avoid extra allocations.
-    """
-    if (
-        sort_keys is False
-        and default is None
-        and ensure_ascii is True
-        and separators == (",", ":")
-        and cls is None
-        and to_bytes is False
-    ):
-        return DEFAULT_PARAMS
-    return JsonDumpsParams(
-        sort_keys=sort_keys,
-        default=default,
-        ensure_ascii=ensure_ascii,
-        separators=separators,
-        cls=cls,
-        to_bytes=to_bytes,
-    )
 
 
 _ORJSON_PARAM_CHECKS: tuple[tuple[Callable[[JsonDumpsParams], bool], str], ...] = (
@@ -178,7 +146,8 @@ def json_dumps(
     ignored parameters are detected and, by default, is shown only once per
     process.
     """
-    params = _make_params(
+    params = replace(
+        DEFAULT_PARAMS,
         sort_keys=sort_keys,
         default=default,
         ensure_ascii=ensure_ascii,
@@ -186,6 +155,8 @@ def json_dumps(
         cls=cls,
         to_bytes=to_bytes,
     )
+    if params == DEFAULT_PARAMS:
+        params = DEFAULT_PARAMS
     orjson = cached_import("orjson", emit="log")
     if orjson is not None:
         return _json_dumps_orjson(orjson, obj, params, **kwargs)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -147,6 +147,16 @@ def test_default_params_reused(monkeypatch):
 
     monkeypatch.setattr(json_utils, "_json_dumps_std", fake_std)
     json_utils.json_dumps({"a": 1})
+    json_utils.json_dumps(
+        {"a": 1},
+        sort_keys=False,
+        default=None,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        cls=None,
+        to_bytes=False,
+    )
     json_utils.json_dumps({"a": 1}, sort_keys=True)
     assert calls[0] is json_utils.DEFAULT_PARAMS
-    assert calls[1] is not json_utils.DEFAULT_PARAMS
+    assert calls[1] is json_utils.DEFAULT_PARAMS
+    assert calls[2] is not json_utils.DEFAULT_PARAMS


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c7c0d5d0088321a47ec53b35acb4af