### PR TITLE
Remove callback_utils module-level aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ instantiate ad-hoc locks directly when they are not shared.
 
 Callback errors are stored in a ring buffer attached to the graph.  The
 buffer retains at most the last 100 errors by default, but the limit can be
-adjusted at runtime via ``tnfr.callback_utils.set_callback_error_limit`` and
-inspected with ``tnfr.callback_utils.get_callback_error_limit``.
+adjusted at runtime via ``tnfr.callback_utils.callback_manager.set_callback_error_limit``
+and inspected with ``tnfr.callback_utils.callback_manager.get_callback_error_limit``.
 
 ---
 

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -30,10 +30,6 @@ __all__ = (
     "CallbackEvent",
     "CallbackManager",
     "callback_manager",
-    "register_callback",
-    "invoke_callbacks",
-    "get_callback_error_limit",
-    "set_callback_error_limit",
     "CallbackError",
 )
 
@@ -387,12 +383,6 @@ def _reconcile_callback(
 # ---------------------------------------------------------------------------
 
 callback_manager = CallbackManager()
-
-# Backwards-compatible function aliases
-register_callback = callback_manager.register_callback
-invoke_callbacks = callback_manager.invoke_callbacks
-get_callback_error_limit = callback_manager.get_callback_error_limit
-set_callback_error_limit = callback_manager.set_callback_error_limit
 
 
 

--- a/tests/test_callback_errors_limit.py
+++ b/tests/test_callback_errors_limit.py
@@ -1,7 +1,5 @@
 from collections import deque
 
-import tnfr.callback_utils as cb_utils
-
 from tnfr.callback_utils import (
     CallbackEvent,
     callback_manager,
@@ -18,13 +16,17 @@ def test_callback_error_list_resets_limit(graph_canon):
     original = deque(maxlen=None)
     G.graph["_callback_errors"] = original
 
-    prev = cb_utils.get_callback_error_limit()
-    cb_utils.set_callback_error_limit(7)
+    prev = callback_manager.get_callback_error_limit()
+    callback_manager.set_callback_error_limit(7)
     try:
         callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP, {})
         err_list = G.graph.get("_callback_errors")
         assert err_list is not original
-        assert err_list.maxlen == cb_utils.get_callback_error_limit() == 7
+        assert (
+            err_list.maxlen
+            == callback_manager.get_callback_error_limit()
+            == 7
+        )
         assert len(err_list) == 1
     finally:
-        cb_utils.set_callback_error_limit(prev)
+        callback_manager.set_callback_error_limit(prev)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Removed module-level callback convenience aliases so the manager remains the sole API.
- Updated documentation and the callback error limit test to use `callback_manager`.
- Verified the callback-focused pytest modules.


------
https://chatgpt.com/codex/tasks/task_e_68c9ea0bb6148321921d211d815ed223