### PR TITLE
Clean up CLI exports and update tests

### DIFF
--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -44,14 +44,9 @@ __all__ = (
     "register_callbacks_and_observer",
     "run_program",
     "resolve_program",
-    "_build_graph_from_args",
-    "_load_sequence",
     "validate_token",
-    "_parse_tokens",
     "parse_thol",
     "TOKEN_MAP",
-    "_save_json",
-    "_args_to_dict",
 )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,15 +8,14 @@ from collections import deque
 
 import pytest
 
-from tnfr.cli import (
-    main,
+from tnfr.cli import main
+from tnfr.cli.arguments import (
+    GRAMMAR_ARG_SPECS,
+    _args_to_dict,
     add_common_args,
     add_grammar_args,
-    _build_graph_from_args,
-    _args_to_dict,
-    _save_json,
 )
-from tnfr.cli.arguments import GRAMMAR_ARG_SPECS
+from tnfr.cli.execution import _build_graph_from_args, _save_json
 from tnfr.constants import METRIC_DEFAULTS
 from tnfr import __version__
 

--- a/tests/test_parse_tokens_errors.py
+++ b/tests/test_parse_tokens_errors.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import pytest
 
+import tnfr.cli as cli_module
 from tnfr import token_parser as core_token_parser
-from tnfr.cli import _parse_tokens, TOKEN_MAP
+from tnfr.token_parser import TOKEN_MAP, _parse_tokens
 
 
 def test_cli_reexports_consolidated_token_parser():
     """Ensure the CLI exposes the consolidated parser API."""
 
-    assert _parse_tokens is core_token_parser._parse_tokens
-    assert TOKEN_MAP is core_token_parser.TOKEN_MAP
+    assert cli_module._parse_tokens is core_token_parser._parse_tokens
+    assert cli_module.TOKEN_MAP is core_token_parser.TOKEN_MAP
 
 
 def test_parse_tokens_value_error_context():

--- a/tests/test_parse_tokens_lazy.py
+++ b/tests/test_parse_tokens_lazy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from tnfr.cli import _parse_tokens
+from tnfr.token_parser import _parse_tokens
 
 
 def test_parse_tokens_lazy_evaluation():

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -8,7 +8,7 @@ import pytest
 
 import tnfr.flatten as flatten_module
 
-from tnfr.cli import _load_sequence
+from tnfr.cli.execution import _load_sequence
 from tnfr.execution import HANDLERS, block, play, seq, target, wait
 from tnfr.flatten import THOLEvaluator, _flatten
 from tnfr.tokens import OpTag, TARGET, THOL, THOL_SENTINEL, WAIT


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- trim private helpers from `tnfr.cli.__all__`
- update CLI-related tests to import internals from their defining modules

## Testing
- `pytest tests/test_cli.py tests/test_program.py tests/test_parse_tokens_lazy.py tests/test_parse_tokens_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca5ff027c08321998202c49240818e