### PR TITLE
Refactor configuration into package structure

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -24,7 +24,7 @@ from ..dynamics import (
     parametric_glyph_selector,
     validate_canon,
 )
-from ..presets import get_preset
+from ..config.presets import get_preset
 from ..config import apply_config
 from ..io import read_structured_file, safe_write, StructuredFileError
 from ..glyph_history import ensure_history

--- a/src/tnfr/config/__init__.py
+++ b/src/tnfr/config/__init__.py
@@ -1,0 +1,12 @@
+"""Configuration package for TNFR.
+
+This package groups helpers and canonical defaults that orchestrate how
+configuration payloads interact with the engine.  The public API mirrors the
+previous module level functions so downstream importers remain stable.
+"""
+
+from __future__ import annotations
+
+from .init import apply_config, load_config
+
+__all__ = ("load_config", "apply_config")

--- a/src/tnfr/config/constants.py
+++ b/src/tnfr/config/constants.py
@@ -1,0 +1,99 @@
+"""Canonical glyph constants tied to configuration presets."""
+
+from __future__ import annotations
+
+import math
+from types import MappingProxyType
+from typing import Mapping
+
+from ..types import Glyph
+
+# -------------------------
+# Orden canónico y clasificaciones funcionales
+# -------------------------
+
+GLYPHS_CANONICAL: tuple[str, ...] = (
+    Glyph.AL.value,  # 0
+    Glyph.EN.value,  # 1
+    Glyph.IL.value,  # 2
+    Glyph.OZ.value,  # 3
+    Glyph.UM.value,  # 4
+    Glyph.RA.value,  # 5
+    Glyph.SHA.value,  # 6
+    Glyph.VAL.value,  # 7
+    Glyph.NUL.value,  # 8
+    Glyph.THOL.value,  # 9
+    Glyph.ZHIR.value,  # 10
+    Glyph.NAV.value,  # 11
+    Glyph.REMESH.value,  # 12
+)
+
+GLYPHS_CANONICAL_SET: frozenset[str] = frozenset(GLYPHS_CANONICAL)
+
+ESTABILIZADORES = (
+    Glyph.IL.value,
+    Glyph.RA.value,
+    Glyph.UM.value,
+    Glyph.SHA.value,
+)
+
+DISRUPTIVOS = (
+    Glyph.OZ.value,
+    Glyph.ZHIR.value,
+    Glyph.NAV.value,
+    Glyph.THOL.value,
+)
+
+# Mapa general de agrupaciones glíficas para referencia cruzada.
+GLYPH_GROUPS: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "estabilizadores": ESTABILIZADORES,
+        "disruptivos": DISRUPTIVOS,
+        # Grupos auxiliares para métricas morfosintácticas
+        "ID": (Glyph.OZ.value,),
+        "CM": (Glyph.ZHIR.value, Glyph.NAV.value),
+        "NE": (Glyph.IL.value, Glyph.THOL.value),
+        "PP_num": (Glyph.SHA.value,),
+        "PP_den": (Glyph.REMESH.value,),
+    }
+)
+
+# -------------------------
+# Mapa de ángulos glíficos
+# -------------------------
+
+# Ángulos canónicos para todos los glyphs reconocidos. Se calculan a partir
+# del orden canónico y reglas de orientación para las categorías
+# "estabilizadores" y "disruptivos".
+
+
+def _build_angle_map() -> dict[str, float]:
+    """Construir el mapa de ángulos en el plano σ."""
+
+    step = 2 * math.pi / len(GLYPHS_CANONICAL)
+    canonical = {g: i * step for i, g in enumerate(GLYPHS_CANONICAL)}
+    angles = dict(canonical)
+
+    # Reglas específicas de orientación
+    for idx, g in enumerate(ESTABILIZADORES):
+        angles[g] = idx * math.pi / 4
+    for idx, g in enumerate(DISRUPTIVOS):
+        angles[g] = math.pi + idx * math.pi / 4
+
+    # Excepciones manuales
+    angles[Glyph.VAL.value] = canonical[Glyph.RA.value]
+    angles[Glyph.NUL.value] = canonical[Glyph.ZHIR.value]
+    angles[Glyph.AL.value] = 0.0
+    return angles
+
+
+ANGLE_MAP: Mapping[str, float] = MappingProxyType(_build_angle_map())
+
+__all__ = (
+    "GLYPHS_CANONICAL",
+    "GLYPHS_CANONICAL_SET",
+    "ESTABILIZADORES",
+    "DISRUPTIVOS",
+    "GLYPH_GROUPS",
+    "ANGLE_MAP",
+)

--- a/src/tnfr/config/init.py
+++ b/src/tnfr/config/init.py
@@ -1,12 +1,13 @@
-"""Configuration utilities."""
+"""Core configuration helpers."""
 
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING
+
 from collections.abc import Mapping
 from pathlib import Path
-from .io import read_structured_file
+from typing import TYPE_CHECKING, Any
 
-from .constants import inject_defaults
+from ..constants import inject_defaults
+from ..io import read_structured_file
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checkers
     import networkx as nx  # type: ignore[import-untyped]
@@ -16,6 +17,7 @@ __all__ = ("load_config", "apply_config")
 
 def load_config(path: str | Path) -> Mapping[str, Any]:
     """Read a JSON/YAML file and return a mapping with parameters."""
+
     path_obj = path if isinstance(path, Path) else Path(path)
     data = read_structured_file(path_obj)
     if not isinstance(data, Mapping):
@@ -23,10 +25,12 @@ def load_config(path: str | Path) -> Mapping[str, Any]:
     return data
 
 
-def apply_config(G: nx.Graph, path: str | Path) -> None:
+def apply_config(G: "nx.Graph", path: str | Path) -> None:
     """Inject parameters from ``path`` into ``G.graph``.
 
-    Reuses :func:`inject_defaults` to keep canonical default semantics.
+    Reuses :func:`tnfr.constants.inject_defaults` to keep canonical default
+    semantics.
     """
+
     cfg = load_config(path)
     inject_defaults(G, cfg, override=True)

--- a/src/tnfr/config/presets.py
+++ b/src/tnfr/config/presets.py
@@ -1,0 +1,61 @@
+"""Predefined TNFR configuration sequences."""
+
+from __future__ import annotations
+
+from ..execution import (
+    CANONICAL_PRESET_NAME,
+    CANONICAL_PROGRAM_TOKENS,
+    block,
+    seq,
+    wait,
+)
+from ..types import Glyph
+
+__all__ = ("get_preset",)
+
+
+_PRESETS = {
+    "arranque_resonante": seq(
+        Glyph.AL,
+        Glyph.EN,
+        Glyph.IL,
+        Glyph.RA,
+        Glyph.VAL,
+        Glyph.UM,
+        wait(3),
+        Glyph.SHA,
+    ),
+    "mutacion_contenida": seq(
+        Glyph.AL,
+        Glyph.EN,
+        block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2),
+        Glyph.RA,
+        Glyph.SHA,
+    ),
+    "exploracion_acople": seq(
+        Glyph.AL,
+        Glyph.EN,
+        Glyph.IL,
+        Glyph.VAL,
+        Glyph.UM,
+        block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1),
+        Glyph.RA,
+        Glyph.SHA,
+    ),
+    CANONICAL_PRESET_NAME: list(CANONICAL_PROGRAM_TOKENS),
+    # Topologías fractales: expansión/contracción modular
+    "fractal_expand": seq(
+        block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL),
+        Glyph.RA,
+    ),
+    "fractal_contract": seq(
+        block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA),
+        Glyph.RA,
+    ),
+}
+
+
+def get_preset(name: str):
+    if name not in _PRESETS:
+        raise KeyError(f"Preset no encontrado: {name}")
+    return _PRESETS[name]

--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -1,98 +1,16 @@
-"""Default glyphs."""
+"""Backward compatibility shim for glyph constants."""
 
 from __future__ import annotations
 
-import math
-from types import MappingProxyType
-from typing import Mapping
+import warnings
 
-from .types import Glyph
+from .config.constants import *  # noqa: F401,F403 - re-export legacy API
+from .config.constants import __all__ as _CONFIG_ALL
 
-# -------------------------
-# Orden canónico y clasificaciones funcionales
-# -------------------------
-
-GLYPHS_CANONICAL: tuple[str, ...] = (
-    Glyph.AL.value,  # 0
-    Glyph.EN.value,  # 1
-    Glyph.IL.value,  # 2
-    Glyph.OZ.value,  # 3
-    Glyph.UM.value,  # 4
-    Glyph.RA.value,  # 5
-    Glyph.SHA.value,  # 6
-    Glyph.VAL.value,  # 7
-    Glyph.NUL.value,  # 8
-    Glyph.THOL.value,  # 9
-    Glyph.ZHIR.value,  # 10
-    Glyph.NAV.value,  # 11
-    Glyph.REMESH.value,  # 12
+warnings.warn(
+    "'tnfr.constants_glyphs' está en desuso; usa 'tnfr.config.constants'",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
-GLYPHS_CANONICAL_SET: frozenset[str] = frozenset(GLYPHS_CANONICAL)
-
-ESTABILIZADORES = (
-    Glyph.IL.value,
-    Glyph.RA.value,
-    Glyph.UM.value,
-    Glyph.SHA.value,
-)
-
-DISRUPTIVOS = (
-    Glyph.OZ.value,
-    Glyph.ZHIR.value,
-    Glyph.NAV.value,
-    Glyph.THOL.value,
-)
-
-# Mapa general de agrupaciones glíficas para referencia cruzada.
-GLYPH_GROUPS: Mapping[str, tuple[str, ...]] = MappingProxyType(
-    {
-        "estabilizadores": ESTABILIZADORES,
-        "disruptivos": DISRUPTIVOS,
-        # Grupos auxiliares para métricas morfosintácticas
-        "ID": (Glyph.OZ.value,),
-        "CM": (Glyph.ZHIR.value, Glyph.NAV.value),
-        "NE": (Glyph.IL.value, Glyph.THOL.value),
-        "PP_num": (Glyph.SHA.value,),
-        "PP_den": (Glyph.REMESH.value,),
-    }
-)
-
-# -------------------------
-# Mapa de ángulos glíficos
-# -------------------------
-
-# Ángulos canónicos para todos los glyphs reconocidos. Se calculan a partir
-# del orden canónico y reglas de orientación para las categorías
-# "estabilizadores" y "disruptivos".
-
-
-def _build_angle_map() -> dict[str, float]:
-    """Construir el mapa de ángulos en el plano σ."""
-    step = 2 * math.pi / len(GLYPHS_CANONICAL)
-    canonical = {g: i * step for i, g in enumerate(GLYPHS_CANONICAL)}
-    angles = dict(canonical)
-
-    # Reglas específicas de orientación
-    for idx, g in enumerate(ESTABILIZADORES):
-        angles[g] = idx * math.pi / 4
-    for idx, g in enumerate(DISRUPTIVOS):
-        angles[g] = math.pi + idx * math.pi / 4
-
-    # Excepciones manuales
-    angles[Glyph.VAL.value] = canonical[Glyph.RA.value]
-    angles[Glyph.NUL.value] = canonical[Glyph.ZHIR.value]
-    angles[Glyph.AL.value] = 0.0
-    return angles
-
-
-ANGLE_MAP: Mapping[str, float] = MappingProxyType(_build_angle_map())
-
-__all__ = (
-    "GLYPHS_CANONICAL",
-    "GLYPHS_CANONICAL_SET",
-    "ESTABILIZADORES",
-    "DISRUPTIVOS",
-    "GLYPH_GROUPS",
-    "ANGLE_MAP",
-)
+__all__ = _CONFIG_ALL

--- a/src/tnfr/execution.py
+++ b/src/tnfr/execution.py
@@ -191,7 +191,7 @@ def basic_canonical_example() -> list[Token]:
     """Reference canonical sequence.
 
     Returns a copy of the canonical preset tokens to keep CLI defaults aligned
-    with :func:`tnfr.presets.get_preset`.
+    with :func:`tnfr.config.presets.get_preset`.
     """
 
     return list(CANONICAL_PROGRAM_TOKENS)

--- a/src/tnfr/flatten.py
+++ b/src/tnfr/flatten.py
@@ -14,7 +14,7 @@ from .utils import (
     flatten_structure,
     normalize_materialize_limit,
 )
-from .constants_glyphs import GLYPHS_CANONICAL_SET
+from .config.constants import GLYPHS_CANONICAL_SET
 from .tokens import THOL, TARGET, WAIT, OpTag, THOL_SENTINEL, Token
 from .types import Glyph
 

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -6,7 +6,7 @@ import csv
 import math
 from itertools import zip_longest, tee
 
-from ..constants_glyphs import GLYPHS_CANONICAL
+from ..config.constants import GLYPHS_CANONICAL
 from ..glyph_history import ensure_history
 from ..io import safe_write
 from ..utils import json_dumps

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 from ..alias import get_attr
 from ..constants import get_aliases, get_param
-from ..constants_glyphs import GLYPH_GROUPS, GLYPHS_CANONICAL
+from ..config.constants import GLYPH_GROUPS, GLYPHS_CANONICAL
 from ..glyph_history import append_metric, last_glyph
 from ..types import Glyph
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -15,7 +15,7 @@ from .glyph_history import (
     append_metric,
 )
 from .utils import mix_groups, normalize_counter
-from .constants_glyphs import GLYPH_GROUPS
+from .config.constants import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
 from .utils import get_logger, get_numpy
 from .metrics.common import compute_coherence

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -1,60 +1,15 @@
-"""Predefined configurations."""
+"""Backward compatibility shim for configuration presets."""
 
 from __future__ import annotations
-from .execution import (
-    CANONICAL_PRESET_NAME,
-    CANONICAL_PROGRAM_TOKENS,
-    block,
-    seq,
-    wait,
+
+import warnings
+
+from .config.presets import get_preset
+
+warnings.warn(
+    "'tnfr.presets' está en desuso; usa 'tnfr.config.presets'",
+    DeprecationWarning,
+    stacklevel=2,
 )
-from .types import Glyph
 
 __all__ = ("get_preset",)
-
-
-_PRESETS = {
-    "arranque_resonante": seq(
-        Glyph.AL,
-        Glyph.EN,
-        Glyph.IL,
-        Glyph.RA,
-        Glyph.VAL,
-        Glyph.UM,
-        wait(3),
-        Glyph.SHA,
-    ),
-    "mutacion_contenida": seq(
-        Glyph.AL,
-        Glyph.EN,
-        block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2),
-        Glyph.RA,
-        Glyph.SHA,
-    ),
-    "exploracion_acople": seq(
-        Glyph.AL,
-        Glyph.EN,
-        Glyph.IL,
-        Glyph.VAL,
-        Glyph.UM,
-        block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1),
-        Glyph.RA,
-        Glyph.SHA,
-    ),
-    CANONICAL_PRESET_NAME: list(CANONICAL_PROGRAM_TOKENS),
-    # Topologías fractales: expansión/contracción modular
-    "fractal_expand": seq(
-        block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL),
-        Glyph.RA,
-    ),
-    "fractal_contract": seq(
-        block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA),
-        Glyph.RA,
-    ),
-}
-
-
-def get_preset(name: str):
-    if name not in _PRESETS:
-        raise KeyError(f"Preset no encontrado: {name}")
-    return _PRESETS[name]

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -20,7 +20,7 @@ from .glyph_history import (
     count_glyphs,
     append_metric,
 )
-from .constants_glyphs import (
+from .config.constants import (
     ANGLE_MAP,
     GLYPHS_CANONICAL,
 )

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -9,7 +9,7 @@ from .constants import get_aliases, get_param
 from .alias import get_attr
 from .sense import sigma_vector_from_graph
 from .helpers.numeric import within_range
-from .constants_glyphs import GLYPHS_CANONICAL_SET
+from .config.constants import GLYPHS_CANONICAL_SET
 
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ from tnfr.cli.execution import (
 from tnfr.constants import METRIC_DEFAULTS
 from tnfr import __version__
 from tnfr.execution import CANONICAL_PRESET_NAME, basic_canonical_example
-from tnfr.presets import get_preset
+from tnfr.config.presets import get_preset
 
 
 def test_cli_version(capsys):

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -49,7 +49,7 @@ def test_load_config_accepts_mapping(monkeypatch, tmp_path):
     def fake_reader(path):
         return data
 
-    monkeypatch.setattr("tnfr.config.read_structured_file", fake_reader)
+    monkeypatch.setattr("tnfr.config.init.read_structured_file", fake_reader)
     path = tmp_path / "dummy.json"
     path.write_text("{}", encoding="utf-8")
     loaded = load_config(path)
@@ -73,7 +73,7 @@ def test_apply_config_passes_path_object(monkeypatch, tmp_path, graph_canon):
         received["path"] = p
         return {}
 
-    monkeypatch.setattr("tnfr.config.load_config", fake_load)
+    monkeypatch.setattr("tnfr.config.init.load_config", fake_load)
     G = graph_canon()
     apply_config(G, path)
     assert received["path"] is path

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -17,7 +17,7 @@ from tnfr.observers import (
 )
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
-from tnfr.constants_glyphs import ANGLE_MAP
+from tnfr.config.constants import ANGLE_MAP
 from tnfr.helpers.numeric import angle_diff
 from tnfr.alias import set_attr
 from tnfr.callback_utils import CallbackEvent


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- create the `tnfr.config` package, relocating `load_config`/`apply_config` while keeping the package entry point aligned with the previous module API
- move glyph constants and preset definitions under `tnfr.config` and update engine and test imports accordingly
- add deprecation shims for `tnfr.constants_glyphs` and `tnfr.presets` so external consumers transition smoothly

## Testing
- `pytest` *(fails: missing optional dependency numpy in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a2a4c7f083219498336c35e51966