### PR TITLE
Centralize callback management via CallbackManager

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -40,7 +40,7 @@ from ..metrics_utils import (
     merge_and_normalize_weights,
     compute_theta_trig,
 )
-from ..callback_utils import invoke_callbacks
+from ..callback_utils import callback_manager
 from ..glyph_history import recent_glyph, ensure_history, append_metric
 from ..selector import (
     _selector_thresholds,
@@ -487,7 +487,7 @@ def _choose_glyph(G, n, selector, use_canon, h_al, h_en, al_max, en_max):
 def _run_before_callbacks(
     G, *, step_idx: int, dt: float | None, use_Si: bool, apply_glyphs: bool
 ) -> None:
-    invoke_callbacks(
+    callback_manager.invoke_callbacks(
         G,
         "before_step",
         {
@@ -605,7 +605,7 @@ def _run_after_callbacks(G, *, step_idx: int) -> None:
         values = h.get(src)
         if values:
             ctx[dst] = values[-1]
-    invoke_callbacks(G, "after_step", ctx)
+    callback_manager.invoke_callbacks(G, "after_step", ctx)
 
 
 def step(

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -11,7 +11,7 @@ from ..constants import (
     get_aliases,
     get_param,
 )
-from ..callback_utils import register_callback
+from ..callback_utils import callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import collect_attr, get_attr, set_attr
 from ..collections_utils import normalize_weights
@@ -669,7 +669,7 @@ def _coherence_step(G, ctx=None):
 
 
 def register_coherence_callbacks(G) -> None:
-    register_callback(
+    callback_manager.register_callback(
         G, event="after_step", func=_coherence_step, name="coherence_step"
     )
 

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..callback_utils import register_callback
+from ..callback_utils import callback_manager
 from ..constants import get_param
 from ..glyph_history import append_metric, ensure_history
 from ..logging_utils import get_logger
@@ -116,7 +116,7 @@ def _metrics_step(G, *args, **kwargs):
 
 
 def register_metrics_callbacks(G) -> None:
-    register_callback(
+    callback_manager.register_callback(
         G, event="after_step", func=_metrics_step, name="metrics_step"
     )
     register_coherence_callbacks(G)

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -10,7 +10,7 @@ from ..constants import (
     get_aliases,
     get_param,
 )
-from ..callback_utils import register_callback
+from ..callback_utils import callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..helpers.numeric import clamp01, _similarity_abs
@@ -214,9 +214,9 @@ def dissonance_events(G, ctx=None):
 
 
 def register_diagnosis_callbacks(G) -> None:
-    register_callback(
+    callback_manager.register_callback(
         G, event="after_step", func=_diagnosis_step, name="diagnosis_step"
     )
-    register_callback(
+    callback_manager.register_callback(
         G, event="after_step", func=dissonance_events, name="dissonance_events"
     )

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,7 +8,7 @@ from .constants import get_aliases, get_param
 from .alias import get_attr
 from .helpers.numeric import angle_diff, list_pvariance
 from .metrics_utils import compute_coherence
-from .callback_utils import register_callback
+from .callback_utils import callback_manager
 from .glyph_history import (
     ensure_history,
     count_glyphs,
@@ -66,7 +66,7 @@ def attach_standard_observer(G):
     if G.graph.get("_STD_OBSERVER"):
         return G
     for event, fn in _STD_CALLBACKS.items():
-        register_callback(G, event, fn)
+        callback_manager.register_callback(G, event, fn)
     G.graph["_STD_OBSERVER"] = "attached"
     return G
 

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -12,7 +12,7 @@ from ..helpers.numeric import list_mean, kahan_sum
 from ..helpers import edge_version_update
 from ..alias import get_attr, set_attr
 from ..rng import make_rng
-from ..callback_utils import invoke_callbacks
+from ..callback_utils import callback_manager
 from ..glyph_history import append_metric, ensure_history, current_step_idx
 from ..import_utils import cached_import
 
@@ -88,7 +88,7 @@ def _log_remesh_event(G, meta):
     if G.graph.get("REMESH_LOG_EVENTS", REMESH_DEFAULTS["REMESH_LOG_EVENTS"]):
         hist = G.graph.setdefault("history", {})
         append_metric(hist, "remesh_events", dict(meta))
-    invoke_callbacks(G, "on_remesh", dict(meta))
+    callback_manager.invoke_callbacks(G, "on_remesh", dict(meta))
 
 
 def apply_network_remesh(G) -> None:

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -13,7 +13,7 @@ from .constants import get_aliases, get_graph_param
 from .alias import get_attr
 from .helpers.numeric import clamp01, kahan_sum2d
 from .import_utils import get_numpy
-from .callback_utils import register_callback
+from .callback_utils import callback_manager
 from .glyph_history import (
     ensure_history,
     last_glyph,
@@ -331,7 +331,7 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
 
 
 def register_sigma_callback(G) -> None:
-    register_callback(
+    callback_manager.register_callback(
         G, event="after_step", func=push_sigma_snapshot, name="sigma_snapshot"
     )
 

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -347,7 +347,7 @@ def register_trace(G) -> None:
     if G.graph.get("_trace_registered"):
         return
 
-    from .callback_utils import register_callback
+    from .callback_utils import callback_manager
 
     for phase in TRACE_FIELDS.keys():
         event = f"{phase}_step"
@@ -358,7 +358,7 @@ def register_trace(G) -> None:
 
             return _cb
 
-        register_callback(
+        callback_manager.register_callback(
             G, event=event, func=_make_cb(phase), name=f"trace_{phase}"
         )
 

--- a/tests/test_callback_errors_limit.py
+++ b/tests/test_callback_errors_limit.py
@@ -4,8 +4,7 @@ import tnfr.callback_utils as cb_utils
 
 from tnfr.callback_utils import (
     CallbackEvent,
-    invoke_callbacks,
-    register_callback,
+    callback_manager,
 )
 
 
@@ -15,14 +14,14 @@ def test_callback_error_list_resets_limit(graph_canon):
     def failing_cb(G, ctx):
         raise RuntimeError("boom")
 
-    register_callback(G, CallbackEvent.BEFORE_STEP, failing_cb, name="fail")
+    callback_manager.register_callback(G, CallbackEvent.BEFORE_STEP, failing_cb, name="fail")
     original = deque(maxlen=None)
     G.graph["_callback_errors"] = original
 
     prev = cb_utils.get_callback_error_limit()
     cb_utils.set_callback_error_limit(7)
     try:
-        invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
+        callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
         err_list = G.graph.get("_callback_errors")
         assert err_list is not original
         assert err_list.maxlen == cb_utils.get_callback_error_limit() == 7

--- a/tests/test_ensure_callbacks.py
+++ b/tests/test_ensure_callbacks.py
@@ -1,10 +1,9 @@
 """Tests for `_ensure_callbacks` behavior."""
 
 from tnfr.callback_utils import (
-    _ensure_callbacks,
     _normalize_callbacks,
-    register_callback,
     CallbackEvent,
+    callback_manager,
 )
 
 
@@ -19,7 +18,7 @@ def test_ensure_callbacks_drops_unknown_events(graph_canon):
         CallbackEvent.BEFORE_STEP.value: [("cb", cb)],
     }
 
-    _ensure_callbacks(G)
+    callback_manager._ensure_callbacks(G)
 
     assert list(G.graph["callbacks"]) == [CallbackEvent.BEFORE_STEP.value]
 
@@ -32,7 +31,7 @@ def test_register_callback_cleans_unknown_events(graph_canon):
 
     G.graph["callbacks"] = {"nope": [("cb", cb)]}
 
-    register_callback(G, CallbackEvent.AFTER_STEP, cb, name="cb")
+    callback_manager.register_callback(G, CallbackEvent.AFTER_STEP, cb, name="cb")
 
     assert list(G.graph["callbacks"]) == [CallbackEvent.AFTER_STEP.value]
 
@@ -51,7 +50,7 @@ def test_ensure_callbacks_only_processes_dirty_events(graph_canon):
     )
     G.graph["_callbacks_dirty"] = {CallbackEvent.BEFORE_STEP.value}
 
-    _ensure_callbacks(G)
+    callback_manager._ensure_callbacks(G)
 
     assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP.value] == {}
     assert G.graph["callbacks"][CallbackEvent.AFTER_STEP.value] == {}

--- a/tests/test_invoke_callbacks.py
+++ b/tests/test_invoke_callbacks.py
@@ -3,7 +3,7 @@
 import networkx as nx
 import pytest
 
-from tnfr.callback_utils import CallbackEvent, invoke_callbacks, register_callback
+from tnfr.callback_utils import CallbackEvent, callback_manager
 
 
 def test_invoke_callbacks_preserves_context(graph_canon):
@@ -12,10 +12,10 @@ def test_invoke_callbacks_preserves_context(graph_canon):
     def cb(G, ctx):
         ctx["called"] = ctx.get("called", 0) + 1
 
-    register_callback(G, CallbackEvent.BEFORE_STEP, cb)
+    callback_manager.register_callback(G, CallbackEvent.BEFORE_STEP, cb)
 
     ctx = {}
-    invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
+    callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
 
     assert ctx["called"] == 1
 
@@ -26,11 +26,11 @@ def test_invoke_callbacks_records_networkx_error(graph_canon):
     def failing_cb(G, ctx):
         G.remove_node("missing")
 
-    register_callback(G, CallbackEvent.BEFORE_STEP, failing_cb)
+    callback_manager.register_callback(G, CallbackEvent.BEFORE_STEP, failing_cb)
 
     ctx = {"step": 5}
     with pytest.raises(nx.NetworkXError):
-        invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
+        callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP, ctx)
 
     err_list = G.graph.get("_callback_errors")
     assert err_list and len(err_list) == 1

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -13,7 +13,7 @@ from tnfr.trace import (
 )
 from tnfr import trace
 from tnfr.helpers.node_cache import get_graph_mapping
-from tnfr.callback_utils import register_callback, invoke_callbacks
+from tnfr.callback_utils import callback_manager
 from types import MappingProxyType
 
 
@@ -38,8 +38,8 @@ def test_trace_metadata_contains_callback_names(graph_canon):
     def foo(G, ctx):
         pass
 
-    register_callback(G, event="before_step", func=foo, name="custom_cb")
-    invoke_callbacks(G, "before_step")
+    callback_manager.register_callback(G, event="before_step", func=foo, name="custom_cb")
+    callback_manager.invoke_callbacks(G, "before_step")
 
     hist = G.graph["history"]["trace_meta"]
     meta = hist[0]
@@ -52,7 +52,7 @@ def test_trace_sigma_no_glyphs(graph_canon):
     # add nodes without glyph history
     G.add_nodes_from([1, 2, 3])
     register_trace(G)
-    invoke_callbacks(G, "after_step")
+    callback_manager.invoke_callbacks(G, "after_step")
     meta = G.graph["history"]["trace_meta"][0]
     assert meta["phase"] == "after"
     assert meta["sigma"] == {
@@ -122,7 +122,7 @@ def test_register_trace_field_runtime(graph_canon):
         return {"custom": 42}
 
     register_trace_field("before", "custom", custom_field)
-    invoke_callbacks(G, "before_step")
+    callback_manager.invoke_callbacks(G, "before_step")
 
     meta = G.graph["history"]["trace_meta"][0]
     assert meta["custom"] == 42


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c82bf8f60483219fa3f466651c42cc