### PR TITLE
Align Kuramoto order with trig cache reuse

### DIFF
--- a/src/tnfr/metrics/trig_cache.py
+++ b/src/tnfr/metrics/trig_cache.py
@@ -89,11 +89,21 @@ def _build_trig_cache(G: GraphLike, np: Any | None = None) -> TrigCache:
     return compute_theta_trig(G.nodes(data=True), np=np)
 
 
-def get_trig_cache(G: GraphLike, *, np: Any | None = None) -> TrigCache:
+def get_trig_cache(
+    G: GraphLike,
+    *,
+    np: Any | None = None,
+    cache_size: int | None = 128,
+) -> TrigCache:
     """Return cached cosines and sines of ``θ`` per node."""
 
     if np is None:
         np = get_numpy()
     version = G.graph.setdefault("_trig_version", 0)
     key = ("_trig", version)
-    return edge_version_cache(G, key, lambda: _build_trig_cache(G, np=np))
+    return edge_version_cache(
+        G,
+        key,
+        lambda: _build_trig_cache(G, np=np),
+        max_entries=cache_size,
+    )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68cc46e37e0083218aec4294a91712d2