### PR TITLE
Refine compute_coherence fallback aggregation

### DIFF
--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -52,21 +52,18 @@ def compute_coherence(
         dnfr_mean = float(np.mean(dnfr_arr))
         depi_mean = float(np.mean(depi_arr))
     else:
-        nodes = list(G.nodes(data=True))
-        dnfr_mean = (
-            kahan_sum_nd(
-                ((abs(get_attr(nd, ALIAS_DNFR, 0.0)),) for _, nd in nodes),
-                dims=1,
-            )[0]
-            / count
+        dnfr_sum, depi_sum = kahan_sum_nd(
+            (
+                (
+                    abs(get_attr(nd, ALIAS_DNFR, 0.0)),
+                    abs(get_attr(nd, ALIAS_DEPI, 0.0)),
+                )
+                for _, nd in G.nodes(data=True)
+            ),
+            dims=2,
         )
-        depi_mean = (
-            kahan_sum_nd(
-                ((abs(get_attr(nd, ALIAS_DEPI, 0.0)),) for _, nd in nodes),
-                dims=1,
-            )[0]
-            / count
-        )
+        dnfr_mean = dnfr_sum / count
+        depi_mean = depi_sum / count
 
     coherence = 1.0 / (1.0 + dnfr_mean + depi_mean)
     return (coherence, dnfr_mean, depi_mean) if return_means else coherence

--- a/tests/test_compute_coherence.py
+++ b/tests/test_compute_coherence.py
@@ -57,3 +57,17 @@ def test_compute_coherence_return_means(graph_canon):
     assert C == pytest.approx(expected_C)
     assert dnfr_mean == pytest.approx(expected_dnfr)
     assert depi_mean == pytest.approx(expected_depi)
+
+
+def test_compute_coherence_without_numpy(monkeypatch, graph_canon):
+    monkeypatch.setattr("tnfr.metrics.common.get_numpy", lambda: None)
+    G = graph_canon()
+    G.add_node(0, dnfr=0.1, dEPI=0.2)
+    G.add_node(1, dnfr=0.4, dEPI=0.5)
+    coherence, dnfr_mean, depi_mean = compute_coherence(G, return_means=True)
+    expected_dnfr = (0.1 + 0.4) / 2
+    expected_depi = (0.2 + 0.5) / 2
+    expected_coherence = 1.0 / (1.0 + expected_dnfr + expected_depi)
+    assert coherence == pytest.approx(expected_coherence)
+    assert dnfr_mean == pytest.approx(expected_dnfr)
+    assert depi_mean == pytest.approx(expected_depi)


### PR DESCRIPTION
## Summary
- collapse the non-numpy coherence path into a single compensated accumulation over |ΔNFR| and |dEPI|
- extend compute_coherence tests to exercise the fallback path and confirm identical means/coherence

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cc35e6dfc88321adc21032b9554b9f