### PR TITLE
Optimize ΔNFR NumPy accumulation

### DIFF
--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -744,12 +744,10 @@ def test_broadcast_accumulation_dense_graph_equivalence():
 
     cache = data_vec.get("cache")
     assert cache is not None
-    flat = cache.neighbor_flat_index_np
-    offsets = cache.neighbor_offsets_np
+    contrib = cache.neighbor_contrib_np
     workspace = cache.neighbor_workspace_np
     signature = cache.neighbor_accum_signature
-    assert isinstance(flat, np.ndarray)
-    assert isinstance(offsets, np.ndarray)
+    assert isinstance(contrib, np.ndarray)
     assert isinstance(workspace, np.ndarray)
 
     for idx, node in enumerate(dense_graph.nodes):
@@ -761,8 +759,7 @@ def test_broadcast_accumulation_dense_graph_equivalence():
     data_vec["A"] = None
     _compute_dnfr(dense_graph, data_vec)
 
-    assert id(cache.neighbor_flat_index_np) == id(flat)
-    assert id(cache.neighbor_offsets_np) == id(offsets)
+    assert id(cache.neighbor_contrib_np) == id(contrib)
     assert id(cache.neighbor_workspace_np) == id(workspace)
     assert cache.neighbor_accum_signature == signature
 
@@ -786,7 +783,7 @@ def test_broadcast_accumulation_invalidation_on_edge_change():
     cache = data_vec.get("cache")
     assert cache is not None
     old_signature = cache.neighbor_accum_signature
-    old_flat = cache.neighbor_flat_index_np.copy()
+    old_contrib_shape = cache.neighbor_contrib_np.shape
 
     base.add_edge(0, len(base) - 1)
     mark_dnfr_prep_dirty(base)
@@ -798,9 +795,7 @@ def test_broadcast_accumulation_invalidation_on_edge_change():
 
     new_signature = cache.neighbor_accum_signature
     assert new_signature != old_signature
-    assert cache.neighbor_flat_index_np.shape[0] != old_flat.shape[0] or not np.array_equal(
-        cache.neighbor_flat_index_np, old_flat
-    )
+    assert cache.neighbor_contrib_np.shape != old_contrib_shape
 
     loop_graph = base.copy()
     loop_graph.graph["vectorized_dnfr"] = False


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Replace the bincount-based neighbour accumulation with a row-wise `np.add.at` strategy to avoid quadratic temporary buffers while keeping ΔNFR outputs stable.
- Simplify the NumPy caching surface so only reusable workspaces and contributions persist between runs.
- Refresh the vectorisation regression tests to assert the leaner caching contract and equivalence with the loop fallback.


------
https://chatgpt.com/codex/tasks/task_e_68f3b113b0a883218cd38de9dd81d540