### PR TITLE
Refactor json_dumps parameter handling to use mappings

### DIFF
--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import is_dataclass
+from typing import Mapping
 
 import tnfr.import_utils as import_utils
 import tnfr.json_utils as json_utils
@@ -119,7 +119,9 @@ def test_params_passed_to_std(monkeypatch):
 
     monkeypatch.setattr(json_utils, "_json_dumps_std", fake_std)
     json_utils.json_dumps({"a": 1})
-    assert is_dataclass(captured["params"])
+    assert isinstance(captured["params"], Mapping)
+    assert captured["params"]["sort_keys"] is False
+    assert captured["params"]["ensure_ascii"] is True
 
 
 def test_params_passed_to_orjson(monkeypatch):
@@ -133,13 +135,15 @@ def test_params_passed_to_orjson(monkeypatch):
 
     monkeypatch.setattr(json_utils, "_json_dumps_orjson", fake_orjson)
     json_utils.json_dumps({"a": 1})
-    assert is_dataclass(captured["params"])
+    assert isinstance(captured["params"], Mapping)
+    assert captured["params"]["sort_keys"] is False
+    assert captured["params"]["ensure_ascii"] is True
 
 
 def test_default_params_reused(monkeypatch):
     _reset_json_utils(monkeypatch, None)
 
-    calls: list[json_utils.JsonDumpsParams] = []
+    calls: list[Mapping[str, object]] = []
 
     def fake_std(obj, params, **kwargs):
         calls.append(params)

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -12,6 +12,8 @@ def test_stable_json_dict_order_deterministic():
     obj = {"b": 1, "a": 2}
     res1 = stable_json(obj)
     res2 = stable_json(obj)
+    assert isinstance(res1, str)
+    assert isinstance(res2, str)
     assert res1 == res2
     assert json.loads(res1) == {"a": 2, "b": 1}
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

### Summary
- Replace the dataclass used to thread json_dumps parameters with a mapping-based configuration and add runtime validation for incoming options.
- Update json_utils and stable_json tests to assert the new mapping contract and default string output.


------
https://chatgpt.com/codex/tasks/task_e_68c859098bb88321b808320e74861d7e