### PR TITLE
Centralize graph helpers in graph_utils

### DIFF
--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -11,10 +11,10 @@ from functools import lru_cache
 
 from .constants import get_aliases
 from .alias import get_attr
+from .graph_utils import get_graph_mapping
 from .helpers import (
     node_set_checksum,
     edge_version_cache,
-    get_graph_mapping,
 )
 from .json_utils import json_dumps
 from .logging_utils import get_logger

--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -1,12 +1,55 @@
 """Utilities for graph-level bookkeeping.
 
-Currently includes helpers to invalidate cached ΔNFR preparation data.
+This module centralises helpers that operate on the metadata stored inside
+graph objects.  Besides flagging ΔNFR preparation caches it also exposes
+lightweight adapters to obtain the canonical ``graph`` mapping and to read
+validated configuration dictionaries.
 """
 
 from __future__ import annotations
-from typing import Any
 
-__all__ = ("mark_dnfr_prep_dirty", "supports_add_edge")
+import warnings
+from types import MappingProxyType
+from typing import Any, Mapping
+
+__all__ = (
+    "get_graph",
+    "get_graph_mapping",
+    "mark_dnfr_prep_dirty",
+    "supports_add_edge",
+)
+
+
+def get_graph(obj: Any) -> Any:
+    """Return ``obj.graph`` when present or ``obj`` otherwise."""
+
+    return getattr(obj, "graph", obj)
+
+
+def get_graph_mapping(
+    G: Any, key: str, warn_msg: str
+) -> Mapping[str, Any] | None:
+    """Return an immutable view of ``G``'s stored mapping for ``key``.
+
+    The helper normalises access to ``G.graph[key]`` by returning
+    ``None`` when the key is missing or holds a non-mapping value.  When a
+    mapping is found it is wrapped in :class:`types.MappingProxyType` to guard
+    against accidental mutation.  ``warn_msg`` is emitted via
+    :func:`warnings.warn` when the stored value is not a mapping.
+    """
+
+    graph = get_graph(G)
+    getter = getattr(graph, "get", None)
+    if getter is None:
+        return None
+
+    data = getter(key)
+    if data is None:
+        return None
+    if not isinstance(data, Mapping):
+        warnings.warn(warn_msg, UserWarning, stacklevel=2)
+        return None
+    return MappingProxyType(data)
 
 
 def mark_dnfr_prep_dirty(G: Any) -> None:
@@ -23,8 +66,6 @@ def mark_dnfr_prep_dirty(G: Any) -> None:
     None
         This function mutates ``G`` in place.
     """
-    from .helpers import get_graph
-
     graph = get_graph(G)
     graph["_dnfr_prep_dirty"] = True
 

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -15,7 +15,7 @@ from ..glyph_history import (
     push_glyph,
     recent_glyph,
 )
-from ..graph_utils import mark_dnfr_prep_dirty
+from ..graph_utils import get_graph, get_graph_mapping, mark_dnfr_prep_dirty
 
 from .edge_cache import (
     EdgeCacheManager,
@@ -28,8 +28,6 @@ from .node_cache import (
     cached_node_list,
     ensure_node_index_map,
     ensure_node_offset_map,
-    get_graph,
-    get_graph_mapping,
     node_set_checksum,
     stable_json,
 )

--- a/src/tnfr/helpers/node_cache.py
+++ b/src/tnfr/helpers/node_cache.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import hashlib
-import warnings
 from dataclasses import dataclass
 from functools import lru_cache
-from types import MappingProxyType
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable
 
 import networkx as nx  # type: ignore[import-untyped]
 
+from ..graph_utils import get_graph, get_graph_mapping
 from ..json_utils import json_dumps
 from ..logging_utils import get_logger
 
@@ -27,30 +26,6 @@ __all__ = (
     "ensure_node_index_map",
     "ensure_node_offset_map",
 )
-
-
-def get_graph(obj: Any) -> Any:
-    """Return ``obj.graph`` if available or ``obj`` otherwise."""
-    return getattr(obj, "graph", obj)
-
-
-def get_graph_mapping(
-    G: Any, key: str, warn_msg: str
-) -> Mapping[str, Any] | None:
-    """Return an immutable view of ``G.graph[key]`` if it is a mapping.
-
-    The mapping is wrapped in :class:`types.MappingProxyType` to prevent
-    accidental modification. ``warn_msg`` is emitted via :func:`warnings.warn`
-    when the stored value is not a mapping. ``None`` is returned when the key is
-    absent or invalid.
-    """
-    data = G.graph.get(key)
-    if data is None:
-        return None
-    if not isinstance(data, Mapping):
-        warnings.warn(warn_msg, UserWarning, stacklevel=2)
-        return None
-    return MappingProxyType(data)
 
 
 def stable_json(obj: Any) -> str:

--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -10,7 +10,7 @@ from typing import Any, Callable
 
 from cachetools import LRUCache, cached
 from .constants import DEFAULTS, get_param
-from .helpers import get_graph
+from .graph_utils import get_graph
 from .locking import get_lock
 
 MASK64 = 0xFFFFFFFFFFFFFFFF

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable, Mapping
 from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
 from .import_utils import cached_import
-from .helpers import get_graph_mapping
+from .graph_utils import get_graph_mapping
 from .collections_utils import is_non_string_sequence
 
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Centralized `get_graph` and `get_graph_mapping` within `tnfr.graph_utils`, updated helper exports, and aligned all call sites to the new location while keeping existing APIs intact.


------
https://chatgpt.com/codex/tasks/task_e_68c88b275d388321881704fd7dff1ebd