### PR TITLE
Clean up PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,9 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Intended Audience :: Science/Research",
-  "Topic :: Scientific/Engineering :: Networks",
-  "Topic :: Scientific/Engineering :: Dynamics",
-  "Topic :: Scientific/Engineering :: Structure",
-  "Topic :: Scientific/Engineering :: Complexity",
-  "Topic :: Scientific/Engineering :: Fractals",
-  "Topic :: Scientific/Engineering :: Resonance",
-  "Topic :: Scientific/Engineering :: TNFR"
+  "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Topic :: Scientific/Engineering :: Mathematics"
 ]
 dependencies = [
   "networkx>=2.6",


### PR DESCRIPTION
## Summary
- remove unofficial TNFR-specific classifiers from the package metadata
- replace them with official Scientific/Engineering categories from the PyPI taxonomy

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f2c8cd0ca883219a016327a7b2b374