### PR TITLE
Refactor gamma increment staging for integrators

### DIFF
--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -7,6 +7,7 @@ import networkx as nx
 from tnfr.constants import inject_defaults
 from tnfr.initialization import init_node_attrs
 from tnfr.dynamics import update_epi_via_nodal_equation, validate_canon
+from tnfr.dynamics import integrators as integrators_mod
 
 
 @pytest.mark.parametrize("method", ["euler", "rk4"])
@@ -38,3 +39,39 @@ def test_epi_limits_preserved(method):
         else:
             assert epi == pytest.approx(e_min)
         assert e_min - 1e-6 <= epi <= e_max + 1e-6
+
+
+@pytest.mark.parametrize("method", ["euler", "rk4"])
+def test_update_epi_uses_shared_gamma_builder(method, monkeypatch):
+    G = nx.path_graph(3)
+    inject_defaults(G)
+    init_node_attrs(G, override=True)
+    G.graph["DT_MIN"] = 0.2
+    G.graph["GAMMA"] = {"type": "none"}
+
+    def const_dnfr(G):
+        for nd in G.nodes.values():
+            nd["ΔNFR"] = 1.0
+            nd["νf"] = 1.0
+
+    const_dnfr(G)
+
+    original_builder = integrators_mod._build_gamma_increments
+    calls: list[tuple[float, float, str]] = []
+
+    def spy_builder(G_arg, dt_step_arg, t_local_arg, *, method: str):
+        calls.append((dt_step_arg, t_local_arg, method))
+        return original_builder(G_arg, dt_step_arg, t_local_arg, method=method)
+
+    monkeypatch.setattr(
+        integrators_mod,
+        "_build_gamma_increments",
+        spy_builder,
+    )
+
+    update_epi_via_nodal_equation(G, dt=0.6, method=method)
+
+    assert len(calls) == 3
+    assert all(call_method == method for _, _, call_method in calls)
+    assert all(dt_step == pytest.approx(0.2) for dt_step, _, _ in calls)
+    assert [t_local for _, t_local, _ in calls] == pytest.approx([0.0, 0.2, 0.4])


### PR DESCRIPTION
## Summary
- add `_build_gamma_increments` to stage Γ contributions with the node base increments once per integration step
- update the Euler and RK4 paths to call the shared helper so both methods reuse the same staging logic
- extend integrator tests with a spy that proves the shared helper is invoked for each sub-step

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c8aeccbaa08321a355b9174874f0a3