### PR TITLE
Refactor nodal integrator helpers

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -63,7 +63,6 @@ from .dnfr import (
 from .integrators import (
     prepare_integration_params,
     update_epi_via_nodal_equation,
-    integrar_epi_euler,
 )
 
 ALIAS_VF = get_aliases("VF")
@@ -83,7 +82,6 @@ __all__ = (
     "prepare_integration_params",
     "update_epi_via_nodal_equation",
     "apply_dnfr_field",
-    "integrar_epi_euler",
     "apply_canonical_clamps",
     "validate_canon",
     "coordinate_global_local_phase",

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -6,7 +6,7 @@ import pytest
 import networkx as nx
 from tnfr.constants import inject_defaults
 from tnfr.initialization import init_node_attrs
-from tnfr.dynamics import step
+from tnfr.dynamics import update_epi_via_nodal_equation, validate_canon
 
 
 @pytest.mark.parametrize("method", ["euler", "rk4"])
@@ -25,9 +25,9 @@ def test_epi_limits_preserved(method):
             nd["νf"] = 1.0
             nd["EPI"] = 0.0
 
-    G.graph["compute_delta_nfr"] = const_dnfr
-
-    step(G, dt=1.0)
+    const_dnfr(G)
+    update_epi_via_nodal_equation(G, dt=1.0, method=method)
+    validate_canon(G)
 
     e_min = G.graph["EPI_MIN"]
     e_max = G.graph["EPI_MAX"]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Consolidated nodal increment assembly for Euler and RK4 integration, removed the redundant `integrar_epi_euler` wrapper, and updated integrator-focused tests to exercise `update_epi_via_nodal_equation` directly.


------
https://chatgpt.com/codex/tasks/task_e_68c8acfc85e083219a929ef5170004d3