### PR TITLE
Allow configuring glyphogram samples in CLI metrics summary

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -100,7 +100,7 @@ def add_canon_toggle(parser: argparse.ArgumentParser) -> None:
 
 def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     """Configure the ``run`` subcommand."""
-    from .execution import cmd_run
+    from .execution import cmd_run, DEFAULT_SUMMARY_SERIES_LIMIT
 
     p_run = sub.add_parser(
         "run",
@@ -116,6 +116,15 @@ def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     p_run.add_argument("--preset", type=str, default=None)
     p_run.add_argument("--sequence-file", type=str, default=None)
     p_run.add_argument("--summary", action="store_true")
+    p_run.add_argument(
+        "--summary-limit",
+        type=int,
+        default=DEFAULT_SUMMARY_SERIES_LIMIT,
+        help=(
+            "Número máximo de muestras por serie en el resumen (<=0 para"
+            " desactivar el recorte)"
+        ),
+    )
     p_run.set_defaults(func=cmd_run)
 
 
@@ -156,4 +165,13 @@ def _add_metrics_parser(sub: argparse._SubParsersAction) -> None:
     add_canon_toggle(p_met)
     add_grammar_selector_args(p_met)
     p_met.add_argument("--save", type=str, default=None)
+    p_met.add_argument(
+        "--summary-limit",
+        type=int,
+        default=None,
+        help=(
+            "Número máximo de muestras por serie en el resumen (<=0 para"
+            " desactivar el recorte)"
+        ),
+    )
     p_met.set_defaults(func=cmd_metrics)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -225,7 +225,7 @@ def test_build_metrics_summary_reuses_metrics_helpers(monkeypatch):
     monkeypatch.setattr("tnfr.metrics.reporting.glyphogram_series", fake_glyphogram)
     monkeypatch.setattr("tnfr.metrics.reporting.sigma_rose", fake_sigma)
 
-    summary, has_latency = build_metrics_summary(G)
+    summary, has_latency = build_metrics_summary(G, series_limit=10)
 
     assert has_latency is True
     assert calls["tg"]["graph"] is G
@@ -252,6 +252,26 @@ def test_build_metrics_summary_handles_empty_latency(monkeypatch):
 
     assert has_latency is False
     assert summary["latency_mean"] == 0.0
+
+
+def test_build_metrics_summary_accepts_unbounded_limit(monkeypatch):
+    G = object()
+
+    monkeypatch.setattr("tnfr.metrics.reporting.Tg_global", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(
+        "tnfr.metrics.reporting.latency_series", lambda *_: {"value": [1.0]}
+    )
+    monkeypatch.setattr(
+        "tnfr.metrics.reporting.glyphogram_series",
+        lambda *_: {"t": list(range(12)), "AL": list(range(12))},
+    )
+    monkeypatch.setattr("tnfr.metrics.reporting.sigma_rose", lambda *_: {})
+
+    summary, has_latency = build_metrics_summary(G, series_limit=0)
+
+    assert has_latency is True
+    assert summary["glyphogram"]["t"] == list(range(12))
+    assert summary["glyphogram"]["AL"] == list(range(12))
 
 
 def test_latency_index_uses_max_denominator(graph_canon):


### PR DESCRIPTION
## Summary
- make the glyphogram trimming length configurable and disable it by default for `tnfr metrics`
- expose a `--summary-limit` CLI flag and thread it into the metrics summary helper
- update metrics and CLI tests to cover bounded and unbounded glyphogram exports

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cc2643771483218ceb50e05807de1a