### PR TITLE
Use graph random seed for topological remesh RNG

### DIFF
--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -290,14 +290,20 @@ def apply_topological_remesh(
     p_rewire: float = 0.2,
     seed: int | None = None,
 ) -> None:
-    """Approximate topological remeshing."""
+    """Approximate topological remeshing.
+
+    When ``seed`` is ``None`` the RNG draws its base seed from
+    ``G.graph['RANDOM_SEED']`` to keep runs reproducible.
+    """
     nodes = list(G.nodes())
     n_before = len(nodes)
     if n_before <= 1:
         return
-    base_seed = 0 if seed is None else int(seed)
+    if seed is None:
+        base_seed = int(G.graph.get("RANDOM_SEED", 0))
+    else:
+        base_seed = int(seed)
     rnd = make_rng(base_seed, -2, G)
-    rnd.seed(base_seed)
 
     if mode is None:
         mode = str(


### PR DESCRIPTION
## Summary
- align topological remesh RNG with graph-level RANDOM_SEED and rely on make_rng hashing for determinism
- extend remesh tests to cover reproducibility and parameter-driven variations

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68cae23694c883218f5bbbda2c543e1a