### PR TITLE
Align random_jitter with global manager usage

### DIFF
--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -170,12 +170,11 @@ def _resolve_jitter_seed(node: NodoProtocol) -> tuple[int, int]:
 def random_jitter(
     node: NodoProtocol,
     amplitude: float,
-    manager: JitterCacheManager | None = None,
 ) -> float:
     """Return deterministic noise in ``[-amplitude, amplitude]`` for ``node``.
 
-    Uses ``manager`` to track per-node jitter sequences. When ``manager`` is
-    ``None`` the global manager from :func:`get_jitter_manager` is used.
+    The per-node jitter sequences are tracked using the global manager
+    returned by :func:`get_jitter_manager`.
     """
     if amplitude < 0:
         raise ValueError("amplitude must be positive")
@@ -185,11 +184,10 @@ def random_jitter(
     seed_root = base_seed(node.G)
     seed_key, scope_id = _resolve_jitter_seed(node)
 
-    manager = manager or get_jitter_manager()
-
     cache_key = (seed_root, scope_id)
     seq = 0
     if cache_enabled(node.G):
+        manager = get_jitter_manager()
         seq = manager.bump(cache_key)
     seed = seed_hash(seed_root, scope_id)
     rng = make_rng(seed, seed_key + seq, node.G)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -22,18 +22,18 @@ def test_glyph_operations_complete():
 
 def test_random_jitter_deterministic(graph_canon):
     reset_jitter_manager()
-    manager = get_jitter_manager()
     G = graph_canon()
     G.add_node(0)
     n0 = NodoNX(G, 0)
 
-    j1 = random_jitter(n0, 0.5, manager)
-    j2 = random_jitter(n0, 0.5, manager)
+    j1 = random_jitter(n0, 0.5)
+    j2 = random_jitter(n0, 0.5)
     assert j1 != j2
 
+    manager = get_jitter_manager()
     manager.clear()
-    j3 = random_jitter(n0, 0.5, manager)
-    j4 = random_jitter(n0, 0.5, manager)
+    j3 = random_jitter(n0, 0.5)
+    j4 = random_jitter(n0, 0.5)
     assert [j3, j4] == [j1, j2]
 
 
@@ -57,13 +57,12 @@ def test_rng_cache_disabled_with_size_zero(graph_canon):
     from tnfr.constants import DEFAULTS
 
     reset_jitter_manager()
-    manager = get_jitter_manager()
     set_cache_maxsize(0)
     G = graph_canon()
     G.add_node(0)
     n0 = NodoNX(G, 0)
-    j1 = random_jitter(n0, 0.5, manager)
-    j2 = random_jitter(n0, 0.5, manager)
+    j1 = random_jitter(n0, 0.5)
+    j2 = random_jitter(n0, 0.5)
     assert j1 == j2
     set_cache_maxsize(DEFAULTS["JITTER_CACHE_SIZE"])
 
@@ -76,7 +75,7 @@ def test_jitter_seq_purges_old_entries():
     nodes = [SimpleNamespace(G=graph) for _ in range(5)]
     first_key = (0, id(nodes[0]))
     for n in nodes:
-        random_jitter(n, 0.1, manager)
+        random_jitter(n, 0.1)
     assert len(manager.seq) == 4
     assert first_key not in manager.seq
 
@@ -105,7 +104,7 @@ def test_jitter_manager_clear_resets_state():
     graph = SimpleNamespace(graph={})
     nodes = [SimpleNamespace(G=graph) for _ in range(3)]
     for node in nodes:
-        random_jitter(node, 0.1, manager)
+        random_jitter(node, 0.1)
     assert len(manager.seq) == 3
     manager.clear()
     assert len(manager.seq) == 0


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68cc2fccd9cc8321802817c82e978f06