### PR TITLE
Align tnfr.import_utils with canonical utils state

### DIFF
--- a/src/tnfr/import_utils.py
+++ b/src/tnfr/import_utils.py
@@ -4,20 +4,7 @@ from __future__ import annotations
 
 import warnings
 
-from .utils.init import (
-    EMIT_MAP,
-    IMPORT_LOG,
-    WarnOnce,
-    _FAILED_IMPORT_LIMIT,
-    _DEFAULT_CACHE_SIZE,
-    _IMPORT_STATE,
-    _reset_import_state,
-    _warn_failure,
-    cached_import,
-    get_numpy,
-    get_nodonx,
-    prune_failed_imports,
-)
+import tnfr.utils.init as _utils_init
 
 __all__ = (
     "cached_import",
@@ -33,4 +20,16 @@ warnings.warn(
     stacklevel=2,
 )
 
-_reset_import_state()
+cached_import = _utils_init.cached_import
+get_numpy = _utils_init.get_numpy
+get_nodonx = _utils_init.get_nodonx
+prune_failed_imports = _utils_init.prune_failed_imports
+
+IMPORT_LOG = _utils_init.IMPORT_LOG
+EMIT_MAP = _utils_init.EMIT_MAP
+WarnOnce = _utils_init.WarnOnce
+_FAILED_IMPORT_LIMIT = _utils_init._FAILED_IMPORT_LIMIT
+_DEFAULT_CACHE_SIZE = _utils_init._DEFAULT_CACHE_SIZE
+_IMPORT_STATE = _utils_init._IMPORT_STATE
+_reset_import_state = _utils_init._reset_import_state
+_warn_failure = _utils_init._warn_failure

--- a/tests/test_import_utils.py
+++ b/tests/test_import_utils.py
@@ -4,11 +4,22 @@ import types
 
 import pytest
 
+import tnfr.import_utils as legacy_import_utils
 import tnfr.utils.init as import_utils
 from tnfr.utils.init import _IMPORT_STATE, cached_import, prune_failed_imports
 
 
 pytestmark = pytest.mark.usefixtures("reset_cached_import")
+
+
+# -- Compatibility layer --------------------------------------------------------------------
+
+
+def test_legacy_import_utils_exposes_same_objects():
+    assert legacy_import_utils.IMPORT_LOG is import_utils.IMPORT_LOG
+    assert legacy_import_utils._IMPORT_STATE is import_utils._IMPORT_STATE
+    assert legacy_import_utils.cached_import is import_utils.cached_import
+    assert legacy_import_utils.prune_failed_imports is import_utils.prune_failed_imports
 
 
 # -- Attribute and fallback handling ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- delegate tnfr.import_utils to tnfr.utils.init via module alias re-exports
- add regression coverage ensuring the legacy wrapper exposes the canonical state objects

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f29673654483218096fe9448939648