### PR TITLE
Delegate CLI free-run execution to dynamics.run

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -22,7 +22,7 @@ from ..metrics import (
 from ..trace import register_trace
 from ..execution import play, seq, block
 from ..dynamics import (
-    step,
+    run,
     default_glyph_selector,
     parametric_glyph_selector,
     validate_canon,
@@ -166,8 +166,16 @@ def run_program(
     if program is None:
         steps = getattr(args, "steps", 100)
         steps = 100 if steps is None else int(steps)
-        for _ in range(steps):
-            step(G)
+        if steps < 0:
+            steps = 0
+
+        run_kwargs: dict[str, Any] = {}
+        for attr in ("dt", "use_Si", "apply_glyphs"):
+            value = getattr(args, attr, None)
+            if value is not None:
+                run_kwargs[attr] = value
+
+        run(G, steps=steps, **run_kwargs)
     else:
         play(G, program)
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

---
- Delegate CLI free-run execution into `tnfr.dynamics.run`, forwarding `steps`, `dt`, `use_Si`, and `apply_glyphs`.
- Keep history persistence and summary logging intact while clamping negative step counts to mirror prior behaviour.
- Extend CLI tests to validate the new delegation path and ensure observable behaviour is unchanged.


------
https://chatgpt.com/codex/tasks/task_e_68cadb60dba88321a96a8e57db41ec2c