### PR TITLE
Remove recompute_abs_max tuple path and refresh cached max benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -20,7 +20,7 @@ PYTHONPATH=src python benchmarks/<script>.py
 
 | Script | Focus | Notes |
 | --- | --- | --- |
-| `cached_abs_max.py` | Cache-aware updates for absolute maxima (`tnfr.alias.set_attr_with_max`). | Demonstrates how cached maxima avoid recomputing `recompute_abs_max` on every assignment. |
+| `cached_abs_max.py` | Cache-aware updates for absolute maxima (`tnfr.alias.set_attr_with_max`). | Demonstrates how cached maxima avoid scanning the graph via `multi_recompute_abs_max` on every assignment. |
 | `collect_attr.py` | Vectorised collection of nodal attributes (`tnfr.alias.collect_attr`). | Requires NumPy; the script exits gracefully when the module is unavailable. |
 | `default_compute_delta_nfr.py` | Core ΔNFR update speed (`tnfr.dynamics.default_compute_delta_nfr`). | Runs multiple passes on random graphs and reports best/median/mean/worst timings. |
 | `neighbor_phase_mean.py` | Fast phase averaging for neighbourhoods (`tnfr.metrics.trig.neighbor_phase_mean`). | Includes a `NodoNX`-based reference to highlight the benefit of the shared `trig_cache` module. |

--- a/benchmarks/cached_abs_max.py
+++ b/benchmarks/cached_abs_max.py
@@ -1,12 +1,17 @@
-"""Benchmark for set_attr_with_max vs recompute_abs_max."""
+"""Benchmark cached updates against full recomputation of |νf| maxima."""
 
 import time
 import networkx as nx
 
-from tnfr.alias import set_attr_with_max, set_attr, recompute_abs_max
+from tnfr.alias import (
+    set_attr_with_max,
+    set_attr,
+    multi_recompute_abs_max,
+)
 from tnfr.constants import get_aliases
 
 ALIAS_VF = get_aliases("VF")
+ALIAS_MAP = {"_vfmax": ALIAS_VF}
 
 
 def run():
@@ -17,7 +22,7 @@ def run():
     for n in G_opt.nodes:
         set_attr_with_max(G_opt, n, ALIAS_VF, 0.0, cache="_vfmax")
         set_attr(G_naive.nodes[n], ALIAS_VF, 0.0)
-    recompute_abs_max(G_naive, ALIAS_VF, key="_vfmax")
+    multi_recompute_abs_max(G_naive, ALIAS_MAP)
 
     nodes = list(G_opt.nodes)
     values = [float(i) for i in range(len(nodes))]
@@ -30,10 +35,10 @@ def run():
     start = time.perf_counter()
     for n, v in zip(nodes, values):
         set_attr(G_naive.nodes[n], ALIAS_VF, v)
-        recompute_abs_max(G_naive, ALIAS_VF, key="_vfmax")
+        multi_recompute_abs_max(G_naive, ALIAS_MAP)
     t_naive = time.perf_counter() - start
 
-    print(f"cached update: {t_opt:.6f}s, naive: {t_naive:.6f}s")
+    print(f"cached update: {t_opt:.6f}s, full recompute: {t_naive:.6f}s")
 
 
 if __name__ == "__main__":

--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -280,15 +280,10 @@ set_attr_str = partial(set_attr_generic, conv=str)
 
 @dataclass(slots=True)
 class AbsMaxResult:
-    """Pair storing an absolute maximum value and its node."""
+    """Absolute maximum value and the node where it occurs."""
 
     max_value: float
     node: Hashable | None
-
-    def as_tuple(self) -> tuple[float, Hashable | None]:
-        """Return ``(max_value, node)`` for backward compatibility."""
-
-        return self.max_value, self.node
 
 
 def _coerce_abs_value(value: Any) -> float:
@@ -326,8 +321,8 @@ def _compute_abs_max_result(
     -------
     AbsMaxResult
         Structure holding the absolute maximum and the node where it
-        occurs. When ``candidate`` is provided, its value is assumed to be
-        the current maximum and no recomputation is performed.
+        occurs. When ``candidate`` is provided, its value is treated as the
+        current maximum and no recomputation is performed.
     """
 
     if candidate is not None:
@@ -346,19 +341,6 @@ def _compute_abs_max_result(
         G.graph[f"{key}_node"] = node
 
     return AbsMaxResult(max_value=max_val, node=node)
-
-
-def recompute_abs_max(
-    G: "networkx.Graph", aliases: tuple[str, ...], *, key: str | None = None
-) -> tuple[float, Hashable | None]:
-    """Recalculate absolute maximum for ``aliases`` in ``G``.
-
-    When ``key`` is provided, the graph caches ``G.graph[key]`` and
-    ``G.graph[f"{key}_node"]`` are updated with the new maximum value and the
-    node where it occurs.
-    """
-
-    return _compute_abs_max_result(G, aliases, key=key).as_tuple()
 
 
 def multi_recompute_abs_max(
@@ -562,6 +544,5 @@ __all__ = [
     "set_scalar",
     "SCALAR_SETTERS",
     *[f"set_{name}" for name in SCALAR_SETTERS],
-    "recompute_abs_max",
     "multi_recompute_abs_max",
 ]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Remove the legacy `recompute_abs_max` helper and the tuple compatibility shim from `AbsMaxResult`, keeping maxima updates centered on the dataclass return path.
- Refresh the cached absolute maximum benchmark to compare cached updates against `multi_recompute_abs_max` scans and update the accompanying README entry.

## Testing
- `pytest tests/test_vf_dnfr_max_update.py`
- `PYTHONPATH=src python benchmarks/cached_abs_max.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9d49a94a4832185beb08960db6b61