### PR TITLE
Remove global state from negative-weight warnings

### DIFF
--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -4,6 +4,7 @@ import math
 from types import MappingProxyType
 
 import pytest
+from tnfr.collections_utils import negative_weights_warn_once
 from tnfr.collections_utils import normalize_weights
 
 
@@ -48,21 +49,26 @@ def test_normalize_weights_warns_on_non_numeric_value(caplog):
 def test_normalize_weights_warn_once(caplog):
     first_key = "warn-once-key-1"
     weights = {first_key: -1.0}
+    warn_once = negative_weights_warn_once()
     with caplog.at_level("WARNING"):
-        normalize_weights(weights, (first_key,))
+        normalize_weights(weights, (first_key,), warn_once=warn_once)
     assert any("Negative weights" in m for m in caplog.messages)
     caplog.clear()
 
     # second call with same key should not warn
     with caplog.at_level("WARNING"):
-        normalize_weights(weights, (first_key,))
+        normalize_weights(weights, (first_key,), warn_once=warn_once)
     assert not any("Negative weights" in m for m in caplog.messages)
 
     # new keys should still trigger warnings
     caplog.clear()
     second_key = "warn-once-key-2"
     with caplog.at_level("WARNING"):
-        normalize_weights({second_key: -1.0}, (second_key,))
+        normalize_weights(
+            {second_key: -1.0},
+            (second_key,),
+            warn_once=warn_once,
+        )
     assert any("Negative weights" in m for m in caplog.messages)
 
 


### PR DESCRIPTION
Summary:
- remove the module-level warn-once cache by introducing a helper and runtime handler resolution for negative-weight warnings
- extend `normalize_weights`'s `warn_once` parameter to accept callables and document how to reuse warn-once state without globals
- adjust the `normalize_weights` warn-once test to rely on the helper instead of clearing shared state

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68c93241dc8883218a6abf752dc2ce23