### PR TITLE
Align accumulate_cos_sin with compensated helper

### DIFF
--- a/src/tnfr/metrics/trig.py
+++ b/src/tnfr/metrics/trig.py
@@ -12,6 +12,7 @@ from itertools import tee
 from typing import Any
 
 from ..import_utils import cached_import, get_numpy
+from ..helpers.numeric import kahan_sum_nd
 
 __all__ = (
     "accumulate_cos_sin",
@@ -34,42 +35,32 @@ def accumulate_cos_sin(
     processed.
     """
 
-    total_cos = 0.0
-    total_sin = 0.0
-    comp_cos = 0.0
-    comp_sin = 0.0
     processed = False
 
-    for cs in it:
-        if cs is None:
-            continue
-        c, s = cs
-        if c is None or s is None:
-            continue
+    def iter_real_pairs():
+        nonlocal processed
+        for cs in it:
+            if cs is None:
+                continue
+            c, s = cs
+            if c is None or s is None:
+                continue
+            try:
+                c_val = float(c)
+                s_val = float(s)
+            except (TypeError, ValueError):
+                continue
+            if not (math.isfinite(c_val) and math.isfinite(s_val)):
+                continue
+            processed = True
+            yield (c_val, s_val)
 
-        processed = True
-        c = float(c)
-        s = float(s)
-
-        # Apply the same compensated summation used in :func:`kahan_sum_nd`
-        t_cos = total_cos + c
-        if abs(total_cos) >= abs(c):
-            comp_cos += (total_cos - t_cos) + c
-        else:
-            comp_cos += (c - t_cos) + total_cos
-        total_cos = t_cos
-
-        t_sin = total_sin + s
-        if abs(total_sin) >= abs(s):
-            comp_sin += (total_sin - t_sin) + s
-        else:
-            comp_sin += (s - t_sin) + total_sin
-        total_sin = t_sin
+    sum_cos, sum_sin = kahan_sum_nd(iter_real_pairs(), dims=2)
 
     if not processed:
         return 0.0, 0.0, False
 
-    return total_cos + comp_cos, total_sin + comp_sin, True
+    return sum_cos, sum_sin, True
 
 
 def _phase_mean_from_iter(


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68cc459dc9988321acd5e543bb1cdb79