### PR TITLE
Remove apply_dnfr_field helper

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -57,7 +57,6 @@ from .dnfr import (
     dnfr_phase_only,
     dnfr_epi_vf_mixed,
     dnfr_laplacian,
-    apply_dnfr_field,
 )
 from .integrators import (
     prepare_integration_params,
@@ -80,7 +79,6 @@ __all__ = (
     "dnfr_laplacian",
     "prepare_integration_params",
     "update_epi_via_nodal_equation",
-    "apply_dnfr_field",
     "apply_canonical_clamps",
     "validate_canon",
     "coordinate_global_local_phase",

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -48,7 +48,6 @@ __all__ = (
     "dnfr_phase_only",
     "dnfr_epi_vf_mixed",
     "dnfr_laplacian",
-    "apply_dnfr_field",
 )
 
 
@@ -620,14 +619,3 @@ def dnfr_laplacian(G) -> None:
     )
 
 
-def apply_dnfr_field(G, w_theta=None, w_epi=None, w_vf=None) -> None:
-    if any(v is not None for v in (w_theta, w_epi, w_vf)):
-        mix = get_param(G, "DNFR_WEIGHTS").copy()
-        if w_theta is not None:
-            mix["phase"] = float(w_theta)
-        if w_epi is not None:
-            mix["epi"] = float(w_epi)
-        if w_vf is not None:
-            mix["vf"] = float(w_vf)
-        G.graph["DNFR_WEIGHTS"] = mix
-    default_compute_delta_nfr(G)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [x] Reproducible seed

Removed the `apply_dnfr_field` convenience wrapper, its `__all__` entry, and the re-export from `tnfr.dynamics`. Callers should invoke `default_compute_delta_nfr` directly when a manual update is needed.

Tests: `pytest tests/test_dnfr_hooks.py tests/test_dynamics_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9cde38e608321b24bbdb53a9d62e1