### PR TITLE
Rename THOL trace capture key to thol_open_nodes

### DIFF
--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -42,7 +42,7 @@ class MetricDefaults:
                 "dnfr_weights",
                 "si_weights",
                 "callbacks",
-                "thol_state",
+                "thol_open_nodes",
                 "sigma",
                 "kuramoto",
                 "glyph_counts",

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -311,7 +311,7 @@ register_trace_field("before", "selector", selector_field)
 register_trace_field("before", "dnfr_weights", dnfr_weights_field)
 register_trace_field("before", "si_weights", si_weights_field)
 register_trace_field("before", "callbacks", callbacks_field)
-register_trace_field("before", "thol_state", thol_state_field)
+register_trace_field("before", "thol_open_nodes", thol_state_field)
 
 register_trace_field("after", "kuramoto", kuramoto_field)
 register_trace_field("after", "sigma", sigma_field)


### PR DESCRIPTION
## Summary
- rename the before-phase trace registration to use the `thol_open_nodes` key
- update the default trace capture list to follow the renamed metadata field

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c96c6531f883219d0f1def780354db