### PR TITLE
Simplify RNG cache management and reinforce deterministic tests

### DIFF
--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -66,9 +66,8 @@ class JitterCache:
     def clear(self) -> None:
         """Clear cached RNGs and jitter state."""
 
-        with self.lock:
-            _clear_rng_cache()
-            self._sequence.reset_unlocked()
+        _clear_rng_cache()
+        self._sequence.clear()
 
     def bump(self, key: tuple[int, int]) -> int:
         """Return current jitter sequence counter for ``key`` and increment it."""

--- a/tests/test_rng_base_seed.py
+++ b/tests/test_rng_base_seed.py
@@ -1,4 +1,13 @@
-from tnfr.rng import base_seed, clear_rng_cache
+from __future__ import annotations
+
+from tnfr.rng import (
+    base_seed,
+    cache_enabled,
+    clear_rng_cache,
+    make_rng,
+    seed_hash,
+    set_cache_maxsize,
+)
 
 
 def test_base_seed_returns_value(graph_canon):
@@ -12,56 +21,106 @@ def test_base_seed_defaults_to_zero(graph_canon):
     assert base_seed(G) == 0
 
 
-def test_cache_clear_no_fail_when_cache_disabled():
+def test_clear_rng_cache_no_fail_when_cache_disabled():
     import tnfr.rng as rng_module
-    old_cache = rng_module._seed_hash_cached
-    old_size = rng_module._CACHE_MAXSIZE
-    rng_module._CACHE_MAXSIZE = 0
-    rng_module._seed_hash_cached = rng_module._make_cache(0)
+
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
     try:
+        set_cache_maxsize(0)
         assert clear_rng_cache() is None
     finally:
-        rng_module._CACHE_MAXSIZE = old_size
-        rng_module._seed_hash_cached = old_cache
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()
 
 
 def test_set_cache_maxsize_resets_cache():
     import tnfr.rng as rng_module
-    old_cache = rng_module._seed_hash_cached
-    old_size = rng_module._CACHE_MAXSIZE
+
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
     try:
-        rng_module._CACHE_MAXSIZE = 2
-        rng_module._seed_hash_cached = rng_module._make_cache(2)
-        # populate cache and keep a reference to the underlying cache object
-        rng_module._seed_hash_cached(1, 1)
-        cache = rng_module._seed_hash_cached.cache
-        assert cache.currsize == 1
+        set_cache_maxsize(2)
+        seed_hash.cache_clear()
+        seed_hash(1, 1)
+        assert len(seed_hash.cache) == 1
 
-        # resetting cache size should clear old cache
-        cache.clear()
-        rng_module._CACHE_MAXSIZE = 3
-        rng_module._seed_hash_cached = rng_module._make_cache(3)
-        assert cache.currsize == 0
+        set_cache_maxsize(3)
+        assert len(seed_hash.cache) == 0
     finally:
-        rng_module._CACHE_MAXSIZE = old_size
-        rng_module._seed_hash_cached = old_cache
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()
 
 
-def test_set_cache_maxsize_allows_one_entry():
+def test_set_cache_maxsize_limits_entries():
     import tnfr.rng as rng_module
-    old_cache = rng_module._seed_hash_cached
-    old_size = rng_module._CACHE_MAXSIZE
-    try:
-        rng_module._CACHE_MAXSIZE = 1
-        rng_module._seed_hash_cached = rng_module._make_cache(1)
-        rng_module._seed_hash_cached(1, 1)
-        cache = rng_module._seed_hash_cached.cache
-        assert cache.maxsize == 1
-        assert cache.currsize == 1
 
-        # adding a different key should evict the previous entry
-        rng_module._seed_hash_cached(2, 2)
-        assert cache.currsize == 1
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
+    try:
+        set_cache_maxsize(1)
+        seed_hash.cache_clear()
+        seed_hash(1, 1)
+        assert len(seed_hash.cache) == 1
+
+        seed_hash(2, 2)
+        assert len(seed_hash.cache) == 1
+        assert (2, 2) in seed_hash.cache
+        assert (1, 1) not in seed_hash.cache
     finally:
-        rng_module._CACHE_MAXSIZE = old_size
-        rng_module._seed_hash_cached = old_cache
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()
+
+
+def test_make_rng_deterministic_without_cache():
+    import tnfr.rng as rng_module
+
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
+    try:
+        set_cache_maxsize(0)
+        seq1 = [make_rng(42, 7).random() for _ in range(3)]
+        seq2 = [make_rng(42, 7).random() for _ in range(3)]
+        assert seq1 == seq2
+    finally:
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()
+
+
+def test_graph_cache_size_applies_when_unlocked(graph_canon):
+    import tnfr.rng as rng_module
+
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
+    try:
+        set_cache_maxsize(rng_module._DEFAULT_CACHE_MAXSIZE)
+        G = graph_canon()
+        G.graph["JITTER_CACHE_SIZE"] = 5
+        make_rng(1, 1, G)
+        assert seed_hash.cache.maxsize == 5
+    finally:
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()
+
+
+def test_manual_disable_blocks_graph_override(graph_canon):
+    import tnfr.rng as rng_module
+
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
+    try:
+        set_cache_maxsize(0)
+        G = graph_canon()
+        # cache_enabled consults graph but keeps manual override disabled
+        assert cache_enabled(G) is False
+        make_rng(1, 2, G)
+        assert cache_enabled(G) is False
+    finally:
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()


### PR DESCRIPTION
### Summary
- replace the custom RNG seed cache factory with a cachetools-backed proxy that respects manual overrides and graph sizing
- simplify jitter cache clearing to rely on `ScopedCounterCache.clear` instead of lock-sensitive helpers
- expand deterministic RNG coverage to ensure manual overrides and graph parameters stay reproducible

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

### Testing
- pytest tests/test_rng_base_seed.py
- pytest tests/test_operators.py::test_rng_cache_disabled_with_size_zero
- pytest *(fails: missing numpy dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c95f8ed828832189d964dc14410606