### PR TITLE
Ensure tnfr.__version__ handles metadata fallback

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -15,8 +15,17 @@ Recommended entry points are:
 
 from __future__ import annotations
 
-from ._version import __version__
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
 from .ontosim import preparar_red
+
+
+try:  # pragma: no cover - exercised in version resolution tests
+    __version__ = metadata.version("tnfr")
+except PackageNotFoundError:  # pragma: no cover - fallback tested explicitly
+    from ._version import __version__ as _fallback_version
+
+    __version__ = _fallback_version
 
 
 def _missing_dependency(name: str, exc: ImportError):

--- a/tests/test_version_resolution.py
+++ b/tests/test_version_resolution.py
@@ -2,9 +2,49 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
+import types
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
 
-def test_version_constant_matches_module() -> None:
-    import tnfr
-    from tnfr import _version
 
-    assert tnfr.__version__ == _version.__version__
+def _clear_tnfr_modules() -> None:
+    """Remove cached :mod:`tnfr` modules so import side effects re-trigger."""
+
+    for name in [key for key in sys.modules if key == "tnfr" or key.startswith("tnfr.")]:
+        sys.modules.pop(name)
+
+
+def test_version_prefers_package_metadata(monkeypatch) -> None:
+    """When metadata is present it should define ``tnfr.__version__``."""
+
+    _clear_tnfr_modules()
+
+    expected = "9.9.9-metadata"
+    monkeypatch.setattr(metadata, "version", lambda name: expected)
+
+    tnfr = importlib.import_module("tnfr")
+
+    assert tnfr.__version__ == expected
+
+
+def test_version_falls_back_to_local_module(monkeypatch) -> None:
+    """If metadata resolution fails the bundled version must be used."""
+
+    _clear_tnfr_modules()
+
+    expected = "9.9.9-local"
+    fake_version_module = types.ModuleType("tnfr._version")
+    fake_version_module.__version__ = expected
+
+    monkeypatch.setitem(sys.modules, "tnfr._version", fake_version_module)
+
+    def _raise(_name: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(metadata, "version", _raise)
+
+    tnfr = importlib.import_module("tnfr")
+
+    assert tnfr.__version__ == expected


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Controlled bifurcation cases (pytest tests/test_version_resolution.py)
- [ ] Phase/νf logs
- [ ] C(t), Si curves

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Resolve `tnfr.__version__` via `importlib.metadata` with a fallback to the bundled `_version` module when metadata is missing.
- Expand the version resolution tests to exercise both the metadata and fallback code paths.


------
https://chatgpt.com/codex/tasks/task_e_68f2c4cca3b8832184b49a6caec95dba