### PR TITLE
Move neighbour phase trig helpers into shared metrics module

### DIFF
--- a/benchmarks/neighbor_phase_mean.py
+++ b/benchmarks/neighbor_phase_mean.py
@@ -4,7 +4,7 @@ import math
 import time
 import networkx as nx
 
-from tnfr.helpers.numeric import neighbor_phase_mean
+from tnfr.metrics.trig import neighbor_phase_mean
 from tnfr.constants import get_aliases
 from tnfr.node import NodoNX
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -25,8 +25,8 @@ from ..helpers.numeric import (
     clamp01,
     angle_diff,
     neighbor_mean,
-    neighbor_phase_mean,
 )
+from ..metrics.trig import neighbor_phase_mean
 from ..alias import (
     get_attr,
     set_vf,

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -16,9 +16,8 @@ from ..constants import DEFAULTS, get_aliases, get_param
 from ..helpers.numeric import (
     angle_diff,
     neighbor_mean,
-    neighbor_phase_mean,
-    _phase_mean_from_iter,
 )
+from ..metrics.trig import neighbor_phase_mean, _phase_mean_from_iter
 from ..helpers import cached_nodes_and_A
 from ..alias import (
     get_attr,

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -10,7 +10,8 @@ from ..alias import get_attr, set_attr
 from ..collections_utils import normalize_weights
 from ..constants import get_aliases
 from ..helpers import edge_version_cache, stable_json
-from ..helpers.numeric import angle_diff, clamp01, neighbor_phase_mean_list
+from ..helpers.numeric import angle_diff, clamp01
+from .trig import neighbor_phase_mean_list
 from ..import_utils import get_numpy
 
 from .common import (

--- a/src/tnfr/metrics/trig.py
+++ b/src/tnfr/metrics/trig.py
@@ -1,0 +1,177 @@
+"""Trigonometric helpers shared across metrics and helpers."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from itertools import tee
+from typing import Any
+
+from ..import_utils import cached_import, get_numpy
+
+__all__ = (
+    "accumulate_cos_sin",
+    "_phase_mean_from_iter",
+    "_neighbor_phase_mean_core",
+    "_neighbor_phase_mean_generic",
+    "neighbor_phase_mean_list",
+    "neighbor_phase_mean",
+)
+
+
+def accumulate_cos_sin(
+    it: Iterable[tuple[float, float] | None],
+) -> tuple[float, float, bool]:
+    """Accumulate cosine and sine pairs with compensated summation.
+
+    ``it`` yields optional ``(cos, sin)`` tuples. Entries with ``None``
+    components are ignored. The returned values are the compensated sums of
+    cosines and sines along with a flag indicating whether any pair was
+    processed.
+    """
+
+    sum_cos = 0.0
+    sum_sin = 0.0
+    comp_cos = 0.0
+    comp_sin = 0.0
+    processed = False
+    for cs in it:
+        if cs is None:
+            continue
+        c, s = cs
+        if c is None or s is None:
+            continue
+        processed = True
+        t = sum_cos + c
+        if abs(sum_cos) >= abs(c):
+            comp_cos += (sum_cos - t) + c
+        else:
+            comp_cos += (c - t) + sum_cos
+        sum_cos = t
+
+        t = sum_sin + s
+        if abs(sum_sin) >= abs(s):
+            comp_sin += (sum_sin - t) + s
+        else:
+            comp_sin += (s - t) + sum_sin
+        sum_sin = t
+
+    return sum_cos + comp_cos, sum_sin + comp_sin, processed
+
+
+def _phase_mean_from_iter(
+    it: Iterable[tuple[float, float] | None], fallback: float
+) -> float:
+    """Return circular mean from an iterator of cosine/sine pairs.
+
+    ``it`` yields optional ``(cos, sin)`` tuples. ``fallback`` is returned if
+    no valid pairs are processed.
+    """
+
+    sum_cos, sum_sin, processed = accumulate_cos_sin(it)
+    if not processed:
+        return fallback
+    return math.atan2(sum_sin, sum_cos)
+
+
+def _neighbor_phase_mean_core(
+    neigh: Sequence[Any],
+    cos_map: dict[Any, float],
+    sin_map: dict[Any, float],
+    np,
+    fallback: float,
+) -> float:
+    """Return circular mean of neighbour phases given trig mappings."""
+
+    def _iter_pairs():
+        for v in neigh:
+            c = cos_map.get(v)
+            s = sin_map.get(v)
+            if c is not None and s is not None:
+                yield c, s
+
+    pairs = _iter_pairs()
+
+    if np is not None:
+        cos_iter, sin_iter = tee(pairs, 2)
+        cos_arr = np.fromiter((c for c, _ in cos_iter), dtype=float)
+        sin_arr = np.fromiter((s for _, s in sin_iter), dtype=float)
+        if cos_arr.size:
+            mean_cos = float(np.mean(cos_arr))
+            mean_sin = float(np.mean(sin_arr))
+            return float(np.arctan2(mean_sin, mean_cos))
+        return fallback
+
+    sum_cos, sum_sin, processed = accumulate_cos_sin(pairs)
+    if not processed:
+        return fallback
+    return math.atan2(sum_sin, sum_cos)
+
+
+def _neighbor_phase_mean_generic(
+    obj,
+    cos_map: dict[Any, float] | None = None,
+    sin_map: dict[Any, float] | None = None,
+    np=None,
+    fallback: float = 0.0,
+) -> float:
+    """Internal helper delegating to :func:`_neighbor_phase_mean_core`.
+
+    ``obj`` may be either a node bound to a graph or a sequence of neighbours.
+    When ``cos_map`` and ``sin_map`` are ``None`` the function assumes ``obj`` is
+    a node and obtains the required trigonometric mappings from the cached
+    structures. Otherwise ``obj`` is treated as an explicit neighbour
+    sequence and ``cos_map``/``sin_map`` must be provided.
+    """
+
+    if np is None:
+        np = get_numpy()
+
+    if cos_map is None or sin_map is None:
+        node = obj
+        if getattr(node, "G", None) is None:
+            raise TypeError(
+                "neighbor_phase_mean requires nodes bound to a graph"
+            )
+        from .trigonometry import get_trig_cache
+
+        trig = get_trig_cache(node.G)
+        fallback = trig.theta.get(node.n, fallback)
+        cos_map = trig.cos
+        sin_map = trig.sin
+        neigh = node.G[node.n]
+    else:
+        neigh = obj
+
+    return _neighbor_phase_mean_core(neigh, cos_map, sin_map, np, fallback)
+
+
+def neighbor_phase_mean_list(
+    neigh: Sequence[Any],
+    cos_th: dict[Any, float],
+    sin_th: dict[Any, float],
+    np=None,
+    fallback: float = 0.0,
+) -> float:
+    """Return circular mean of neighbour phases from cosine/sine mappings.
+
+    This is a thin wrapper over :func:`_neighbor_phase_mean_generic` that
+    operates on explicit neighbour lists.
+    """
+
+    return _neighbor_phase_mean_generic(
+        neigh, cos_map=cos_th, sin_map=sin_th, np=np, fallback=fallback
+    )
+
+
+def neighbor_phase_mean(obj, n=None) -> float:
+    """Circular mean of neighbour phases.
+
+    The :class:`NodoNX` import is cached after the first call.
+    """
+
+    NodoNX = cached_import("tnfr.node", "NodoNX")
+    if NodoNX is None:
+        raise ImportError("NodoNX is unavailable")
+    node = NodoNX(obj, n) if n is not None else obj
+    return _neighbor_phase_mean_generic(node)

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -10,9 +10,9 @@ from ..constants import DEFAULTS, get_aliases, get_param
 from ..helpers.numeric import (
     list_mean,
     angle_diff,
-    neighbor_phase_mean,
     neighbor_mean,
 )
+from ..metrics.trig import neighbor_phase_mean
 from ..import_utils import get_nodonx
 from ..rng import make_rng
 from tnfr import glyph_history

--- a/tests/test_neighbor_phase_mean_missing_trig.py
+++ b/tests/test_neighbor_phase_mean_missing_trig.py
@@ -1,8 +1,8 @@
 import math
 import pytest
 
-import tnfr.helpers.numeric as numeric
-from tnfr.helpers.numeric import (
+import tnfr.metrics.trig as trig
+from tnfr.metrics.trig import (
     neighbor_phase_mean_list,
     _neighbor_phase_mean_core,
 )
@@ -32,7 +32,7 @@ def test_neighbor_phase_mean_list_delegates_generic(monkeypatch):
         return 1.23
 
     monkeypatch.setattr(
-        "tnfr.helpers.numeric._neighbor_phase_mean_generic", fake_generic
+        "tnfr.metrics.trig._neighbor_phase_mean_generic", fake_generic
     )
     result = neighbor_phase_mean_list(neigh, cos_th, sin_th, np=None, fallback=0.0)
     assert result == pytest.approx(1.23)
@@ -66,18 +66,18 @@ def test_neighbor_phase_mean_generic_uses_cached_numpy(monkeypatch):
         calls += 1
         return fake_np
 
-    monkeypatch.setattr(numeric, "get_numpy", fake_get_numpy)
+    monkeypatch.setattr(trig, "get_numpy", fake_get_numpy)
 
-    original_core = numeric._neighbor_phase_mean_core
+    original_core = trig._neighbor_phase_mean_core
     captured_np = []
 
     def wrapped_core(neigh, cos_map, sin_map, np_arg, fallback):
         captured_np.append(np_arg)
         return original_core(neigh, cos_map, sin_map, np_arg, fallback)
 
-    monkeypatch.setattr(numeric, "_neighbor_phase_mean_core", wrapped_core)
+    monkeypatch.setattr(trig, "_neighbor_phase_mean_core", wrapped_core)
 
-    result = numeric._neighbor_phase_mean_generic(
+    result = trig._neighbor_phase_mean_generic(
         [1, 2],
         cos_map={1: 1.0, 2: 0.0},
         sin_map={1: 0.0, 2: 1.0},

--- a/tests/test_neighbor_phase_mean_no_graph.py
+++ b/tests/test_neighbor_phase_mean_no_graph.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tnfr.helpers.numeric import neighbor_phase_mean
+from tnfr.metrics.trig import neighbor_phase_mean
 from tnfr.constants import get_aliases
 from tnfr.alias import set_attr
 
@@ -37,7 +37,7 @@ def test_neighbor_phase_mean_uses_generic(monkeypatch, graph_canon):
         calls.append((obj, cos_map, sin_map, np, fallback))
         return 0.0
 
-    monkeypatch.setattr("tnfr.helpers.numeric._neighbor_phase_mean_generic", fake_generic)
+    monkeypatch.setattr("tnfr.metrics.trig._neighbor_phase_mean_generic", fake_generic)
     neighbor_phase_mean(G, 1)
     assert len(calls) == 1
     node_arg, cos_map, sin_map, np_arg, fallback = calls[0]

--- a/tests/test_trig_cache_reuse.py
+++ b/tests/test_trig_cache_reuse.py
@@ -4,7 +4,7 @@ import pytest
 from tnfr.constants import get_aliases
 from tnfr.metrics.trigonometry import get_trig_cache
 from tnfr.metrics.sense_index import compute_Si
-from tnfr.helpers.numeric import neighbor_phase_mean
+from tnfr.metrics.trig import neighbor_phase_mean
 from tnfr.alias import set_attr
 import tnfr.import_utils as import_utils
 


### PR DESCRIPTION
## Summary
- centralize `neighbor_phase_mean` helpers inside a new `tnfr.metrics.trig` module and expose lazy wrappers from `helpers.numeric`
- update helpers, dynamics, operators, benchmarks, and sense index utilities to consume the shared trig helpers
- refresh neighbour phase tests to target the new module while keeping cache behaviour checks intact

## Testing
- `pytest tests/test_neighbor_phase_mean_no_graph.py tests/test_neighbor_phase_mean_missing_trig.py tests/test_trig_cache_reuse.py tests/test_neighbors_map_cache.py`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c862b8f1448321b1d4a22155b0d510