### PR TITLE
Consolidate caching utilities into shared module

### DIFF
--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -15,9 +15,8 @@ from ..glyph_history import (
     push_glyph,
     recent_glyph,
 )
+from ..cache import node_set_checksum, stable_json
 from ..graph_utils import get_graph, get_graph_mapping, mark_dnfr_prep_dirty
-
-from .cache_utils import node_set_checksum, stable_json
 from .edge_cache import (
     EdgeCacheManager,
     cached_nodes_and_A,

--- a/src/tnfr/helpers/node_cache.py
+++ b/src/tnfr/helpers/node_cache.py
@@ -5,14 +5,14 @@ from typing import Any
 
 import networkx as nx  # type: ignore[import-untyped]
 
-from ..graph_utils import get_graph, get_graph_mapping
-from .cache_utils import (
+from ..cache import (
     NODE_SET_CHECKSUM_KEY,
-    node_set_checksum,
-    stable_json,
     _node_repr,
     _node_repr_digest,
+    node_set_checksum,
+    stable_json,
 )
+from ..graph_utils import get_graph, get_graph_mapping
 
 __all__ = (
     "NODE_SET_CHECKSUM_KEY",

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -2,7 +2,7 @@ import hashlib
 import timeit
 from unittest.mock import patch
 
-from tnfr.helpers.cache_utils import (
+from tnfr.cache import (
     NODE_SET_CHECKSUM_KEY,
     node_set_checksum,
     stable_json,

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from tnfr.helpers.cache_utils import stable_json
+from tnfr.cache import stable_json
 from .utils import clear_orjson_cache
 
 


### PR DESCRIPTION
## Summary
- introduce `tnfr.cache` to host shared checksum, locking, and cache manager helpers
- refactor edge and node cache helpers to use the shared API and drop redundant utilities
- update exports and tests to point at the consolidated cache module

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c892ffec78832195904a66362082f6