### PR TITLE
Unify CLI metrics summary through public helper

### DIFF
--- a/src/tnfr/metrics/__init__.py
+++ b/src/tnfr/metrics/__init__.py
@@ -9,6 +9,7 @@ from .reporting import (
     latency_series,
     glyphogram_series,
     glyph_top,
+    build_metrics_summary,
 )
 from .coherence import (
     coherence_matrix,
@@ -29,6 +30,7 @@ __all__ = (
     "latency_series",
     "glyphogram_series",
     "glyph_top",
+    "build_metrics_summary",
     "coherence_matrix",
     "local_phase_sync",
     "local_phase_sync_weighted",


### PR DESCRIPTION
## Summary
- add a public build_metrics_summary helper in tnfr.metrics.reporting that gathers Tg, latency, rose and glyphogram data
- export the new helper, update the CLI to call it and keep the existing payload structure intact
- adjust metrics and CLI tests to target the shared helper and confirm the CLI wiring uses it

## Testing
- pytest tests/test_metrics.py tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cc24f906788321b6e79830f50eb492