### PR TITLE
Delegate helper exports to tnfr.utils

### DIFF
--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -7,21 +7,24 @@ cache invalidation.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
-from ..utils.cache import (
-    EdgeCacheManager,
-    cached_node_list,
-    cached_nodes_and_A,
-    edge_version_cache,
-    edge_version_update,
-    ensure_node_index_map,
-    ensure_node_offset_map,
-    increment_edge_version,
-    node_set_checksum,
-    stable_json,
-)
-from ..utils.graph import get_graph, get_graph_mapping, mark_dnfr_prep_dirty
+if TYPE_CHECKING:  # pragma: no cover - import-time only for typing
+    from ..utils import (
+        EdgeCacheManager,
+        cached_node_list,
+        cached_nodes_and_A,
+        edge_version_cache,
+        edge_version_update,
+        ensure_node_index_map,
+        ensure_node_offset_map,
+        get_graph,
+        get_graph_mapping,
+        increment_edge_version,
+        mark_dnfr_prep_dirty,
+        node_set_checksum,
+        stable_json,
+    )
 from .numeric import (
     angle_diff,
     clamp,
@@ -53,6 +56,37 @@ __all__ = (
     "push_glyph",
     "recent_glyph",
 )
+
+
+_UTIL_EXPORTS = {
+    "EdgeCacheManager",
+    "cached_node_list",
+    "cached_nodes_and_A",
+    "edge_version_cache",
+    "edge_version_update",
+    "ensure_node_index_map",
+    "ensure_node_offset_map",
+    "get_graph",
+    "get_graph_mapping",
+    "increment_edge_version",
+    "mark_dnfr_prep_dirty",
+    "node_set_checksum",
+    "stable_json",
+}
+
+
+def __getattr__(name: str):  # pragma: no cover - simple delegation
+    if name in _UTIL_EXPORTS:
+        from .. import utils as _utils
+
+        value = getattr(_utils, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - simple reflection
+    return sorted(set(__all__))
 
 
 def _glyph_history_proxy(name: str) -> Callable[..., Any]:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- delegate helper exports to `tnfr.utils` so the helpers package sources cache and graph utilities from the shared utilities hub
- add lazy attribute delegation in `tnfr.helpers` to avoid circular imports while keeping the `__all__` contract intact

## Testing
- `pytest tests/test_glyph_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68f35aa6722083219c47f34340c34031