### PR TITLE
Remove manual cache manager argument from edge_version_cache

### DIFF
--- a/src/tnfr/cache.py
+++ b/src/tnfr/cache.py
@@ -476,7 +476,6 @@ def edge_version_cache(
     builder: Callable[[], T],
     *,
     max_entries: int | None = 128,
-    manager: EdgeCacheManager | None = None,
 ) -> T:
     """Return cached ``builder`` output tied to the edge version of ``G``."""
 
@@ -488,12 +487,9 @@ def edge_version_cache(
         return builder()
 
     graph = get_graph(G)
-    if manager is None:
-        manager = graph.get("_edge_cache_manager")  # type: ignore[assignment]
-        if not isinstance(manager, EdgeCacheManager) or manager.graph is not graph:
-            manager = EdgeCacheManager(graph)
-            graph["_edge_cache_manager"] = manager
-    else:
+    manager = graph.get("_edge_cache_manager")  # type: ignore[assignment]
+    if not isinstance(manager, EdgeCacheManager) or manager.graph is not graph:
+        manager = EdgeCacheManager(graph)
         graph["_edge_cache_manager"] = manager
 
     cache, locks = manager.get_cache(max_entries)

--- a/tests/test_edge_version_cache.py
+++ b/tests/test_edge_version_cache.py
@@ -68,16 +68,15 @@ def test_edge_version_cache_lock_cleanup(graph_and_manager, max_entries):
         assert set(locks) == set(cache)
 
 
-@pytest.mark.parametrize("pass_manager", [False, True])
-def test_edge_version_cache_manager(graph_and_manager, pass_manager):
-    G, manager = graph_and_manager()
-    if pass_manager:
-        edge_version_cache(G, "a", lambda: 1, manager=manager)
-        assert G.graph.get("_edge_cache_manager") is manager
-    else:
-        edge_version_cache(G, "a", lambda: 1)
-        manager = G.graph.get("_edge_cache_manager")
-        assert isinstance(manager, EdgeCacheManager)
+def test_edge_version_cache_manager(graph_and_manager):
+    G, _ = graph_and_manager()
+    assert "_edge_cache_manager" not in G.graph
+
+    edge_version_cache(G, "a", lambda: 1)
+    manager = G.graph.get("_edge_cache_manager")
+    assert isinstance(manager, EdgeCacheManager)
+    assert manager.graph is G.graph
+
     edge_version_cache(G, "b", lambda: 2)
     assert G.graph.get("_edge_cache_manager") is manager
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Automatically manage the edge cache manager so cache callers no longer need to pass it explicitly and adjust the unit tests to validate the implicit lifecycle.


------
https://chatgpt.com/codex/tasks/task_e_68cc2eda6e848321afb21aba622a3600