### PR TITLE
Clarify metrics module exports and update helper imports

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -17,8 +17,8 @@ from ..metrics import (
     glyphogram_series,
     glyph_top,
     export_metrics,
-    _metrics_step,
 )
+from ..metrics.core import _metrics_step
 from ..trace import register_trace
 from ..execution import play, seq, basic_canonical_example
 from ..dynamics import (

--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .core import register_metrics_callbacks, _metrics_step
+from .core import register_metrics_callbacks
 from .reporting import (
     Tg_global,
     Tg_by_node,
@@ -10,16 +10,7 @@ from .reporting import (
     glyphogram_series,
     glyph_top,
 )
-from .glyph_timing import (
-    _tg_state,
-    _update_tg,
-    _update_latency_index,
-    _update_epi_support,
-    _compute_advanced_metrics,
-)
 from .coherence import (
-    _aggregate_si,
-    _track_stability,
     coherence_matrix,
     local_phase_sync,
     local_phase_sync_weighted,
@@ -38,14 +29,6 @@ __all__ = (
     "latency_series",
     "glyphogram_series",
     "glyph_top",
-    "_tg_state",
-    "_update_tg",
-    "_update_latency_index",
-    "_update_epi_support",
-    "_track_stability",
-    "_aggregate_si",
-    "_compute_advanced_metrics",
-    "_metrics_step",
     "coherence_matrix",
     "local_phase_sync",
     "local_phase_sync_weighted",

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tnfr.metrics import _metrics_step
+from tnfr.metrics.core import _metrics_step
 from tnfr.glyph_history import push_glyph, ensure_history
 
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -8,7 +8,8 @@ import networkx as nx
 from tnfr.constants import inject_defaults
 from tnfr.initialization import init_node_attrs
 from tnfr.dynamics import step
-from tnfr.metrics import register_metrics_callbacks, _metrics_step
+from tnfr.metrics import register_metrics_callbacks
+from tnfr.metrics.core import _metrics_step
 from tnfr.operators import apply_glyph, apply_remesh_if_globally_stable
 from tnfr.types import Glyph
 from tnfr.glyph_history import ensure_history

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -8,15 +8,13 @@ from tnfr.constants import (
     get_aliases,
 )
 from tnfr.alias import get_attr, set_attr
-from tnfr.metrics import (
-    _metrics_step,
+from tnfr.metrics.coherence import _track_stability, _aggregate_si
+from tnfr.metrics.core import LATENT_GLYPH, _metrics_step
+from tnfr.metrics.glyph_timing import (
     _update_latency_index,
     _update_epi_support,
-    _track_stability,
-    _aggregate_si,
     _compute_advanced_metrics,
 )
-from tnfr.metrics.core import LATENT_GLYPH
 from tnfr.metrics.core import _update_sigma
 from tnfr.metrics.glyph_timing import DEFAULT_EPI_SUPPORT_LIMIT
 


### PR DESCRIPTION
## Summary
- remove underscored helpers from `tnfr.metrics` exports, keeping the public API focused on reporting and registration
- update CLI wiring and tests to import private helpers from their defining modules
- validate targeted metric suites and a CLI run to confirm the import surface remains functional

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cb261e40648321b3dd4dc1994a2ee6