### PR TITLE
Inline neighbour means and drop helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ when orchestrating TNFR experiments.
   scalars, ``dims=2`` for paired values, etc.).
 * ``angle_diff(a, b)`` — compute minimal angular differences (radians) to
   compare structural phases.
-* ``neighbor_mean(G, n, aliases, default=0.0)`` — obtain the mean value of an
-  attribute among the neighbours of ``n`` leveraging cached graph aliases.
 
 ### Glyph history helpers
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from collections import deque
 from operator import itemgetter
+from statistics import StatisticsError, fmean
 from typing import Any
 
 # Importar compute_Si y apply_glyph a nivel de módulo evita el coste de
@@ -24,7 +25,6 @@ from ..helpers.numeric import (
     clamp,
     clamp01,
     angle_diff,
-    neighbor_mean,
 )
 from ..metrics.trig import neighbor_phase_mean
 from ..alias import (
@@ -318,7 +318,12 @@ def adapt_vf_by_coherence(G) -> None:
 
         if nd["stable_count"] >= tau:
             vf = get_attr(nd, ALIAS_VF, 0.0)
-            vf_bar = neighbor_mean(G, n, ALIAS_VF, default=vf)
+            try:
+                vf_bar = fmean(
+                    get_attr(G.nodes[v], ALIAS_VF, vf) for v in G.neighbors(n)
+                )
+            except StatisticsError:
+                vf_bar = float(vf)
             updates[n] = vf + mu * (vf_bar - vf)
 
     for n, vf_new in updates.items():

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -30,7 +30,6 @@ from .numeric import (
     clamp,
     clamp01,
     kahan_sum_nd,
-    neighbor_mean,
 )
 
 __all__ = (
@@ -53,7 +52,6 @@ __all__ = (
     "kahan_sum_nd",
     "last_glyph",
     "mark_dnfr_prep_dirty",
-    "neighbor_mean",
     "node_set_checksum",
     "push_glyph",
     "recent_glyph",

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 from collections.abc import Iterable, Sequence
-from statistics import fmean, StatisticsError
 import math
-
-from ..alias import get_attr
 
 _TRIG_MODULE = None
 
@@ -28,7 +25,6 @@ __all__ = (
     "within_range",
     "kahan_sum_nd",
     "angle_diff",
-    "neighbor_mean",
 )
 
 
@@ -103,16 +99,6 @@ def angle_diff(a: float, b: float) -> float:
     """Return the minimal difference between two angles in radians."""
     return (float(a) - float(b) + math.pi) % math.tau - math.pi
 
-
-def neighbor_mean(
-    G, n, aliases: tuple[str, ...], default: float = 0.0
-) -> float:
-    """Mean of ``aliases`` attribute among neighbours of ``n``."""
-    vals = (get_attr(G.nodes[v], aliases, default) for v in G.neighbors(n))
-    try:
-        return fmean(vals)
-    except StatisticsError:
-        return float(default)
 
 def _phase_mean_from_iter(
     it: Iterable[tuple[float, float] | None], fallback: float

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -9,13 +9,11 @@ from statistics import fmean, StatisticsError
 
 from ..constants import DEFAULTS, get_aliases, get_param
 
-from ..helpers.numeric import (
-    angle_diff,
-    neighbor_mean,
-)
+from ..helpers.numeric import angle_diff
 from ..metrics.trig import neighbor_phase_mean
 from ..import_utils import get_nodonx
 from ..rng import make_rng
+from ..alias import get_attr
 from tnfr import glyph_history
 from ..types import Glyph
 
@@ -92,7 +90,12 @@ def get_neighbor_epi(node: NodoProtocol) -> tuple[list[NodoProtocol], float]:
     if hasattr(node, "G"):
         if not _any_neighbor_has(node, ALIAS_EPI):
             return [], epi
-        epi_bar = neighbor_mean(node.G, node.n, ALIAS_EPI, default=epi)
+        try:
+            epi_bar = fmean(
+                get_attr(node.G.nodes[v], ALIAS_EPI, epi) for v in neigh
+            )
+        except StatisticsError:
+            epi_bar = float(epi)
         NodoNX = get_nodonx()
         if NodoNX is None:
             raise ImportError("NodoNX is unavailable")

--- a/tests/test_numeric_helpers.py
+++ b/tests/test_numeric_helpers.py
@@ -1,29 +1,7 @@
 import networkx as nx  # type: ignore[import-untyped]
 import pytest
 
-from tnfr.helpers.numeric import neighbor_mean
 from tnfr.observers import phase_sync
-
-
-def test_neighbor_mean_returns_default_when_no_neighbors():
-    G = nx.Graph()
-    G.add_node(0)
-
-    assert neighbor_mean(G, 0, ("EPI",), default=2.5) == pytest.approx(2.5)
-
-
-def test_neighbor_mean_averages_existing_values():
-    G = nx.Graph()
-    G.add_nodes_from(
-        (
-            (0, {}),
-            (1, {"EPI": 1.0}),
-            (2, {"EPI": 3.0}),
-        )
-    )
-    G.add_edges_from(((0, 1), (0, 2)))
-
-    assert neighbor_mean(G, 0, ("EPI",), default=0.0) == pytest.approx(2.0)
 
 
 def test_phase_sync_statistics_fallback(monkeypatch):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Remove the shared `neighbor_mean` helper and stop re-exporting it from the helpers package.
- Inline guarded `fmean` calls for neighbour averages inside DNFR hooks, VF adaptation, and operator utilities.
- Update public docs and tests to reflect the inlined averaging strategy.


------
https://chatgpt.com/codex/tasks/task_e_68c8ad5bfc7883219bfd0da845bf2295