### PR TITLE
Use public step function in step cache tests

### DIFF
--- a/tests/test_program_step_cache.py
+++ b/tests/test_program_step_cache.py
@@ -1,7 +1,6 @@
 import threading
 import tnfr.dynamics as dyn
 import tnfr.program as program
-from tnfr.program import _advance
 
 
 def test_advance_caches_step(monkeypatch, graph_canon):
@@ -18,10 +17,10 @@ def test_advance_caches_step(monkeypatch, graph_canon):
     monkeypatch.setattr(dyn, "step", first_step)
     program.get_step_fn.cache_clear()
     step_fn = program.get_step_fn()
-    _advance(G, step_fn)
+    step_fn(G)
     monkeypatch.setattr(dyn, "step", second_step)
     step_fn = program.get_step_fn()
-    _advance(G, step_fn)
+    step_fn(G)
     assert calls == [1, 1]
     program.get_step_fn.cache_clear()
 
@@ -44,7 +43,7 @@ def test_advance_thread_safe(monkeypatch, graph_canon):
 
     def worker():
         barrier.wait()
-        _advance(G, program.get_step_fn())
+        program.get_step_fn()(G)
 
     threads = [threading.Thread(target=worker) for _ in range(5)]
     for t in threads:
@@ -53,7 +52,7 @@ def test_advance_thread_safe(monkeypatch, graph_canon):
         t.join()
 
     monkeypatch.setattr(dyn, "step", second_step)
-    _advance(G, program.get_step_fn())
+    program.get_step_fn()(G)
 
     assert calls == [1] * 6
     program.get_step_fn.cache_clear()


### PR DESCRIPTION
## Summary
- replace the private `_advance` helper in the program step cache tests with calls to the cached public step function
- drop the private import so the test exercises only the public API surface

## Testing
- pytest tests/test_program_step_cache.py


------
https://chatgpt.com/codex/tasks/task_e_68c8a9d9a10883219f559304e9bc3e51