### PR TITLE
Document sigma trace fallback parameter usage

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -69,8 +69,10 @@ kuramoto_R_psi: _KuramotoFn = cast(
 
 
 def _sigma_fallback(
-    G: Any, weight_mode: str | None = None
+    G: Any, _weight_mode: str | None = None
 ) -> dict[str, float]:
+    """Return a null sigma vector regardless of ``_weight_mode``."""
+
     return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Renamed the sigma trace fallback parameter to `_weight_mode` and documented that the value is ignored because the fallback always returns the null vector. Confirmed the existing sigma trace call path still functions and passes the related trace and sense test suites.

------
https://chatgpt.com/codex/tasks/task_e_68cc19c0ab5c8321843cab742a81a9cb