### PR TITLE
Remove unused sigma_series helper

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -41,7 +41,6 @@ __all__ = (
     "sigma_vector_from_graph",
     "push_sigma_snapshot",
     "register_sigma_callback",
-    "sigma_series",
     "sigma_rose",
 )
 
@@ -333,25 +332,6 @@ def register_sigma_callback(G) -> None:
         func=push_sigma_snapshot,
         name="sigma_snapshot",
     )
-
-
-# -------------------------
-# Series de utilidad
-# -------------------------
-
-
-def sigma_series(G, key: str | None = None) -> dict[str, list[float]]:
-    cfg = _sigma_cfg(G)
-    key = key or cfg.get("history_key", "sigma_global")
-    hist = ensure_history(G)
-    xs = hist.get(key, [])
-    if not xs:
-        return {"t": [], "angle": [], "mag": []}
-    return {
-        "t": [float(x.get("t", i)) for i, x in enumerate(xs)],
-        "angle": [float(x["angle"]) for x in xs],
-        "mag": [float(x["mag"]) for x in xs],
-    }
 
 
 def sigma_rose(G, steps: int | None = None) -> dict[str, int]:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [x] Reproducible seed

## Summary
- Remove the unused `sigma_series` helper and drop it from the module export list to match current usage.

## Testing
- pytest tests/test_sense.py

------
https://chatgpt.com/codex/tasks/task_e_68c9cebddbbc8321bfa31f0780facefd