### PR TITLE
Inline preset helper sequences in presets module

### DIFF
--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -4,32 +4,37 @@ from __future__ import annotations
 from .execution import seq, block, wait, basic_canonical_example
 from .types import Glyph
 
-# Secuencias comunes
-ARRANQUE_BASICO = seq(Glyph.AL, Glyph.EN)
-CIERRE_BASICO = seq(Glyph.RA, Glyph.SHA)
-NUCLEO_VAL_UM = seq(Glyph.VAL, Glyph.UM)
-
-__all__ = (
-    "ARRANQUE_BASICO",
-    "CIERRE_BASICO",
-    "NUCLEO_VAL_UM",
-    "get_preset",
-)
+__all__ = ("get_preset",)
 
 
 _PRESETS = {
-    "arranque_resonante": ARRANQUE_BASICO
-    + seq(Glyph.IL, Glyph.RA)
-    + NUCLEO_VAL_UM
-    + seq(wait(3), Glyph.SHA),
-    "mutacion_contenida": ARRANQUE_BASICO
-    + seq(block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2))
-    + CIERRE_BASICO,
-    "exploracion_acople": ARRANQUE_BASICO
-    + seq(Glyph.IL)
-    + NUCLEO_VAL_UM
-    + seq(block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1))
-    + CIERRE_BASICO,
+    "arranque_resonante": seq(
+        Glyph.AL,
+        Glyph.EN,
+        Glyph.IL,
+        Glyph.RA,
+        Glyph.VAL,
+        Glyph.UM,
+        wait(3),
+        Glyph.SHA,
+    ),
+    "mutacion_contenida": seq(
+        Glyph.AL,
+        Glyph.EN,
+        block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2),
+        Glyph.RA,
+        Glyph.SHA,
+    ),
+    "exploracion_acople": seq(
+        Glyph.AL,
+        Glyph.EN,
+        Glyph.IL,
+        Glyph.VAL,
+        Glyph.UM,
+        block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1),
+        Glyph.RA,
+        Glyph.SHA,
+    ),
     "ejemplo_canonico": basic_canonical_example(),
     # Topologías fractales: expansión/contracción modular
     "fractal_expand": seq(


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

---

- Removed redundant preset helper aliases and inlined their sequences inside `_PRESETS`.
- Updated the public exports to reflect the streamlined preset API.
- Verified the CLI preset flow via the dedicated pytest module.


------
https://chatgpt.com/codex/tasks/task_e_68cbd43f740c8321b7108d60849acb46