### PR TITLE
Consolidate CLI token parsing with core helpers

### DIFF
--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -16,8 +16,7 @@ from .arguments import (
     _add_metrics_parser,
     _args_to_dict,
 )
-from .token_parser import _parse_tokens
-from ..token_map import TOKEN_MAP
+from ..token_parser import _parse_tokens, validate_token, parse_thol, TOKEN_MAP
 from .execution import (
     build_basic_graph,
     apply_cli_config,
@@ -47,7 +46,9 @@ __all__ = (
     "resolve_program",
     "_build_graph_from_args",
     "_load_sequence",
+    "validate_token",
     "_parse_tokens",
+    "parse_thol",
     "TOKEN_MAP",
     "_save_json",
     "_args_to_dict",

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -38,7 +38,7 @@ from ..types import Glyph
 from ..json_utils import json_dumps
 
 from .arguments import _args_to_dict
-from .token_parser import _parse_tokens
+from ..token_parser import _parse_tokens
 
 logger = get_logger(__name__)
 

--- a/src/tnfr/cli/token_parser.py
+++ b/src/tnfr/cli/token_parser.py
@@ -1,6 +1,0 @@
-from __future__ import annotations
-
-from ..token_parser import validate_token, _parse_tokens
-from ..token_map import TOKEN_MAP, parse_thol
-
-__all__ = ("validate_token", "_parse_tokens", "parse_thol", "TOKEN_MAP")

--- a/src/tnfr/token_parser.py
+++ b/src/tnfr/token_parser.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any, Callable, Iterator
 
 from .collections_utils import flatten_structure
-from .token_map import TOKEN_MAP
+from .token_map import TOKEN_MAP, parse_thol
 
-__all__ = ("validate_token", "_parse_tokens", "TOKEN_MAP")
+__all__ = ("validate_token", "_parse_tokens", "parse_thol", "TOKEN_MAP")
 
 
 def validate_token(

--- a/tests/test_cli_core_parser_equivalence.py
+++ b/tests/test_cli_core_parser_equivalence.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from tnfr.cli import _parse_tokens
-from tnfr.token_parser import _parse_tokens as core_parse_tokens
-
-
-def test_cli_and_core_parsers_share_behavior():
-    tokens = [{"WAIT": 1}, {"TARGET": "A"}]
-    assert list(_parse_tokens(tokens)) == list(core_parse_tokens(tokens))


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Consolidated the CLI token exports onto the shared `tnfr.token_parser` helpers and removed the redundant equivalence test.


------
https://chatgpt.com/codex/tasks/task_e_68c8749570dc8321a9c12bb4c142ce01