### PR TITLE
Expose shared string type guard

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -105,6 +105,7 @@ __all__ = (
     "normalize_materialize_limit",
     "is_non_string_sequence",
     "flatten_structure",
+    "STRING_TYPES",
     "ensure_collection",
     "prepare_weights",
     "normalize_weights",

--- a/src/tnfr/flatten.py
+++ b/src/tnfr/flatten.py
@@ -9,6 +9,7 @@ from .collections_utils import (
     MAX_MATERIALIZE_DEFAULT,
     ensure_collection,
     flatten_structure,
+    STRING_TYPES,
     normalize_materialize_limit,
 )
 from .constants_glyphs import GLYPHS_CANONICAL_SET
@@ -24,9 +25,6 @@ __all__ = [
 ]
 
 
-_STRING_TYPES = (str, bytes, bytearray)
-
-
 def _iter_source(
     seq: Iterable[Token] | Sequence[Token] | Any,
     *,
@@ -34,10 +32,10 @@ def _iter_source(
 ) -> Iterable[Any]:
     """Yield items from ``seq`` enforcing ``max_materialize`` when needed."""
 
-    if isinstance(seq, Collection) and not isinstance(seq, _STRING_TYPES):
+    if isinstance(seq, Collection) and not isinstance(seq, STRING_TYPES):
         return seq
 
-    if isinstance(seq, _STRING_TYPES):
+    if isinstance(seq, STRING_TYPES):
         return (seq,)
 
     if not isinstance(seq, Iterable):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68ca54de413c83219921bdc924ae9186