### PR TITLE
Align CLI logging with shared configuration

### DIFF
--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -23,7 +23,7 @@ from .execution import (
     resolve_program,
 )
 from .. import __version__
-from ..utils import get_logger
+from ..utils import _configure_root, get_logger
 
 logger = get_logger(__name__)
 
@@ -43,9 +43,19 @@ __all__ = (
 
 
 def main(argv: Optional[list[str]] = None) -> int:
-    logging.basicConfig(
-        level=logging.INFO, format="%(message)s", stream=sys.stdout, force=True
-    )
+    _configure_root()
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    formatter = logging.Formatter("%(message)s")
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
 
     p = argparse.ArgumentParser(
         prog="tnfr",


### PR DESCRIPTION
## Summary
- route the CLI entry point through `tnfr.utils._configure_root()` so it shares the project-wide logging initialisation
- rebuild the CLI stream handler to keep stdout-bound, message-only INFO output consistent with previous behaviour
- verify the CLI interface still behaves by exercising the existing CLI test suite

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Testing
- `pytest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68f3574351888321ae161542eac9bd50