### PR TITLE
Enable NumPy neighbor accumulation when vectorized_dnfr is disabled

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1202,12 +1202,8 @@ def _build_neighbor_sums_common(G, data, *, use_numpy: bool):
     """Build neighbour accumulators honouring the requested NumPy path."""
 
     nodes = data["nodes"]
-    np_module = get_numpy() if use_numpy else None
-    if np_module is None:
-        if not nodes:
-            return _init_neighbor_sums(data)
-
-    if np_module is not None:
+    np_module = get_numpy()
+    if use_numpy and np_module is not None:
         if not nodes:
             return _init_neighbor_sums(data, np=np_module)
 
@@ -1235,6 +1231,26 @@ def _build_neighbor_sums_common(G, data, *, use_numpy: bool):
             _accumulate_neighbors_dense if use_dense else _accumulate_neighbors_numpy
         )
         return accumulator(
+            G,
+            data,
+            x=x,
+            y=y,
+            epi_sum=epi_sum,
+            vf_sum=vf_sum,
+            count=count,
+            deg_sum=deg_sum,
+            np=np_module,
+        )
+
+    if np_module is not None:
+        if not nodes:
+            return _init_neighbor_sums(data, np=np_module)
+
+        x, y, epi_sum, vf_sum, count, deg_sum, _ = _init_neighbor_sums(
+            data, np=np_module
+        )
+        _ensure_numpy_state_vectors(data, np_module)
+        return _accumulate_neighbors_numpy(
             G,
             data,
             x=x,


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- allow the neighbour accumulation helpers to reuse NumPy buffers even when `vectorized_dnfr` is disabled, keeping the pure-Python loop as a last resort
- ensure the shared cache retains converted state vectors and edge indices across ΔNFR evaluations
- add regression coverage that compares the NumPy-assisted path with the pure-Python baseline when NumPy is available but vectorization is disabled

## Testing
- `pytest tests/test_dynamics_vectorized.py`


------
https://chatgpt.com/codex/tasks/task_e_68f3d1ab27508321b819a41229164cfd