### PR TITLE
Refine callback event usage to rely on CallbackEvent enum

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -36,7 +36,7 @@ from ..alias import (
 from ..metrics.sense_index import compute_Si
 from ..metrics.common import compute_dnfr_accel_max, merge_and_normalize_weights
 from ..metrics.trig_cache import compute_theta_trig
-from ..callback_utils import callback_manager
+from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import recent_glyph, ensure_history, append_metric
 from ..selector import (
     _selector_thresholds,
@@ -486,7 +486,7 @@ def _run_before_callbacks(
 ) -> None:
     callback_manager.invoke_callbacks(
         G,
-        "before_step",
+        CallbackEvent.BEFORE_STEP.value,
         {
             "step": step_idx,
             "dt": dt,
@@ -602,7 +602,7 @@ def _run_after_callbacks(G, *, step_idx: int) -> None:
         values = h.get(src)
         if values:
             ctx[dst] = values[-1]
-    callback_manager.invoke_callbacks(G, "after_step", ctx)
+    callback_manager.invoke_callbacks(G, CallbackEvent.AFTER_STEP.value, ctx)
 
 
 def step(

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -11,7 +11,7 @@ from ..constants import (
     get_aliases,
     get_param,
 )
-from ..callback_utils import callback_manager
+from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import collect_attr, get_attr, set_attr
 from ..collections_utils import normalize_weights
@@ -666,7 +666,10 @@ def _coherence_step(G, ctx=None):
 
 def register_coherence_callbacks(G) -> None:
     callback_manager.register_callback(
-        G, event="after_step", func=_coherence_step, name="coherence_step"
+        G,
+        event=CallbackEvent.AFTER_STEP.value,
+        func=_coherence_step,
+        name="coherence_step",
     )
 
 

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..callback_utils import callback_manager
+from ..callback_utils import CallbackEvent, callback_manager
 from ..constants import get_param
 from ..glyph_history import append_metric, ensure_history
 from ..logging_utils import get_logger
@@ -117,7 +117,10 @@ def _metrics_step(G, *args, **kwargs):
 
 def register_metrics_callbacks(G) -> None:
     callback_manager.register_callback(
-        G, event="after_step", func=_metrics_step, name="metrics_step"
+        G,
+        event=CallbackEvent.AFTER_STEP.value,
+        func=_metrics_step,
+        name="metrics_step",
     )
     register_coherence_callbacks(G)
     register_diagnosis_callbacks(G)

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -10,7 +10,7 @@ from ..constants import (
     get_aliases,
     get_param,
 )
-from ..callback_utils import callback_manager
+from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
 from ..helpers.numeric import clamp01, similarity_abs
@@ -215,8 +215,14 @@ def dissonance_events(G, ctx=None):
 
 def register_diagnosis_callbacks(G) -> None:
     callback_manager.register_callback(
-        G, event="after_step", func=_diagnosis_step, name="diagnosis_step"
+        G,
+        event=CallbackEvent.AFTER_STEP.value,
+        func=_diagnosis_step,
+        name="diagnosis_step",
     )
     callback_manager.register_callback(
-        G, event="after_step", func=dissonance_events, name="dissonance_events"
+        G,
+        event=CallbackEvent.AFTER_STEP.value,
+        func=dissonance_events,
+        name="dissonance_events",
     )

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -48,8 +48,8 @@ def _std_log(kind: str, G, ctx: dict):
 
 
 _STD_CALLBACKS = {
-    "before_step": partial(_std_log, "before"),
-    "after_step": partial(_std_log, "after"),
+    CallbackEvent.BEFORE_STEP.value: partial(_std_log, "before"),
+    CallbackEvent.AFTER_STEP.value: partial(_std_log, "after"),
     CallbackEvent.ON_REMESH.value: partial(_std_log, "remesh"),
 }
 

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -103,8 +103,8 @@ def preparar_red(
     G.graph.setdefault(
         "callbacks",
         {
-            "before_step": [],
-            "after_step": [],
+            CallbackEvent.BEFORE_STEP.value: [],
+            CallbackEvent.AFTER_STEP.value: [],
             CallbackEvent.ON_REMESH.value: [],
         },
     )

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -13,7 +13,7 @@ from .constants import get_aliases, get_graph_param
 from .alias import get_attr
 from .helpers.numeric import clamp01, kahan_sum_nd
 from .import_utils import get_numpy
-from .callback_utils import callback_manager
+from .callback_utils import CallbackEvent, callback_manager
 from .glyph_history import (
     ensure_history,
     last_glyph,
@@ -328,7 +328,10 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
 
 def register_sigma_callback(G) -> None:
     callback_manager.register_callback(
-        G, event="after_step", func=push_sigma_snapshot, name="sigma_snapshot"
+        G,
+        event=CallbackEvent.AFTER_STEP.value,
+        func=push_sigma_snapshot,
+        name="sigma_snapshot",
     )
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- replace direct `"before_step"`/`"after_step"` usages with `CallbackEvent` values across dynamics, observers, metrics, sense utilities, and default graph setup
- make the callback manager validate events via the enum itself and drop the redundant `_CALLBACK_EVENTS` helper
- update trace tests to assert against enum-provided event keys and invocations


------
https://chatgpt.com/codex/tasks/task_e_68c9c52007748321b1a31097ca200cc8