### PR TITLE
Simplify NumPy import caching and update tests

### DIFF
--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -34,11 +34,6 @@ def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
 
     monkeypatch.setattr(
         import_utils,
-        "_NP_CACHE",
-        import_utils._NP_CACHE_SENTINEL,
-    )
-    monkeypatch.setattr(
-        import_utils,
         "cached_import",
         lambda module, attr=None, **kwargs: sentinel if module == "numpy" else None,
     )

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -109,6 +109,14 @@ def test_cache_invalidated_on_node_rename():
 
 
 def test_prepare_dnfr_data_refreshes_cached_vectors(monkeypatch):
+    original_cached_import = import_utils.cached_import
+
+    def fake_cached_import(module, attr=None, **kwargs):
+        if module == "numpy":
+            return None
+        return original_cached_import(module, attr=attr, **kwargs)
+
+    monkeypatch.setattr(import_utils, "cached_import", fake_cached_import)
     cos_calls, sin_calls = _counting_trig(monkeypatch)
     G = _setup_graph()
     default_compute_delta_nfr(G)
@@ -208,7 +216,6 @@ def test_cached_node_list_invalidate_on_node_rename():
 
 
 def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon):
-    monkeypatch.setattr(import_utils, "_NP_CACHE", import_utils._NP_CACHE_SENTINEL)
     monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
     G = graph_canon()
     G.add_edge(0, 1)
@@ -219,7 +226,6 @@ def test_cached_nodes_and_A_returns_none_without_numpy(monkeypatch, graph_canon)
 
 
 def test_cached_nodes_and_A_requires_numpy(monkeypatch, graph_canon):
-    monkeypatch.setattr(import_utils, "_NP_CACHE", import_utils._NP_CACHE_SENTINEL)
     monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
     G = graph_canon()
     G.add_edge(0, 1)

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -61,7 +61,6 @@ def test_phase_sync_equivalent_with_without_numpy(monkeypatch, graph_canon):
         set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     ps_np = phase_sync(G)
-    monkeypatch.setattr(import_utils, "_NP_CACHE", import_utils._NP_CACHE_SENTINEL)
     monkeypatch.setattr(import_utils, "cached_import", lambda *a, **k: None)
     monkeypatch.setattr("tnfr.observers.get_numpy", import_utils.get_numpy)
     ps_py = phase_sync(G)

--- a/tests/test_trig_cache_reuse.py
+++ b/tests/test_trig_cache_reuse.py
@@ -41,11 +41,6 @@ def test_trig_cache_reuse_between_modules(monkeypatch, graph_canon):
         return original_cached_import(module, attr=attr, **kwargs)
 
     monkeypatch.setattr(import_utils, "cached_import", fake_cached_import)
-    monkeypatch.setattr(
-        import_utils,
-        "_NP_CACHE",
-        import_utils._NP_CACHE_SENTINEL,
-    )
 
     G = graph_canon()
     sentinel = object()


### PR DESCRIPTION
## Summary
- reuse the shared cached_import implementation for NumPy lookups and avoid sentinel globals
- reset the NumPy-missing debug flag when clearing caches to keep retry behaviour predictable
- update cache-related tests to accommodate the new mechanism and keep NumPy/pure-Python parity checks

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cc3abbd3908321a1ca2041f231e67b