### PR TITLE
Align CLI sequence default with canonical preset

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -20,7 +20,7 @@ from ..metrics import (
     _metrics_step,
 )
 from ..trace import register_trace
-from ..execution import play, seq, block
+from ..execution import play, seq, basic_canonical_example
 from ..dynamics import (
     run,
     default_glyph_selector,
@@ -225,17 +225,7 @@ def cmd_sequence(args: argparse.Namespace) -> int:
             "No se puede usar --preset y --sequence-file al mismo tiempo"
         )
         return 1
-    program = resolve_program(
-        args,
-        default=seq(
-            Glyph.AL,
-            Glyph.EN,
-            Glyph.IL,
-            block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=1),
-            Glyph.RA,
-            Glyph.SHA,
-        ),
-    )
+    program = resolve_program(args, default=basic_canonical_example())
 
     run_program(None, program, args)
     return 0


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68caddaccb788321a8d4b334a6329c27