### PR TITLE
Remove _args_to_dict re-export from CLI package

### DIFF
--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -14,7 +14,6 @@ from .arguments import (
     _add_run_parser,
     _add_sequence_parser,
     _add_metrics_parser,
-    _args_to_dict,
 )
 from .execution import (
     build_basic_graph,


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

This change removes the private `_args_to_dict` helper from the public import surface of `tnfr.cli` while keeping all CLI functionality and tests intact.


------
https://chatgpt.com/codex/tasks/task_e_68cc1e42df908321b6b50477b51cdc3e