### PR TITLE
Refactor cache-reset fixtures in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import networkx as nx
 
 from tnfr.constants import inject_defaults
+from tnfr.import_utils import cached_import, prune_failed_imports
 
 
 @pytest.fixture
@@ -16,3 +17,16 @@ def graph_canon():
         return G
 
     return _factory
+
+
+@pytest.fixture(scope="module")
+def reset_cached_import():
+    """Provide a helper to reset cached import state for tests."""
+
+    def _reset() -> None:
+        cached_import.cache_clear()
+        prune_failed_imports()
+
+    _reset()
+    yield _reset
+    _reset()

--- a/tests/test_alias_accessor_usage.py
+++ b/tests/test_alias_accessor_usage.py
@@ -19,9 +19,9 @@ class CountingDict(dict):
         return super().__contains__(item)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def clear_alias_cache():
-    """Reset the global alias tuple cache around each test for determinism."""
+    """Reset the global alias tuple cache around the module tests."""
 
     _alias_cache.cache_clear()
     yield

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -2,28 +2,27 @@ import importlib
 import sys
 import types
 
+import pytest
 from cachetools import TTLCache
 import tnfr.import_utils as import_utils
 from tnfr.import_utils import cached_import, prune_failed_imports, _IMPORT_STATE
 
 
-def reset() -> None:
-    cached_import.cache_clear()
-    prune_failed_imports()
+pytestmark = pytest.mark.usefixtures("reset_cached_import")
 
 
-def test_cached_import_attribute_and_fallback(monkeypatch):
-    reset()
+def test_cached_import_attribute_and_fallback(monkeypatch, reset_cached_import):
+    reset_cached_import()
     fake_mod = types.SimpleNamespace(value=5)
     monkeypatch.setitem(sys.modules, "fake_mod", fake_mod)
     assert cached_import("fake_mod", attr="value") == 5
-    reset()
+    reset_cached_import()
     monkeypatch.delitem(sys.modules, "fake_mod")
     assert cached_import("fake_mod", attr="value", fallback=1) == 1
 
 
-def test_cached_import_uses_cache(monkeypatch):
-    reset()
+def test_cached_import_uses_cache(monkeypatch, reset_cached_import):
+    reset_cached_import()
     calls = {"n": 0}
 
     def fake_import(_name):
@@ -36,8 +35,8 @@ def test_cached_import_uses_cache(monkeypatch):
     assert calls["n"] == 1
 
 
-def test_cached_import_uses_provided_lock(monkeypatch):
-    reset()
+def test_cached_import_uses_provided_lock(monkeypatch, reset_cached_import):
+    reset_cached_import()
     calls = {"lock": 0}
     orig_lock = import_utils.threading.Lock
 
@@ -54,8 +53,8 @@ def test_cached_import_uses_provided_lock(monkeypatch):
     assert calls["lock"] == 0
 
 
-def test_cached_import_uses_shared_lock_when_missing(monkeypatch):
-    reset()
+def test_cached_import_uses_shared_lock_when_missing(monkeypatch, reset_cached_import):
+    reset_cached_import()
     calls = {"lock": 0}
     orig_lock = import_utils.threading.Lock
 
@@ -71,8 +70,8 @@ def test_cached_import_uses_shared_lock_when_missing(monkeypatch):
     assert calls["lock"] == 0
 
 
-def test_cache_clear_and_prune_reset_all(monkeypatch):
-    reset()
+def test_cache_clear_and_prune_reset_all(monkeypatch, reset_cached_import):
+    reset_cached_import()
 
     def fake_import(_name):
         raise ImportError("boom")


### PR DESCRIPTION
## Summary
- add a module-scoped `reset_cached_import` fixture so cached import tests share a single cleanup helper
- switch the alias accessor cache reset to module scope to avoid per-test duplication
- update cached-import focused tests to consume the shared fixture and avoid nested ImportRegistry locks

## Testing
- pytest tests/test_alias_accessor_usage.py -vv
- pytest tests/test_alias_iterable.py tests/test_alias_helpers_threadsafe.py -vv
- pytest tests/test_cached_import.py -vv
- pytest tests/test_import_utils.py -vv
- pytest *(fails: missing optional modules such as `tomli`/`yaml` and pre-existing graph weight expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b9b859dc832182dc2704487ce072