### PR TITLE
Remove unused logger from numeric helpers

### DIFF
--- a/src/tnfr/graph_utils.py
+++ b/src/tnfr/graph_utils.py
@@ -22,7 +22,6 @@ __all__ = (
 
 def get_graph(obj: Any) -> Any:
     """Return ``obj.graph`` when present or ``obj`` otherwise."""
-
     return getattr(obj, "graph", obj)
 
 
@@ -37,7 +36,6 @@ def get_graph_mapping(
     against accidental mutation.  ``warn_msg`` is emitted via
     :func:`warnings.warn` when the stored value is not a mapping.
     """
-
     graph = get_graph(G)
     getter = getattr(graph, "get", None)
     if getter is None:

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -9,9 +9,6 @@ import math
 
 from ..import_utils import get_numpy
 from ..alias import get_attr
-from ..logging_utils import get_logger
-
-logger = get_logger(__name__)
 
 _TRIG_MODULE = None
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Removed the unused logger dependency from the numeric helpers module and tidied graph utility docstrings to satisfy the repository linting profile.

------
https://chatgpt.com/codex/tasks/task_e_68c892a78698832180a21f8835839571