### PR TITLE
Ensure cache tests focus on public APIs

### DIFF
--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,16 +1,6 @@
-import pytest
+"""Pruebas enfocadas en los helpers públicos de cache."""
 
-import tnfr.import_utils as import_utils
-from tnfr import dynamics
-from tnfr.cache import (
-    _ensure_node_map,
-    cached_node_list,
-    cached_nodes_and_A,
-    edge_version_update,
-    ensure_node_index_map,
-    ensure_node_offset_map,
-    increment_edge_version,
-)
+from tnfr.cache import edge_version_update, ensure_node_index_map, ensure_node_offset_map
 
 
 def test_edge_version_update_scopes_mutations(graph_canon):
@@ -19,31 +9,6 @@ def test_edge_version_update_scopes_mutations(graph_canon):
     with edge_version_update(G):
         assert G.graph["_edge_version"] == start + 1
     assert G.graph["_edge_version"] == start + 2
-
-
-def test_cached_nodes_and_A_reuse_and_invalidate(graph_canon):
-    G = graph_canon()
-    G.add_edges_from([(0, 1), (1, 2)])
-    data1 = dynamics._prepare_dnfr_data(G)
-    nodes1 = data1["nodes"]
-    data2 = dynamics._prepare_dnfr_data(G)
-    assert nodes1 is data2["nodes"]
-    G.add_edge(0, 2)
-    increment_edge_version(G)
-    data3 = dynamics._prepare_dnfr_data(G)
-    assert data3["idx"] is not data1["idx"]
-    assert data3["theta"] is not data1["theta"]
-
-
-def test_cached_nodes_and_A_invalidate_on_node_addition(graph_canon):
-    G = graph_canon()
-    G.add_edge(0, 1)
-    data1 = dynamics._prepare_dnfr_data(G)
-    nodes1 = data1["nodes"]
-    G.add_node(2)
-    increment_edge_version(G)
-    data2 = dynamics._prepare_dnfr_data(G)
-    assert data2["nodes"] is not nodes1
 
 
 def test_node_offset_map_updates_on_node_addition(graph_canon):
@@ -70,16 +35,6 @@ def test_node_offset_map_updates_on_node_replacement(graph_canon):
     assert 0 not in mapping2 and 2 in mapping2
 
 
-def test__ensure_node_map_creates_multiple_maps(graph_canon):
-    G = graph_canon()
-    G.add_nodes_from([2, 0, 1])
-    mapping = _ensure_node_map(G, attrs=("idx", "offset"), sort=False)
-    cache = G.graph["_node_list_cache"]
-    assert mapping is cache.idx
-    assert cache.offset == {2: 0, 0: 1, 1: 2}
-    assert mapping == {2: 0, 0: 1, 1: 2}
-
-
 def test_node_maps_order(graph_canon):
     G = graph_canon()
     G.add_nodes_from([2, 0, 1])
@@ -89,59 +44,3 @@ def test_node_maps_order(graph_canon):
     offset_map = ensure_node_offset_map(G)
     assert offset_map == {0: 0, 1: 1, 2: 2}
     assert ensure_node_index_map(G) is idx_map
-
-
-def test_cache_node_list_updates_on_dirty(graph_canon):
-    G = graph_canon()
-    G.add_nodes_from([0, 1])
-    nodes1 = cached_node_list(G)
-    nodes2 = cached_node_list(G)
-    assert nodes1 is nodes2
-    G.graph["_node_list_dirty"] = True
-    nodes3 = cached_node_list(G)
-    assert nodes3 is not nodes1
-
-
-def test_cache_node_list_invalidate_on_node_replacement(graph_canon):
-    G = graph_canon()
-    G.add_nodes_from([0, 1])
-    nodes1 = cached_node_list(G)
-    G.remove_node(0)
-    G.add_node(2)
-    nodes2 = cached_node_list(G)
-    assert nodes2 is not nodes1
-    assert set(nodes2) == {1, 2}
-
-
-def test_cache_node_list_cache_updated_on_node_set_change(graph_canon):
-    G = graph_canon()
-    G.add_nodes_from([0, 1])
-    nodes1 = cached_node_list(G)
-    cache1 = G.graph["_node_list_cache"]
-    G.add_node(2)
-    nodes2 = cached_node_list(G)
-    cache2 = G.graph["_node_list_cache"]
-    assert nodes2 is not nodes1
-    assert cache2 is not cache1
-    assert set(nodes2) == {0, 1, 2}
-    assert G.graph["_node_list_len"] == 3
-
-
-def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
-    monkeypatch.setattr(import_utils, "_NP_CACHE", import_utils._NP_CACHE_SENTINEL)
-    monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
-    G = graph_canon()
-    G.add_edge(0, 1)
-    nodes, A = cached_nodes_and_A(G)
-    assert A is None
-    assert isinstance(nodes, tuple)
-    assert nodes == (0, 1)
-
-
-def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
-    monkeypatch.setattr(import_utils, "_NP_CACHE", import_utils._NP_CACHE_SENTINEL)
-    monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
-    G = graph_canon()
-    G.add_edge(0, 1)
-    with pytest.raises(RuntimeError):
-        cached_nodes_and_A(G, require_numpy=True)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Extend `tests/test_dnfr_cache.py` to validate `cached_nodes_and_A` and `cached_node_list` behavior strictly through public access points, including numpy dependency handling.
- Simplify `tests/test_cache_helpers.py` so it only exercises the exported helper functions that manage node indices and edge version scoping.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbee1f0d108321b1f18a4e55b1b684