### PR TITLE
Add runtime validation for export dependency manifest

### DIFF
--- a/tests/test_export_dependencies.py
+++ b/tests/test_export_dependencies.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 
 def test_preparar_red_dependencies():
     from tnfr import EXPORT_DEPENDENCIES
@@ -50,3 +52,14 @@ def test_structural_helpers_dependencies():
         deps = EXPORT_DEPENDENCIES[helper]
         assert set(deps["submodules"]) == expected_submodules
         assert deps["third_party"] == expected_third_party
+
+
+def test_manifest_validator_catches_mismatches(monkeypatch):
+    import tnfr
+
+    broken_manifest = dict(tnfr.EXPORT_DEPENDENCIES)
+    broken_manifest.pop("run")
+    monkeypatch.setattr(tnfr, "EXPORT_DEPENDENCIES", broken_manifest)
+
+    with pytest.raises(tnfr.ExportDependencyError, match="run"):
+        tnfr._validate_export_dependencies()


### PR DESCRIPTION
## Summary
- add a validator that checks __all__ against EXPORT_DEPENDENCIES during import
- raise an actionable ExportDependencyError when the manifest is out of sync
- extend export dependency tests to cover the new validator guardrail

## Testing
- pytest tests/test_export_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68f33ad77b648321958ea1bcae6822f2