### PR TITLE
Remove unused args parameter from CLI callback registration helper

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -132,9 +132,7 @@ def apply_cli_config(G: "nx.Graph", args: argparse.Namespace) -> None:
         }
 
 
-def register_callbacks_and_observer(
-    G: "nx.Graph", _args: argparse.Namespace
-) -> None:
+def register_callbacks_and_observer(G: "nx.Graph") -> None:
     _attach_callbacks(G)
     validate_canon(G)
 
@@ -145,7 +143,7 @@ def _build_graph_from_args(args: argparse.Namespace) -> "nx.Graph":
     if getattr(args, "observer", False):
         G.graph["ATTACH_STD_OBSERVER"] = True
     preparar_red(G)
-    register_callbacks_and_observer(G, args)
+    register_callbacks_and_observer(G)
     return G
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

### Summary
- Drop the unused `args` parameter from `register_callbacks_and_observer` and adjust its caller.
- Keep callback registration focused on the graph context and validate the canon without redundant inputs.

### Testing
- `pytest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbd515c6ac8321ad913b5d0d3f614a