### PR TITLE
Inline neighbour averaging for ΔNFR and operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ when orchestrating TNFR experiments.
   scalars, ``dims=2`` for paired values, etc.).
 * ``angle_diff(a, b)`` — compute minimal angular differences (radians) to
   compare structural phases.
-* ``neighbor_mean(G, n, aliases, default=0.0)`` — obtain the mean value of an
-  attribute among the neighbours of ``n`` leveraging cached graph aliases.
 
 ### Glyph history helpers
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -24,7 +24,6 @@ from ..helpers.numeric import (
     clamp,
     clamp01,
     angle_diff,
-    neighbor_mean,
 )
 from ..metrics.trig import neighbor_phase_mean
 from ..alias import (
@@ -316,7 +315,14 @@ def adapt_vf_by_coherence(G) -> None:
 
         if nd["stable_count"] >= tau:
             vf = get_attr(nd, ALIAS_VF, 0.0)
-            vf_bar = neighbor_mean(G, n, ALIAS_VF, default=vf)
+            neigh = list(G.neighbors(n))
+            if neigh:
+                total = 0.0
+                for v in neigh:
+                    total += float(get_attr(G.nodes[v], ALIAS_VF, vf))
+                vf_bar = total / len(neigh)
+            else:
+                vf_bar = float(vf)
             updates[n] = vf + mu * (vf_bar - vf)
 
     for n, vf_new in updates.items():

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -13,10 +13,7 @@ from typing import Any, Callable
 
 from ..collections_utils import normalize_weights
 from ..constants import DEFAULTS, get_aliases, get_param
-from ..helpers.numeric import (
-    angle_diff,
-    neighbor_mean,
-)
+from ..helpers.numeric import angle_diff
 from ..metrics.trig import neighbor_phase_mean, _phase_mean_from_iter
 from ..helpers import cached_nodes_and_A
 from ..alias import (
@@ -561,12 +558,26 @@ def dnfr_epi_vf_mixed(G) -> None:
 
     def g_epi(G, n, nd):
         epi_i = get_attr(nd, ALIAS_EPI, 0.0)
-        epi_bar = neighbor_mean(G, n, ALIAS_EPI, default=epi_i)
+        neighbors = list(G.neighbors(n))
+        if neighbors:
+            total = 0.0
+            for v in neighbors:
+                total += float(get_attr(G.nodes[v], ALIAS_EPI, epi_i))
+            epi_bar = total / len(neighbors)
+        else:
+            epi_bar = float(epi_i)
         return epi_bar - epi_i
 
     def g_vf(G, n, nd):
         vf_i = get_attr(nd, ALIAS_VF, 0.0)
-        vf_bar = neighbor_mean(G, n, ALIAS_VF, default=vf_i)
+        neighbors = list(G.neighbors(n))
+        if neighbors:
+            total = 0.0
+            for v in neighbors:
+                total += float(get_attr(G.nodes[v], ALIAS_VF, vf_i))
+            vf_bar = total / len(neighbors)
+        else:
+            vf_bar = float(vf_i)
         return vf_bar - vf_i
 
     _apply_dnfr_hook(

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -30,7 +30,6 @@ from .numeric import (
     clamp,
     clamp01,
     kahan_sum_nd,
-    neighbor_mean,
 )
 
 __all__ = (
@@ -53,7 +52,6 @@ __all__ = (
     "kahan_sum_nd",
     "last_glyph",
     "mark_dnfr_prep_dirty",
-    "neighbor_mean",
     "node_set_checksum",
     "push_glyph",
     "recent_glyph",

--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from statistics import fmean, StatisticsError
 import math
-
-from ..alias import get_attr
 
 __all__ = (
     "clamp",
@@ -14,7 +11,6 @@ __all__ = (
     "within_range",
     "kahan_sum_nd",
     "angle_diff",
-    "neighbor_mean",
 )
 
 
@@ -88,15 +84,3 @@ def kahan_sum_nd(
 def angle_diff(a: float, b: float) -> float:
     """Return the minimal difference between two angles in radians."""
     return (float(a) - float(b) + math.pi) % math.tau - math.pi
-
-
-def neighbor_mean(
-    G, n, aliases: tuple[str, ...], default: float = 0.0
-) -> float:
-    """Mean of ``aliases`` attribute among neighbours of ``n``."""
-    vals = (get_attr(G.nodes[v], aliases, default) for v in G.neighbors(n))
-    try:
-        return fmean(vals)
-    except StatisticsError:
-        return float(default)
-

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -7,12 +7,10 @@ import heapq
 from itertools import islice
 from statistics import fmean, StatisticsError
 
+from ..alias import get_attr
 from ..constants import DEFAULTS, get_aliases, get_param
 
-from ..helpers.numeric import (
-    angle_diff,
-    neighbor_mean,
-)
+from ..helpers.numeric import angle_diff
 from ..metrics.trig import neighbor_phase_mean
 from ..import_utils import get_nodonx
 from ..rng import make_rng
@@ -92,7 +90,16 @@ def get_neighbor_epi(node: NodoProtocol) -> tuple[list[NodoProtocol], float]:
     if hasattr(node, "G"):
         if not _any_neighbor_has(node, ALIAS_EPI):
             return [], epi
-        epi_bar = neighbor_mean(node.G, node.n, ALIAS_EPI, default=epi)
+        G = node.G
+        total = 0.0
+        count = 0
+        for v in neigh:
+            if hasattr(v, "EPI"):
+                total += float(v.EPI)
+            else:
+                total += float(get_attr(G.nodes[v], ALIAS_EPI, epi))
+            count += 1
+        epi_bar = total / count if count else float(epi)
         NodoNX = get_nodonx()
         if NodoNX is None:
             raise ImportError("NodoNX is unavailable")

--- a/tests/test_numeric_helpers.py
+++ b/tests/test_numeric_helpers.py
@@ -1,29 +1,7 @@
 import networkx as nx  # type: ignore[import-untyped]
 import pytest
 
-from tnfr.helpers.numeric import neighbor_mean
 from tnfr.observers import phase_sync
-
-
-def test_neighbor_mean_returns_default_when_no_neighbors():
-    G = nx.Graph()
-    G.add_node(0)
-
-    assert neighbor_mean(G, 0, ("EPI",), default=2.5) == pytest.approx(2.5)
-
-
-def test_neighbor_mean_averages_existing_values():
-    G = nx.Graph()
-    G.add_nodes_from(
-        (
-            (0, {}),
-            (1, {"EPI": 1.0}),
-            (2, {"EPI": 3.0}),
-        )
-    )
-    G.add_edges_from(((0, 1), (0, 2)))
-
-    assert neighbor_mean(G, 0, ("EPI",), default=0.0) == pytest.approx(2.0)
 
 
 def test_phase_sync_statistics_fallback(monkeypatch):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c92a76712c8321894bd8a86d427c73