### PR TITLE
Refactor validator imports to use utils facade

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -582,7 +582,7 @@ def _maybe_remesh(G) -> None:
 
 
 def _run_validators(G) -> None:
-    from ..utils.validators import run_validators
+    from ..utils import run_validators
 
     run_validators(G)
 

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -27,7 +27,7 @@ __all__ = (
 
 @lru_cache(maxsize=1)
 def _resolve_validate_window():
-    from .utils.validators import validate_window
+    from .utils import validate_window
 
     return validate_window
 

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -14,12 +14,16 @@ from .glyph_history import (
     count_glyphs,
     append_metric,
 )
-from .utils import mix_groups, normalize_counter
+from .utils import (
+    get_logger,
+    get_numpy,
+    mix_groups,
+    normalize_counter,
+    validate_window,
+)
 from .config.constants import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
-from .utils import get_logger, get_numpy
 from .metrics.common import compute_coherence
-from .utils.validators import validate_window
 
 ALIAS_THETA = get_aliases("THETA")
 

--- a/tests/test_validate_window.py
+++ b/tests/test_validate_window.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 
-from tnfr.utils.validators import validate_window
+from tnfr.utils import validate_window
 
 
 @pytest.mark.parametrize("value", [True, False])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,7 +7,7 @@ from tnfr.constants import (
     get_aliases,
 )
 from tnfr.initialization import init_node_attrs
-from tnfr.utils.validators import run_validators
+from tnfr.utils import run_validators
 from tnfr.alias import set_attr, set_attr_str
 from tnfr.io import read_structured_file, StructuredFileError
 from tnfr.config import load_config
@@ -72,7 +72,9 @@ def test_validator_sigma_norm(monkeypatch):
     def fake_sigma(G):
         return {"mag": 1.5}
 
-    monkeypatch.setattr("tnfr.utils.validators.sigma_vector_from_graph", fake_sigma)
+    monkeypatch.setitem(
+        run_validators.__globals__, "sigma_vector_from_graph", fake_sigma
+    )
     with pytest.raises(ValueError):
         run_validators(G)
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- route observer, glyph history, and dynamics validator hooks through `tnfr.utils` so callers no longer import the validators submodule directly
- update validator tests to pull helpers from `tnfr.utils` and adjust monkeypatching to use the re-exported globals


------
https://chatgpt.com/codex/tasks/task_e_68f350f2c05c83219eee8418987d9ced