### PR TITLE
Remove deprecated get_module_logger alias

### DIFF
--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -1,9 +1,7 @@
 """Logging utilities for TNFR.
 
 Centralises creation of module-specific loggers so that all TNFR
-modules share a consistent configuration.  ``get_module_logger`` is
-retained as a lightweight alias to ``get_logger`` for backwards
-compatibility.
+modules share a consistent configuration.
 """
 
 from __future__ import annotations
@@ -13,7 +11,7 @@ import threading
 from collections import OrderedDict
 from typing import Any, Hashable, Mapping
 
-__all__ = ("_configure_root", "get_logger", "get_module_logger", "WarnOnce", "warn_once")
+__all__ = ("_configure_root", "get_logger", "WarnOnce", "warn_once")
 
 _LOGGING_CONFIGURED = False
 
@@ -39,11 +37,6 @@ def get_logger(name: str) -> logging.Logger:
     """Return a module-specific logger."""
     _configure_root()
     return logging.getLogger(name)
-
-
-# Backwards compatibility --------------------------------------------------
-
-get_module_logger = get_logger
 
 
 class WarnOnce:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- remove the unused ``get_module_logger`` alias from the logging utilities and rely on ``get_logger`` exclusively
- adjust the module exports and documentation to reflect the single supported accessor


------
https://chatgpt.com/codex/tasks/task_e_68c892d0ebfc832183f5a3c061a08745