### PR TITLE
Add coverage test for TraceMetadata field producers

### DIFF
--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -102,6 +102,21 @@ def test_mapping_field_returns_proxy(graph_canon):
         mapping["b"] = 2
 
 
+def test_trace_metadata_fields_have_generators(graph_canon):
+    """Each ``TraceMetadata`` key has a registered producer."""
+
+    G = graph_canon()
+    register_trace(G)
+
+    produced_keys = set()
+    for phase_fields in trace.TRACE_FIELDS.values():
+        for getter in phase_fields.values():
+            produced_keys.update(getter(G).keys())
+
+    missing = set(trace.TraceMetadata.__annotations__) - produced_keys
+    assert not missing, f"Trace fields without producers: {sorted(missing)}"
+
+
 def test_get_graph_mapping_returns_proxy(graph_canon):
     G = graph_canon()
     data = {"a": 1}


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- ensure each `TraceMetadata` key has at least one registered trace field producing it, catching regressions when metadata producers are removed

## Testing
- pytest tests/test_trace.py


------
https://chatgpt.com/codex/tasks/task_e_68c9c3bb02cc8321aabc2ab1fe67e760