### PR TITLE
Remove deprecated ttl argument from cached_import

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -155,7 +155,6 @@ def cached_import(
     fallback: Any | None = None,
     cache: MutableMapping[str, Any] | None = None,
     lock: threading.Lock | None = None,
-    ttl: float | None = None,
     emit: Literal["warn", "log", "both"] = "warn",
 ) -> Any | None:
     """Import ``module_name`` (and optional ``attr``) with caching and fallback.
@@ -173,9 +172,6 @@ def cached_import(
         :func:`functools.lru_cache` is used.
     lock:
         Lock guarding ``cache`` when a custom mapping is supplied.
-    ttl:
-        Deprecated; retained for backwards compatibility. The shared cache
-        ignores this argument.
     emit:
         Destination for warnings emitted on failure (``"warn"``/``"log"``/``"both"``).
     """


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c96c59725883218b8b29cc068e21df