### PR TITLE
Remove redundant CLI specs helper

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -4,10 +4,10 @@ import argparse
 from typing import Any
 
 from ..gamma import GAMMA_REGISTRY
-from .utils import spec, specs
+from .utils import spec
 
 
-GRAMMAR_ARG_SPECS = specs(
+GRAMMAR_ARG_SPECS = (
     spec("--grammar.enabled", action=argparse.BooleanOptionalAction),
     spec("--grammar.zhir_requires_oz_window", type=int),
     spec("--grammar.zhir_dnfr_min", type=float),
@@ -20,7 +20,7 @@ GRAMMAR_ARG_SPECS = specs(
 
 
 # Especificaciones para opciones relacionadas con el histórico
-HISTORY_ARG_SPECS = specs(
+HISTORY_ARG_SPECS = (
     spec("--save-history", type=str),
     spec("--export-history-base", type=str),
     spec("--export-format", choices=["csv", "json"], default="json"),
@@ -28,7 +28,7 @@ HISTORY_ARG_SPECS = specs(
 
 
 # Argumentos comunes a los subcomandos
-COMMON_ARG_SPECS = specs(
+COMMON_ARG_SPECS = (
     spec("--nodes", type=int, default=24),
     spec("--topology", choices=["ring", "complete", "erdos"], default="ring"),
     spec("--seed", type=int, default=1),

--- a/src/tnfr/cli/utils.py
+++ b/src/tnfr/cli/utils.py
@@ -19,7 +19,8 @@ def spec(opt: str, /, **kwargs: Any) -> tuple[str, dict[str, Any]]:
     Returns
     -------
     tuple[str, dict[str, Any]]
-        A pair suitable for :func:`specs`. If ``dest`` is not provided it is
+        A pair suitable for collecting into argument specification sequences.
+        If ``dest`` is not provided it is
         derived from ``opt`` by stripping leading dashes and replacing dots and
         hyphens with underscores. ``default`` defaults to ``None`` so missing
         options can be filtered easily.
@@ -33,15 +34,3 @@ def spec(opt: str, /, **kwargs: Any) -> tuple[str, dict[str, Any]]:
     return opt, kwargs
 
 
-def specs(
-    *pairs: tuple[str, dict[str, Any]]
-) -> list[tuple[str, dict[str, Any]]]:
-    """Build a list of argument specifications.
-
-    Each pair contains an option string and a mapping of keyword arguments
-    for :meth:`argparse.ArgumentParser.add_argument`. The helper simply
-    converts the variadic sequence into a list, which makes the specs
-    reusable across parsers.
-    """
-
-    return list(pairs)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cbed2e94448321b8134e414fcd759e