### PR TITLE
Align syntax validation messaging with canonical operators

### DIFF
--- a/src/tnfr/validation/syntax.py
+++ b/src/tnfr/validation/syntax.py
@@ -10,9 +10,15 @@ from ..config.operator_names import (
     AUTOORGANIZACION,
     RECEPCION,
     COHERENCIA,
+    DISONANCIA,
+    ACOPLAMIENTO,
+    RESONANCIA,
     SILENCIO,
     CONTRACCION,
     AUTOORGANIZACION_CIERRES,
+    EMISION,
+    RECURSIVIDAD,
+    TRANSICION,
 )
 
 __all__ = ("validate_sequence",)
@@ -24,7 +30,8 @@ def _validate_start(token: str) -> tuple[bool, str]:
     if not isinstance(token, str):
         return False, "tokens must be str"
     if token not in INICIO_VALIDOS:
-        return False, "must start with emission or recursion"
+        valid_tokens = ", ".join((EMISION, RECURSIVIDAD))
+        return False, f"must start with {valid_tokens}"
     return True, ""
 
 
@@ -34,9 +41,10 @@ def _validate_intermediate(
     """Check that the central TNFR segment is present."""
 
     if not (found_recepcion and found_coherencia):
-        return False, "missing input→coherence segment"
+        return False, f"missing {RECEPCION}→{COHERENCIA} segment"
     if not seen_intermedio:
-        return False, "missing tension/coupling/resonance segment"
+        intermedio_tokens = ", ".join((DISONANCIA, ACOPLAMIENTO, RESONANCIA))
+        return False, f"missing {intermedio_tokens} segment"
     return True, ""
 
 
@@ -44,7 +52,8 @@ def _validate_end(last_token: str, open_thol: bool) -> tuple[bool, str]:
     """Validate closing operator and any pending THOL blocks."""
 
     if last_token not in CIERRE_VALIDO:
-        return False, "sequence must end with silence/transition/recursion"
+        cierre_tokens = ", ".join((SILENCIO, TRANSICION, RECURSIVIDAD))
+        return False, f"sequence must end with {cierre_tokens}"
     if open_thol:
         return False, "THOL block without closure"
     return True, ""


### PR DESCRIPTION
## Summary
- update syntax validation error strings to interpolate canonical operator name constants so guidance stays aligned with TNFR configuration.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f2b4853b28832187bcb9bfe6314d5e