### PR TITLE
Switch WarnOnce to set-backed cache

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -194,7 +194,11 @@ def _convert_and_validate_weights(
         if error_on_negative:
             raise ValueError(NEGATIVE_WEIGHTS_MSG % negatives)
         if warn_once:
-            _log_negative_keys_once(negatives)
+            new_negatives = {
+                key: weight for key, weight in negatives.items() if _log_negative_keys_once.check(key)
+            }
+            if new_negatives:
+                logger.warning(NEGATIVE_WEIGHTS_MSG, new_negatives)
         else:
             logger.warning(NEGATIVE_WEIGHTS_MSG, negatives)
         for key, weight in negatives.items():

--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -66,7 +66,7 @@ def _json_dumps_orjson(
         ignored.update(kwargs)
     if ignored:
         combo = frozenset(ignored)
-        _warn_orjson_params_once({combo: _format_ignored_params(combo)})
+        _warn_orjson_params_once(combo, _format_ignored_params(combo))
 
     option = orjson.OPT_SORT_KEYS if params["sort_keys"] else 0
     data = orjson.dumps(obj, option=option, default=params["default"])


### PR DESCRIPTION
## Summary
- replace `WarnOnce` with a set-backed cache and a `check` helper for keyed suppression
- update `json_utils` and `collections_utils` to pass explicit keys to the warn-once helper
- exercise warn-once flows with the focused pytest targets

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c8ad30fd6c8321a95ca359deb67841