### PR TITLE
Remove legacy metric graph defaults

### DIFF
--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -98,9 +98,6 @@ class MetricDefaults:
             },
         }
     )
-    EPI_SUPPORT_THR: float = 0.05
-    GLYPH_LOAD_WINDOW: int = 50
-    WBAR_WINDOW: int = 25
 
 
 METRIC_DEFAULTS = asdict(MetricDefaults())

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -18,7 +18,7 @@ from ..constants import (
     get_param,
     get_graph_param,
 )
-from ..observers import glyph_load, kuramoto_order
+from ..observers import DEFAULT_GLYPH_LOAD_SPAN, glyph_load, kuramoto_order
 
 from ..helpers.numeric import (
     clamp,
@@ -164,8 +164,7 @@ def _read_adaptive_params(
 def _compute_state(G, cfg: dict[str, Any]) -> tuple[str, float, float]:
     """Return current state (stable/dissonant/transition) and metrics."""
     R = kuramoto_order(G)
-    win = get_graph_param(G, "GLYPH_LOAD_WINDOW", int)
-    dist = glyph_load(G, window=win)
+    dist = glyph_load(G, window=DEFAULT_GLYPH_LOAD_SPAN)
     disr = float(dist.get("_disruptivos", 0.0)) if dist else 0.0
 
     R_hi = float(cfg.get("R_hi", 0.90))

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -19,7 +19,13 @@ from ..helpers.numeric import clamp01
 from ..helpers import ensure_node_index_map
 from .common import compute_coherence, min_max_range
 from .trig_cache import compute_theta_trig, get_trig_cache
-from ..observers import glyph_load, kuramoto_order, phase_sync
+from ..observers import (
+    DEFAULT_GLYPH_LOAD_SPAN,
+    DEFAULT_WBAR_SPAN,
+    glyph_load,
+    kuramoto_order,
+    phase_sync,
+)
 from ..sense import sigma_vector
 from ..import_utils import get_numpy
 from ..logging_utils import get_logger
@@ -698,10 +704,10 @@ def _update_coherence(G, hist) -> None:
         (depi_mean, "depi_mean"),
     )
 
-    wbar_w = int(get_param(G, "WBAR_WINDOW"))
     cs = hist["C_steps"]
     if cs:
-        w = min(len(cs), max(1, wbar_w))
+        window = min(len(cs), DEFAULT_WBAR_SPAN)
+        w = max(1, window)
         wbar = sum(cs[-w:]) / w
         _record_metrics(hist, (wbar, "W_bar"))
 
@@ -721,8 +727,7 @@ def _update_phase_sync(G, hist) -> None:
 def _update_sigma(G, hist) -> None:
     """Record glyph load and associated Σ⃗ vector."""
 
-    win = int(get_param(G, "GLYPH_LOAD_WINDOW"))
-    gl = glyph_load(G, window=win)
+    gl = glyph_load(G, window=DEFAULT_GLYPH_LOAD_SPAN)
     _record_metrics(
         hist,
         (gl.get("_estabilizadores", 0.0), "glyph_load_estab"),

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -78,7 +78,6 @@ def _metrics_step(G, *args, **kwargs):
 
     hist = ensure_history(G)
     dt = float(get_param(G, "DT"))
-    thr = float(get_param(G, "EPI_SUPPORT_THR"))
     eps_dnfr = float(get_param(G, "EPS_DNFR_STABLE"))
     eps_depi = float(get_param(G, "EPS_DEPI_STABLE"))
     t = float(G.graph.get("_t", 0.0))
@@ -112,7 +111,7 @@ def _metrics_step(G, *args, **kwargs):
         logger.debug("observer update failed: %s", exc)
 
     _aggregate_si(G, hist)
-    _compute_advanced_metrics(G, hist, t, dt, cfg, thr)
+    _compute_advanced_metrics(G, hist, t, dt, cfg)
 
 
 def register_metrics_callbacks(G) -> None:

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -15,6 +15,7 @@ from ..types import Glyph
 ALIAS_EPI = get_aliases("EPI")
 
 LATENT_GLYPH = Glyph.SHA.value
+DEFAULT_EPI_SUPPORT_LIMIT = 0.05
 
 
 @dataclass
@@ -127,14 +128,19 @@ def _update_latency_index(G, hist, n_total, n_latent, t):
     append_metric(hist, "latency_index", {"t": t, "value": li})
 
 
-def _update_epi_support(G, hist, t, thr):
+def _update_epi_support(
+    G,
+    hist,
+    t,
+    threshold: float = DEFAULT_EPI_SUPPORT_LIMIT,
+):
     """Measure EPI support and normalized magnitude."""
 
     total = 0.0
     count = 0
     for _, nd in G.nodes(data=True):
         epi_val = abs(get_attr(nd, ALIAS_EPI, 0.0))
-        if epi_val >= thr:
+        if epi_val >= threshold:
             total += epi_val
             count += 1
     epi_norm = (total / count) if count else 0.0
@@ -165,12 +171,19 @@ def _update_morph_metrics(G, hist, counts, t):
     )
 
 
-def _compute_advanced_metrics(G, hist, t, dt, cfg, thr):
+def _compute_advanced_metrics(
+    G,
+    hist,
+    t,
+    dt,
+    cfg,
+    threshold: float = DEFAULT_EPI_SUPPORT_LIMIT,
+):
     """Compute glyph timing derived metrics."""
 
     save_by_node = bool(cfg.get("save_by_node", True))
     counts, n_total, n_latent = _update_tg(G, hist, dt, save_by_node)
     _update_glyphogram(G, hist, counts, t, n_total)
     _update_latency_index(G, hist, n_total, n_latent, t)
-    _update_epi_support(G, hist, t, thr)
+    _update_epi_support(G, hist, t, threshold)
     _update_morph_metrics(G, hist, counts, t)

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -5,7 +5,7 @@ from functools import partial
 import statistics
 from statistics import StatisticsError, pvariance
 
-from .constants import get_aliases, get_param
+from .constants import get_aliases
 from .alias import get_attr
 from .helpers.numeric import angle_diff
 from .callback_utils import CallbackEvent, callback_manager
@@ -31,10 +31,15 @@ __all__ = (
     "kuramoto_order",
     "glyph_load",
     "wbar",
+    "DEFAULT_GLYPH_LOAD_SPAN",
+    "DEFAULT_WBAR_SPAN",
 )
 
 
 logger = get_logger(__name__)
+
+DEFAULT_GLYPH_LOAD_SPAN = 50
+DEFAULT_WBAR_SPAN = 25
 
 
 
@@ -119,13 +124,14 @@ def glyph_load(G, window: int | None = None) -> dict:
     """Return distribution of glyphs applied in the network.
 
     - ``window``: if provided, count only the last ``window`` events per node;
-      otherwise use the deque's maxlen.
+      otherwise use :data:`DEFAULT_GLYPH_LOAD_SPAN`.
     Returns a dict with proportions per glyph and useful aggregates.
     """
     if window == 0:
         return {"_count": 0}
-    window_int: int | None = None
-    if window is not None:
+    if window is None:
+        window_int = DEFAULT_GLYPH_LOAD_SPAN
+    else:
         window_int = validate_window(window, positive=True)
     total = count_glyphs(G, window=window_int, last_only=(window_int == 1))
     dist, count = normalize_counter(total)
@@ -147,7 +153,7 @@ def wbar(G, window: int | None = None) -> float:
     if not cs:
         # fallback: coherencia instantánea
         return compute_coherence(G)
-    w_param = get_param(G, "WBAR_WINDOW") if window is None else window
+    w_param = DEFAULT_WBAR_SPAN if window is None else window
     w = validate_window(w_param, positive=True)
     w = min(len(cs), w)
     return float(statistics.fmean(cs[-w:]))

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -216,12 +216,12 @@ def test_glyph_load_zero_window(graph_canon):
     assert glyph_load(G, window=0) == {"_count": 0}
 
 
-def test_wbar_uses_default_window(graph_canon):
+def test_wbar_uses_default_window(monkeypatch, graph_canon):
     G = graph_canon()
     hist = G.graph.setdefault("history", {})
-    hist["C_steps"] = [0.5, 1.0]
-    G.graph.pop("WBAR_WINDOW", None)
-    assert wbar(G) == pytest.approx(0.75)
+    hist["C_steps"] = [0.5, 1.0, 1.5]
+    monkeypatch.setattr("tnfr.observers.DEFAULT_WBAR_SPAN", 2)
+    assert wbar(G) == pytest.approx((1.0 + 1.5) / 2)
 
 
 def test_attach_standard_observer_registers_callbacks(graph_canon):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Removed the `EPI_SUPPORT_THR`, `GLYPH_LOAD_WINDOW`, and `WBAR_WINDOW` entries from `MetricDefaults` and replaced their usage with internal defaults. Updated coherence/glyph timing observers to consume the new constants and adjusted diagnostics/tests accordingly to keep metric semantics intact without relying on graph-level defaults.

------
https://chatgpt.com/codex/tasks/task_e_68c9c704e4d48321a92f98e7ae69536d