### PR TITLE
Cache vectorized ΔNFR edge indices for consistent neighbor sums

### DIFF
--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -37,3 +37,39 @@ def test_default_compute_delta_nfr_paths(vectorized):
     default_compute_delta_nfr(G)
     dnfr = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
     assert len(dnfr) == 5
+
+
+def _build_weighted_graph(factory, n_nodes: int, topo_weight: float):
+    G = factory(n_nodes)
+    for idx, node in enumerate(G.nodes):
+        set_attr(G.nodes[node], ALIAS_THETA, 0.15 * (idx + 1))
+        set_attr(G.nodes[node], ALIAS_EPI, 0.05 * (idx + 2))
+        set_attr(G.nodes[node], ALIAS_VF, 0.12 * (idx + 3))
+    G.graph["DNFR_WEIGHTS"] = {
+        "phase": 0.35,
+        "epi": 0.25,
+        "vf": 0.3,
+        "topo": topo_weight,
+    }
+    return G
+
+
+@pytest.mark.parametrize("factory", [nx.path_graph, nx.complete_graph])
+@pytest.mark.parametrize("topo_weight", [0.0, 0.4])
+def test_vectorized_matches_reference(factory, topo_weight):
+    np = pytest.importorskip("numpy")
+    del np  # only needed to guarantee NumPy availability
+
+    G_list = _build_weighted_graph(factory, 6, topo_weight)
+    G_vec = _build_weighted_graph(factory, 6, topo_weight)
+
+    default_compute_delta_nfr(G_list)
+
+    G_vec.graph["vectorized_dnfr"] = True
+    default_compute_delta_nfr(G_vec)
+
+    dnfr_list = collect_attr(G_list, G_list.nodes, ALIAS_DNFR, 0.0)
+    dnfr_vec = collect_attr(G_vec, G_vec.nodes, ALIAS_DNFR, 0.0)
+    assert dnfr_vec == pytest.approx(dnfr_list)
+    assert G_vec.graph.get("_DNFR_META") == G_list.graph.get("_DNFR_META")
+    assert G_vec.graph.get("_dnfr_hook_name") == G_list.graph.get("_dnfr_hook_name")


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Cache reusable NumPy edge index arrays for ΔNFR preparation and reuse them across graph versions to avoid rebuilding adjacency matrices.
- Replace adjacency-matrix multiplications with `np.take`/`np.add.at` neighbor aggregations, including the optional topological term.
- Extend vectorized ΔNFR tests to compare sparse and dense graphs with and without the topological contribution.

## Testing
- `pytest tests/test_dynamics_vectorized.py tests/test_dnfr_cache.py -q`
- `pytest tests/test_edge_cases.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68f35f2fb9948321b41c1c15991c1076