### PR TITLE
Update README optional import helper paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ pip install tnfr
 
 ### Optional imports with cache
 
-Use ``tnfr.cached_import`` to load optional dependencies and cache the result
-via a process-wide LRU cache. Missing modules (or attributes) yield ``None``
-without triggering repeated imports. The helper records failures and emits a
-single warning per module to keep logs tidy. When optional packages are
-installed at runtime call ``prune_failed_imports`` to clear the consolidated
-failure/warning registry before retrying:
+Use ``tnfr.utils.cached_import`` to load optional dependencies and cache the
+result via a process-wide LRU cache. Missing modules (or attributes) yield
+``None`` without triggering repeated imports. The helper records failures and
+emits a single warning per module to keep logs tidy. When optional packages are
+installed at runtime call ``tnfr.utils.prune_failed_imports`` to clear the
+consolidated failure/warning registry before retrying:
 
 ```python
-from tnfr import cached_import, prune_failed_imports
+from tnfr.utils import cached_import, prune_failed_imports
 
 np = cached_import("numpy")
 safe_load = cached_import("yaml", "safe_load")


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Update the optional import helper narrative to reference `tnfr.utils.cached_import` and `tnfr.utils.prune_failed_imports`.
- Adjust the accompanying example to import the helpers from `tnfr.utils`.
- Ensure README references consistently use the `tnfr.utils` namespace for these helpers.


------
https://chatgpt.com/codex/tasks/task_e_68f343fa914c8321b3b54abf67ed7a29