### PR TITLE
Refine glyph vf scaling logic

### DIFF
--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -286,19 +286,16 @@ factor_nul = 0.85
 _SCALE_FACTORS = {Glyph.VAL: factor_val, Glyph.NUL: factor_nul}
 
 
-def _op_scale(node: NodoProtocol, glyph: Glyph, factor: float) -> None:
-    if glyph is Glyph.VAL:
-        node.vf *= factor
-    else:
-        node.vf *= factor
+def _op_scale(node: NodoProtocol, factor: float) -> None:
+    node.vf *= factor
 
 
 def _make_scale_op(glyph: Glyph):
     def _op(node: NodoProtocol, gf: dict[str, Any]) -> None:
-        factor_val = get_factor(gf, "VAL_scale", _SCALE_FACTORS[Glyph.VAL])
-        factor_nul = get_factor(gf, "NUL_scale", _SCALE_FACTORS[Glyph.NUL])
-        factor = factor_val if glyph is Glyph.VAL else factor_nul
-        _op_scale(node, glyph, factor)
+        key = "VAL_scale" if glyph is Glyph.VAL else "NUL_scale"
+        default = _SCALE_FACTORS[glyph]
+        factor = get_factor(gf, key, default)
+        _op_scale(node, factor)
 
     return _op
 


### PR DESCRIPTION
## Summary
- simplify the scale operator to apply the selected factor directly to the node frequency
- limit glyph factor lookups to the relevant key during scale operator construction

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68c9dbd2780c8321a92488fdac35f335