### PR TITLE
Align cache utility imports with tnfr.utils facade

### DIFF
--- a/benchmarks/prepare_dnfr_data.py
+++ b/benchmarks/prepare_dnfr_data.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 from tnfr.constants import get_aliases
 from tnfr.dynamics import _prepare_dnfr_data
-from tnfr.utils.cache import cached_nodes_and_A
+from tnfr.utils import cached_nodes_and_A
 from tnfr.alias import set_attr, collect_attr
 
 ALIAS_THETA = get_aliases("THETA")

--- a/documentation.txt
+++ b/documentation.txt
@@ -90,7 +90,7 @@ Key utilities (`tnfr.utils`)
 - **Structural history** (`tnfr.helpers.glyph_history`): `push_glyph`,
   `recent_glyph`, `ensure_history`, `last_glyph`, `count_glyphs` to track applied
   operators and observation windows.
-- **Caches and ΔNFR** (`tnfr.utils.cache` / `tnfr.utils.graph`):
+- **Caches and ΔNFR** (`tnfr.utils` / `tnfr.utils.graph`):
   `cached_node_list`, `ensure_node_index_map`, `ensure_node_offset_map`,
   `node_set_checksum`, `stable_json`, `get_graph_mapping`, `EdgeCacheManager`,
   `cached_nodes_and_A`, `edge_version_update`, `mark_dnfr_prep_dirty` to keep

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -22,7 +22,7 @@ from .metric import (
 from ..immutable import _is_immutable
 
 try:  # pragma: no cover - optional dependency
-    from ..utils.cache import ensure_node_offset_map
+    from ..utils import ensure_node_offset_map
 except ImportError:  # noqa: BLE001 - allow any import error
     ensure_node_offset_map = None
 

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -15,13 +15,12 @@ from ..alias import (
     get_attr,
     set_dnfr,
 )
-from ..utils.cache import cached_nodes_and_A
 from ..constants import DEFAULTS, get_aliases, get_param
 from ..helpers.numeric import angle_diff
 from ..metrics.common import merge_and_normalize_weights
 from ..metrics.trig import _phase_mean_from_iter, neighbor_phase_mean
 from ..metrics.trig_cache import compute_theta_trig
-from ..utils import get_numpy, normalize_weights
+from ..utils import cached_nodes_and_A, get_numpy, normalize_weights
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")

--- a/src/tnfr/dynamics/sampling.py
+++ b/src/tnfr/dynamics/sampling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ..utils.cache import cached_node_list
+from ..utils import cached_node_list
 from ..rng import _rng_for_step, base_seed
 
 __all__ = ("update_node_sample",)
@@ -12,8 +12,8 @@ def update_node_sample(G, *, step: int) -> None:
     The sample is limited by ``UM_CANDIDATE_COUNT`` and refreshed every
     simulation step. When the network is small (``< 50`` nodes) or the limit
     is non‑positive, the full node set is used and sampling is effectively
-    disabled. A snapshot of nodes is cached via a
-    :class:`~tnfr.utils.cache.NodeCache` instance stored in
+    disabled. A snapshot of nodes is cached via the NodeCache helper from
+    ``tnfr.utils`` stored in
     ``G.graph['_node_list_cache']`` and reused across steps; it is only refreshed
     when the graph size changes. Sampling operates directly on the cached
     tuple of nodes.

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -11,8 +11,13 @@ from types import MappingProxyType
 
 from .constants import DEFAULTS, get_aliases
 from .alias import get_attr
-from .utils import get_graph_mapping, get_logger, json_dumps
-from .utils.cache import edge_version_cache, node_set_checksum
+from .utils import (
+    edge_version_cache,
+    get_graph_mapping,
+    get_logger,
+    json_dumps,
+    node_set_checksum,
+)
 from .metrics.trig_cache import get_trig_cache
 
 ALIAS_THETA = get_aliases("THETA")

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -7,18 +7,8 @@ cache invalidation.
 
 from __future__ import annotations
 
-from ..utils.cache import (
-    EdgeCacheManager,
-    cached_node_list,
-    cached_nodes_and_A,
-    edge_version_cache,
-    edge_version_update,
-    ensure_node_index_map,
-    ensure_node_offset_map,
-    increment_edge_version,
-    node_set_checksum,
-    stable_json,
-)
+from typing import TYPE_CHECKING
+
 from ..utils.graph import get_graph, get_graph_mapping, mark_dnfr_prep_dirty
 from .numeric import (
     angle_diff,
@@ -27,8 +17,28 @@ from .numeric import (
     kahan_sum_nd,
 )
 
+if TYPE_CHECKING:  # pragma: no cover - import only for static analysis
+    from ..utils import (
+        EdgeCacheManager,
+        cached_node_list,
+        cached_nodes_and_A,
+        edge_version_cache,
+        edge_version_update,
+        ensure_node_index_map,
+        ensure_node_offset_map,
+        increment_edge_version,
+        node_set_checksum,
+        stable_json,
+    )
+
 
 def __getattr__(name: str):
+    if name in _CACHE_EXPORTS:
+        from .. import utils as _utils
+
+        value = getattr(_utils, name)
+        globals()[name] = value
+        return value
     if name in _GLYPH_HISTORY_EXPORTS:
         from .. import glyph_history as _glyph_history
 
@@ -62,6 +72,18 @@ __all__ = (
     "recent_glyph",
 )
 
+_CACHE_EXPORTS = (
+    "EdgeCacheManager",
+    "cached_node_list",
+    "cached_nodes_and_A",
+    "edge_version_cache",
+    "edge_version_update",
+    "ensure_node_index_map",
+    "ensure_node_offset_map",
+    "increment_edge_version",
+    "node_set_checksum",
+    "stable_json",
+)
 _GLYPH_HISTORY_EXPORTS = (
     "count_glyphs",
     "ensure_history",

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -15,7 +15,6 @@ from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import ensure_history, append_metric
 from ..alias import collect_attr, get_attr, set_attr
 from ..helpers.numeric import clamp01
-from ..utils.cache import ensure_node_index_map
 from .common import compute_coherence, min_max_range
 from .trig_cache import compute_theta_trig, get_trig_cache
 from ..observers import (
@@ -26,7 +25,12 @@ from ..observers import (
     phase_sync,
 )
 from ..sense import sigma_vector
-from ..utils import get_logger, get_numpy, normalize_weights
+from ..utils import (
+    ensure_node_index_map,
+    get_logger,
+    get_numpy,
+    normalize_weights,
+)
 
 logger = get_logger(__name__)
 

--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -6,11 +6,10 @@ from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Sequence
 
 from ..alias import collect_attr, get_attr, multi_recompute_abs_max
-from ..utils.cache import edge_version_cache
 from ..constants import DEFAULTS, get_aliases
 from ..helpers.numeric import clamp01, kahan_sum_nd
 from ..types import GraphLike
-from ..utils import get_numpy, normalize_weights
+from ..utils import edge_version_cache, get_numpy, normalize_weights
 
 ALIAS_DNFR = get_aliases("DNFR")
 ALIAS_D2EPI = get_aliases("D2EPI")

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -7,11 +7,15 @@ from functools import partial
 from typing import Any
 
 from ..alias import get_attr, set_attr
-from ..utils.cache import edge_version_cache, stable_json
 from ..constants import get_aliases
 from ..helpers.numeric import angle_diff, clamp01
 from ..types import GraphLike
-from ..utils import get_numpy, normalize_weights
+from ..utils import (
+    edge_version_cache,
+    get_numpy,
+    normalize_weights,
+    stable_json,
+)
 from .trig import neighbor_phase_mean_list
 
 from .common import (

--- a/src/tnfr/metrics/trig_cache.py
+++ b/src/tnfr/metrics/trig_cache.py
@@ -11,10 +11,9 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
 from ..alias import get_attr
-from ..utils.cache import edge_version_cache
 from ..constants import get_aliases
 from ..types import GraphLike
-from ..utils import get_numpy
+from ..utils import edge_version_cache, get_numpy
 
 ALIAS_THETA = get_aliases("THETA")
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -16,12 +16,12 @@ from .alias import (
     set_dnfr,
     set_theta,
 )
-from .utils.cache import (
+from .utils import (
     cached_node_list,
     ensure_node_offset_map,
     increment_edge_version,
+    supports_add_edge,
 )
-from .utils import supports_add_edge
 from .locking import get_lock
 
 ALIAS_EPI = get_aliases("EPI")

--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -3,7 +3,6 @@ from typing import Any, TYPE_CHECKING
 
 from cachetools import LRUCache
 
-from ..utils.cache import ensure_node_offset_map
 from ..rng import (
     ScopedCounterCache,
     make_rng,
@@ -12,7 +11,7 @@ from ..rng import (
     clear_rng_cache as _clear_rng_cache,
     seed_hash,
 )
-from ..utils import get_nodonx
+from ..utils import ensure_node_offset_map, get_nodonx
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..node import NodoProtocol

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -8,14 +8,13 @@ from io import StringIO
 from collections import deque
 from statistics import fmean, StatisticsError
 
-from ..utils.cache import edge_version_update
 from ..constants import DEFAULTS, REMESH_DEFAULTS, get_aliases, get_param
 from ..helpers.numeric import kahan_sum_nd
 from ..alias import get_attr, set_attr
 from ..rng import make_rng
 from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import append_metric, ensure_history, current_step_idx
-from ..utils import cached_import
+from ..utils import cached_import, edge_version_update
 
 ALIAS_EPI = get_aliases("EPI")
 

--- a/tests/test_cache_helpers.py
+++ b/tests/test_cache_helpers.py
@@ -1,6 +1,10 @@
 """Pruebas enfocadas en los helpers públicos de cache."""
 
-from tnfr.utils.cache import edge_version_update, ensure_node_index_map, ensure_node_offset_map
+from tnfr.utils import (
+    edge_version_update,
+    ensure_node_index_map,
+    ensure_node_offset_map,
+)
 
 
 def test_edge_version_update_scopes_mutations(graph_canon):

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -3,7 +3,7 @@ import networkx as nx
 
 from tnfr.constants import THETA_PRIMARY
 from tnfr.metrics import coherence_matrix, local_phase_sync_weighted
-from tnfr.utils.cache import ensure_node_index_map
+from tnfr.utils import ensure_node_index_map
 
 
 def make_graph(graph_canon, offset=0):

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -14,10 +14,10 @@ from tnfr.constants import (
     VF_PRIMARY,
     DNFR_PRIMARY,
 )
-from tnfr.utils.cache import (
-    increment_edge_version,
+from tnfr.utils import (
     cached_node_list,
     cached_nodes_and_A,
+    increment_edge_version,
 )
 
 

--- a/tests/test_edge_version_cache.py
+++ b/tests/test_edge_version_cache.py
@@ -1,7 +1,7 @@
 import pytest
 from concurrent.futures import ThreadPoolExecutor
 
-from tnfr.utils.cache import (
+from tnfr.utils import (
     EdgeCacheManager,
     edge_version_cache,
     increment_edge_version,

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -7,7 +7,7 @@ import pytest
 from tnfr.constants import inject_defaults, merge_overrides
 from tnfr.dynamics import update_epi_via_nodal_equation
 from tnfr.gamma import eval_gamma, GAMMA_REGISTRY, GammaEntry
-from tnfr.utils.cache import EdgeCacheManager, increment_edge_version
+from tnfr.utils import EdgeCacheManager, increment_edge_version
 
 
 def test_gamma_linear_integration(graph_canon):

--- a/tests/test_neighbors_map_cache.py
+++ b/tests/test_neighbors_map_cache.py
@@ -1,7 +1,7 @@
 from types import MappingProxyType
 
 from tnfr.metrics.common import ensure_neighbors_map
-from tnfr.utils.cache import increment_edge_version
+from tnfr.utils import increment_edge_version
 
 
 def test_neighbors_map_reuses_proxy(graph_canon):

--- a/tests/test_node_offset.py
+++ b/tests/test_node_offset.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-from tnfr.utils.cache import ensure_node_offset_map
+from tnfr.utils import ensure_node_offset_map
 from tnfr.node import NodoNX
 
 

--- a/tests/test_node_sample.py
+++ b/tests/test_node_sample.py
@@ -5,7 +5,7 @@ import pytest
 from tnfr.dynamics import step, _update_node_sample
 from tnfr.rng import clear_rng_cache
 from tnfr.constants import inject_defaults
-from tnfr.utils.cache import cached_nodes_and_A, increment_edge_version
+from tnfr.utils import cached_nodes_and_A, increment_edge_version
 import networkx as nx
 import json
 import os

--- a/tests/test_node_set_checksum.py
+++ b/tests/test_node_set_checksum.py
@@ -2,13 +2,13 @@ import hashlib
 import timeit
 from unittest.mock import patch
 
-from tnfr.utils.cache import (
+from tnfr.utils import (
     NODE_SET_CHECKSUM_KEY,
     clear_node_repr_cache,
     node_set_checksum,
     stable_json,
 )
-from tnfr.utils.cache import increment_edge_version
+from tnfr.utils import increment_edge_version
 
 
 def build_graph(graph_canon):

--- a/tests/test_si_helpers.py
+++ b/tests/test_si_helpers.py
@@ -5,7 +5,7 @@ from tnfr.constants import get_aliases
 from tnfr.metrics.sense_index import compute_Si_node, get_Si_weights
 from tnfr.metrics.trig_cache import get_trig_cache
 from tnfr.alias import get_attr, set_attr, set_theta
-from tnfr.utils.cache import increment_edge_version
+from tnfr.utils import increment_edge_version
 
 ALIAS_DNFR = get_aliases("DNFR")
 ALIAS_SI = get_aliases("SI")

--- a/tests/test_stable_json.py
+++ b/tests/test_stable_json.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from tnfr.utils.cache import stable_json
+from tnfr.utils import stable_json
 from .utils import clear_orjson_cache
 
 


### PR DESCRIPTION
## Summary
- update TNFR core modules, helpers, and documentation to import cache utilities from `tnfr.utils`
- refresh benchmarks and tests to exercise the cache helpers through the `tnfr.utils` public facade
- lazily expose cache exports from `tnfr.helpers` to avoid import-order regressions while re-exporting the unified API

## Testing
- `pytest` *(fails: `tests/test_validators.py::test_validator_sigma_norm` unexpectedly reports no ValueError; passes when run in isolation)*
- `pytest -k sigma_norm -vv`


------
https://chatgpt.com/codex/tasks/task_e_68f34da5390c8321a46c7566986fc5bc