### PR TITLE
Streamline CLI test coverage

### DIFF
--- a/tests/integration/test_cli_end_to_end.py
+++ b/tests/integration/test_cli_end_to_end.py
@@ -1,0 +1,35 @@
+"""Pruebas de integración para los comandos de la CLI."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tnfr.cli import main
+
+
+pytestmark = pytest.mark.slow
+
+
+def test_metrics_command_generates_output(tmp_path):
+    out = tmp_path / "metrics.json"
+    rc = main(["metrics", "--nodes", "6", "--steps", "10", "--save", str(out)])
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert "Tg_global" in data
+    assert "latency_mean" in data
+
+
+def test_sequence_command_with_file(tmp_path):
+    seq_file = tmp_path / "seq.json"
+    seq_file.write_text('[{"WAIT": 1}]', encoding="utf-8")
+    rc = main(["sequence", "--sequence-file", str(seq_file), "--nodes", "5"])
+    assert rc == 0
+
+
+def test_run_command_reports_summary(capsys):
+    rc = main(["run", "--nodes", "5", "--steps", "1", "--summary"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Tg global" in out

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -1,7 +1,10 @@
 """Pruebas de cli sanity."""
 
 from __future__ import annotations
+
 import argparse
+from unittest import mock
+
 from tnfr.cli import (
     main,
     add_common_args,
@@ -11,26 +14,74 @@ from tnfr.cli import (
 )
 from tnfr.cli.arguments import GRAMMAR_ARG_SPECS
 from tnfr.constants import METRIC_DEFAULTS
-from tnfr.io import read_structured_file
 from tnfr import __version__
 
 
-def test_cli_metrics_runs(tmp_path):
-    out = tmp_path / "m.json"
-    rc = main(
-        ["metrics", "--nodes", "10", "--steps", "50", "--save", str(out)]
-    )
+def test_cli_metrics_collects_and_saves_metrics(tmp_path):
+    """El subcomando metrics delega en la ejecución y persiste los datos."""
+
+    sentinel_graph = object()
+    save_path = tmp_path / "m.json"
+
+    with (
+        mock.patch(
+            "tnfr.cli.execution.run_program", return_value=sentinel_graph
+        ) as run_program,
+        mock.patch("tnfr.cli.execution.Tg_global", return_value=0.5),
+        mock.patch(
+            "tnfr.cli.execution.latency_series", return_value={"value": [2.0]}
+        ),
+        mock.patch("tnfr.cli.execution.sigma_rose", return_value={"rose": 1}),
+        mock.patch(
+            "tnfr.cli.execution.glyphogram_series",
+            return_value={"glyph": list(range(3))},
+        ),
+        mock.patch("tnfr.cli.execution._save_json") as save_json,
+    ):
+        rc = main(
+            ["metrics", "--nodes", "10", "--steps", "50", "--save", str(save_path)]
+        )
+
     assert rc == 0
-    data = read_structured_file(out)
-    assert "Tg_global" in data
-    assert "latency_mean" in data
+    run_program.assert_called_once()
+    run_args = run_program.call_args.args
+    assert run_args[0] is None
+    assert run_args[1] is None
+    parsed_args = run_args[2]
+    assert parsed_args.nodes == 10
+    assert parsed_args.steps == 50
+    save_json.assert_called_once()
+    assert save_json.call_args.args[0] == str(save_path)
+    payload = save_json.call_args.args[1]
+    assert payload["Tg_global"] == 0.5
+    assert payload["latency_mean"] == 2.0
+    assert payload["rose"] == {"rose": 1}
+    assert payload["glyphogram"] == {"glyph": [0, 1, 2]}
 
 
-def test_cli_sequence_file(tmp_path):
+def test_cli_sequence_file_uses_loaded_program(tmp_path):
+    """El comando sequence usa la secuencia cargada sin ejecutar la engine real."""
+
     seq_file = tmp_path / "seq.json"
-    seq_file.write_text('[{"WAIT": 1}]', encoding="utf-8")
-    rc = main(["sequence", "--sequence-file", str(seq_file), "--nodes", "5"])
+    sentinel_program = object()
+
+    with (
+        mock.patch(
+            "tnfr.cli.execution._load_sequence",
+            return_value=sentinel_program,
+        ) as load_sequence,
+        mock.patch("tnfr.cli.execution.run_program") as run_program,
+    ):
+        rc = main(["sequence", "--sequence-file", str(seq_file), "--nodes", "5"])
+
     assert rc == 0
+    load_sequence.assert_called_once()
+    loaded_path = load_sequence.call_args.args[0]
+    assert str(loaded_path) == str(seq_file)
+    run_program.assert_called_once()
+    run_args = run_program.call_args.args
+    assert run_args[0] is None
+    assert run_args[1] is sentinel_program
 
 
 def test_cli_version(capsys):
@@ -40,28 +91,45 @@ def test_cli_version(capsys):
     assert __version__ in out
 
 
-def test_cli_run_erdos_p():
-    rc = main(
-        [
-            "run",
-            "--topology",
-            "erdos",
-            "--p",
-            "0.9",
-            "--nodes",
-            "5",
-            "--steps",
-            "1",
-        ]
-    )
-    assert rc == 0
+def test_cli_run_passes_args_and_logs_summary():
+    """El subcomando run construye argumentos y solicita el resumen."""
 
+    sentinel_graph = object()
 
-def test_cli_run_summary(capsys):
-    rc = main(["run", "--nodes", "5", "--steps", "1", "--summary"])
+    with (
+        mock.patch(
+            "tnfr.cli.execution.run_program", return_value=sentinel_graph
+        ) as run_program,
+        mock.patch("tnfr.cli.execution._log_run_summaries") as log_summary,
+    ):
+        rc = main(
+            [
+                "run",
+                "--topology",
+                "erdos",
+                "--p",
+                "0.9",
+                "--nodes",
+                "5",
+                "--steps",
+                "1",
+                "--summary",
+            ]
+        )
+
     assert rc == 0
-    out = capsys.readouterr().out
-    assert "Tg global" in out
+    run_program.assert_called_once()
+    run_args = run_program.call_args.args
+    assert run_args[0] is None
+    assert run_args[1] is None
+    parsed_args = run_args[2]
+    assert parsed_args.topology == "erdos"
+    assert parsed_args.p == 0.9
+    assert parsed_args.summary is True
+    log_summary.assert_called_once()
+    log_args = log_summary.call_args.args
+    assert log_args[0] is sentinel_graph
+    assert log_args[1] is parsed_args
 
 
 def test_grammar_args_help_group(capsys):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Convert the CLI "sanity" scenarios into unit tests that patch the engine entry points so they assert argument wiring without running the simulation.
- Add a `tests/integration` suite with the former end-to-end CLI invocations, marked as `slow` so they stay out of the fast unit runs while remaining available.

## Testing
- `pytest tests/test_cli_sanity.py -vv`
- `pytest tests/integration/test_cli_end_to_end.py -vv -m slow`
- `pytest` *(interrupted after covering a subset of the suite; full run remains long-running)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ad3ced6c8321acb3e285e8e690ba