### PR TITLE
Annotate pytestmark for vulture

### DIFF
--- a/tests/integration/test_cli_end_to_end.py
+++ b/tests/integration/test_cli_end_to_end.py
@@ -9,7 +9,7 @@ import pytest
 from tnfr.cli import main
 
 
-pytestmark = pytest.mark.slow
+pytestmark = pytest.mark.slow  # noqa: F841
 
 
 def test_metrics_command_generates_output(tmp_path):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add a noqa suppression to the module-level `pytestmark` so vulture no longer flags it as dead code while keeping the slow marker active

## Testing
- `vulture tests`


------
https://chatgpt.com/codex/tasks/task_e_68c9b4a249488321bdc448f6aeb31cc5