### PR TITLE
Refine neighbor EPI aggregation when scanning graph neighbors

### DIFF
--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -154,6 +154,20 @@ def test_get_neighbor_epi_no_neighbors_returns_defaults(graph_canon):
     assert node.EPI == pytest.approx(1.5)
 
 
+def test_get_neighbor_epi_without_epi_alias_returns_empty(graph_canon):
+    G = graph_canon()
+    G.add_node(0, EPI=2.0)
+    G.add_node(1)
+    G.add_edge(0, 1)
+
+    node = NodoNX(G, 0)
+    neighbors, epi_bar = get_neighbor_epi(node)
+
+    assert neighbors == []
+    assert epi_bar == pytest.approx(2.0)
+    assert node.EPI == pytest.approx(2.0)
+
+
 def test_um_candidate_subset_proximity(graph_canon):
     G = graph_canon()
     inject_defaults(G)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Fuse neighbor alias detection with EPI averaging to avoid repeated traversals and skip conversions when no coherent neighbors contribute.
- Extend operator tests to cover neighbors lacking EPI aliases, ensuring the empty-result semantics are preserved.

## Testing
- pytest tests/test_operators.py


------
https://chatgpt.com/codex/tasks/task_e_68ca6d6cf6608321902c19478716ca56