### PR TITLE
Refine optional parser fallbacks via cached_import

### DIFF
--- a/tests/test_missing_dependency_error_cache.py
+++ b/tests/test_missing_dependency_error_cache.py
@@ -1,11 +1,13 @@
-from tnfr.io import _missing_dependency_error
+from tnfr.io import _MISSING_TOML_ERROR, _MISSING_YAML_ERROR
 
 
 def test_missing_dependency_error_cached() -> None:
-    cls1 = _missing_dependency_error("fake_dep")
-    cls2 = _missing_dependency_error("fake_dep")
-    assert cls1 is cls2
-    assert issubclass(cls1, Exception)
-    assert cls1.__doc__ == "Fallback error used when fake_dep is missing."
-    cls3 = _missing_dependency_error("other_dep")
-    assert cls3 is not cls1
+    assert issubclass(_MISSING_TOML_ERROR, Exception)
+    assert (
+        _MISSING_TOML_ERROR.__doc__
+        == "Fallback error used when tomllib/tomli is missing."
+    )
+    assert issubclass(_MISSING_YAML_ERROR, Exception)
+    assert _MISSING_YAML_ERROR.__doc__ == (
+        "Fallback error used when pyyaml is missing."
+    )

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -90,9 +90,7 @@ def test_read_structured_file_missing_dependency(
     def fake_safe_load(_: str) -> None:
         raise ImportError("pyyaml is not installed")
 
-    monkeypatch.setattr(
-        io_mod, "yaml", type("Y", (), {"safe_load": fake_safe_load})
-    )
+    monkeypatch.setattr(io_mod, "_YAML_SAFE_LOAD", fake_safe_load)
 
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
@@ -111,9 +109,7 @@ def test_read_structured_file_missing_dependency_toml(
     def fake_loads(_: str) -> None:
         raise ImportError("toml is not installed")
 
-    monkeypatch.setattr(
-        io_mod, "tomllib", type("T", (), {"loads": fake_loads})
-    )
+    monkeypatch.setattr(io_mod, "_TOML_LOADS", fake_loads)
 
     with pytest.raises(StructuredFileError) as excinfo:
         read_structured_file(path)
@@ -168,6 +164,14 @@ def test_read_structured_file_ignores_missing_yaml_when_parsing_json(
 ):
     path = tmp_path / "data.json"
     path.write_text('{"a": 1}', encoding="utf-8")
+    def missing_yaml(*_: object, **__: object) -> None:
+        raise ImportError("pyyaml is not installed")
+
+    def missing_toml(*_: object, **__: object) -> None:
+        raise ImportError("toml is not installed")
+
+    monkeypatch.setattr(io_mod, "_YAML_SAFE_LOAD", missing_yaml)
+    monkeypatch.setattr(io_mod, "_TOML_LOADS", missing_toml)
     monkeypatch.setattr(io_mod, "yaml", None)
     monkeypatch.setattr(io_mod, "tomllib", None)
     assert read_structured_file(path) == {"a": 1}


### PR DESCRIPTION
## Summary
- route YAML and TOML parsing through cached_import with explicit fallbacks and logging
- expose dedicated fallback error classes for missing parser dependencies
- update structured file error coverage to exercise the new cached_import paths

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c8a455959483218082413d8f0a3a4d