### PR TITLE
Remove deprecated parameter aliases

### DIFF
--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -76,7 +76,7 @@ def preparar_red(
         }
     )
     G.graph.setdefault("history", history)
-    # REMESH_TAU: alias legado resuelto por ``get_param``
+    # Memoria global de REMESH
     tau = int(get_param(G, "REMESH_TAU_GLOBAL"))
     maxlen = max(2 * tau + 5, 64)
     G.graph.setdefault("_epi_hist", deque(maxlen=maxlen))


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- remove the legacy parameter alias table and deprecated attribute exports so `get_param` only considers canonical keys.
- simplify `get_param` to fall back directly to `DEFAULTS` when a graph does not override a parameter.
- refresh the ontosim comment to describe the REMESH memory lookup without mentioning the dropped alias.

## Testing
- `pytest` *(fails: optional numpy dependency unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87708ced48321ad258934763def64