### PR TITLE
Simplify ensure_collection string handling

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -137,7 +137,6 @@ def ensure_collection(
     *,
     max_materialize: int | None = MAX_MATERIALIZE_DEFAULT,
     error_msg: str | None = None,
-    treat_strings_as_iterables: bool = False,
 ) -> Collection[T]:
     """Return ``it`` as a :class:`Collection`, materializing when needed.
 
@@ -145,7 +144,7 @@ def ensure_collection(
 
     1. Existing collections are returned directly. String-like inputs
        (``str``, ``bytes`` and ``bytearray``) are wrapped as a single item
-       tuple unless ``treat_strings_as_iterables=True``.
+       tuple.
     2. The object must be an :class:`Iterable`; otherwise ``TypeError`` is
        raised.
     3. Remaining iterables are materialized up to ``max_materialize`` items.
@@ -158,9 +157,7 @@ def ensure_collection(
     # Step 1: early-return for collections and raw strings/bytes
     if isinstance(it, Collection):
         if isinstance(it, STRING_TYPES):
-            if not treat_strings_as_iterables:
-                return (cast(T, it),)
-            # fall through for materialization when treating as iterable
+            return (cast(T, it),)
         else:
             return it
 

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -21,20 +21,6 @@ def test_wraps_bytearray():
     assert ensure_collection(arr) == (arr,)
 
 
-def test_string_materialized_when_requested():
-    assert ensure_collection("node", treat_strings_as_iterables=True) == tuple("node")
-
-
-def test_bytes_materialized_when_requested():
-    data = b"node"
-    assert ensure_collection(data, treat_strings_as_iterables=True) == tuple(data)
-
-
-def test_bytearray_materialized_when_requested():
-    arr = bytearray(b"node")
-    assert ensure_collection(arr, treat_strings_as_iterables=True) == tuple(arr)
-
-
 def test_iterable_not_iterator_materialized():
     class CustomIterable:
         def __iter__(self):


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [x] Reproducible seed

## Summary
- remove the `treat_strings_as_iterables` parameter from `ensure_collection` and streamline the string handling documentation
- update tests to reflect the leaner helper API while preserving remaining coverage

## Testing
- `pytest tests/test_ensure_collection.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc4dd441548321958b50f37445e793