### PR TITLE
Document Node.js dependency install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,13 @@ prune_failed_imports()
 
 Some auxiliary tooling (such as documentation builds) relies on Node.js
 packages defined in `package.json`. These are **not** required to run the
-Python engine itself. If you need them, install with:
+Python engine itself. If you need them, install from the repository root using
+your preferred package manager:
 
 ```bash
 npm install
+# or
+pnpm install
 ```
 
 The resulting `node_modules/` directory is ignored by version control.


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Confirmed that the existing `.gitignore` already excludes `node_modules/` so the folder remains untracked after clearing the index.
- Documented in the README that auxiliary Node.js tooling dependencies should be installed with either `npm install` or `pnpm install` from the repository root.

## Testing
- `./scripts/run_tests.sh` *(fails: pre-existing test failures unrelated to documentation update; suite reports 6 failing tests around node caching and public API expectations).*

------
https://chatgpt.com/codex/tasks/task_e_68c9f68a039483219fcdca0db601d4b6