### PR TITLE
Remove glyph_dwell_stats from metrics exports

### DIFF
--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -9,7 +9,6 @@ from .reporting import (
     latency_series,
     glyphogram_series,
     glyph_top,
-    glyph_dwell_stats,
 )
 from .glyph_timing import (
     _tg_state,
@@ -39,7 +38,6 @@ __all__ = (
     "latency_series",
     "glyphogram_series",
     "glyph_top",
-    "glyph_dwell_stats",
     "_tg_state",
     "_update_tg",
     "_update_latency_index",

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -32,7 +32,6 @@ from .glyph_timing import (
 from .reporting import (
     Tg_by_node,
     Tg_global,
-    glyph_dwell_stats,
     glyphogram_series,
     glyph_top,
     latency_series,
@@ -65,7 +64,6 @@ __all__ = [
     "latency_series",
     "glyphogram_series",
     "glyph_top",
-    "glyph_dwell_stats",
 ]
 
 

--- a/src/tnfr/metrics/reporting.py
+++ b/src/tnfr/metrics/reporting.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from heapq import nlargest
-from statistics import mean, median
+from statistics import mean
 
 from ..glyph_history import ensure_history
 from .glyph_timing import for_each_glyph
@@ -14,7 +14,6 @@ __all__ = [
     "latency_series",
     "glyphogram_series",
     "glyph_top",
-    "glyph_dwell_stats",
 ]
 
 
@@ -93,26 +92,3 @@ def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
         raise ValueError("k must be a positive integer")
     tg = Tg_global(G, normalize=True)
     return nlargest(k, tg.items(), key=lambda kv: kv[1])
-
-
-def glyph_dwell_stats(G, n) -> dict[str, dict[str, float]]:
-    """Per-node dwell time statistics for each glyph."""
-
-    hist = ensure_history(G)
-    rec = hist.get("Tg_by_node", {}).get(n, {})
-    out: dict[str, dict[str, float]] = {}
-
-    def add(g):
-        runs = list(rec.get(g, []))
-        if not runs:
-            out[g] = {"mean": 0.0, "median": 0.0, "max": 0.0, "count": 0}
-        else:
-            out[g] = {
-                "mean": float(mean(runs)),
-                "median": float(median(runs)),
-                "max": float(max(runs)),
-                "count": int(len(runs)),
-            }
-
-    for_each_glyph(add)
-    return out


### PR DESCRIPTION
Removed the deprecated `glyph_dwell_stats` reporting helper from the metrics package exports.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c9cfa2f520832187df57c6f07ba270