### PR TITLE
Simplify numpy import helper caching

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -228,17 +228,20 @@ _NP_CACHE_SENTINEL = object()
 _NP_CACHE: Any | None | object = _NP_CACHE_SENTINEL
 
 
-def get_numpy(logger: Any | None = None) -> Any | None:
-    """Return cached NumPy module if available."""
+def get_numpy() -> Any | None:
+    """Return the cached :mod:`numpy` module when available.
+
+    The first call performs a lazy import via :func:`cached_import`; later calls
+    reuse the stored result. When :mod:`numpy` cannot be imported the function
+    logs a debug message and returns ``None`` to signal that pure Python fallbacks
+    should be used instead.
+    """
 
     global _NP_CACHE
     if _NP_CACHE is _NP_CACHE_SENTINEL:
-        resolved_logger = logger or get_logger(__name__)
         np = cached_import("numpy")
         if np is None:
-            resolved_logger.debug(
-                "Failed to import numpy; continuing in non-vectorised mode"
-            )
+            logger.debug("Failed to import numpy; continuing in non-vectorised mode")
         _NP_CACHE = np
     return _NP_CACHE
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -78,7 +78,7 @@ def test_phase_sync_numpy_and_python_consistent(monkeypatch, graph_canon):
         set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     ps_np = phase_sync(G)
-    monkeypatch.setattr("tnfr.import_utils.get_numpy", lambda logger=None: None)
+    monkeypatch.setattr("tnfr.import_utils.get_numpy", lambda: None)
     monkeypatch.setattr("tnfr.observers.get_numpy", lambda: None)
     ps_py = phase_sync(G)
     assert ps_np == pytest.approx(ps_py)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Simplifies the `get_numpy` helper to rely on the module logger directly and updates the associated tests to use the streamlined API.


------
https://chatgpt.com/codex/tasks/task_e_68cbc4fce0d48321bca654065cd5acc6