### PR TITLE
Refactor validator utilities into utils module

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -582,7 +582,7 @@ def _maybe_remesh(G) -> None:
 
 
 def _run_validators(G) -> None:
-    from ..validators import run_validators
+    from ..utils.validators import run_validators
 
     run_validators(G)
 

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -27,7 +27,7 @@ __all__ = (
 
 @lru_cache(maxsize=1)
 def _resolve_validate_window():
-    from .validators import validate_window
+    from .utils.validators import validate_window
 
     return validate_window
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -19,7 +19,7 @@ from .config.constants import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
 from .utils import get_logger, get_numpy
 from .metrics.common import compute_coherence
-from .validators import validate_window
+from .utils.validators import validate_window
 
 ALIAS_THETA = get_aliases("THETA")
 

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -89,6 +89,8 @@ __all__ = (
     "DEFAULT_PARAMS",
     "json_dumps",
     "clear_orjson_param_warnings",
+    "validate_window",
+    "run_validators",
     "_configure_root",
     "_LOGGING_CONFIGURED",
     "_reset_logging_state",
@@ -116,13 +118,20 @@ _DEFAULT_CACHE_SIZE = _init._DEFAULT_CACHE_SIZE
 EMIT_MAP = _init.EMIT_MAP
 
 _DYNAMIC_EXPORTS = {"IMPORT_LOG", "_IMPORT_STATE", "_LOGGING_CONFIGURED"}
+_VALIDATOR_EXPORTS = {"validate_window", "run_validators"}
 
 
 def __getattr__(name: str):  # pragma: no cover - trivial delegation
     if name in _DYNAMIC_EXPORTS:
         return getattr(_init, name)
+    if name in _VALIDATOR_EXPORTS:
+        from .validators import run_validators, validate_window
+
+        if name == "validate_window":
+            return validate_window
+        return run_validators
     raise AttributeError(name)
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial delegation
-    return sorted(set(globals()) | _DYNAMIC_EXPORTS)
+    return sorted(set(globals()) | _DYNAMIC_EXPORTS | _VALIDATOR_EXPORTS)

--- a/src/tnfr/utils/validators.py
+++ b/src/tnfr/utils/validators.py
@@ -1,0 +1,84 @@
+"""Validation utilities for TNFR graph structures."""
+
+from __future__ import annotations
+
+import numbers
+import sys
+
+from ..alias import get_attr
+from ..config.constants import GLYPHS_CANONICAL_SET
+from ..constants import get_aliases, get_param
+from ..helpers.numeric import within_range
+from ..sense import sigma_vector_from_graph
+
+ALIAS_EPI = get_aliases("EPI")
+ALIAS_VF = get_aliases("VF")
+
+__all__ = ("validate_window", "run_validators")
+
+
+def validate_window(window: int, *, positive: bool = False) -> int:
+    """Validate ``window`` as an ``int`` and return it.
+
+    Non-integer values raise :class:`TypeError`. When ``positive`` is ``True``
+    the value must be strictly greater than zero; otherwise it may be zero.
+    Negative values always raise :class:`ValueError`.
+    """
+
+    if isinstance(window, bool) or not isinstance(window, numbers.Integral):
+        raise TypeError("'window' must be an integer")
+    if window < 0 or (positive and window == 0):
+        kind = "positive" if positive else "non-negative"
+        raise ValueError(f"'window'={window} must be {kind}")
+    return int(window)
+
+
+def _require_attr(data, alias, node, name):
+    """Return attribute value or raise if missing."""
+    val = get_attr(data, alias, None)
+    if val is None:
+        raise ValueError(f"Missing {name} attribute in node {node}")
+    return val
+
+
+def _validate_sigma(G) -> None:
+    sv = sigma_vector_from_graph(G)
+    if sv.get("mag", 0.0) > 1.0 + sys.float_info.epsilon:
+        raise ValueError("σ norm exceeds 1")
+
+
+def _check_epi_vf(epi, vf, epi_min, epi_max, vf_min, vf_max, n):
+    _check_range(epi, epi_min, epi_max, "EPI", n)
+    _check_range(vf, vf_min, vf_max, "VF", n)
+
+
+def _out_of_range_msg(name, node, val):
+    return f"{name} out of range in node {node}: {val}"
+
+
+def _check_range(val, lower, upper, name, node, tol: float = 1e-9):
+    if not within_range(val, lower, upper, tol):
+        raise ValueError(_out_of_range_msg(name, node, val))
+
+
+def _check_glyph(g, n):
+    if g and g not in GLYPHS_CANONICAL_SET:
+        raise KeyError(f"Invalid glyph {g} in node {n}")
+
+
+def run_validators(G) -> None:
+    """Run all invariant validators on ``G`` with a single node pass."""
+    from ..glyph_history import last_glyph
+
+    epi_min = float(get_param(G, "EPI_MIN"))
+    epi_max = float(get_param(G, "EPI_MAX"))
+    vf_min = float(get_param(G, "VF_MIN"))
+    vf_max = float(get_param(G, "VF_MAX"))
+
+    for n, data in G.nodes(data=True):
+        epi = _require_attr(data, ALIAS_EPI, n, "EPI")
+        vf = _require_attr(data, ALIAS_VF, n, "VF")
+        _check_epi_vf(epi, vf, epi_min, epi_max, vf_min, vf_max, n)
+        _check_glyph(last_glyph(data), n)
+
+    _validate_sigma(G)

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -1,84 +1,15 @@
-"""Validation utilities."""
+"""Compatibility shim for :mod:`tnfr.utils.validators`."""
 
 from __future__ import annotations
 
-import numbers
-import sys
+import warnings
 
-from .constants import get_aliases, get_param
-from .alias import get_attr
-from .sense import sigma_vector_from_graph
-from .helpers.numeric import within_range
-from .config.constants import GLYPHS_CANONICAL_SET
-
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_VF = get_aliases("VF")
+from .utils.validators import run_validators, validate_window
 
 __all__ = ("validate_window", "run_validators")
 
-
-def validate_window(window: int, *, positive: bool = False) -> int:
-    """Validate ``window`` as an ``int`` and return it.
-
-    Non-integer values raise :class:`TypeError`. When ``positive`` is ``True``
-    the value must be strictly greater than zero; otherwise it may be zero.
-    Negative values always raise :class:`ValueError`.
-    """
-
-    if isinstance(window, bool) or not isinstance(window, numbers.Integral):
-        raise TypeError("'window' must be an integer")
-    if window < 0 or (positive and window == 0):
-        kind = "positive" if positive else "non-negative"
-        raise ValueError(f"'window'={window} must be {kind}")
-    return int(window)
-
-
-def _require_attr(data, alias, node, name):
-    """Return attribute value or raise if missing."""
-    val = get_attr(data, alias, None)
-    if val is None:
-        raise ValueError(f"Missing {name} attribute in node {node}")
-    return val
-
-
-def _validate_sigma(G) -> None:
-    sv = sigma_vector_from_graph(G)
-    if sv.get("mag", 0.0) > 1.0 + sys.float_info.epsilon:
-        raise ValueError("σ norm exceeds 1")
-
-
-def _check_epi_vf(epi, vf, epi_min, epi_max, vf_min, vf_max, n):
-    _check_range(epi, epi_min, epi_max, "EPI", n)
-    _check_range(vf, vf_min, vf_max, "VF", n)
-
-
-def _out_of_range_msg(name, node, val):
-    return f"{name} out of range in node {node}: {val}"
-
-
-def _check_range(val, lower, upper, name, node, tol: float = 1e-9):
-    if not within_range(val, lower, upper, tol):
-        raise ValueError(_out_of_range_msg(name, node, val))
-
-
-def _check_glyph(g, n):
-    if g and g not in GLYPHS_CANONICAL_SET:
-        raise KeyError(f"Invalid glyph {g} in node {n}")
-
-
-def run_validators(G) -> None:
-    """Run all invariant validators on ``G`` with a single node pass."""
-    from .glyph_history import last_glyph
-
-    epi_min = float(get_param(G, "EPI_MIN"))
-    epi_max = float(get_param(G, "EPI_MAX"))
-    vf_min = float(get_param(G, "VF_MIN"))
-    vf_max = float(get_param(G, "VF_MAX"))
-
-    for n, data in G.nodes(data=True):
-        epi = _require_attr(data, ALIAS_EPI, n, "EPI")
-        vf = _require_attr(data, ALIAS_VF, n, "VF")
-        _check_epi_vf(epi, vf, epi_min, epi_max, vf_min, vf_max, n)
-        _check_glyph(last_glyph(data), n)
-
-    _validate_sigma(G)
+warnings.warn(
+    "'tnfr.validators' is deprecated; import from 'tnfr.utils.validators' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/tests/test_validate_window.py
+++ b/tests/test_validate_window.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 
-from tnfr.validators import validate_window
+from tnfr.utils.validators import validate_window
 
 
 @pytest.mark.parametrize("value", [True, False])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,7 +7,7 @@ from tnfr.constants import (
     get_aliases,
 )
 from tnfr.initialization import init_node_attrs
-from tnfr.validators import run_validators
+from tnfr.utils.validators import run_validators
 from tnfr.alias import set_attr, set_attr_str
 from tnfr.io import read_structured_file, StructuredFileError
 from tnfr.config import load_config
@@ -72,7 +72,7 @@ def test_validator_sigma_norm(monkeypatch):
     def fake_sigma(G):
         return {"mag": 1.5}
 
-    monkeypatch.setattr("tnfr.validators.sigma_vector_from_graph", fake_sigma)
+    monkeypatch.setattr("tnfr.utils.validators.sigma_vector_from_graph", fake_sigma)
     with pytest.raises(ValueError):
         run_validators(G)
 


### PR DESCRIPTION
## Summary
- move validator helpers into the new `tnfr.utils.validators` module and expose them via the utils namespace
- update observers, glyph history, dynamics, and tests to import validators from the new location
- leave a `tnfr.validators` compatibility shim that warns about the new module path

## Testing
- pytest tests/test_validate_window.py tests/test_validators.py *(fails: missing numpy dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68f3418deed483219e4dbb156f8cf554