### PR TITLE
Remove deprecated locking context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ as the environment may be misconfigured and imports will fail.
 ## Locking policy
 
 The engine centralises reusable process-wide locks in
-`tnfr.locking`. Modules obtain named locks via `locking.get_lock()` or
-use `locking.locked()` as a context manager. This avoids scattering
-`threading.Lock` instances across the codebase and ensures that shared
-resources are synchronised consistently. Module-level caches or global
-state should always use these named locks; only short-lived objects may
-instantiate ad-hoc locks directly when they are not shared.
+`tnfr.locking`. Modules obtain named locks via `locking.get_lock()` and
+use the returned `threading.Lock` in their own critical sections. This
+avoids scattering `threading.Lock` instances across the codebase and
+ensures that shared resources are synchronised consistently.
+Module-level caches or global state should always use these named
+locks; only short-lived objects may instantiate ad-hoc locks directly
+when they are not shared.
 
 ---
 

--- a/src/tnfr/locking.py
+++ b/src/tnfr/locking.py
@@ -9,8 +9,6 @@ redefining locks repeatedly.
 from __future__ import annotations
 
 import threading
-from contextlib import contextmanager
-from collections.abc import Iterator
 from weakref import WeakValueDictionary
 
 # Registry of locks by name guarded by ``_REGISTRY_LOCK``.
@@ -36,19 +34,4 @@ def get_lock(name: str) -> threading.Lock:
     return lock
 
 
-@contextmanager
-def locked(name: str) -> Iterator[None]:
-    """Context manager acquiring the lock for ``name``.
-
-    Usage::
-
-        with locked("resource"):
-            ...  # critical section
-    """
-
-    lock = get_lock(name)
-    with lock:
-        yield
-
-
-__all__ = ["get_lock", "locked"]
+__all__ = ["get_lock"]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- remove the unused `locked()` context manager and drop related imports
- update README locking guidance to recommend `get_lock` exclusively

------
https://chatgpt.com/codex/tasks/task_e_68ca5a61f6a88321a9e3a2657b34e78e