### PR TITLE
Align vectorized ΔNFR with alias-aware cache reuse

### DIFF
--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -8,7 +8,7 @@ from tnfr.dynamics import (
     _compute_dnfr,
 )
 from tnfr.constants import get_aliases
-from tnfr.alias import set_attr, collect_attr
+from tnfr.alias import set_attr, collect_attr, get_attr
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
@@ -31,16 +31,44 @@ def _setup_graph():
     return G
 
 
-@pytest.mark.xfail(reason="vectorized strategy differs under alias mapping")
 def test_strategies_share_precomputed_data():
     pytest.importorskip("numpy")
     G = _setup_graph()
+    G.graph["vectorized_dnfr"] = True
     data = _prepare_dnfr_data(G)
     _compute_dnfr(G, data, use_numpy=False)
     dnfr_loop = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
     for n in G.nodes:
         set_attr(G.nodes[n], ALIAS_DNFR, 0.0)
-    data = _prepare_dnfr_data(G)
     _compute_dnfr(G, data, use_numpy=True)
     dnfr_vec = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
     assert dnfr_loop == pytest.approx(dnfr_vec)
+
+
+def test_prepare_dnfr_numpy_vectors_match_aliases():
+    pytest.importorskip("numpy")
+    G = _setup_graph()
+    G.graph["vectorized_dnfr"] = True
+    data = _prepare_dnfr_data(G)
+    assert data["A"] is not None
+    assert data["theta_np"] is not None
+    assert data["epi_np"] is not None
+    assert data["vf_np"] is not None
+    assert data["cos_theta_np"] is not None
+    assert data["sin_theta_np"] is not None
+    assert data["deg_array"] is not None
+
+    theta_expected = [get_attr(G.nodes[n], ALIAS_THETA, 0.0) for n in G.nodes]
+    epi_expected = [get_attr(G.nodes[n], ALIAS_EPI, 0.0) for n in G.nodes]
+    vf_expected = [get_attr(G.nodes[n], ALIAS_VF, 0.0) for n in G.nodes]
+    deg_expected = [float(G.degree(n)) for n in G.nodes]
+
+    assert data["theta_np"].tolist() == pytest.approx(theta_expected)
+    assert data["epi_np"].tolist() == pytest.approx(epi_expected)
+    assert data["vf_np"].tolist() == pytest.approx(vf_expected)
+    assert data["deg_array"].tolist() == pytest.approx(deg_expected)
+
+    # Ensure we can reuse the prepared data for the vectorised computation
+    _compute_dnfr(G, data, use_numpy=True)
+    dnfr_vec = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
+    assert all(isinstance(val, float) for val in dnfr_vec)


### PR DESCRIPTION
## Summary
- unify ΔNFR preparation so cached alias-aware vectors expose NumPy mirrors for the vectorized path
- reuse the shared neighbour sum and mean builders so looped and vectorized ΔNFR agree
- add regression coverage that exercises the NumPy branch and validates its alias-aware data

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68ca81c646348321a61294b72fc634d8