### PR TITLE
Avoid private cache access in alias cache tests

### DIFF
--- a/tests/test_alias_key_cache.py
+++ b/tests/test_alias_key_cache.py
@@ -71,4 +71,8 @@ def test_key_cache_threadsafe(accessor, max_workers):
         with ThreadPoolExecutor(max_workers=max_workers) as ex:
             list(ex.map(worker, range(16)))
 
-    assert len(accessor._key_cache) == 1
+    assert len(d) == 1
+    assert set(d.keys()) == {"k"}
+    final_value = accessor.get(d, aliases)
+    assert isinstance(final_value, int)
+    assert d["k"] == final_value


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Replace the private `_key_cache` assertion in the alias accessor tests with checks based on the public dictionary state.
- Confirm the threaded accessor exercise relies on `AliasAccessor.get` for verification instead of internal attributes.

## Testing
- pytest tests/test_alias_key_cache.py


------
https://chatgpt.com/codex/tasks/task_e_68c885371ae48321bb4d23264a59b8d4