### PR TITLE
Refactor weight normalization helpers

### DIFF
--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Protocol, Sequence
 
 from ..alias import get_attr, multi_recompute_abs_max
-from ..collections_utils import prepare_weights
+from ..collections_utils import normalize_weights
 from ..constants import DEFAULTS, get_aliases
 from ..helpers import edge_version_cache
 from ..helpers.numeric import clamp01, kahan_sum
@@ -102,20 +102,14 @@ def merge_and_normalize_weights(
     """Merge defaults for ``key`` and normalise ``fields``."""
 
     w = merge_graph_weights(G, key)
-    weights, keys_list, total = prepare_weights(
+    return normalize_weights(
         w,
         fields,
-        default,
+        default=default,
         error_on_conversion=False,
         error_on_negative=False,
         warn_once=True,
     )
-    if not keys_list:
-        return {}
-    if total <= 0:
-        uniform = 1.0 / len(keys_list)
-        return {k: uniform for k in keys_list}
-    return {k: val / total for k, val in weights.items()}
 
 
 def compute_dnfr_accel_max(G: GraphLike) -> dict[str, float]:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Centralizes weight conversion and negative checking in a shared helper used by both `prepare_weights` and `normalize_weights`, and lets `merge_and_normalize_weights` delegate to the public normalization helper. Behavioural coverage is kept through the existing weight normalization tests.


------
https://chatgpt.com/codex/tasks/task_e_68c86570655883219211a02207fd86a3