### PR TITLE
Refactor CLI history tests for run/sequence parity

### DIFF
--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -1,95 +1,79 @@
 """Pruebas de cli history."""
 
-from tnfr.cli import main, _save_json
-import json
 from collections import deque
+import json
+
+import pytest
+
+from tnfr.cli import _save_json, main
 
 
-def test_cli_run_save_history(tmp_path):
+def _cli_args(command, *extra):
+    base = {
+        "run": ["run", "--nodes", "5", "--steps", "0"],
+        "sequence": ["sequence", "--nodes", "5"],
+    }.get(command)
+    if base is None:
+        raise ValueError(f"Unsupported command: {command!r}")
+    return base + list(extra)
+
+
+@pytest.mark.parametrize("command", ["run", "sequence"])
+def test_cli_save_history(tmp_path, command):
     path = tmp_path / "non" / "existing" / "hist.json"
     assert not path.parent.exists()
-    rc = main(
-        ["run", "--nodes", "5", "--steps", "0", "--save-history", str(path)]
-    )
+    rc = main(_cli_args(command, "--save-history", str(path)))
     assert rc == 0
     data = json.loads(path.read_text())
     assert isinstance(data, dict)
-    assert len(data["C_steps"]) == 1
+    assert "C_steps" in data
+    assert len(data["C_steps"]) >= 1
+    if command == "run":
+        assert len(data["C_steps"]) == 1
 
 
-def test_cli_run_export_metrics(tmp_path):
+@pytest.mark.parametrize("command", ["run", "sequence"])
+def test_cli_export_history(tmp_path, command):
     base = tmp_path / "other" / "history"
     assert not base.parent.exists()
-    rc = main(
-        [
-            "run",
-            "--nodes",
-            "5",
-            "--steps",
-            "0",
-            "--export-history-base",
-            str(base),
-        ]
-    )
+    rc = main(_cli_args(command, "--export-history-base", str(base)))
     assert rc == 0
-    data = json.loads((base.with_suffix(".json")).read_text())
+    data = json.loads(base.with_suffix(".json").read_text())
     assert isinstance(data, dict)
-    assert len(data["glyphogram"]["t"]) == 1
+    glyphogram = data["glyphogram"]
+    assert "t" in glyphogram
+    assert len(glyphogram["t"]) >= 1
+    if command == "run":
+        assert len(glyphogram["t"]) == 1
 
 
-def test_cli_run_save_and_export_metrics(tmp_path):
+def test_cli_run_save_and_export_history(tmp_path):
     save_path = tmp_path / "hist.json"
     export_base = tmp_path / "history"
     rc = main(
-        [
+        _cli_args(
             "run",
-            "--nodes",
-            "5",
-            "--steps",
-            "0",
             "--save-history",
             str(save_path),
             "--export-history-base",
             str(export_base),
-        ]
+        )
     )
     assert rc == 0
     data_save = json.loads(save_path.read_text())
-    data_export = json.loads((export_base.with_suffix(".json")).read_text())
+    data_export = json.loads(export_base.with_suffix(".json").read_text())
     assert isinstance(data_save, dict)
     assert isinstance(data_export, dict)
     assert len(data_save["C_steps"]) == 1
-    assert len(data_export["glyphogram"]["t"]) == 1
+    glyphogram = data_export["glyphogram"]
+    assert "t" in glyphogram
+    assert len(glyphogram["t"]) == 1
 
 
-def test_cli_sequence_save_history(tmp_path):
-    path = tmp_path / "non" / "existing" / "hist.json"
-    assert not path.parent.exists()
-    rc = main(["sequence", "--nodes", "5", "--save-history", str(path)])
-    assert rc == 0
-    data = json.loads(path.read_text())
-    assert isinstance(data, dict)
-
-
-def test_cli_sequence_export_metrics(tmp_path):
-    base = tmp_path / "other" / "history"
-    assert not base.parent.exists()
-    rc = main(["sequence", "--nodes", "5", "--export-history-base", str(base)])
-    assert rc == 0
-    data = json.loads((base.with_suffix(".json")).read_text())
-    assert isinstance(data, dict)
-
-
-def test_cli_run_no_history_args(tmp_path, monkeypatch):
+@pytest.mark.parametrize("command", ["run", "sequence"])
+def test_cli_without_history_args(tmp_path, monkeypatch, command):
     monkeypatch.chdir(tmp_path)
-    rc = main(["run", "--nodes", "5", "--steps", "0"])
-    assert rc == 0
-    assert not any(tmp_path.iterdir())
-
-
-def test_cli_sequence_no_history_args(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    rc = main(["sequence", "--nodes", "5"])
+    rc = main(_cli_args(command))
     assert rc == 0
     assert not any(tmp_path.iterdir())
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Parameterized the history CLI tests to reuse a shared argument builder and cover both `run` and `sequence` flows without duplication.
- Reinforced expectations on saved and exported history payloads to assert presence of coherence series while keeping flexibility for sequence defaults.
- Retained the sanity CLI suite focused on general command coverage by isolating history-specific checks in the dedicated module.

## Testing
- PYTHONPATH=src pytest tests/test_cli_history.py tests/test_cli_sanity.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a1bb5d588321ade056b87e1904d6