### PR TITLE
Remove slow benchmark from glyph history window tests

### DIFF
--- a/tests/test_glyph_history_windowing.py
+++ b/tests/test_glyph_history_windowing.py
@@ -9,7 +9,6 @@ Terminología clave empleada por los helpers:
 """
 
 from collections import deque
-import time
 
 import pytest
 
@@ -144,16 +143,6 @@ def test_recent_glyph_discards_non_iterable_history():
     nd = {"glyph_history": 1}  # type: ignore[assignment]
     assert not glyph_history.recent_glyph(nd, "A", window=1)
     assert list(nd["glyph_history"]) == []
-
-
-@pytest.mark.slow
-def test_recent_glyph_benchmark_under_large_window():
-    nd = _make_node([str(i) for i in range(1000)], window=1000)
-    start = time.perf_counter()
-    for _ in range(1000):
-        glyph_history.recent_glyph(nd, "999", window=1000)
-    duration = time.perf_counter() - start
-    assert duration < 0.1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Removed the redundant slow benchmark from the glyph history windowing test module so the suite focuses on behavioral coverage without timing sensitivity.

------
https://chatgpt.com/codex/tasks/task_e_68cbc6f0a5748321b2636e60bbf4b681