### PR TITLE
Fix glyph history window validation import path

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -6,9 +6,9 @@ from typing import Any
 from collections import deque, Counter
 from itertools import islice
 from collections.abc import Iterable, Mapping
-from functools import lru_cache
 
 from .constants import get_param
+from .utils import validate_window
 from .utils.data import ensure_collection
 from .utils.init import get_logger
 
@@ -26,23 +26,12 @@ __all__ = (
 )
 
 
-@lru_cache(maxsize=1)
-def _resolve_validate_window():
-    from .utils import validate_window
-
-    return validate_window
-
-
-def _validate_window(window: int, *, positive: bool = False) -> int:
-    return _resolve_validate_window()(window, positive=positive)
-
-
 def _ensure_history(
     nd: dict[str, Any], window: int, *, create_zero: bool = False
 ) -> tuple[int, deque | None]:
     """Validate ``window`` and ensure ``nd['glyph_history']`` deque."""
 
-    v_window = _validate_window(window)
+    v_window = validate_window(window)
     if v_window == 0 and not create_zero:
         return v_window, None
     hist = nd.setdefault("glyph_history", deque(maxlen=v_window))
@@ -266,7 +255,7 @@ def count_glyphs(
     """
 
     if window is not None:
-        window = _validate_window(window)
+        window = validate_window(window)
         if window == 0:
             return Counter()
 

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -125,11 +125,13 @@ def __getattr__(name: str):  # pragma: no cover - trivial delegation
     if name in _DYNAMIC_EXPORTS:
         return getattr(_init, name)
     if name in _VALIDATOR_EXPORTS:
-        from .validators import run_validators, validate_window
-
         if name == "validate_window":
-            return validate_window
-        return run_validators
+            from .validators import validate_window as _validate_window
+
+            return _validate_window
+        from .validators import run_validators as _run_validators
+
+        return _run_validators
     raise AttributeError(name)
 
 

--- a/src/tnfr/utils/validators.py
+++ b/src/tnfr/utils/validators.py
@@ -9,8 +9,6 @@ from ..alias import get_attr
 from ..config.constants import GLYPHS_CANONICAL_SET
 from ..constants import get_aliases, get_param
 from ..helpers.numeric import within_range
-from ..sense import sigma_vector_from_graph
-
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")
 
@@ -42,6 +40,8 @@ def _require_attr(data, alias, node, name):
 
 
 def _validate_sigma(G) -> None:
+    from ..sense import sigma_vector_from_graph
+
     sv = sigma_vector_from_graph(G)
     if sv.get("mag", 0.0) > 1.0 + sys.float_info.epsilon:
         raise ValueError("σ norm exceeds 1")


### PR DESCRIPTION
## Summary
- Directly import `validate_window` within glyph history helpers and reuse it at call sites.
- Ensure `tnfr.utils` lazily imports validator helpers without triggering circular dependencies.
- Defer sigma vector import in validators so glyph history can depend on `validate_window` safely.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f35549459c83219ec5793cd6c2c9de