### PR TITLE
Clarify metrics callbacks context handling

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -664,7 +664,9 @@ def local_phase_sync(G, n):
     return local_phase_sync_weighted(G, n, nodes_order=nodes, W_row=W)
 
 
-def _coherence_step(G, ctx=None):
+def _coherence_step(G, ctx: dict[str, Any] | None = None):
+    del ctx
+
     if not get_param(G, "COHERENCE").get("enabled", True):
         return
     coherence_matrix(G)

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ..callback_utils import CallbackEvent, callback_manager
 from ..constants import get_param
 from ..glyph_history import append_metric, ensure_history
@@ -67,8 +69,10 @@ __all__ = [
 ]
 
 
-def _metrics_step(G, *args, **kwargs):
+def _metrics_step(G, ctx: dict[str, Any] | None = None):
     """Update operational TNFR metrics per step."""
+
+    del ctx
 
     cfg = get_param(G, "METRICS")
     if not cfg.get("enabled", True):

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -144,7 +144,9 @@ def _node_diagnostics(
     }
 
 
-def _diagnosis_step(G, ctx=None):
+def _diagnosis_step(G, ctx: dict[str, Any] | None = None):
+    del ctx
+
     dcfg = get_param(G, "DIAGNOSIS")
     if not dcfg.get("enabled", True):
         return
@@ -181,11 +183,14 @@ def _diagnosis_step(G, ctx=None):
     append_metric(hist, key, diag)
 
 
-def dissonance_events(G, ctx=None):
+def dissonance_events(G, ctx: dict[str, Any] | None = None):
     """Emit per-node structural dissonance start/end events.
 
     Events are recorded as ``"dissonance_start"`` and ``"dissonance_end"``.
     """
+
+    del ctx
+
     hist = ensure_history(G)
     # eventos de disonancia se registran en ``history['events']``
     norms = G.graph.get("_sel_norms", {})

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -353,7 +353,9 @@ def register_trace(G) -> None:
         event = f"{phase}_step"
 
         def _make_cb(ph):
-            def _cb(G, *args, **kwargs):
+            def _cb(G, ctx: dict[str, Any] | None = None):
+                del ctx
+
                 _trace_capture(G, ph, TRACE_FIELDS.get(ph, {}))
 
             return _cb

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -10,7 +10,7 @@ def test_phase_sync_and_kuramoto_recorded(graph_canon):
     G = graph_canon()
     G.add_node(1, theta=0.0)
     G.add_node(2, theta=0.0)
-    _metrics_step(G)
+    _metrics_step(G, ctx=None)
     hist = ensure_history(G)
     assert hist["phase_sync"][-1] == pytest.approx(1.0)
     assert "kuramoto_R" in hist

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -22,7 +22,7 @@ def G_small():
     init_node_attrs(G, override=True)
     G.graph["RANDOM_SEED"] = 7
     register_metrics_callbacks(G)
-    _metrics_step(G)
+    _metrics_step(G, ctx=None)
     return G
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -145,7 +145,7 @@ def test_pp_val_zero_when_no_remesh(graph_canon):
     G.add_node(0, EPI_kind=LATENT_GLYPH)
     inject_defaults(G)
 
-    _metrics_step(G)
+    _metrics_step(G, ctx=None)
 
     morph = G.graph["history"]["morph"][0]
     assert morph["PP"] == 0.0
@@ -158,7 +158,7 @@ def test_pp_val_handles_missing_sha(graph_canon):
     G.add_node(0, EPI_kind="REMESH")
     inject_defaults(G)
 
-    _metrics_step(G)
+    _metrics_step(G, ctx=None)
 
     morph = G.graph["history"]["morph"][0]
     assert morph["PP"] == 0.0
@@ -182,11 +182,11 @@ def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
             nd = G.nodes[n]
             nd["glyph_history"] = [nd.get("EPI_kind")]
         G.graph["_t"] = 0
-        _metrics_step(G)
+        _metrics_step(G, ctx=None)
         G.nodes[0]["EPI_kind"] = "NAV"
         G.nodes[0].setdefault("glyph_history", []).append("NAV")
         G.graph["_t"] = 1
-        _metrics_step(G)
+        _metrics_step(G, ctx=None)
 
     hist_true = G_true.graph["history"]
     hist_false = G_false.graph["history"]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

### Summary
- Update `_metrics_step`, `_coherence_step`, `_diagnosis_step` and `dissonance_events` to accept an optional callback context and discard it internally.
- Adjust trace callback construction to match the new context-based signature.
- Refresh direct test invocations to pass `ctx=None`, keeping coverage aligned with the new API.

### Testing
- `pytest` *(fails: missing optional dependency `numpy` required by unrelated tests)*


------
https://chatgpt.com/codex/tasks/task_e_68cc15ee478483218b2417a3ccbcd15c