### PR TITLE
Keep tnfr.logging_utils in sync with the canonical logging state

### DIFF
--- a/src/tnfr/logging_utils.py
+++ b/src/tnfr/logging_utils.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 import warnings
 
-from .utils.init import (
-    WarnOnce,
-    _LOGGING_CONFIGURED,
-    _reset_logging_state,
-    _configure_root,
-    get_logger,
-    warn_once,
-)
+import tnfr.utils.init as _utils_init
 
-__all__ = ("_configure_root", "get_logger", "WarnOnce", "warn_once")
+__all__ = ("_configure_root", "get_logger", "WarnOnce", "warn_once", "_LOGGING_CONFIGURED")
+
+get_logger = _utils_init.get_logger
+warn_once = _utils_init.warn_once
+WarnOnce = _utils_init.WarnOnce
+_configure_root = _utils_init._configure_root
+
+
+def __getattr__(name: str):
+    if name == "_LOGGING_CONFIGURED":
+        return getattr(_utils_init, name)
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | {"_LOGGING_CONFIGURED"})
+
 
 warnings.warn(
     "'tnfr.logging_utils' is deprecated; import from 'tnfr.utils' instead",
@@ -21,4 +30,4 @@ warnings.warn(
     stacklevel=2,
 )
 
-_reset_logging_state()
+_utils_init._reset_logging_state()

--- a/tests/test_logging_utils_proxy_state.py
+++ b/tests/test_logging_utils_proxy_state.py
@@ -1,0 +1,26 @@
+import importlib
+import logging
+
+
+def reload_logging_modules():
+    import tnfr.logging_utils as logging_proxy
+    import tnfr.utils.init as logging_core
+
+    logging.getLogger().handlers.clear()
+    logging.getLogger().setLevel(logging.NOTSET)
+
+    logging_core = importlib.reload(logging_core)
+    logging_proxy = importlib.reload(logging_proxy)
+    return logging_proxy, logging_core
+
+
+def test_logging_utils_reflects_logging_configured_flag():
+    proxy, core = reload_logging_modules()
+
+    assert core._LOGGING_CONFIGURED is False
+    assert proxy._LOGGING_CONFIGURED is False
+
+    proxy.get_logger("tnfr.test.logging_proxy_state")
+
+    assert core._LOGGING_CONFIGURED is True
+    assert proxy._LOGGING_CONFIGURED is True


### PR DESCRIPTION
## Summary
- proxy `tnfr.logging_utils` through `tnfr.utils.init` to keep exports consistent and live
- expose `_LOGGING_CONFIGURED` via module attribute lookup so both modules share the same state
- add a regression test validating the shared configuration flag after calling `get_logger`

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f297a0cab48321b2afc442853c8888