### PR TITLE
Explicit ctx argument for metrics callbacks

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -51,7 +51,7 @@ def _attach_callbacks(G: "nx.Graph") -> None:
     register_sigma_callback(G)
     register_metrics_callbacks(G)
     register_trace(G)
-    _metrics_step(G)
+    _metrics_step(G, ctx=None)
 
 
 def _persist_history(G: "nx.Graph", args: argparse.Namespace) -> None:

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from statistics import fmean, StatisticsError
 from operator import ge, le
+from typing import Any
 
 from ..constants import (
     VF_KEY,


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68cc1785ced4832197e3732aba517cfb