### PR TITLE
Reuse cached numpy in neighbor phase mean helper

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -167,6 +167,9 @@ def _neighbor_phase_mean_generic(
     sequence and ``cos_map``/``sin_map`` must be provided.
     """
 
+    if np is None:
+        np = get_numpy()
+
     if cos_map is None or sin_map is None:
         node = obj
         if getattr(node, "G", None) is None:
@@ -180,12 +183,8 @@ def _neighbor_phase_mean_generic(
         cos_map = trig.cos
         sin_map = trig.sin
         neigh = node.G[node.n]
-        if np is None:
-            np = get_numpy()
     else:
         neigh = obj
-        if np is None:
-            np = get_numpy()
 
     return _neighbor_phase_mean_core(neigh, cos_map, sin_map, np, fallback)
 

--- a/tests/test_neighbor_phase_mean_missing_trig.py
+++ b/tests/test_neighbor_phase_mean_missing_trig.py
@@ -1,6 +1,7 @@
 import math
 import pytest
 
+import tnfr.helpers.numeric as numeric
 from tnfr.helpers.numeric import (
     neighbor_phase_mean_list,
     _neighbor_phase_mean_core,
@@ -36,3 +37,53 @@ def test_neighbor_phase_mean_list_delegates_generic(monkeypatch):
     result = neighbor_phase_mean_list(neigh, cos_th, sin_th, np=None, fallback=0.0)
     assert result == pytest.approx(1.23)
     assert captured["args"] == (neigh, cos_th, sin_th, None, 0.0)
+
+
+def test_neighbor_phase_mean_generic_uses_cached_numpy(monkeypatch):
+    calls = 0
+
+    class FakeArray(list):
+        @property
+        def size(self):
+            return len(self)
+
+    class FakeNumpy:
+        def fromiter(self, iterable, dtype=float):
+            return FakeArray(list(iterable))
+
+        def mean(self, arr):
+            if not arr:
+                return 0.0
+            return sum(arr) / len(arr)
+
+        def arctan2(self, y, x):
+            return math.atan2(y, x)
+
+    fake_np = FakeNumpy()
+
+    def fake_get_numpy():
+        nonlocal calls
+        calls += 1
+        return fake_np
+
+    monkeypatch.setattr(numeric, "get_numpy", fake_get_numpy)
+
+    original_core = numeric._neighbor_phase_mean_core
+    captured_np = []
+
+    def wrapped_core(neigh, cos_map, sin_map, np_arg, fallback):
+        captured_np.append(np_arg)
+        return original_core(neigh, cos_map, sin_map, np_arg, fallback)
+
+    monkeypatch.setattr(numeric, "_neighbor_phase_mean_core", wrapped_core)
+
+    result = numeric._neighbor_phase_mean_generic(
+        [1, 2],
+        cos_map={1: 1.0, 2: 0.0},
+        sin_map={1: 0.0, 2: 1.0},
+        fallback=0.5,
+    )
+
+    assert calls == 1
+    assert captured_np == [fake_np]
+    assert result == pytest.approx(math.pi / 4)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Cache the numpy module once per neighbor phase mean computation and reuse it throughout the circular mean calculation.
- Added a regression test that verifies the cached numpy object is passed through to the core routine and maintains the expected phase result.

## Testing
- `pytest tests/test_neighbor_phase_mean_missing_trig.py tests/test_neighbor_phase_mean_no_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68c84ea170dc8321943b8f7a52695bc9