### PR TITLE
Adjust gamma warning helper to accept arbitrary args

### DIFF
--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -158,7 +158,7 @@ def test_gamma_spec_normalized_once(graph_canon, monkeypatch):
     G.graph["GAMMA"] = []  # invalid spec
     emitted = []
 
-    def fake_warn(message, category=None, stacklevel=1):
+    def fake_warn(message, *args, **kwargs):
         emitted.append(message)
 
     monkeypatch.setattr("tnfr.graph_utils.warnings.warn", fake_warn)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- allow the gamma warning test helper to accept arbitrary positional and keyword arguments so it mirrors `warnings.warn`

## Testing
- `pytest tests/test_gamma.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc1293f26c8321bb2c987f29dcd4b9