### PR TITLE
Ensure ΔNFR cache vectors refresh with node state

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -219,7 +219,7 @@ def _prepare_dnfr_data(G, *, cache_size: int | None = 128) -> dict:
     cache, idx, theta, epi, vf, cos_theta, sin_theta, refreshed = (
         _init_dnfr_cache(G, nodes, cache, checksum, dirty)
     )
-    if refreshed:
+    if cache is not None:
         _refresh_dnfr_vectors(G, nodes, cache)
 
     w_phase = float(weights.get("phase", 0.0))


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cbf4c620dc83219772a6aee7b920d5