### PR TITLE
Remove unused get_logger references in dynamics and sense modules

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -46,8 +46,6 @@ from ..selector import (
     _apply_selector_hysteresis,
 )
 
-from ..logging_utils import get_logger
-
 from .sampling import update_node_sample as _update_node_sample
 from .dnfr import (
     _prepare_dnfr_data,
@@ -75,8 +73,6 @@ ALIAS_EPI = get_aliases("EPI")
 ALIAS_SI = get_aliases("SI")
 ALIAS_D2EPI = get_aliases("D2EPI")
 ALIAS_DSI = get_aliases("DSI")
-
-logger = get_logger(__name__)
 
 __all__ = (
     "default_compute_delta_nfr",

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -26,10 +26,6 @@ from ..alias import (
 from ..metrics.trig_cache import compute_theta_trig
 from ..metrics.common import merge_and_normalize_weights
 from ..import_utils import get_numpy
-from ..logging_utils import get_logger
-
-logger = get_logger(__name__)
-
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -24,13 +24,9 @@ from .constants_glyphs import (
     ANGLE_MAP,
     GLYPHS_CANONICAL,
 )
-from .logging_utils import get_logger
-
 # -------------------------
 # Canon: orden circular de glyphs y ángulos
 # -------------------------
-
-logger = get_logger(__name__)
 
 GLYPH_UNITS: dict[str, complex] = {
     g: complex(math.cos(a), math.sin(a)) for g, a in ANGLE_MAP.items()


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Remove unused `get_logger` imports and cached logger instances from `dynamics.dnfr`, `dynamics.__init__`, and `sense` so logging is only resolved when actually emitting events.

## Testing
- `pytest tests/test_sense.py`
- `pytest tests/test_dnfr_cache.py tests/test_dnfr_precompute.py tests/test_dynamics_helpers.py tests/test_dynamics_vectorized.py tests/test_integrators.py`
- Attempted full `pytest` run; interrupted after ~10 minutes (42 tests passed) due to suite duration.


------
https://chatgpt.com/codex/tasks/task_e_68c892c1ea2c8321aac20df15527ae0b