### PR TITLE
Handle invalid CLI presets gracefully

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,20 @@ def test_cli_run_erdos_low_nodes(monkeypatch, nodes, p_arg, expected_p):
     assert recorded["p"] == pytest.approx(expected_p)
 
 
+@pytest.mark.parametrize("command", ["run", "sequence"])
+def test_cli_invalid_preset_exits_gracefully(capsys, command):
+    args = [command, "--preset", "nope"]
+    if command == "run":
+        args.extend(["--steps", "0"])
+
+    rc = main(args)
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "Preset desconocido" in captured.out
+    assert "nope" in captured.out
+
+
 def test_cli_metrics_generates_metrics_payload(tmp_path):
     out = tmp_path / "metrics.json"
     rc = main(["metrics", "--nodes", "6", "--steps", "5", "--save", str(out)])


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Handled missing CLI presets by logging a user-facing error, exiting with a non-zero status, and covering the regression with CLI tests.


------
https://chatgpt.com/codex/tasks/task_e_68cbb2bf97848321914751cb03b773fe