### PR TITLE
Centralize GraphLike protocol in tnfr.types

### DIFF
--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import Any, Iterable, Mapping, Protocol, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from ..alias import get_attr, multi_recompute_abs_max
 from ..collections_utils import normalize_weights
@@ -11,6 +11,7 @@ from ..constants import DEFAULTS, get_aliases
 from ..helpers import edge_version_cache
 from ..helpers.numeric import clamp01, kahan_sum
 from ..import_utils import get_numpy
+from ..types import GraphLike
 
 ALIAS_DNFR = get_aliases("DNFR")
 ALIAS_D2EPI = get_aliases("D2EPI")
@@ -28,20 +29,6 @@ __all__ = (
     "min_max_range",
     "_get_vf_dnfr_max",
 )
-
-
-class GraphLike(Protocol):
-    """Protocol for graph objects used throughout the metrics package."""
-
-    graph: dict[str, Any]
-
-    def nodes(self, data: bool = ...) -> Iterable[Any]: ...
-
-    def number_of_nodes(self) -> int: ...
-
-    def neighbors(self, n: Any) -> Iterable[Any]: ...
-
-    def __iter__(self) -> Iterable[Any]: ...
 
 
 def compute_coherence(

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -13,9 +13,9 @@ from ..helpers import edge_version_cache, stable_json
 from ..helpers.numeric import angle_diff, clamp01
 from .trig import neighbor_phase_mean_list
 from ..import_utils import get_numpy
+from ..types import GraphLike
 
 from .common import (
-    GraphLike,
     ensure_neighbors_map,
     merge_graph_weights,
     _get_vf_dnfr_max,

--- a/src/tnfr/metrics/trig_cache.py
+++ b/src/tnfr/metrics/trig_cache.py
@@ -14,8 +14,7 @@ from ..alias import get_attr
 from ..constants import get_aliases
 from ..helpers import edge_version_cache
 from ..import_utils import get_numpy
-
-from .common import GraphLike
+from ..types import GraphLike
 
 ALIAS_THETA = get_aliases("THETA")
 

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -1,11 +1,31 @@
-"""Type definitions."""
+"""Type definitions and protocols shared across the engine."""
 
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Iterable, Protocol
 
-__all__ = ("NodeState", "Glyph")
+__all__ = ("GraphLike", "NodeState", "Glyph")
+
+
+class GraphLike(Protocol):
+    """Protocol for graph objects used throughout TNFR metrics.
+
+    The metrics helpers assume a single coherent graph interface so that
+    coherence, resonance and derived indicators read/write data through the
+    same structural access points.
+    """
+
+    graph: dict[str, Any]
+
+    def nodes(self, data: bool = ...) -> Iterable[Any]: ...
+
+    def number_of_nodes(self) -> int: ...
+
+    def neighbors(self, n: Any) -> Iterable[Any]: ...
+
+    def __iter__(self) -> Iterable[Any]: ...
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- move the GraphLike protocol definition into `tnfr.types` and document its canonical scope for metrics helpers
- import GraphLike from `tnfr.types` across coherence and trigonometric helpers while keeping the previous re-export for compatibility
- update sense-index utilities to rely on the shared protocol definition

## Testing
- pytest tests/test_compute_coherence.py tests/test_neighbors_map_cache.py tests/test_merge_and_normalize_weights.py tests/test_vf_dnfr_max_update.py tests/test_trig_cache_reuse.py tests/test_compute_theta_trig.py tests/test_compute_Si_numpy_usage.py tests/test_si_helpers.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c87e934c5883219f322b2ee456812a