### PR TITLE
Document networkx requirement for dynamics helpers

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -14,16 +14,16 @@ The imports are grouped as follows:
 ``step`` / ``run``
     Provided by :mod:`tnfr.dynamics`.  These helpers rely on the
     machinery defined within the :mod:`tnfr.dynamics` package (operator
-    orchestration, validation hooks and metrics integration) and do not
-    require additional third-party packages.
+    orchestration, validation hooks and metrics integration) and require
+    the ``networkx`` package for graph handling.
 
 ``preparar_red``
     Defined in :mod:`tnfr.ontosim`.  Besides :mod:`tnfr.ontosim`
     itself, the helper imports :mod:`tnfr.callback_utils`,
     :mod:`tnfr.constants`, :mod:`tnfr.dynamics`, :mod:`tnfr.glyph_history`,
     :mod:`tnfr.initialization` and :mod:`tnfr.utils` to assemble the
-    graph preparation pipeline.  No third-party packages are required at
-    import time.
+    graph preparation pipeline.  It also requires ``networkx`` at import
+    time.
 
 ``create_nfr`` / ``run_sequence``
     Re-exported from :mod:`tnfr.structural`.  They depend on
@@ -49,11 +49,11 @@ from .ontosim import preparar_red
 EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
     "step": {
         "submodules": ("tnfr.dynamics",),
-        "third_party": (),
+        "third_party": ("networkx",),
     },
     "run": {
         "submodules": ("tnfr.dynamics",),
-        "third_party": (),
+        "third_party": ("networkx",),
     },
     "preparar_red": {
         "submodules": (
@@ -65,7 +65,7 @@ EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
             "tnfr.initialization",
             "tnfr.utils",
         ),
-        "third_party": (),
+        "third_party": ("networkx",),
     },
     "create_nfr": {
         "submodules": (

--- a/tests/test_export_dependencies.py
+++ b/tests/test_export_dependencies.py
@@ -18,7 +18,19 @@ def test_preparar_red_dependencies():
 
     preparar = EXPORT_DEPENDENCIES["preparar_red"]
     assert set(preparar["submodules"]) == expected
-    assert preparar["third_party"] == ()
+    assert preparar["third_party"] == ("networkx",)
+
+
+def test_dynamics_helpers_dependencies():
+    from tnfr import EXPORT_DEPENDENCIES
+
+    expected_submodules = {"tnfr.dynamics"}
+    expected_third_party = ("networkx",)
+
+    for helper in ("step", "run"):
+        deps = EXPORT_DEPENDENCIES[helper]
+        assert set(deps["submodules"]) == expected_submodules
+        assert deps["third_party"] == expected_third_party
 
 
 def test_structural_helpers_dependencies():


### PR DESCRIPTION
### Summary
- document the networkx dependency for step, run, and preparar_red in the public API module
- update EXPORT_DEPENDENCIES so these helpers declare networkx under third_party
- expand the export dependency tests to cover the dynamics helpers and revised metadata

### Testing
- pytest tests/test_export_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68f3389018a88321971f9ff118a07c77