### PR TITLE
Document official test runner usage in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,28 @@ This project uses English exclusively for code identifiers and docstrings. When 
 - Write docstrings and comments in English.
 - Update existing code to maintain this convention when modifying files.
 
-Please run the test suite with `pytest` before submitting a pull request.
+## Testing
+
+Run the full quality gate from the project root with:
+
+```bash
+./scripts/run_tests.sh
+```
+
+The helper sets up `PYTHONPATH` and orchestrates the tooling invoked by the
+continuous integration workflow:
+
+- `pydocstyle` for targeted docstring style checks.
+- `coverage run --source=src -m pytest` to execute the test suite under
+  coverage.
+- `coverage report -m` to display the aggregate coverage summary.
+- `vulture --min-confidence 80 src tests` to detect unused code paths.
+
+To forward additional flags to `pytest`, append them after `--`, e.g.
+`./scripts/run_tests.sh -- -k coherence`.
+
+The [README Tests section](README.md#tests) repeats these instructions so that
+contributors can find them quickly while browsing the project overview.
+
 Make sure to honor the patterns in `.gitignore` so that dependency and build
 artifacts (e.g., `node_modules/` or `dist/`) are not committed.

--- a/README.md
+++ b/README.md
@@ -118,14 +118,22 @@ tree out of version control.
 ## Tests
 
 Run the test suite from the project root using the helper script, which sets
-the necessary `PYTHONPATH`:
+the necessary `PYTHONPATH` and mirrors the checks described in
+[`CONTRIBUTING.md`](CONTRIBUTING.md):
 
 ```bash
 ./scripts/run_tests.sh
 ```
 
-Avoid running `pytest` directly or executing the script from other directories,
-as the environment may be misconfigured and imports will fail.
+The script sequentially executes `pydocstyle`, `pytest` under `coverage`, the
+coverage summary, and `vulture --min-confidence 80 src tests`. Avoid running
+`pytest` directly or executing the script from other directories, as the
+environment may be misconfigured and imports will fail. To pass additional
+flags to `pytest`, append them after `--`, for example:
+
+```bash
+./scripts/run_tests.sh -- -k coherence
+```
 
 ## Locking policy
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Document `./scripts/run_tests.sh` as the canonical test entry point in CONTRIBUTING.
- Note that the script invokes pydocstyle, pytest under coverage, coverage reporting, and vulture.
- Sync the README Tests section with the contributing guide, including instructions for passing extra pytest arguments.

## Testing
- `./scripts/run_tests.sh` *(fails: vulture flags tests/test_gamma.py:161 unused variable 'category')*

------
https://chatgpt.com/codex/tasks/task_e_68ca7640f5a08321a317c9b04f6ef3cc