### PR TITLE
Remove NodeState dataclass from public API

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -9,7 +9,6 @@ Recommended entry points are:
 - ``step`` and ``run`` in :mod:`tnfr.dynamics`
 - ``preparar_red`` in :mod:`tnfr.ontosim`
 - ``create_nfr`` and ``run_sequence`` in :mod:`tnfr.structural`
-- ``NodeState`` in :mod:`tnfr.types`
 - ``cached_import`` and ``prune_failed_imports`` for optional dependencies
 """
 
@@ -17,7 +16,6 @@ from __future__ import annotations
 
 from .import_utils import cached_import, prune_failed_imports
 from .ontosim import preparar_red
-from .types import NodeState
 
 
 def _missing_dependency(name: str, exc: ImportError):
@@ -87,7 +85,6 @@ __all__ = [
     "run",
     "preparar_red",
     "create_nfr",
-    "NodeState",
 ]
 
 if _HAS_RUN_SEQUENCE:

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Iterable, Protocol
 
-__all__ = ("GraphLike", "NodeState", "Glyph")
+__all__ = ("GraphLike", "Glyph")
 
 
 class GraphLike(Protocol):
@@ -26,17 +25,6 @@ class GraphLike(Protocol):
     def neighbors(self, n: Any) -> Iterable[Any]: ...
 
     def __iter__(self) -> Iterable[Any]: ...
-
-
-@dataclass(slots=True)
-class NodeState:
-    EPI: float = 0.0
-    vf: float = 0.0  # νf
-    theta: float = 0.0  # θ
-    Si: float = 0.0
-    epi_kind: str = ""
-    extra: dict[str, Any] = field(default_factory=dict)
-
 
 class Glyph(str, Enum):
     """Canonical TNFR glyphs."""

--- a/tests/test_node_state_extra.py
+++ b/tests/test_node_state_extra.py
@@ -1,8 +1,0 @@
-from tnfr.types import NodeState
-
-
-def test_node_state_extra_access():
-    state = NodeState()
-    assert state.extra == {}
-    state.extra["foo"] = "bar"
-    assert state.extra["foo"] == "bar"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,7 +9,6 @@ def test_public_exports():
         "run",
         "preparar_red",
         "create_nfr",
-        "NodeState",
     }
     if getattr(tnfr, "_HAS_RUN_SEQUENCE", False):
         expected.add("run_sequence")
@@ -23,7 +22,6 @@ def test_basic_flow():
     tnfr.step(G)
     tnfr.run(G, steps=2)
     assert len(G.graph["history"]["C_steps"]) == 3
-    assert isinstance(tnfr.NodeState(), tnfr.NodeState)
 
 
 def test_topological_remesh_not_exported():


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Remove the unused `NodeState` dataclass from `tnfr.types` and narrow the module exports accordingly.
- Stop re-exporting `NodeState` via the package namespace and update the public API expectations.
- Drop the redundant NodeState-focused test module now that the dataclass is gone.

## Testing
- `pytest tests/test_public_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb3496028883219ce461722f5ab10f