### PR TITLE
Handle base-package circular import messages

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -90,7 +90,8 @@ def _is_internal_import_error(exc: ImportError) -> bool:
 
     message = str(exc)
     lowered = message.lower()
-    if "tnfr." in message and (
+    mentions_base_package = "module 'tnfr'" in lowered or 'module "tnfr"' in lowered
+    if ("tnfr." in message or mentions_base_package) and (
         "circular import" in lowered or "partially initialized module" in lowered
     ):
         return True

--- a/tests/test_public_init.py
+++ b/tests/test_public_init.py
@@ -1,0 +1,12 @@
+import pytest
+
+from tnfr import _is_internal_import_error
+
+
+def test_circular_import_message_with_base_package_name_counts_as_internal():
+    exc = ImportError(
+        "cannot import name 'create_nfr' from partially initialized module 'tnfr' "
+        "(most likely due to a circular import)"
+    )
+
+    assert _is_internal_import_error(exc) is True


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- classify circular-import ImportErrors that mention the base `tnfr` package name as internal failures
- add a regression test ensuring `_is_internal_import_error` accepts the package-level circular import wording

## Testing
- `pytest` *(fails: missing optional dependency `numpy` required by unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f33622cd108321b581ca2a1b70adfa