### PR TITLE
Reuse cached node tuples for adjacency caching

### DIFF
--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -33,7 +33,8 @@ def test_cached_nodes_and_A_reuse_and_invalidate(graph_canon):
     G.add_edge(0, 2)
     increment_edge_version(G)
     data3 = dynamics._prepare_dnfr_data(G)
-    assert data3["nodes"] is not nodes1
+    assert data3["idx"] is not data1["idx"]
+    assert data3["theta"] is not data1["theta"]
 
 
 def test_cached_nodes_and_A_invalidate_on_node_addition(graph_canon):
@@ -135,7 +136,8 @@ def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon)
     G.add_edge(0, 1)
     nodes, A = cached_nodes_and_A(G)
     assert A is None
-    assert nodes == [0, 1]
+    assert isinstance(nodes, tuple)
+    assert nodes == (0, 1)
 
 
 def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):


### PR DESCRIPTION
### Summary
- rework `cached_nodes_and_A` to reuse `cached_node_list` and stored checksum values instead of recomputing node listings
- adjust ΔNFR cache coverage for tuple outputs and refreshed buffers after edge mutations
- extend node sampling tests to exercise adjacency caching across graph updates

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

### Testing
- python -m pytest tests/test_cache_helpers.py
- python -m pytest tests/test_node_sample.py
- python -m pytest tests/test_dnfr_cache.py tests/test_dnfr_precompute.py
- python -m pytest tests/test_gamma.py

------
https://chatgpt.com/codex/tasks/task_e_68c9fb01a2a8832189de502a62011053