### PR TITLE
Remove argparse-internals CLI test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@ import networkx as nx  # type: ignore[import-untyped]
 
 from tnfr.cli import main
 from tnfr.cli.arguments import (
-    GRAMMAR_ARG_SPECS,
     _args_to_dict,
     add_common_args,
     add_grammar_args,
@@ -414,10 +413,3 @@ def test_args_to_dict_filters_none_values():
     assert result == {"enabled": True}
 
 
-def test_grammar_args_dest_and_default():
-    parser = argparse.ArgumentParser()
-    add_grammar_args(parser)
-    for opt, _ in GRAMMAR_ARG_SPECS:
-        action = next(a for a in parser._actions if opt in a.option_strings)
-        assert action.dest == opt.lstrip("-").replace(".", "_")
-        assert action.default is None


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases (test suite)

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- remove the CLI grammar argument test that asserted argparse internals
- drop the unused `GRAMMAR_ARG_SPECS` import now that observable checks cover grammar options

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68cbe9897e30832198b6b0c872701127