### PR TITLE
Refactor optional import caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ pip install tnfr
 
 ### Optional imports with cache
 
-Use ``tnfr.cached_import`` to load optional dependencies and cache the result.
-It returns ``None`` when the module (or attribute) is missing, avoiding
-repeated import attempts. Call ``prune_failed_imports`` to discard records of
-previous failures when dependencies are installed at runtime; this prevents
-stale failure logs from lingering:
+Use ``tnfr.cached_import`` to load optional dependencies and cache the result
+via a process-wide LRU cache. Missing modules (or attributes) yield ``None``
+without triggering repeated imports. The helper records failures and emits a
+single warning per module to keep logs tidy. When optional packages are
+installed at runtime call ``prune_failed_imports`` to clear the consolidated
+failure/warning registry before retrying:
 
 ```python
 from tnfr import cached_import, prune_failed_imports

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -20,8 +20,6 @@ def _reset_json_utils(monkeypatch, module):
     )
     clear_orjson_cache()
     import_utils.prune_failed_imports()
-    with import_utils._WARNED_STATE.lock:
-        import_utils._WARNED_STATE.clear()
 
 
 def test_lazy_orjson_import(monkeypatch):
@@ -78,8 +76,6 @@ def test_json_dumps_returns_str_by_default():
 def test_json_dumps_without_orjson(monkeypatch, caplog):
     clear_orjson_cache()
     import_utils.prune_failed_imports()
-    with import_utils._WARNED_STATE.lock:
-        import_utils._WARNED_STATE.clear()
 
     original = import_utils.importlib.import_module
 

--- a/tests/test_warn_failure_emit.py
+++ b/tests/test_warn_failure_emit.py
@@ -1,12 +1,11 @@
 import logging
 import warnings
 
-from tnfr.import_utils import _warn_failure, _WARNED_MODULES, _WARNED_LOCK
+from tnfr.import_utils import IMPORT_LOG, _warn_failure
 
 
 def _clear_warned():
-    with _WARNED_LOCK:
-        _WARNED_MODULES.clear()
+    IMPORT_LOG.clear()
 
 
 def test_warn_failure_warns_only(caplog):


### PR DESCRIPTION
### Summary
- replace the TTL-based cached_import implementation with an lru_cache-backed helper and a consolidated ImportRegistry
- expose the new IMPORT_LOG.clear() entry point and update dependent documentation and tests

### Testing
- `pytest -k import_utils`


------
https://chatgpt.com/codex/tasks/task_e_68c85a90ce2c8321baed8a23ab30105f