### PR TITLE
Curate helper API exports and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,62 @@ inspected with ``tnfr.callback_utils.get_callback_error_limit``.
 
 ---
 
+## Helper utilities API
+
+`tnfr.helpers` bundles a compact set of public helpers that stay stable across
+releases. They provide ergonomic access to the most common preparation steps
+when orchestrating TNFR experiments.
+
+### Collections and numeric helpers
+
+* ``ensure_collection(it, *, max_materialize=...)`` — materialize potentially
+  lazy iterables once, enforcing a configurable limit to keep simulations
+  bounded.
+* ``clamp(x, a, b)`` and ``clamp01(x)`` — restrict scalars to safe ranges for
+  operator parameters.
+* ``list_mean(xs, default=0.0)`` — return the arithmetic mean with a fallback
+  when the input is empty.
+* ``kahan_sum(values)``, ``kahan_sum2d(values)`` and ``kahan_sum_nd(values,
+  dims)`` — numerically stable accumulators used to track coherence magnitudes
+  across long trajectories.
+* ``angle_diff(a, b)`` — compute minimal angular differences (radians) to
+  compare structural phases.
+* ``neighbor_mean(G, n, aliases, default=0.0)`` — obtain the mean value of an
+  attribute among the neighbours of ``n`` leveraging cached graph aliases.
+
+### Glyph history helpers
+
+* ``push_glyph(nd, glyph, window)`` — update node history respecting the
+  configured rolling window.
+* ``recent_glyph(nd, glyph, window)`` — test whether a glyph appeared in the
+  recent history of a node.
+* ``ensure_history(G)`` — prepare the graph-level history container with the
+  appropriate bounds.
+* ``last_glyph(nd)`` — inspect the most recent glyph emitted by a node.
+* ``count_glyphs(G, window=None, *, last_only=False)`` — aggregate glyph usage
+  across the network either from the whole history or a limited window.
+
+### Graph caches and ΔNFR invalidation
+
+* ``cached_node_list(G)`` — lazily cache a stable tuple of node identifiers,
+  respecting opt-in sorted ordering.
+* ``ensure_node_index_map(G)`` / ``ensure_node_offset_map(G)`` — expose cached
+  index and offset mappings for graphs that need to project nodes to arrays.
+* ``node_set_checksum(G, nodes=None, *, presorted=False, store=True)`` —
+  produce deterministic BLAKE2b hashes to detect topology changes.
+* ``stable_json(obj)`` — render deterministic JSON strings suited for hashing
+  and reproducible logs.
+* ``get_graph(obj)`` / ``get_graph_mapping(G, key, warn_msg)`` — normalise
+  access to graph-level metadata regardless of wrappers.
+* ``EdgeCacheManager`` together with ``edge_version_cache``,
+  ``cached_nodes_and_A`` and ``edge_version_update`` encapsulate the edge
+  version cache. ``increment_edge_version`` bumps the version manually for
+  imperative workflows.
+* ``mark_dnfr_prep_dirty(G)`` — invalidate precomputed ΔNFR preparation when
+  mutating edges outside the cache helpers.
+
+---
+
 ## Why TNFR (in 60 seconds)
 
 * **From objects to coherences:** you model **processes** that hold, not fixed entities.

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -1,81 +1,75 @@
+"""Curated high-level helpers exposed by :mod:`tnfr.helpers`.
+
+The module is intentionally small and surfaces utilities that are stable for
+external use, covering data preparation, glyph history management, and graph
+cache invalidation.
+"""
+
 from __future__ import annotations
 
-from ..graph_utils import mark_dnfr_prep_dirty
-
-from ..collections_utils import (
-    MAX_MATERIALIZE_DEFAULT,
-    ensure_collection,
-    normalize_weights,
-    normalize_counter,
-    mix_groups,
-)
+from ..collections_utils import ensure_collection
 from ..glyph_history import (
-    push_glyph,
-    recent_glyph,
+    count_glyphs,
     ensure_history,
     last_glyph,
-    count_glyphs,
+    push_glyph,
+    recent_glyph,
 )
+from ..graph_utils import mark_dnfr_prep_dirty
 
-from .numeric import (
-    clamp,
-    clamp01,
-    list_mean,
-    kahan_sum_nd,
-    kahan_sum,
-    kahan_sum2d,
-    angle_diff,
-    neighbor_mean,
+from .edge_cache import (
+    EdgeCacheManager,
+    cached_nodes_and_A,
+    edge_version_cache,
+    edge_version_update,
+    increment_edge_version,
 )
 from .node_cache import (
-    NODE_SET_CHECKSUM_KEY,
+    cached_node_list,
+    ensure_node_index_map,
+    ensure_node_offset_map,
     get_graph,
     get_graph_mapping,
     node_set_checksum,
     stable_json,
-    cached_node_list,
-    ensure_node_index_map,
-    ensure_node_offset_map,
 )
-from .edge_cache import (
-    EdgeCacheManager,
-    edge_version_cache,
-    cached_nodes_and_A,
-    increment_edge_version,
-    edge_version_update,
+from .numeric import (
+    angle_diff,
+    clamp,
+    clamp01,
+    kahan_sum,
+    kahan_sum2d,
+    kahan_sum_nd,
+    list_mean,
+    neighbor_mean,
 )
 
 __all__ = (
-    "MAX_MATERIALIZE_DEFAULT",
-    "ensure_collection",
+    "EdgeCacheManager",
+    "angle_diff",
+    "cached_node_list",
+    "cached_nodes_and_A",
     "clamp",
     "clamp01",
-    "list_mean",
-    "kahan_sum_nd",
-    "kahan_sum",
-    "kahan_sum2d",
-    "angle_diff",
-    "normalize_weights",
-    "neighbor_mean",
-    "push_glyph",
-    "recent_glyph",
-    "ensure_history",
-    "last_glyph",
     "count_glyphs",
-    "normalize_counter",
-    "mix_groups",
-    "cached_node_list",
-    "NODE_SET_CHECKSUM_KEY",
+    "edge_version_cache",
+    "edge_version_update",
+    "ensure_collection",
+    "ensure_history",
     "ensure_node_index_map",
     "ensure_node_offset_map",
-    "stable_json",
-    "EdgeCacheManager",
-    "edge_version_cache",
-    "cached_nodes_and_A",
-    "increment_edge_version",
-    "edge_version_update",
-    "node_set_checksum",
     "get_graph",
     "get_graph_mapping",
+    "increment_edge_version",
+    "kahan_sum",
+    "kahan_sum2d",
+    "kahan_sum_nd",
+    "last_glyph",
+    "list_mean",
     "mark_dnfr_prep_dirty",
+    "neighbor_mean",
+    "node_set_checksum",
+    "push_glyph",
+    "recent_glyph",
+    "stable_json",
 )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- limit `tnfr.helpers` to a curated set of high-level utilities and describe the scope in the module docstring
- document the public helper groups in the README so external users know where to import lower-level helpers

## Testing
- `./scripts/run_tests.sh` *(stopped after ~12 minutes once 42 tests completed to avoid excessive runtime)*
- `pytest tests/test_edge_version_cache.py tests/test_node_set_checksum.py tests/test_neighbors_map_cache.py tests/test_count_glyphs.py tests/test_history.py tests/test_history_series.py tests/test_history_counter.py tests/test_glyph_history_windowing.py tests/test_kahan_sum.py tests/test_list_mean.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c88612d5508321a27f5e79d3c15b98