### PR TITLE
Ensure NodeBase all_nodes returns canonical graph nodes

### DIFF
--- a/src/tnfr/cache.py
+++ b/src/tnfr/cache.py
@@ -132,7 +132,10 @@ def stable_json(obj: Any) -> str:
 def _node_repr_digest(obj: Any) -> tuple[str, bytes]:
     """Return cached stable representation and digest for ``obj``."""
 
-    repr_ = stable_json(obj)
+    try:
+        repr_ = stable_json(obj)
+    except TypeError:
+        repr_ = repr(obj)
     digest = hashlib.blake2b(repr_.encode("utf-8"), digest_size=16).digest()
     return repr_, digest
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -21,7 +21,7 @@ from .alias import (
     set_dnfr,
     set_theta,
 )
-from .helpers import increment_edge_version, ensure_node_offset_map
+from .helpers import cached_node_list, increment_edge_version, ensure_node_offset_map
 from .graph_utils import supports_add_edge
 from .node_base import NodeBase
 from .operators import apply_glyph_obj
@@ -402,6 +402,7 @@ class NodoNX(NodeBase, NodoProtocol):
         return mapping.get(self.n, 0)
 
     def all_nodes(self) -> Iterable[NodoProtocol]:
-        return (NodoNX.from_graph(self.G, v) for v in self.G.nodes())
+        nodes = cached_node_list(self.G)
+        return (NodoNX.from_graph(self.G, v) for v in nodes)
 
 

--- a/src/tnfr/node_base.py
+++ b/src/tnfr/node_base.py
@@ -1,7 +1,26 @@
 from __future__ import annotations
 
+import weakref
+from threading import RLock
 from typing import Iterable, MutableMapping
-from .helpers import ensure_node_offset_map
+
+from .helpers import cached_node_list, ensure_node_offset_map
+
+_NODE_LOCK = RLock()
+_PLAIN_GRAPH_REGISTRY: dict[int, set[int]] = {}
+_NODE_LOOKUP: "weakref.WeakValueDictionary[int, NodeBase]" = weakref.WeakValueDictionary()
+_NODE_REGISTRATIONS: "weakref.WeakKeyDictionary[NodeBase, int]" = weakref.WeakKeyDictionary()
+_NODE_FINALIZERS: "weakref.WeakKeyDictionary[NodeBase, object]" = weakref.WeakKeyDictionary()
+
+
+def _remove_node_from_graph(node_id: int, graph_id: int) -> None:
+    with _NODE_LOCK:
+        registry = _PLAIN_GRAPH_REGISTRY.get(graph_id)
+        if registry is None:
+            return
+        registry.discard(node_id)
+        if not registry:
+            _PLAIN_GRAPH_REGISTRY.pop(graph_id, None)
 
 
 class NodeBase:
@@ -9,6 +28,37 @@ class NodeBase:
 
     graph: object
     epi_kind: str
+
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+        if name == "graph":
+            self._sync_graph_registration(value)
+
+    def _sync_graph_registration(self, graph: object) -> None:
+        with _NODE_LOCK:
+            node_id = id(self)
+            graph_id_old = _NODE_REGISTRATIONS.pop(self, None)
+            if graph_id_old is not None:
+                registry = _PLAIN_GRAPH_REGISTRY.get(graph_id_old)
+                if registry is not None:
+                    registry.discard(node_id)
+                    if not registry:
+                        _PLAIN_GRAPH_REGISTRY.pop(graph_id_old, None)
+            finalizer = _NODE_FINALIZERS.pop(self, None)
+            if finalizer is not None:
+                finalizer.detach()
+            if graph is None or hasattr(graph, "nodes"):
+                return
+            data = graph.graph if hasattr(graph, "graph") else graph
+            if isinstance(data, MutableMapping):
+                graph_id_new = id(data)
+                registry = _PLAIN_GRAPH_REGISTRY.setdefault(graph_id_new, set())
+                registry.add(node_id)
+                _NODE_LOOKUP[node_id] = self
+                _NODE_REGISTRATIONS[self] = graph_id_new
+                _NODE_FINALIZERS[self] = weakref.finalize(
+                    self, _remove_node_from_graph, node_id, graph_id_new
+                )
 
     def _glyph_storage(self) -> MutableMapping[str, object]:
         """Return mapping holding glyph history for this node."""
@@ -24,4 +74,47 @@ class NodeBase:
         graph = self.graph
         data = graph.graph if hasattr(graph, "graph") else graph
         nodes = data.get("_all_nodes")
-        return nodes if nodes is not None else [self]
+        if nodes is not None:
+            return nodes
+
+        target_graph = None
+        if hasattr(graph, "nodes"):
+            target_graph = graph
+        else:
+            maybe_graph = getattr(self, "G", None)
+            if maybe_graph is not None and hasattr(maybe_graph, "graph"):
+                try:
+                    if maybe_graph.graph is data:
+                        target_graph = maybe_graph
+                except AttributeError:
+                    pass
+
+        if target_graph is not None:
+            return cached_node_list(target_graph)
+
+        cache = data.get("_node_list_cache")
+        if cache is not None:
+            cached = getattr(cache, "nodes", None)
+            if cached is not None:
+                return cached
+
+        if isinstance(data, MutableMapping) and not hasattr(graph, "nodes"):
+            self._sync_graph_registration(graph)
+            with _NODE_LOCK:
+                registry = _PLAIN_GRAPH_REGISTRY.get(id(data))
+                if registry:
+                    nodes: list[NodeBase] = []
+                    cleaned = False
+                    for node_id in list(registry):
+                        node_obj = _NODE_LOOKUP.get(node_id)
+                        if node_obj is None:
+                            registry.discard(node_id)
+                            cleaned = True
+                            continue
+                        nodes.append(node_obj)
+                    if cleaned and not registry:
+                        _PLAIN_GRAPH_REGISTRY.pop(id(data), None)
+                    if nodes:
+                        return tuple(nodes)
+
+        return [self]

--- a/tests/test_node_all_nodes.py
+++ b/tests/test_node_all_nodes.py
@@ -1,9 +1,9 @@
 """Pruebas de node all nodes."""
 
-from tnfr.node import NodoTNFR
+from tnfr.node import NodoTNFR, NodoNX
 
 
-def test_all_nodes_returns_full_list():
+def test_all_nodes_respects_manual_override():
     a = NodoTNFR()
     b = NodoTNFR()
     graph = {"_all_nodes": [a, b]}
@@ -12,3 +12,26 @@ def test_all_nodes_returns_full_list():
 
     assert set(a.all_nodes()) == {a, b}
     assert set(b.all_nodes()) == {a, b}
+
+
+def test_all_nodes_tnfr_graph():
+    graph = {}
+    a = NodoTNFR(graph=graph)
+    b = NodoTNFR(graph=graph)
+
+    assert set(a.all_nodes()) == {a, b}
+    assert set(b.all_nodes()) == {a, b}
+
+
+def test_all_nodes_nodonx(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([0, 1])
+    a = NodoNX(G, 0)
+    b = NodoNX(G, 1)
+
+    nodes_from_a = tuple(a.all_nodes())
+    nodes_from_b = tuple(b.all_nodes())
+
+    assert {n.n for n in nodes_from_a} == {0, 1}
+    assert {n.n for n in nodes_from_b} == {0, 1}
+    assert all(isinstance(n, NodoNX) for n in nodes_from_a)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

- Added a registry-backed fallback for `NodeBase.all_nodes` while delegating `networkx` graphs to `cached_node_list`.
- Updated `NodoNX.all_nodes` to reuse cached node tuples.
- Relaxed node checksum hashing to tolerate non-JSON node objects and expanded coverage tests.

Tests: `pytest tests/test_node_all_nodes.py tests/test_node_sample.py tests/test_node_offset.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9fd257a248321bb9ea302cb02db04