### PR TITLE
Remove vendored node_modules artifacts and clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ prune_failed_imports()
 ```
 
 All project tooling is now Python-native; no Node.js or npm workflows are
-required to build, test, or document the engine.
+required to build, test, or document the engine. The repository therefore
+does not vendor any JavaScript dependencies and keeps the `node_modules/`
+tree out of version control.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- Remove the checked-in `node_modules/` tree and rely on the existing ignore rule to prevent reintroducing it.
- Explicitly state in the README that JavaScript dependencies are not vendored and the repository is Python-only tooling.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68ca6618003c8321a963b50d1d8ff21f