### PR TITLE
Remove legacy σ alias from sense module

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -192,10 +192,6 @@ def _sigma_from_iterable(
     }
 
 
-# Retro-compatibilidad
-_sigma_from_vectors = _sigma_from_iterable
-
-
 def _ema_update(
     prev: dict[str, float], current: dict[str, float], alpha: float
 ) -> dict[str, float]:

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -7,7 +7,6 @@ from tnfr.sense import (
     sigma_vector_node,
     sigma_vector_from_graph,
     _node_weight,
-    _sigma_from_vectors,
     _sigma_from_iterable,
     glyph_unit,
     glyph_angle,
@@ -78,18 +77,6 @@ def test_sigma_vector_from_graph_matches_naive(graph_canon):
     for key in ("x", "y", "mag", "angle", "n"):
         assert vec_opt[key] == pytest.approx(vec_ref[key])
     assert t_opt <= t_ref * 2
-
-
-def test_sigma_from_vectors_accepts_single_complex():
-    vec = _sigma_from_vectors(1 + 1j)
-    assert vec["n"] == 1
-    assert vec["x"] == pytest.approx(1.0)
-    assert vec["y"] == pytest.approx(1.0)
-
-
-def test_sigma_from_vectors_rejects_invalid_iterable():
-    with pytest.raises(TypeError, match="real or complex"):
-        _sigma_from_vectors("abc")
 
 
 def test_sigma_from_iterable_rejects_str():


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Removed the `_sigma_from_vectors` compatibility alias from `tnfr.sense` to consolidate the σ-vector helpers.
- Updated the sense tests to import `_sigma_from_iterable` directly and dropped redundant alias coverage.

## Testing
- `pytest` *(fails: baseline gamma/node/public API suites unrelated to this change)*


------
https://chatgpt.com/codex/tasks/task_e_68c9d3efdf9c8321a7ab38c900b06dfb