### PR TITLE
Refactor helper cache exports to eager imports

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -9,7 +9,8 @@ from collections.abc import Iterable, Mapping
 from functools import lru_cache
 
 from .constants import get_param
-from .utils import ensure_collection, get_logger
+from .utils.data import ensure_collection
+from .utils.init import get_logger
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- ensure `tnfr.helpers` re-exports caching utilities directly from `tnfr.utils.cache`, removing `__getattr__` indirection
- add lazy glyph history wrappers that avoid circular imports while keeping the helpers API stable
- decouple glyph history from the `tnfr.utils` aggregator to prevent recursive import failures

## Testing
- pytest tests/test_edge_version_cache.py tests/test_dnfr_cache.py tests/test_node_sample.py tests/test_gamma.py


------
https://chatgpt.com/codex/tasks/task_e_68f353ffd0b88321afd16eaf88192de3