### PR TITLE
Improve tnfr public API dependency diagnostics

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -4,20 +4,65 @@ This package only re-exports a handful of high level helpers.  Most
 functionality lives in submodules that should be imported directly, for
 example :mod:`tnfr.metrics`, :mod:`tnfr.observers` or the DSL utilities
 in :mod:`tnfr.tokens`, :mod:`tnfr.flatten` and :mod:`tnfr.execution`.
-Recommended entry points are:
 
-- ``step`` and ``run`` in :mod:`tnfr.dynamics`
-- ``preparar_red`` in :mod:`tnfr.ontosim`
-- ``create_nfr`` and ``run_sequence`` in :mod:`tnfr.structural`
-- ``cached_import`` and ``prune_failed_imports`` in :mod:`tnfr.utils` for
-  optional dependencies
+Exported helpers and their dependencies
+---------------------------------------
+The :data:`EXPORT_DEPENDENCIES` mapping enumerates which internal
+submodules and third-party packages are required to load each helper.
+The imports are grouped as follows:
+
+``step`` / ``run``
+    Provided by :mod:`tnfr.dynamics`.  These helpers rely exclusively on
+    internal TNFR modules (``tnfr.operators``, ``tnfr.metrics`` and
+    friends) and do not require additional third-party packages.
+
+``preparar_red``
+    Defined in :mod:`tnfr.ontosim`.  It configures graphs generated via
+    :mod:`networkx`, but the helper itself only depends on TNFR modules
+    such as :mod:`tnfr.constants`, :mod:`tnfr.dynamics` and
+    :mod:`tnfr.utils`.
+
+``create_nfr`` / ``run_sequence``
+    Re-exported from :mod:`tnfr.structural`.  Both helpers require the
+    ``networkx`` package in addition to TNFR structural utilities
+    (``tnfr.structural``, ``tnfr.validation`` and operator registries).
+
+``cached_import`` and ``prune_failed_imports`` remain available from
+``tnfr.utils`` for optional dependency management.
 """
 
 from __future__ import annotations
 
-from importlib import metadata
+import warnings
+from importlib import import_module, metadata
 from importlib.metadata import PackageNotFoundError
+from typing import Any
+
 from .ontosim import preparar_red
+
+
+EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
+    "step": {
+        "submodules": ("tnfr.dynamics",),
+        "third_party": (),
+    },
+    "run": {
+        "submodules": ("tnfr.dynamics",),
+        "third_party": (),
+    },
+    "preparar_red": {
+        "submodules": ("tnfr.ontosim",),
+        "third_party": (),
+    },
+    "create_nfr": {
+        "submodules": ("tnfr.structural",),
+        "third_party": ("networkx",),
+    },
+    "run_sequence": {
+        "submodules": ("tnfr.structural",),
+        "third_party": ("networkx",),
+    },
+}
 
 
 try:  # pragma: no cover - exercised in version resolution tests
@@ -28,32 +73,79 @@ except PackageNotFoundError:  # pragma: no cover - fallback tested explicitly
     __version__ = _fallback_version
 
 
-def _missing_dependency(name: str, exc: ImportError):
-    def _stub(*args, **kwargs):
+def _is_internal_import_error(exc: ImportError) -> bool:
+    missing_name = getattr(exc, "name", None) or ""
+    if missing_name.startswith("tnfr"):
+        return True
+    missing_path = getattr(exc, "path", None) or ""
+    if missing_path:
+        normalized = missing_path.replace("\\", "/")
+        if "/tnfr/" in normalized or normalized.endswith("/tnfr"):
+            return True
+    return False
+
+
+def _missing_dependency(name: str, exc: ImportError, *, module: str | None = None):
+    missing_name = getattr(exc, "name", None)
+
+    def _stub(*args: Any, **kwargs: Any):
         raise ImportError(
             f"{name} is unavailable because required dependencies could not be imported. "
             f"Original error ({exc.__class__.__name__}): {exc}. "
             "Install the missing packages (e.g. 'networkx' or grammar modules)."
         ) from exc
 
+    _stub.__tnfr_missing_dependency__ = {
+        "export": name,
+        "module": module,
+        "missing": missing_name,
+    }
     return _stub
 
 
-try:  # pragma: no cover - exercised in import tests
-    from .dynamics import step, run
-except ImportError as exc:  # pragma: no cover - no missing deps in CI
-    step = _missing_dependency("step", exc)
-    run = _missing_dependency("run", exc)
+_MISSING_EXPORTS: dict[str, dict[str, Any]] = {}
 
 
-_HAS_RUN_SEQUENCE = False
-try:  # pragma: no cover - exercised in import tests
-    from .structural import create_nfr, run_sequence
-except ImportError as exc:  # pragma: no cover - no missing deps in CI
-    create_nfr = _missing_dependency("create_nfr", exc)
-    run_sequence = _missing_dependency("run_sequence", exc)
-else:
-    _HAS_RUN_SEQUENCE = True
+def _assign_exports(module: str, names: tuple[str, ...]) -> bool:
+    try:  # pragma: no cover - exercised in import tests
+        mod = import_module(f".{module}", __name__)
+    except ImportError as exc:  # pragma: no cover - no missing deps in CI
+        if _is_internal_import_error(exc):
+            raise
+        for export_name in names:
+            stub = _missing_dependency(export_name, exc, module=module)
+            globals()[export_name] = stub
+            _MISSING_EXPORTS[export_name] = getattr(
+                stub, "__tnfr_missing_dependency__", {}
+            )
+        return False
+    else:
+        for export_name in names:
+            globals()[export_name] = getattr(mod, export_name)
+        return True
+
+
+_assign_exports("dynamics", ("step", "run"))
+
+
+_HAS_RUN_SEQUENCE = _assign_exports("structural", ("create_nfr", "run_sequence"))
+
+
+def _emit_missing_dependency_warning() -> None:
+    if not _MISSING_EXPORTS:
+        return
+    details = ", ".join(
+        f"{name} (missing: {info.get('missing') or 'unknown'})"
+        for name, info in sorted(_MISSING_EXPORTS.items())
+    )
+    warnings.warn(
+        "TNFR helpers disabled because dependencies are missing: " + details,
+        ImportWarning,
+        stacklevel=2,
+    )
+
+
+_emit_missing_dependency_warning()
 
 
 __all__ = [

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,17 @@
+import importlib
+import sys
+import warnings
+
+import pytest
+
 import tnfr
 from tnfr.metrics import register_metrics_callbacks
+
+
+def _clear_tnfr_modules() -> None:
+    for name in list(sys.modules):
+        if name == "tnfr" or name.startswith("tnfr."):
+            sys.modules.pop(name)
 
 
 def test_public_exports():
@@ -26,3 +38,55 @@ def test_basic_flow():
 
 def test_topological_remesh_not_exported():
     assert not hasattr(tnfr, "apply_topological_remesh")
+
+
+def test_public_api_missing_optional_dependency(monkeypatch):
+    real_import_module = importlib.import_module
+
+    def fail_structural(name, package=None):
+        if package == "tnfr" and name == ".structural":
+            raise ImportError("No module named 'networkx'", name="networkx")
+        if package is None and name == "tnfr.structural":
+            raise ImportError("No module named 'networkx'", name="networkx")
+        return real_import_module(name, package)
+
+    with monkeypatch.context() as m:
+        _clear_tnfr_modules()
+        m.setattr(importlib, "import_module", fail_structural)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            module = importlib.import_module("tnfr")
+        missing = [w for w in caught if issubclass(w.category, ImportWarning)]
+        assert missing
+        assert any(
+            "create_nfr" in str(w.message) and "networkx" in str(w.message)
+            for w in missing
+        )
+        with pytest.raises(ImportError) as excinfo:
+            module.create_nfr("n1")
+        assert "networkx" in str(excinfo.value)
+        with pytest.raises(ImportError):
+            module.run_sequence(None, None, [])
+        assert not getattr(module, "_HAS_RUN_SEQUENCE", False)
+    _clear_tnfr_modules()
+    globals()["tnfr"] = importlib.import_module("tnfr")
+
+
+def test_public_api_internal_import_error(monkeypatch):
+    real_import_module = importlib.import_module
+
+    def fail_dynamics(name, package=None):
+        if package == "tnfr" and name == ".dynamics":
+            raise ImportError("circular import", name="tnfr.dynamics")
+        if package is None and name == "tnfr.dynamics":
+            raise ImportError("circular import", name="tnfr.dynamics")
+        return real_import_module(name, package)
+
+    with monkeypatch.context() as m:
+        _clear_tnfr_modules()
+        m.setattr(importlib, "import_module", fail_dynamics)
+        with pytest.raises(ImportError) as excinfo:
+            importlib.import_module("tnfr")
+        assert excinfo.value.name == "tnfr.dynamics"
+        _clear_tnfr_modules()
+    globals()["tnfr"] = importlib.import_module("tnfr")


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

---

- Document the dependency mapping for public helpers and centralize import handling so missing external packages are surfaced without masking circular imports.
- Emit diagnostics when exports are stubbed and add regression coverage that differentiates missing optional dependencies from internal ImportErrors.


------
https://chatgpt.com/codex/tasks/task_e_68f2cad92c548321b3b158b4c676f9e2