### PR TITLE
Adjust json_dumps parameter handling and warnings

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,7 @@ import tnfr.json_utils as json_utils
 
 
 def clear_orjson_cache() -> None:
-    """Clear cached :mod:`orjson` module and warning state."""
-    json_utils._warn_orjson_params_once.clear()
+    """Clear cached :mod:`orjson` module."""
     cache_clear = getattr(json_utils.cached_import, "cache_clear", None)
     if cache_clear:
         cache_clear()


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Replace the one-time warning helper with direct warnings whenever orjson ignores unsupported arguments.
- Introduce a `JsonDumpsParams` dataclass to hold serialization options and streamline parameter handling.
- Update JSON utility tests to reflect the simplified warning behavior and new parameter container.

## Testing
- pytest tests/test_json_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68c8ad0eb60483218be08bdc1ace4950