### PR TITLE
Promote materialize limit normalizer for reuse

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -102,6 +102,7 @@ def flatten_structure(
 
 __all__ = (
     "MAX_MATERIALIZE_DEFAULT",
+    "normalize_materialize_limit",
     "is_non_string_sequence",
     "flatten_structure",
     "ensure_collection",
@@ -121,7 +122,7 @@ limit.
 """
 
 
-def _validate_limit(max_materialize: int | None) -> int | None:
+def normalize_materialize_limit(max_materialize: int | None) -> int | None:
     """Normalize and validate ``max_materialize`` returning a usable limit."""
     if max_materialize is None:
         return None
@@ -168,7 +169,7 @@ def ensure_collection(
         raise TypeError(f"{it!r} is not iterable")
 
     # Step 3: validate limit and materialize items once
-    limit = _validate_limit(max_materialize)
+    limit = normalize_materialize_limit(max_materialize)
     if limit is None:
         return tuple(it)
     if limit == 0:

--- a/src/tnfr/flatten.py
+++ b/src/tnfr/flatten.py
@@ -9,6 +9,7 @@ from .collections_utils import (
     MAX_MATERIALIZE_DEFAULT,
     ensure_collection,
     flatten_structure,
+    normalize_materialize_limit,
 )
 from .constants_glyphs import GLYPHS_CANONICAL_SET
 from .tokens import THOL, TARGET, WAIT, OpTag, THOL_SENTINEL, Token
@@ -24,17 +25,6 @@ __all__ = [
 
 
 _STRING_TYPES = (str, bytes, bytearray)
-
-
-def _normalize_limit(max_materialize: int | None) -> int | None:
-    """Validate ``max_materialize`` mirroring :func:`ensure_collection`."""
-
-    if max_materialize is None:
-        return None
-    limit = int(max_materialize)
-    if limit < 0:
-        raise ValueError("'max_materialize' must be non-negative")
-    return limit
 
 
 def _iter_source(
@@ -53,7 +43,7 @@ def _iter_source(
     if not isinstance(seq, Iterable):
         raise TypeError(f"{seq!r} is not iterable")
 
-    limit = _normalize_limit(max_materialize)
+    limit = normalize_materialize_limit(max_materialize)
     if limit is None:
         return seq
     if limit == 0:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Promoted the materialize limit validator to a public helper and reused it in the flattening utilities to keep error flows consistent.

------
https://chatgpt.com/codex/tasks/task_e_68ca538964b48321873831851cadf3d0