### PR TITLE
Clarify helper dependency manifest and guard with tests

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -12,20 +12,25 @@ submodules and third-party packages are required to load each helper.
 The imports are grouped as follows:
 
 ``step`` / ``run``
-    Provided by :mod:`tnfr.dynamics`.  These helpers rely exclusively on
-    internal TNFR modules (``tnfr.operators``, ``tnfr.metrics`` and
-    friends) and do not require additional third-party packages.
+    Provided by :mod:`tnfr.dynamics`.  These helpers rely on the
+    machinery defined within the :mod:`tnfr.dynamics` package (operator
+    orchestration, validation hooks and metrics integration) and do not
+    require additional third-party packages.
 
 ``preparar_red``
-    Defined in :mod:`tnfr.ontosim`.  It configures graphs generated via
-    :mod:`networkx`, but the helper itself only depends on TNFR modules
-    such as :mod:`tnfr.constants`, :mod:`tnfr.dynamics` and
-    :mod:`tnfr.utils`.
+    Defined in :mod:`tnfr.ontosim`.  Besides :mod:`tnfr.ontosim`
+    itself, the helper imports :mod:`tnfr.callback_utils`,
+    :mod:`tnfr.constants`, :mod:`tnfr.dynamics`, :mod:`tnfr.glyph_history`,
+    :mod:`tnfr.initialization` and :mod:`tnfr.utils` to assemble the
+    graph preparation pipeline.  No third-party packages are required at
+    import time.
 
 ``create_nfr`` / ``run_sequence``
-    Re-exported from :mod:`tnfr.structural`.  Both helpers require the
-    ``networkx`` package in addition to TNFR structural utilities
-    (``tnfr.structural``, ``tnfr.validation`` and operator registries).
+    Re-exported from :mod:`tnfr.structural`.  They depend on
+    :mod:`tnfr.structural`, :mod:`tnfr.constants`, :mod:`tnfr.dynamics`,
+    :mod:`tnfr.operators.definitions`, :mod:`tnfr.operators.registry` and
+    :mod:`tnfr.validation`, and additionally require the ``networkx``
+    package.
 
 ``cached_import`` and ``prune_failed_imports`` remain available from
 ``tnfr.utils`` for optional dependency management.
@@ -51,15 +56,37 @@ EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
         "third_party": (),
     },
     "preparar_red": {
-        "submodules": ("tnfr.ontosim",),
+        "submodules": (
+            "tnfr.ontosim",
+            "tnfr.callback_utils",
+            "tnfr.constants",
+            "tnfr.dynamics",
+            "tnfr.glyph_history",
+            "tnfr.initialization",
+            "tnfr.utils",
+        ),
         "third_party": (),
     },
     "create_nfr": {
-        "submodules": ("tnfr.structural",),
+        "submodules": (
+            "tnfr.structural",
+            "tnfr.constants",
+            "tnfr.dynamics",
+            "tnfr.operators.definitions",
+            "tnfr.operators.registry",
+            "tnfr.validation",
+        ),
         "third_party": ("networkx",),
     },
     "run_sequence": {
-        "submodules": ("tnfr.structural",),
+        "submodules": (
+            "tnfr.structural",
+            "tnfr.constants",
+            "tnfr.dynamics",
+            "tnfr.operators.definitions",
+            "tnfr.operators.registry",
+            "tnfr.validation",
+        ),
         "third_party": ("networkx",),
     },
 }

--- a/tests/test_export_dependencies.py
+++ b/tests/test_export_dependencies.py
@@ -1,0 +1,40 @@
+"""Ensure the exported dependency manifest stays in sync with helpers."""
+
+from __future__ import annotations
+
+
+def test_preparar_red_dependencies():
+    from tnfr import EXPORT_DEPENDENCIES
+
+    expected = {
+        "tnfr.ontosim",
+        "tnfr.callback_utils",
+        "tnfr.constants",
+        "tnfr.dynamics",
+        "tnfr.glyph_history",
+        "tnfr.initialization",
+        "tnfr.utils",
+    }
+
+    preparar = EXPORT_DEPENDENCIES["preparar_red"]
+    assert set(preparar["submodules"]) == expected
+    assert preparar["third_party"] == ()
+
+
+def test_structural_helpers_dependencies():
+    from tnfr import EXPORT_DEPENDENCIES
+
+    expected_submodules = {
+        "tnfr.structural",
+        "tnfr.constants",
+        "tnfr.dynamics",
+        "tnfr.operators.definitions",
+        "tnfr.operators.registry",
+        "tnfr.validation",
+    }
+    expected_third_party = ("networkx",)
+
+    for helper in ("create_nfr", "run_sequence"):
+        deps = EXPORT_DEPENDENCIES[helper]
+        assert set(deps["submodules"]) == expected_submodules
+        assert deps["third_party"] == expected_third_party


### PR DESCRIPTION
## Summary
- expand `EXPORT_DEPENDENCIES` to list the concrete `tnfr` submodules required by the public helpers
- sync the inline documentation with the richer dependency manifest
- add a regression test to ensure the manifest stays aligned with `preparar_red`, `create_nfr`, and `run_sequence`

## Testing
- pytest tests/test_export_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68f336c194308321a22364ad14fb8a36