### PR TITLE
Deduplicate warn_once handling for logging and JSON helpers

### DIFF
--- a/src/tnfr/json_utils.py
+++ b/src/tnfr/json_utils.py
@@ -14,13 +14,21 @@ import json
 from typing import Any, Callable
 
 from .import_utils import cached_import
-from .logging_utils import get_logger
+from .logging_utils import get_logger, warn_once
 
 _ORJSON_PARAMS_MSG = (
     "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson: %s"
 )
 
 logger = get_logger(__name__)
+
+_warn_ignored_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
+
+
+def clear_orjson_param_warnings() -> None:
+    """Reset cached warnings for ignored :mod:`orjson` parameters."""
+
+    _warn_ignored_params_once.clear()
 
 
 def _format_ignored_params(combo: frozenset[str]) -> str:
@@ -70,7 +78,7 @@ def _json_dumps_orjson(
 
     ignored = _collect_ignored_params(params, kwargs)
     if ignored:
-        logger.warning(_ORJSON_PARAMS_MSG, _format_ignored_params(ignored))
+        _warn_ignored_params_once(ignored, _format_ignored_params(ignored))
 
     option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
     data = orjson.dumps(obj, option=option, default=params.default)

--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections import OrderedDict
 from typing import Any, Hashable, Mapping
 
 __all__ = ("_configure_root", "get_logger", "WarnOnce", "warn_once")
@@ -40,34 +39,66 @@ def get_logger(name: str) -> logging.Logger:
 
 
 class WarnOnce:
-    """Log a message once per unique key.
+    """Log a warning only once for each unique key.
 
-    The callable maintains an LRU set of keys limited by ``maxsize`` using
-    an :class:`collections.OrderedDict` to preserve coherence while avoiding
-    unbounded growth. New keys trigger a warning with their associated
-    values, repeated keys are ignored. ``clear()`` resets the tracked keys,
-    aiding controlled tests.
+    ``WarnOnce`` tracks seen keys in a bounded :class:`set`. When ``maxsize`` is
+    reached an arbitrary key is evicted to keep memory usage stable; ordered
+    eviction is intentionally avoided to keep the implementation lightweight.
+    Instances are callable and accept either a mapping of keys to values or a
+    single key/value pair. Passing ``maxsize <= 0`` disables caching and logs on
+    every invocation.
     """
 
     def __init__(self, logger: logging.Logger, msg: str, *, maxsize: int = 1024) -> None:
         self._logger = logger
         self._msg = msg
         self._maxsize = maxsize
-        self._seen: OrderedDict[Hashable, None] = OrderedDict()
+        self._seen: set[Hashable] = set()
         self._lock = threading.Lock()
 
-    def __call__(self, mapping: Mapping[Hashable, Any]) -> None:
-        new: dict[Hashable, Any] = {}
+    def _mark_seen(self, key: Hashable) -> bool:
+        """Return ``True`` when ``key`` has not been seen before."""
+
+        if self._maxsize <= 0:
+            # Caching disabled – always log.
+            return True
+        if key in self._seen:
+            return False
+        if len(self._seen) >= self._maxsize:
+            # ``set.pop()`` removes an arbitrary element which is acceptable for
+            # this lightweight cache.
+            self._seen.pop()
+        self._seen.add(key)
+        return True
+
+    def __call__(
+        self,
+        data: Mapping[Hashable, Any] | Hashable,
+        value: Any | None = None,
+    ) -> None:
+        """Log new keys found in ``data``.
+
+        ``data`` may be a mapping of keys to payloads or a single key. When
+        called with a single key ``value`` customises the payload passed to the
+        logging message; the key itself is used when ``value`` is omitted.
+        """
+
+        if isinstance(data, Mapping):
+            new_items: dict[Hashable, Any] = {}
+            with self._lock:
+                for key, item_value in data.items():
+                    if self._mark_seen(key):
+                        new_items[key] = item_value
+            if new_items:
+                self._logger.warning(self._msg, new_items)
+            return
+
+        key = data
+        payload = value if value is not None else data
         with self._lock:
-            for k, v in mapping.items():
-                if k not in self._seen:
-                    self._seen[k] = None
-                    self._seen.move_to_end(k)
-                    new[k] = v
-                    if len(self._seen) > self._maxsize:
-                        self._seen.popitem(last=False)
-        if new:
-            self._logger.warning(self._msg, new)
+            should_log = self._mark_seen(key)
+        if should_log:
+            self._logger.warning(self._msg, payload)
 
     def clear(self) -> None:
         """Reset tracked keys."""

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -38,7 +38,7 @@ def test_lazy_orjson_import(monkeypatch):
     assert calls["n"] == 2
 
 
-def test_warns_each_time(monkeypatch, caplog):
+def test_warns_once_per_combo(monkeypatch, caplog):
     monkeypatch.setattr(
         json_utils, "cached_import", lambda *a, **k: DummyOrjson()
     )
@@ -48,7 +48,7 @@ def test_warns_each_time(monkeypatch, caplog):
         for _ in range(2):
             json_utils.json_dumps({}, ensure_ascii=False)
 
-    assert sum("ignored" in r.message for r in caplog.records) == 2
+    assert sum("ignored" in r.message for r in caplog.records) == 1
 
 
 def test_warns_for_each_combo(monkeypatch, caplog):
@@ -62,7 +62,7 @@ def test_warns_for_each_combo(monkeypatch, caplog):
         json_utils.json_dumps({}, ensure_ascii=False, separators=(";", ":"))
         json_utils.json_dumps({}, ensure_ascii=False, separators=(";", ":"))
 
-    assert sum("ignored" in r.message for r in caplog.records) == 3
+    assert sum("ignored" in r.message for r in caplog.records) == 2
 
 
 def test_json_dumps_returns_str_by_default():
@@ -100,7 +100,7 @@ def test_json_dumps_with_orjson_warns(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         json_utils.json_dumps({"a": 1}, ensure_ascii=False)
         json_utils.json_dumps({"a": 1}, ensure_ascii=False)
-    assert sum("ignored" in r.message for r in caplog.records) == 2
+    assert sum("ignored" in r.message for r in caplog.records) == 1
 
 
 def test_params_passed_to_std(monkeypatch):

--- a/tests/test_logging_module.py
+++ b/tests/test_logging_module.py
@@ -21,3 +21,51 @@ def test_get_logger_configures_root_once():
     assert root.handlers[0].formatter is not None
     logging_utils.get_logger("again")
     assert len(root.handlers) == 1
+
+
+def test_warn_once_with_mapping(caplog):
+    logger = logging.getLogger("tnfr.test.warn_once.mapping")
+    warn_once = logging_utils.warn_once(logger, "values: %s")
+
+    with caplog.at_level(logging.WARNING):
+        warn_once({"a": 1, "b": 2})
+        warn_once({"a": 3, "c": 4})
+
+    messages = [record.message for record in caplog.records]
+    assert messages == ["values: {'a': 1, 'b': 2}", "values: {'c': 4}"]
+
+
+def test_warn_once_with_key_payload(caplog):
+    logger = logging.getLogger("tnfr.test.warn_once.key")
+    warn_once = logging_utils.warn_once(logger, "value: %s")
+
+    with caplog.at_level(logging.WARNING):
+        warn_once("alpha", "alpha warning")
+        warn_once("alpha", "alpha warning repeat")
+        warn_once("beta", "beta warning")
+
+    messages = [record.message for record in caplog.records]
+    assert messages == ["value: alpha warning", "value: beta warning"]
+
+
+def test_warn_once_clear_and_unbounded(caplog):
+    logger = logging.getLogger("tnfr.test.warn_once.clear")
+    warn_once = logging_utils.warn_once(logger, "value: %s")
+
+    with caplog.at_level(logging.WARNING):
+        warn_once("gamma", "first")
+        warn_once.clear()
+        warn_once("gamma", "second")
+        warn_once("gamma", "third")
+
+    messages = [record.message for record in caplog.records]
+    assert messages == ["value: first", "value: second"]
+
+    caplog.clear()
+    unbounded = logging_utils.warn_once(logger, "value: %s", maxsize=0)
+    with caplog.at_level(logging.WARNING):
+        unbounded("repeat", "first")
+        unbounded("repeat", "second")
+
+    messages = [record.message for record in caplog.records]
+    assert messages == ["value: first", "value: second"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,3 +6,6 @@ def clear_orjson_cache() -> None:
     cache_clear = getattr(json_utils.cached_import, "cache_clear", None)
     if cache_clear:
         cache_clear()
+    clear_warns = getattr(json_utils, "clear_orjson_param_warnings", None)
+    if clear_warns:
+        clear_warns()


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

* Replace the `WarnOnce` helper with a set-backed cache that supports mapping and key/value inputs while keeping thread safety and zero-size bypasses.
* Use the refreshed helper inside `json_utils` to suppress repeated ignored-parameter warnings and expose a reset hook for tests.
* Extend logging and JSON tests (plus helpers) to exercise the new behaviours.


------
https://chatgpt.com/codex/tasks/task_e_68c937bc14008321a008921806efae6f