### PR TITLE
Centralizar caché de jitter en rng y simplificar operador

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,14 +248,14 @@ from tnfr.operators import get_jitter_manager
 manager = get_jitter_manager()
 # Resize cache to keep only 512 entries
 manager.max_entries = 512
-manager.setup(force=True)
 
-# or in a single call
+# or in a single call that also clears previous counters
 manager.setup(max_entries=512)
 ```
 
 ``setup`` preserves the current size unless a new ``max_entries`` value is
-supplied. Custom sizes persist across subsequent ``setup`` calls.
+supplied. Custom sizes persist across subsequent ``setup`` calls, and
+``max_entries`` assignments take effect immediately.
 
 ### Edge version tracking
 

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -25,7 +25,6 @@ from .jitter import (
     get_jitter_manager,
     reset_jitter_manager,
     random_jitter,
-    _get_jitter_cache,
 )
 from .remesh import (
     apply_network_remesh,
@@ -44,7 +43,6 @@ __all__ = [
     "get_jitter_manager",
     "reset_jitter_manager",
     "random_jitter",
-    "_get_jitter_cache",
     "get_neighbor_epi",
     "get_glyph_factors",
     "GLYPH_OPERATIONS",


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c8a796a48083218fa870f2491ebc7b