### PR TITLE
Align tests with tnfr.utils namespace

### DIFF
--- a/src/tnfr/utils/data.py
+++ b/src/tnfr/utils/data.py
@@ -13,8 +13,8 @@ from .init import get_logger, warn_once as _warn_once_factory
 
 T = TypeVar("T")
 
-_collections_logger = get_logger("tnfr.collections_utils")
-_value_logger = get_logger("tnfr.value_utils")
+_collections_logger = get_logger("tnfr.utils.data.collections")
+_value_logger = get_logger("tnfr.utils.data")
 
 STRING_TYPES = (str, bytes, bytearray)
 

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -1,5 +1,5 @@
 import pytest
-from tnfr.collections_utils import ensure_collection
+from tnfr.utils import ensure_collection
 
 
 def test_existing_collection_returned_as_is():

--- a/tests/test_flatten_structure.py
+++ b/tests/test_flatten_structure.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tnfr.collections_utils import flatten_structure
+from tnfr.utils import flatten_structure
 
 
 def _make_set() -> set[int]:

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -161,7 +161,7 @@ def test_gamma_spec_normalized_once(graph_canon, monkeypatch):
     def fake_warn(message, *_args, **_kwargs):
         emitted.append(message)
 
-    monkeypatch.setattr("tnfr.graph_utils.warnings.warn", fake_warn)
+    monkeypatch.setattr("tnfr.utils.graph.warnings.warn", fake_warn)
     eval_gamma(G, 0, t=0.0)
     eval_gamma(G, 0, t=0.0)
     assert len(emitted) == 1

--- a/tests/test_get_attr_default.py
+++ b/tests/test_get_attr_default.py
@@ -48,7 +48,7 @@ def test_get_attr_default_is_converted():
 def test_get_attr_default_logs_on_failure(caplog):
     d = {}
     acc = AliasAccessor(int)
-    with caplog.at_level(logging.DEBUG, logger="tnfr.value_utils"):
+    with caplog.at_level(logging.DEBUG, logger="tnfr.utils.data"):
         result = acc.get(d, ("x",), default="bad")
     assert result is None
     assert len(caplog.records) == 1

--- a/tests/test_glyph_helpers.py
+++ b/tests/test_glyph_helpers.py
@@ -2,7 +2,7 @@
 
 from collections import Counter
 
-from tnfr.collections_utils import normalize_counter, mix_groups
+from tnfr.utils import normalize_counter, mix_groups
 
 
 def test_normalize_counter():

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -4,8 +4,8 @@ import math
 from types import MappingProxyType
 
 import pytest
-from tnfr.collections_utils import negative_weights_warn_once
-from tnfr.collections_utils import normalize_weights
+from tnfr.utils import negative_weights_warn_once
+from tnfr.utils import normalize_weights
 
 
 def test_normalize_weights_warns_on_negative_value(caplog):

--- a/tests/test_selector_utils.py
+++ b/tests/test_selector_utils.py
@@ -14,7 +14,7 @@ from tnfr.selector import (
     _apply_selector_hysteresis,
 )
 from tnfr.constants import DEFAULTS, get_aliases
-from tnfr.collections_utils import normalize_weights
+from tnfr.utils import normalize_weights
 from tnfr.dynamics import _configure_selector_weights
 
 ALIAS_DNFR = get_aliases("DNFR")

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -12,7 +12,7 @@ from tnfr.trace import (
     CallbackSpec,
 )
 from tnfr import trace
-from tnfr.graph_utils import get_graph_mapping
+from tnfr.utils import get_graph_mapping
 from tnfr.callback_utils import CallbackEvent, callback_manager
 from types import MappingProxyType
 

--- a/tests/test_value_utils.py
+++ b/tests/test_value_utils.py
@@ -2,14 +2,14 @@
 
 import logging
 
-from tnfr.value_utils import convert_value
+from tnfr.utils import convert_value
 
 
 def test_convert_value_logs_debug_by_default(caplog):
     def conv(_):
         raise ValueError("bad")
 
-    with caplog.at_level(logging.DEBUG, logger="tnfr.value_utils"):
+    with caplog.at_level(logging.DEBUG, logger="tnfr.utils.data"):
         ok, result = convert_value("x", conv, key="foo")
 
     assert not ok and result is None
@@ -21,7 +21,7 @@ def test_convert_value_logs_custom_level(caplog):
     def conv(_):
         raise ValueError("bad")
 
-    with caplog.at_level(logging.INFO, logger="tnfr.value_utils"):
+    with caplog.at_level(logging.INFO, logger="tnfr.utils.data"):
         ok, result = convert_value(
             "x", conv, key="foo", log_level=logging.INFO
         )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases (targeted pytest suite)

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f3445bb894832188aa0561adb60fa6