### PR TITLE
Use direct pyproject parsing for version fallback

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -15,7 +15,7 @@ Recommended entry points are:
 
 from __future__ import annotations
 
-from importlib import import_module
+import re
 
 from .ontosim import preparar_red
 
@@ -61,28 +61,14 @@ except PackageNotFoundError:  # pragma: no cover
 
     pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
     __version__ = "0+unknown"
-    for module_name in ("tomllib", "tomli"):
-        try:
-            parser = import_module(module_name)
-        except ModuleNotFoundError:
-            continue
-
-        load = getattr(parser, "load", None)
-        if load is None:
-            continue
-        try:
-            with pyproject_path.open("rb") as f:
-                data = load(f)
-        except (OSError, AttributeError, TypeError, ValueError):
-            continue
-        try:
-            project = data["project"]
-            project_version = project["version"]
-        except (KeyError, TypeError, ValueError):
-            continue
-        if isinstance(project_version, str):
-            __version__ = project_version
-            break
+    try:
+        text = pyproject_path.read_text(encoding="utf-8")
+    except OSError:
+        pass
+    else:
+        match = re.search(r"^version\s*=\s*\"([^\"]+)\"", text, flags=re.MULTILINE)
+        if match:
+            __version__ = match.group(1)
 
 __all__ = [
     "__version__",

--- a/tests/test_version_resolution.py
+++ b/tests/test_version_resolution.py
@@ -24,9 +24,7 @@ def test_version_falls_back_to_pyproject() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     script = textwrap.dedent(
         """
-        import importlib
         import importlib.metadata as metadata
-        import re
         import sys
         from types import ModuleType
         import warnings
@@ -48,30 +46,6 @@ def test_version_falls_back_to_pyproject() -> None:
             for attr in attributes:
                 setattr(module, attr, lambda *args, **kwargs: None)
             sys.modules[module_name] = module
-
-        real_import_module = importlib.import_module
-
-        def fake_import_module(name, package=None):
-            if name == "tomllib":
-                raise ModuleNotFoundError("tomllib missing in test")
-            return real_import_module(name, package)
-
-        importlib.import_module = fake_import_module
-
-        module = ModuleType("tomli")
-        pattern = r'^version\\s*=\\s*"([^\"]+)"'
-
-        def load(handle):
-            data = handle.read()
-            if isinstance(data, bytes):
-                data = data.decode("utf-8")
-            match = re.search(pattern, data, flags=re.MULTILINE)
-            if not match:
-                raise ValueError("Missing version field")
-            return {{"project": {{"version": match.group(1)}}}}
-
-        module.load = load
-        sys.modules["tomli"] = module
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")


### PR DESCRIPTION
## Summary
- parse the package version from pyproject.toml when distribution metadata is unavailable
- align the version fallback test with the simplified parsing approach

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f2bfb39a808321abc371a22e3779f6