### PR TITLE
Remove invalidate_edge_version_cache helper

### DIFF
--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -44,7 +44,6 @@ from .edge_cache import (
     EdgeCacheManager,
     edge_version_cache,
     cached_nodes_and_A,
-    invalidate_edge_version_cache,
     increment_edge_version,
     edge_version_update,
 )
@@ -79,7 +78,6 @@ __all__ = (
     "EdgeCacheManager",
     "edge_version_cache",
     "cached_nodes_and_A",
-    "invalidate_edge_version_cache",
     "increment_edge_version",
     "edge_version_update",
     "node_set_checksum",

--- a/src/tnfr/helpers/edge_cache.py
+++ b/src/tnfr/helpers/edge_cache.py
@@ -33,7 +33,6 @@ __all__ = (
     "EdgeCacheManager",
     "edge_version_cache",
     "cached_nodes_and_A",
-    "invalidate_edge_version_cache",
     "increment_edge_version",
     "edge_version_update",
 )
@@ -197,17 +196,6 @@ def edge_version_cache(
             return value
 
 
-def invalidate_edge_version_cache(G: Any) -> None:
-    """Clear cached entries associated with ``G``."""
-
-    graph = get_graph(G)
-    cache, locks = EdgeCacheManager(graph).get_cache(None, create=False)
-    if isinstance(cache, (dict, LRUCache)):
-        cache.clear()
-    if isinstance(locks, dict):
-        locks.clear()
-
-
 def cached_nodes_and_A(
     G: nx.Graph, *, cache_size: int | None = 1, require_numpy: bool = False
 ) -> tuple[list[int], Any]:
@@ -236,7 +224,11 @@ def cached_nodes_and_A(
 def _reset_edge_caches(graph: Any, G: Any) -> None:
     """Clear caches affected by edge updates."""
 
-    invalidate_edge_version_cache(G)
+    cache, locks = EdgeCacheManager(graph).get_cache(None, create=False)
+    if isinstance(cache, (dict, LRUCache)):
+        cache.clear()
+    if isinstance(locks, dict):
+        locks.clear()
     mark_dnfr_prep_dirty(G)
     clear_node_repr_cache()
     for key in EDGE_VERSION_CACHE_KEYS:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- remove `invalidate_edge_version_cache` and inline its responsibilities in `_reset_edge_caches`
- stop re-exporting the deleted helper from the helpers package

## Testing
- `pytest` *(fails: missing optional dependency numpy in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8836c0c948321a7a6a9c5a824b3a5