### PR TITLE
Move validate_window helper to validators module

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -12,7 +12,6 @@ from .glyph_history import (
     ensure_history,
     count_glyphs,
     append_metric,
-    validate_window,
 )
 from .collections_utils import normalize_counter, mix_groups
 from .constants_glyphs import GLYPH_GROUPS
@@ -20,6 +19,7 @@ from .gamma import kuramoto_R_psi
 from .logging_utils import get_logger
 from .import_utils import get_numpy
 from .metrics.common import compute_coherence
+from .validators import validate_window
 
 ALIAS_THETA = get_aliases("THETA")
 

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import numbers
 import sys
 
 from .constants import get_aliases, get_param
 from .alias import get_attr
-from .glyph_history import last_glyph
 from .sense import sigma_vector_from_graph
 from .helpers.numeric import within_range
 from .constants_glyphs import GLYPHS_CANONICAL_SET
@@ -14,7 +14,23 @@ from .constants_glyphs import GLYPHS_CANONICAL_SET
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")
 
-__all__ = ("run_validators",)
+__all__ = ("validate_window", "run_validators")
+
+
+def validate_window(window: int, *, positive: bool = False) -> int:
+    """Validate ``window`` as an ``int`` and return it.
+
+    Non-integer values raise :class:`TypeError`. When ``positive`` is ``True``
+    the value must be strictly greater than zero; otherwise it may be zero.
+    Negative values always raise :class:`ValueError`.
+    """
+
+    if isinstance(window, bool) or not isinstance(window, numbers.Integral):
+        raise TypeError("'window' must be an integer")
+    if window < 0 or (positive and window == 0):
+        kind = "positive" if positive else "non-negative"
+        raise ValueError(f"'window'={window} must be {kind}")
+    return int(window)
 
 
 def _require_attr(data, alias, node, name):
@@ -52,6 +68,8 @@ def _check_glyph(g, n):
 
 def run_validators(G) -> None:
     """Run all invariant validators on ``G`` with a single node pass."""
+    from .glyph_history import last_glyph
+
     epi_min = float(get_param(G, "EPI_MIN"))
     epi_max = float(get_param(G, "EPI_MAX"))
     vf_min = float(get_param(G, "VF_MIN"))

--- a/tests/test_validate_window.py
+++ b/tests/test_validate_window.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 
-from tnfr.glyph_history import validate_window
+from tnfr.validators import validate_window
 
 
 @pytest.mark.parametrize("value", [True, False])


### PR DESCRIPTION
### Summary
- relocate `validate_window` into `tnfr.validators` and expose it from there
- update history utilities to resolve the validator lazily to avoid circular imports
- refresh observers and tests to reference the new validator location

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

### Testing
- pytest tests/test_validate_window.py


------
https://chatgpt.com/codex/tasks/task_e_68c87111ffc48321817c2c56af27ba25