### PR TITLE
Expose sequence compiler helper for tests and rely on public APIs

### DIFF
--- a/src/tnfr/execution.py
+++ b/src/tnfr/execution.py
@@ -8,7 +8,11 @@ from typing import Any, Optional
 
 import networkx as nx  # networkx is used at runtime
 
-from .collections_utils import ensure_collection, is_non_string_sequence
+from .collections_utils import (
+    MAX_MATERIALIZE_DEFAULT,
+    ensure_collection,
+    is_non_string_sequence,
+)
 from .constants import get_param
 from .dynamics import step
 from .flatten import _flatten
@@ -29,6 +33,7 @@ __all__ = [
     "HANDLERS",
     "_apply_glyph_to_targets",
     "_record_trace",
+    "compile_sequence",
     "basic_canonical_example",
     "block",
     "play",
@@ -143,6 +148,16 @@ def play(
         if handler is None:
             raise ValueError(f"Unknown operation: {op}")
         curr_target = handler(G, payload, curr_target, trace, step_fn)
+
+
+def compile_sequence(
+    sequence: Iterable[Token] | Sequence[Token] | Any,
+    *,
+    max_materialize: int | None = MAX_MATERIALIZE_DEFAULT,
+) -> list[tuple[OpTag, Any]]:
+    """Return the operations executed by :func:`play` for ``sequence``."""
+
+    return _flatten(sequence, max_materialize=max_materialize)
 
 
 def seq(*tokens: Token) -> list[Token]:

--- a/src/tnfr/flatten.py
+++ b/src/tnfr/flatten.py
@@ -20,10 +20,6 @@ from .types import Glyph
 
 __all__ = [
     "THOLEvaluator",
-    "_flatten",
-    "_flatten_glyph",
-    "_flatten_target",
-    "_flatten_wait",
     "parse_program_tokens",
 ]
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- expose `compile_sequence` in `tnfr.execution` as a public wrapper over the canonical flattening pipeline.
- update `tests/test_program.py` to exercise wait, target and THOL behaviours via the public execution interfaces.
- prune private helpers from `tnfr.flatten.__all__` now that test coverage no longer relies on them.

## Testing
- `pytest` *(fails: missing optional dependency `numpy` required by unrelated test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd069f96c83218a71c3148673ac30