### PR TITLE
Rename similarity helper for diagnostics

### DIFF
--- a/src/tnfr/helpers/numeric.py
+++ b/src/tnfr/helpers/numeric.py
@@ -9,6 +9,7 @@ __all__ = (
     "clamp",
     "clamp01",
     "within_range",
+    "similarity_abs",
     "kahan_sum_nd",
     "angle_diff",
 )
@@ -47,7 +48,7 @@ def _norm01(x: float, lo: float, hi: float) -> float:
     return clamp01((float(x) - float(lo)) / (float(hi) - float(lo)))
 
 
-def _similarity_abs(a: float, b: float, lo: float, hi: float) -> float:
+def similarity_abs(a: float, b: float, lo: float, hi: float) -> float:
     """Return absolute similarity of ``a`` and ``b`` over ``[lo, hi]``.
 
     It computes ``1`` minus the normalized absolute difference between

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -13,7 +13,7 @@ from ..constants import (
 from ..callback_utils import callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
-from ..helpers.numeric import clamp01, _similarity_abs
+from ..helpers.numeric import clamp01, similarity_abs
 from .common import compute_dnfr_accel_max, min_max_range, normalize_dnfr
 from .coherence import (
     local_phase_sync,
@@ -38,7 +38,7 @@ def _symmetry_index(
     if epi_min is None or epi_max is None:
         epi_iter = (get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in G.nodes())
         epi_min, epi_max = min_max_range(epi_iter, default=(0.0, 1.0))
-    return _similarity_abs(epi_i, epi_bar, epi_min, epi_max)
+    return similarity_abs(epi_i, epi_bar, epi_min, epi_max)
 
 
 def _state_from_thresholds(Rloc, dnfr_n, cfg):

--- a/tests/test_numeric_helpers.py
+++ b/tests/test_numeric_helpers.py
@@ -1,6 +1,7 @@
 import networkx as nx  # type: ignore[import-untyped]
 import pytest
 
+from tnfr.helpers.numeric import similarity_abs
 from tnfr.observers import phase_sync
 
 
@@ -20,3 +21,19 @@ def test_phase_sync_statistics_fallback(monkeypatch):
     diffs = [0.0, 0.1, -0.1]
     expected_var = sum(d * d for d in diffs) / len(diffs)
     assert phase_sync(G, R=1.0, psi=0.0) == pytest.approx(1.0 / (1.0 + expected_var))
+
+
+@pytest.mark.parametrize(
+    "a, b, lo, hi, expected",
+    [
+        (0.5, 0.5, 0.0, 1.0, 1.0),
+        (0.0, 1.0, 0.0, 1.0, 0.0),
+        (1.0, 1.5, 1.0, 3.0, 0.75),
+    ],
+)
+def test_similarity_abs_scales_difference(a, b, lo, hi, expected):
+    assert similarity_abs(a, b, lo, hi) == pytest.approx(expected)
+
+
+def test_similarity_abs_degenerate_range_returns_full_similarity():
+    assert similarity_abs(1.0, 2.0, 1.0, 1.0) == pytest.approx(1.0)


### PR DESCRIPTION
Summary of changes:
- rename `_similarity_abs` to the exported `similarity_abs` helper for reuse in diagnostics.
- update diagnosis metrics to consume the renamed helper.
- extend numeric helper tests to exercise the public similarity calculation.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c94f0bdaf08321845eb17f3e730609