### PR TITLE
Respect ΔNFR vectorization toggles and add regression tests

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1214,7 +1214,7 @@ def _accumulate_neighbors_numpy(
 
 
 def _build_neighbor_sums_common(G, data, *, use_numpy: bool):
-    np_module = get_numpy()
+    np_module = get_numpy() if use_numpy else None
     nodes = data["nodes"]
     if not nodes:
         if np_module is not None:
@@ -1647,7 +1647,11 @@ def _compute_dnfr(G, data, *, use_numpy: bool | None = None) -> None:
     """
     np_module = get_numpy()
     cache: DnfrCache | None = data.get("cache")
-    vector_flag = np_module is not None
+
+    if use_numpy is None:
+        vector_flag = _should_vectorize(G, np_module)
+    else:
+        vector_flag = bool(use_numpy) and np_module is not None
 
     if vector_flag:
         _ensure_numpy_state_vectors(data, np_module)

--- a/tests/test_dnfr_vectorization_flags.py
+++ b/tests/test_dnfr_vectorization_flags.py
@@ -1,0 +1,123 @@
+import networkx as nx
+import pytest
+
+from tnfr.alias import collect_attr, set_attr
+from tnfr.constants import get_aliases
+from tnfr.dynamics import _compute_dnfr, _prepare_dnfr_data
+import tnfr.dynamics.dnfr as dnfr_module
+
+
+ALIAS_THETA = get_aliases("THETA")
+ALIAS_EPI = get_aliases("EPI")
+ALIAS_VF = get_aliases("VF")
+ALIAS_DNFR = get_aliases("DNFR")
+
+
+def _graph_fixture(size: int = 4) -> nx.Graph:
+    G = nx.path_graph(size)
+    for n in G.nodes:
+        set_attr(G.nodes[n], ALIAS_THETA, 0.1 * (n + 1))
+        set_attr(G.nodes[n], ALIAS_EPI, 0.2 * (n + 1))
+        set_attr(G.nodes[n], ALIAS_VF, 0.3 * (n + 1))
+    G.graph["DNFR_WEIGHTS"] = {
+        "phase": 0.4,
+        "epi": 0.3,
+        "vf": 0.2,
+        "topo": 0.1,
+    }
+    return G
+
+
+def _assert_loop_state(data):
+    cache = data.get("cache")
+    assert data.get("edge_src") is None
+    assert data.get("neighbor_workspace_np") is None
+    if cache is not None:
+        assert cache.edge_src is None
+        assert cache.neighbor_workspace_np is None
+        assert cache.neighbor_contrib_np is None
+
+
+def _assert_vector_state(data, np):
+    workspace = data.get("neighbor_workspace_np")
+    assert workspace is not None
+    assert isinstance(workspace, np.ndarray)
+    cache = data.get("cache")
+    if cache is not None:
+        assert cache.neighbor_workspace_np is workspace
+        assert cache.edge_src is not None
+
+
+def test_compute_dnfr_loop_path_when_use_numpy_false(monkeypatch):
+    pytest.importorskip("numpy")
+
+    G = _graph_fixture()
+    G.graph["vectorized_dnfr"] = False
+    data = _prepare_dnfr_data(G)
+
+    def _forbid_vector(*_, **__):
+        raise AssertionError("vector accumulation should be disabled")
+
+    monkeypatch.setattr(dnfr_module, "_accumulate_neighbors_numpy", _forbid_vector)
+    monkeypatch.setattr(dnfr_module, "_accumulate_neighbors_dense", _forbid_vector)
+
+    _compute_dnfr(G, data, use_numpy=False)
+
+    _assert_loop_state(data)
+    dnfr_values = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
+    assert all(isinstance(val, float) for val in dnfr_values)
+
+
+def test_compute_dnfr_loop_path_when_graph_disables_numpy(monkeypatch):
+    pytest.importorskip("numpy")
+
+    G = _graph_fixture()
+    G.graph["vectorized_dnfr"] = False
+    data = _prepare_dnfr_data(G)
+
+    def _forbid_vector(*_, **__):
+        raise AssertionError("vector accumulation should be disabled")
+
+    monkeypatch.setattr(dnfr_module, "_accumulate_neighbors_numpy", _forbid_vector)
+    monkeypatch.setattr(dnfr_module, "_accumulate_neighbors_dense", _forbid_vector)
+
+    _compute_dnfr(G, data)
+
+    _assert_loop_state(data)
+    dnfr_values = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
+    assert all(isinstance(val, float) for val in dnfr_values)
+
+
+def test_compute_dnfr_explicit_numpy_overrides_graph_flag(monkeypatch):
+    np = pytest.importorskip("numpy")
+
+    G = _graph_fixture()
+    G.graph["vectorized_dnfr"] = False
+    data = _prepare_dnfr_data(G)
+
+    # Force the sparse accumulation path so NumPy buffers are used explicitly.
+    data["prefer_sparse"] = True
+    data["A"] = None
+
+    calls = {"numpy": 0, "dense": 0}
+
+    original_numpy = dnfr_module._accumulate_neighbors_numpy
+    original_dense = dnfr_module._accumulate_neighbors_dense
+
+    def _spy_numpy(*args, **kwargs):
+        calls["numpy"] += 1
+        return original_numpy(*args, **kwargs)
+
+    def _spy_dense(*args, **kwargs):
+        calls["dense"] += 1
+        return original_dense(*args, **kwargs)
+
+    monkeypatch.setattr(dnfr_module, "_accumulate_neighbors_numpy", _spy_numpy)
+    monkeypatch.setattr(dnfr_module, "_accumulate_neighbors_dense", _spy_dense)
+
+    _compute_dnfr(G, data, use_numpy=True)
+
+    assert calls["numpy"] + calls["dense"] >= 1
+    _assert_vector_state(data, np)
+    dnfr_values = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
+    assert all(isinstance(val, float) for val in dnfr_values)


### PR DESCRIPTION
## Summary
- derive the ΔNFR vectorisation flag from explicit use_numpy overrides or graph preferences
- short-circuit neighbour accumulation to the loop fallback when vectorisation is disabled
- exercise loop and vector paths with explicit toggles to prevent regressions

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f3a3ef1a908321823fbb2a40372d1a