### PR TITLE
Remove compact_every from HistoryDict API

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,6 @@ the graph (or override the default) to keep only the most recent entries. The
 value must be non‑negative; negative values raise ``ValueError``. When the
 limit is positive the library uses bounded `deque` objects and removes the
 least populated series when the number of history keys grows beyond the limit.
-Compaction of internal usage counters happens every
-``HISTORY_COMPACT_EVERY`` accesses, which can also be adjusted through
-``G.graph``.
 
 ### Random node sampling
 

--- a/benchmarks/ensure_history_trim.py
+++ b/benchmarks/ensure_history_trim.py
@@ -12,7 +12,6 @@ def run():
     G = nx.Graph()
     inject_defaults(G)
     G.graph["HISTORY_MAXLEN"] = 1000
-    G.graph["HISTORY_COMPACT_EVERY"] = 100
     hist = {f"k{i}": [] for i in range(2000)}
     G.graph["history"] = HistoryDict(hist, maxlen=2000)
 

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -121,7 +121,6 @@ class CoreDefaults:
     VALIDATORS_STRICT: bool = False
     PROGRAM_TRACE_MAXLEN: int = 50
     HISTORY_MAXLEN: int = 0
-    HISTORY_COMPACT_EVERY: int = 100
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c7df8566ac8321a5a66ab8571105c0