### PR TITLE
Centralize TNFR operator name constants

### DIFF
--- a/src/tnfr/config/operator_names.py
+++ b/src/tnfr/config/operator_names.py
@@ -1,0 +1,63 @@
+"""Canonical operator name constants and reusable sets."""
+
+from __future__ import annotations
+
+# Individual operator identifiers
+EMISION = "emision"
+RECEPCION = "recepcion"
+COHERENCIA = "coherencia"
+DISONANCIA = "disonancia"
+ACOPLAMIENTO = "acoplamiento"
+RESONANCIA = "resonancia"
+SILENCIO = "silencio"
+EXPANSION = "expansion"
+CONTRACCION = "contraccion"
+AUTOORGANIZACION = "autoorganizacion"
+MUTACION = "mutacion"
+TRANSICION = "transicion"
+RECURSIVIDAD = "recursividad"
+
+# Canonical collections used by validation and orchestration logic
+ALL_OPERATOR_NAMES = frozenset(
+    {
+        EMISION,
+        RECEPCION,
+        COHERENCIA,
+        DISONANCIA,
+        ACOPLAMIENTO,
+        RESONANCIA,
+        SILENCIO,
+        EXPANSION,
+        CONTRACCION,
+        AUTOORGANIZACION,
+        MUTACION,
+        TRANSICION,
+        RECURSIVIDAD,
+    }
+)
+
+INICIO_VALIDOS = frozenset({EMISION, RECURSIVIDAD})
+TRAMO_INTERMEDIO = frozenset({DISONANCIA, ACOPLAMIENTO, RESONANCIA})
+CIERRE_VALIDO = frozenset({SILENCIO, TRANSICION, RECURSIVIDAD})
+AUTOORGANIZACION_CIERRES = frozenset({SILENCIO, CONTRACCION})
+
+__all__ = [
+    "EMISION",
+    "RECEPCION",
+    "COHERENCIA",
+    "DISONANCIA",
+    "ACOPLAMIENTO",
+    "RESONANCIA",
+    "SILENCIO",
+    "EXPANSION",
+    "CONTRACCION",
+    "AUTOORGANIZACION",
+    "MUTACION",
+    "TRANSICION",
+    "RECURSIVIDAD",
+    "ALL_OPERATOR_NAMES",
+    "INICIO_VALIDOS",
+    "TRAMO_INTERMEDIO",
+    "CIERRE_VALIDO",
+    "AUTOORGANIZACION_CIERRES",
+]

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -44,6 +44,7 @@ from ..selector import (
     _calc_selector_score,
     _apply_selector_hysteresis,
 )
+from ..config.operator_names import TRANSICION
 
 from .sampling import update_node_sample as _update_node_sample
 from .dnfr import (
@@ -174,7 +175,7 @@ def _compute_state(G, cfg: dict[str, Any]) -> tuple[str, float, float]:
     elif (R <= R_lo) or (disr >= disr_hi):
         state = "disonante"
     else:
-        state = "transicion"
+        state = TRANSICION
     return state, float(R), disr
 
 

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -11,6 +11,7 @@ from ..constants import (
     get_aliases,
     get_param,
 )
+from ..config.operator_names import TRANSICION
 from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import get_attr
@@ -60,14 +61,14 @@ def _state_from_thresholds(Rloc, dnfr_n, cfg):
     if all(comp(val, thr) for val, thr, comp in dissonant_checks.values()):
         return "disonante"
 
-    return "transicion"
+    return TRANSICION
 
 
 def _recommendation(state, cfg):
     adv = cfg.get("advice", {})
     key = {
         "estable": "stable",
-        "transicion": "transition",
+        TRANSICION: "transition",
         "disonante": "dissonant",
     }[state]
     return list(adv.get(key, []))

--- a/src/tnfr/operators/definitions.py
+++ b/src/tnfr/operators/definitions.py
@@ -7,6 +7,21 @@ from typing import Any
 import networkx as nx  # type: ignore[import-untyped]
 
 from ..types import Glyph
+from ..config.operator_names import (
+    EMISION,
+    RECEPCION,
+    COHERENCIA,
+    DISONANCIA,
+    ACOPLAMIENTO,
+    RESONANCIA,
+    SILENCIO,
+    EXPANSION,
+    CONTRACCION,
+    AUTOORGANIZACION,
+    MUTACION,
+    TRANSICION,
+    RECURSIVIDAD,
+)
 
 __all__ = (
     "Operador",
@@ -51,7 +66,7 @@ class Emision(Operador):
     """Aplicación del operador de emisión (símbolo ``AL``)."""
 
     __slots__ = ()
-    name = "emision"
+    name = EMISION
     glyph = Glyph.AL.value
 
 
@@ -59,7 +74,7 @@ class Recepcion(Operador):
     """Operador de recepción (símbolo ``EN``)."""
 
     __slots__ = ()
-    name = "recepcion"
+    name = RECEPCION
     glyph = Glyph.EN.value
 
 
@@ -67,7 +82,7 @@ class Coherencia(Operador):
     """Operador de coherencia (símbolo ``IL``)."""
 
     __slots__ = ()
-    name = "coherencia"
+    name = COHERENCIA
     glyph = Glyph.IL.value
 
 
@@ -75,7 +90,7 @@ class Disonancia(Operador):
     """Operador de disonancia (símbolo ``OZ``)."""
 
     __slots__ = ()
-    name = "disonancia"
+    name = DISONANCIA
     glyph = Glyph.OZ.value
 
 
@@ -83,7 +98,7 @@ class Acoplamiento(Operador):
     """Operador de acoplamiento (símbolo ``UM``)."""
 
     __slots__ = ()
-    name = "acoplamiento"
+    name = ACOPLAMIENTO
     glyph = Glyph.UM.value
 
 
@@ -91,7 +106,7 @@ class Resonancia(Operador):
     """Operador de resonancia (símbolo ``RA``)."""
 
     __slots__ = ()
-    name = "resonancia"
+    name = RESONANCIA
     glyph = Glyph.RA.value
 
 
@@ -99,7 +114,7 @@ class Silencio(Operador):
     """Operador de silencio (símbolo ``SHA``)."""
 
     __slots__ = ()
-    name = "silencio"
+    name = SILENCIO
     glyph = Glyph.SHA.value
 
 
@@ -107,7 +122,7 @@ class Expansion(Operador):
     """Operador de expansión (símbolo ``VAL``)."""
 
     __slots__ = ()
-    name = "expansion"
+    name = EXPANSION
     glyph = Glyph.VAL.value
 
 
@@ -115,7 +130,7 @@ class Contraccion(Operador):
     """Operador de contracción (símbolo ``NUL``)."""
 
     __slots__ = ()
-    name = "contraccion"
+    name = CONTRACCION
     glyph = Glyph.NUL.value
 
 
@@ -123,7 +138,7 @@ class Autoorganizacion(Operador):
     """Operador de autoorganización (símbolo ``THOL``)."""
 
     __slots__ = ()
-    name = "autoorganizacion"
+    name = AUTOORGANIZACION
     glyph = Glyph.THOL.value
 
 
@@ -131,7 +146,7 @@ class Mutacion(Operador):
     """Operador de mutación (símbolo ``ZHIR``)."""
 
     __slots__ = ()
-    name = "mutacion"
+    name = MUTACION
     glyph = Glyph.ZHIR.value
 
 
@@ -139,7 +154,7 @@ class Transicion(Operador):
     """Operador de transición (símbolo ``NAV``)."""
 
     __slots__ = ()
-    name = "transicion"
+    name = TRANSICION
     glyph = Glyph.NAV.value
 
 
@@ -147,5 +162,5 @@ class Recursividad(Operador):
     """Operador de recursividad (símbolo ``REMESH``)."""
 
     __slots__ = ()
-    name = "recursividad"
+    name = RECURSIVIDAD
     glyph = Glyph.REMESH.value

--- a/src/tnfr/validation/syntax.py
+++ b/src/tnfr/validation/syntax.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 from ..operators.registry import OPERADORES
+from ..config.operator_names import (
+    INICIO_VALIDOS,
+    TRAMO_INTERMEDIO,
+    CIERRE_VALIDO,
+    AUTOORGANIZACION,
+    RECEPCION,
+    COHERENCIA,
+    SILENCIO,
+    CONTRACCION,
+    AUTOORGANIZACION_CIERRES,
+)
 
 __all__ = ("validate_sequence",)
-
-
-_INICIO_VALIDOS = {"emision", "recursividad"}
-_TRAMO_INTERMEDIO = {"disonancia", "acoplamiento", "resonancia"}
-_CIERRE_VALIDO = {"silencio", "transicion", "recursividad"}
 
 
 def _validate_start(token: str) -> tuple[bool, str]:
@@ -17,7 +23,7 @@ def _validate_start(token: str) -> tuple[bool, str]:
 
     if not isinstance(token, str):
         return False, "tokens must be str"
-    if token not in _INICIO_VALIDOS:
+    if token not in INICIO_VALIDOS:
         return False, "must start with emission or recursion"
     return True, ""
 
@@ -37,7 +43,7 @@ def _validate_intermediate(
 def _validate_end(last_token: str, open_thol: bool) -> tuple[bool, str]:
     """Validate closing operator and any pending THOL blocks."""
 
-    if last_token not in _CIERRE_VALIDO:
+    if last_token not in CIERRE_VALIDO:
         return False, "sequence must end with silence/transition/recursion"
     if open_thol:
         return False, "THOL block without closure"
@@ -76,16 +82,16 @@ def _validate_token_sequence(nombres: list[str]) -> tuple[bool, str]:
             return False, "tokens must be str"
         nombres_set.add(n)
 
-        if n == "recepcion" and not found_recepcion:
+        if n == RECEPCION and not found_recepcion:
             found_recepcion = True
-        elif found_recepcion and n == "coherencia" and not found_coherencia:
+        elif found_recepcion and n == COHERENCIA and not found_coherencia:
             found_coherencia = True
-        elif found_coherencia and not seen_intermedio and n in _TRAMO_INTERMEDIO:
+        elif found_coherencia and not seen_intermedio and n in TRAMO_INTERMEDIO:
             seen_intermedio = True
 
-        if n == "autoorganizacion":
+        if n == AUTOORGANIZACION:
             open_thol = True
-        elif open_thol and n in {"silencio", "contraccion"}:
+        elif open_thol and n in AUTOORGANIZACION_CIERRES:
             open_thol = False
 
     ok, msg = _validate_known_tokens(nombres_set)

--- a/tests/test_diagnosis_state.py
+++ b/tests/test_diagnosis_state.py
@@ -1,6 +1,7 @@
 """Tests for _state_from_thresholds."""
 
 from tnfr.metrics.diagnosis import _state_from_thresholds
+from tnfr.config.operator_names import TRANSICION
 
 
 def test_state_from_thresholds_checks_all_conditions():
@@ -10,4 +11,4 @@ def test_state_from_thresholds_checks_all_conditions():
     }
     assert _state_from_thresholds(0.9, 0.1, cfg) == "estable"
     assert _state_from_thresholds(0.3, 0.6, cfg) == "disonante"
-    assert _state_from_thresholds(0.5, 0.3, cfg) == "transicion"
+    assert _state_from_thresholds(0.5, 0.3, cfg) == TRANSICION

--- a/tests/test_operator_names.py
+++ b/tests/test_operator_names.py
@@ -1,0 +1,16 @@
+"""Tests ensuring operator name constants stay aligned with registry."""
+
+from tnfr.config import operator_names as names
+from tnfr.operators.registry import OPERADORES
+
+
+def test_registry_matches_operator_constants() -> None:
+    assert set(OPERADORES.keys()) == names.ALL_OPERATOR_NAMES
+
+
+def test_validation_sets_are_subsets() -> None:
+    assert names.INICIO_VALIDOS <= names.ALL_OPERATOR_NAMES
+    assert names.TRAMO_INTERMEDIO <= names.ALL_OPERATOR_NAMES
+    assert names.CIERRE_VALIDO <= names.ALL_OPERATOR_NAMES
+    assert names.AUTOORGANIZACION in names.ALL_OPERATOR_NAMES
+    assert names.AUTOORGANIZACION_CIERRES <= names.ALL_OPERATOR_NAMES

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -14,6 +14,15 @@ from tnfr.structural import (
     validate_sequence,
 )
 from tnfr.constants import EPI_PRIMARY
+from tnfr.config.operator_names import (
+    EMISION,
+    RECEPCION,
+    COHERENCIA,
+    RESONANCIA,
+    SILENCIO,
+    AUTOORGANIZACION,
+    TRANSICION,
+)
 
 
 def test_create_nfr_basic():
@@ -51,12 +60,12 @@ def test_invalid_sequence():
 
 def test_thol_requires_closure():
     names = [
-        "emision",
-        "recepcion",
-        "coherencia",
-        "autoorganizacion",
-        "resonancia",
-        "transicion",
+        EMISION,
+        RECEPCION,
+        COHERENCIA,
+        AUTOORGANIZACION,
+        RESONANCIA,
+        TRANSICION,
     ]
     ok, msg = validate_sequence(names)
     assert not ok
@@ -64,11 +73,11 @@ def test_thol_requires_closure():
 
 def test_validate_sequence_rejects_unknown_tokens():
     names = [
-        "emision",
-        "recepcion",
-        "coherencia",
-        "resonancia",
-        "silencio",
+        EMISION,
+        RECEPCION,
+        COHERENCIA,
+        RESONANCIA,
+        SILENCIO,
         "desconocido",
     ]
     ok, msg = validate_sequence(names)
@@ -91,12 +100,12 @@ def test_thol_closed_by_silencio():
 
 def test_sequence_rejects_trailing_tokens():
     names = [
-        "emision",
-        "recepcion",
-        "coherencia",
-        "resonancia",
-        "silencio",
-        "emision",
+        EMISION,
+        RECEPCION,
+        COHERENCIA,
+        RESONANCIA,
+        SILENCIO,
+        EMISION,
     ]
     ok, msg = validate_sequence(names)
     assert not ok


### PR DESCRIPTION
## Summary
- introduce `tnfr.config.operator_names` to define canonical operator identifiers and reusable validation sets
- reuse the shared constants across operator definitions, syntax validation, metrics, and dynamics modules
- extend structural tests and add a dedicated suite that asserts the registry and validation sets stay aligned with the constants

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f2b0f027948321a8b9489060d02bea