### PR TITLE
Trim metrics core exports to public API

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -10,7 +10,6 @@ from ..glyph_history import append_metric, ensure_history
 from ..logging_utils import get_logger
 from .coherence import (
     _aggregate_si,
-    _record_metrics,
     _track_stability,
     _update_coherence,
     _update_phase_sync,
@@ -18,19 +17,7 @@ from .coherence import (
     register_coherence_callbacks,
 )
 from .diagnosis import register_diagnosis_callbacks
-from .glyph_timing import (
-    GlyphTiming,
-    _compute_advanced_metrics,
-    LATENT_GLYPH,
-    _tg_state,
-    _update_tg,
-    _update_tg_node,
-    _update_glyphogram,
-    _update_latency_index,
-    _update_epi_support,
-    _update_morph_metrics,
-    for_each_glyph,
-)
+from .glyph_timing import _compute_advanced_metrics
 from .reporting import (
     Tg_by_node,
     Tg_global,
@@ -42,23 +29,6 @@ from .reporting import (
 logger = get_logger(__name__)
 
 __all__ = [
-    "LATENT_GLYPH",
-    "GlyphTiming",
-    "_tg_state",
-    "for_each_glyph",
-    "_update_tg_node",
-    "_update_tg",
-    "_update_glyphogram",
-    "_update_latency_index",
-    "_update_epi_support",
-    "_update_morph_metrics",
-    "_update_coherence",
-    "_record_metrics",
-    "_update_phase_sync",
-    "_update_sigma",
-    "_track_stability",
-    "_aggregate_si",
-    "_compute_advanced_metrics",
     "_metrics_step",
     "register_metrics_callbacks",
     "Tg_global",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -8,14 +8,14 @@ from tnfr.constants import (
     get_aliases,
 )
 from tnfr.alias import get_attr, set_attr
-from tnfr.metrics.coherence import _track_stability, _aggregate_si
-from tnfr.metrics.core import LATENT_GLYPH, _metrics_step
+from tnfr.metrics.coherence import _track_stability, _aggregate_si, _update_sigma
+from tnfr.metrics.core import _metrics_step
 from tnfr.metrics.glyph_timing import (
+    LATENT_GLYPH,
     _update_latency_index,
     _update_epi_support,
     _compute_advanced_metrics,
 )
-from tnfr.metrics.core import _update_sigma
 from tnfr.metrics.glyph_timing import DEFAULT_EPI_SUPPORT_LIMIT
 from tnfr.metrics.reporting import build_metrics_summary
 

--- a/tests/test_update_tg_node.py
+++ b/tests/test_update_tg_node.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import builtins
 
-from tnfr.metrics.core import _update_tg_node, GlyphTiming
+from tnfr.metrics.glyph_timing import _update_tg_node, GlyphTiming
 from tnfr.glyph_history import push_glyph
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cc3ef68f3c8321b182a5af852f3c03