### PR TITLE
Adjust fake warn helper signature for gamma tests

### DIFF
--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -158,7 +158,7 @@ def test_gamma_spec_normalized_once(graph_canon, monkeypatch):
     G.graph["GAMMA"] = []  # invalid spec
     emitted = []
 
-    def fake_warn(message, *args, **kwargs):
+    def fake_warn(message, *_args, **_kwargs):
         emitted.append(message)
 
     monkeypatch.setattr("tnfr.graph_utils.warnings.warn", fake_warn)


### PR DESCRIPTION
## Summary
- update the gamma warning helper used in tests to accept arbitrary args/kwargs without binding an unused category parameter
- ensure compatibility with `warnings.warn` is maintained for the monkeypatch

## Testing
- pytest tests/test_gamma.py

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68cc18b44f188321b60a76833d030e8a