### PR TITLE
Remove legacy std_* observer exports

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -25,9 +25,6 @@ ALIAS_THETA = get_aliases("THETA")
 
 __all__ = (
     "attach_standard_observer",
-    "std_before",
-    "std_after",
-    "std_on_remesh",
     "kuramoto_metrics",
     "phase_sync",
     "kuramoto_order",
@@ -54,11 +51,6 @@ _STD_CALLBACKS = {
     "after_step": partial(_std_log, "after"),
     "on_remesh": partial(_std_log, "remesh"),
 }
-
-# alias conservados por compatibilidad
-std_before = _STD_CALLBACKS["before_step"]
-std_after = _STD_CALLBACKS["after_step"]
-std_on_remesh = _STD_CALLBACKS["on_remesh"]
 
 
 def attach_standard_observer(G):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

### Summary
- Removed the deprecated `std_before`, `std_after`, and `std_on_remesh` aliases from `tnfr.observers` to keep the public API focused on the canonical callbacks.
- Updated `__all__` accordingly so only the supported observer helpers remain exported.
- Verified no internal modules or tests import the removed names.

### Testing
- `pytest`
- `pytest tests/test_observers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c892effb9483218a8a19e86ddd5c4b