### PR TITLE
Switch neighbor accumulation to bincount and add dense benchmark

### DIFF
--- a/benchmarks/neighbor_accumulation_dense_bincount.py
+++ b/benchmarks/neighbor_accumulation_dense_bincount.py
@@ -1,0 +1,204 @@
+"""Benchmark dense-graph neighbour accumulation (bincount vs np.add.at)."""
+
+from __future__ import annotations
+
+import statistics
+import time
+
+import networkx as nx
+
+from tnfr.constants import get_aliases
+from tnfr.dynamics.dnfr import (
+    _accumulate_neighbors_numpy,
+    _build_edge_index_arrays,
+    _init_neighbor_sums,
+    _prepare_dnfr_data,
+    _resolve_numpy_degree_array,
+)
+
+try:
+    import numpy as np
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency guard
+    raise RuntimeError("NumPy is required to run this benchmark") from exc
+
+
+ALIAS_THETA = get_aliases("THETA")
+ALIAS_EPI = get_aliases("EPI")
+ALIAS_VF = get_aliases("VF")
+
+
+def _build_dense_graph(num_nodes: int, *, seed: int, probability: float) -> nx.Graph:
+    """Create a dense random graph with deterministic TNFR state."""
+
+    graph = nx.gnp_random_graph(num_nodes, probability, seed=seed)
+    for node in graph.nodes:
+        attr = graph.nodes[node]
+        attr[ALIAS_THETA] = 0.03 * (node + 1)
+        attr[ALIAS_EPI] = 0.11 * (node + 2)
+        attr[ALIAS_VF] = 0.09 * (node + 3)
+    graph.graph["DNFR_WEIGHTS"] = {
+        "phase": 0.45,
+        "epi": 0.25,
+        "vf": 0.2,
+        "topo": 0.1,
+    }
+    return graph
+
+
+def _legacy_add_at_accumulation(G, data, *, buffers):
+    """Reference implementation using ``np.add.at`` for accumulation."""
+
+    x, y, epi_sum, vf_sum, count, deg_sum, _ = buffers
+    nodes = data["nodes"]
+    if not nodes:
+        return buffers
+
+    cache = data.get("cache")
+    state = {
+        key: data.get(key)
+        for key in ("cos_theta_np", "sin_theta_np", "epi_np", "vf_np")
+    }
+    for key, fallback in (
+        ("cos_theta_np", "cos_theta"),
+        ("sin_theta_np", "sin_theta"),
+        ("epi_np", "epi"),
+        ("vf_np", "vf"),
+    ):
+        if state[key] is None:
+            state[key] = np.array(data[fallback], dtype=float)
+            data[key] = state[key]
+            if cache is not None:
+                setattr(cache, key, state[key])
+
+    edge_src = data.get("edge_src")
+    edge_dst = data.get("edge_dst")
+    if edge_src is None or edge_dst is None:
+        edge_src, edge_dst = _build_edge_index_arrays(G, nodes, data["idx"], np)
+        data["edge_src"] = edge_src
+        data["edge_dst"] = edge_dst
+        if cache is not None:
+            cache.edge_src = edge_src
+            cache.edge_dst = edge_dst
+
+    x.fill(0.0)
+    y.fill(0.0)
+    epi_sum.fill(0.0)
+    vf_sum.fill(0.0)
+    count.fill(0.0)
+    deg_array = None
+    if deg_sum is not None:
+        deg_sum.fill(0.0)
+        deg_array = _resolve_numpy_degree_array(data, count, cache=cache, np=np)
+
+    if edge_src.size:
+        stacked = np.empty((edge_src.size, 4 + (1 if deg_array is not None else 0)), dtype=float)
+        np.take(state["cos_theta_np"], edge_dst, out=stacked[:, 0])
+        np.take(state["sin_theta_np"], edge_dst, out=stacked[:, 1])
+        np.take(state["epi_np"], edge_dst, out=stacked[:, 2])
+        np.take(state["vf_np"], edge_dst, out=stacked[:, 3])
+        np.add.at(count, edge_src, 1.0)
+        np.add.at(x, edge_src, stacked[:, 0])
+        np.add.at(y, edge_src, stacked[:, 1])
+        np.add.at(epi_sum, edge_src, stacked[:, 2])
+        np.add.at(vf_sum, edge_src, stacked[:, 3])
+        if deg_array is not None and deg_sum is not None:
+            np.take(deg_array, edge_dst, out=stacked[:, -1])
+            np.add.at(deg_sum, edge_src, stacked[:, -1])
+    else:
+        if deg_sum is not None:
+            deg_sum.fill(0.0)
+
+    return buffers
+
+
+def _run_bincount(G, data, buffers):
+    return _accumulate_neighbors_numpy(
+        G,
+        data,
+        x=buffers[0],
+        y=buffers[1],
+        epi_sum=buffers[2],
+        vf_sum=buffers[3],
+        count=buffers[4],
+        deg_sum=buffers[5],
+        np=np,
+    )
+
+
+def run(
+    num_nodes: int = 360,
+    edge_probability: float = 0.7,
+    repeats: int = 5,
+    loops: int = 8,
+) -> None:
+    """Time bincount-based accumulation versus the legacy add.at path."""
+
+    bincount_times: list[float] = []
+    add_at_times: list[float] = []
+
+    for rep in range(repeats):
+        base = _build_dense_graph(num_nodes, seed=rep + 42, probability=edge_probability)
+
+        modern_graph = base.copy()
+        modern_data = _prepare_dnfr_data(modern_graph)
+        modern_buffers = _init_neighbor_sums(modern_data, np=np)
+
+        start = time.perf_counter()
+        for _ in range(loops):
+            _run_bincount(modern_graph, modern_data, modern_buffers)
+        bincount_times.append(time.perf_counter() - start)
+
+        legacy_graph = base.copy()
+        legacy_data = _prepare_dnfr_data(legacy_graph)
+        legacy_buffers = _init_neighbor_sums(legacy_data, np=np)
+
+        start = time.perf_counter()
+        for _ in range(loops):
+            _legacy_add_at_accumulation(legacy_graph, legacy_data, buffers=legacy_buffers)
+        add_at_times.append(time.perf_counter() - start)
+
+        modern_result = _run_bincount(modern_graph, modern_data, modern_buffers)
+        legacy_result = _legacy_add_at_accumulation(
+            legacy_graph, legacy_data, buffers=legacy_buffers
+        )
+        for new_arr, old_arr in zip(modern_result, legacy_result):
+            if new_arr is None or old_arr is None:
+                assert new_arr is old_arr is None
+            else:
+                np.testing.assert_allclose(new_arr, old_arr, rtol=1e-9, atol=1e-9)
+
+    def _stats(values: list[float]) -> tuple[float, float, float, float]:
+        return (
+            min(values),
+            statistics.median(values),
+            sum(values) / len(values),
+            max(values),
+        )
+
+    bincount_stats = _stats(bincount_times)
+    add_at_stats = _stats(add_at_times)
+
+    if bincount_stats[1] >= add_at_stats[1]:  # pragma: no cover - guard rail
+        raise RuntimeError(
+            "Bincount accumulation did not outperform the np.add.at baseline"
+        )
+
+    print(
+        "Dense neighbor accumulation (bincount vs add.at)"
+        f" on {num_nodes} nodes (p={edge_probability}):"
+    )
+    print(
+        "bincount best={:.6f}s median={:.6f}s mean={:.6f}s worst={:.6f}s".format(
+            *bincount_stats
+        )
+    )
+    print(
+        "add.at   best={:.6f}s median={:.6f}s mean={:.6f}s worst={:.6f}s".format(
+            *add_at_stats
+        )
+    )
+
+
+if __name__ == "__main__":
+    run()
+

--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -131,7 +131,7 @@ def test_prepare_reuses_neighbor_workspace_vectorized():
 
     reused = _prepare_dnfr_data(G)
     assert reused["neighbor_workspace_np"] is workspace_first
-    assert reused["neighbor_contrib_np"] is data["neighbor_contrib_np"]
+    assert reused["neighbor_edge_weights_np"] is data["neighbor_edge_weights_np"]
 
     _compute_dnfr(G, reused)
     assert reused["neighbor_workspace_np"] is cache.neighbor_workspace_np

--- a/tests/test_dnfr_vectorization_flags.py
+++ b/tests/test_dnfr_vectorization_flags.py
@@ -37,7 +37,7 @@ def _assert_loop_state(data):
     if cache is not None:
         assert cache.edge_src is None
         assert cache.neighbor_workspace_np is None
-        assert cache.neighbor_contrib_np is None
+        assert cache.neighbor_edge_weights_np is None
 
 
 def _assert_vector_state(data, np):
@@ -48,6 +48,10 @@ def _assert_vector_state(data, np):
     if cache is not None:
         assert cache.neighbor_workspace_np is workspace
         assert cache.edge_src is not None
+        weights = cache.neighbor_edge_weights_np
+        if data.get("edge_count", 0):
+            assert isinstance(weights, np.ndarray)
+            assert weights.shape[0] == data["edge_count"]
 
 
 def test_compute_dnfr_uses_numpy_even_when_graph_disables_vectorization():

--- a/tests/test_dynamics_vectorized.py
+++ b/tests/test_dynamics_vectorized.py
@@ -546,8 +546,9 @@ def test_edge_accumulation_workspace_cached_and_stable(topo_weight, monkeypatch)
     cache = data_vec.get("cache")
     assert cache is not None
     workspace = cache.neighbor_workspace_np
-    contrib = cache.neighbor_contrib_np
-    assert workspace is not None and contrib is not None
+    weights = cache.neighbor_edge_weights_np
+    assert workspace is not None
+    assert weights is not None
 
     with numpy_disabled(monkeypatch):
         loop_graph = base.copy()
@@ -607,7 +608,7 @@ def test_edge_accumulation_workspace_cached_and_stable(topo_weight, monkeypatch)
     )
 
     assert cache.neighbor_workspace_np is workspace
-    assert cache.neighbor_contrib_np is contrib
+    assert cache.neighbor_edge_weights_np is weights
 
     for arr, snapshot in zip(result_second[:-1], snapshots):
         if arr is None or snapshot is None:
@@ -768,11 +769,11 @@ def test_broadcast_accumulation_dense_graph_equivalence():
 
     cache = data_vec.get("cache")
     assert cache is not None
-    contrib = cache.neighbor_contrib_np
     workspace = cache.neighbor_workspace_np
     signature = cache.neighbor_accum_signature
-    assert isinstance(contrib, np.ndarray)
     assert isinstance(workspace, np.ndarray)
+    weights = cache.neighbor_edge_weights_np
+    assert isinstance(weights, np.ndarray)
 
     for idx, node in enumerate(dense_graph.nodes):
         set_attr(dense_graph.nodes[node], ALIAS_EPI, 0.17 * (idx + 5))
@@ -783,7 +784,7 @@ def test_broadcast_accumulation_dense_graph_equivalence():
     data_vec["A"] = None
     _compute_dnfr(dense_graph, data_vec)
 
-    assert id(cache.neighbor_contrib_np) == id(contrib)
+    assert id(cache.neighbor_edge_weights_np) == id(weights)
     assert id(cache.neighbor_workspace_np) == id(workspace)
     assert cache.neighbor_accum_signature == signature
 
@@ -807,7 +808,7 @@ def test_broadcast_accumulation_invalidation_on_edge_change():
     cache = data_vec.get("cache")
     assert cache is not None
     old_signature = cache.neighbor_accum_signature
-    old_contrib_shape = cache.neighbor_contrib_np.shape
+    old_weights_shape = cache.neighbor_edge_weights_np.shape
 
     base.add_edge(0, len(base) - 1)
     mark_dnfr_prep_dirty(base)
@@ -819,7 +820,7 @@ def test_broadcast_accumulation_invalidation_on_edge_change():
 
     new_signature = cache.neighbor_accum_signature
     assert new_signature != old_signature
-    assert cache.neighbor_contrib_np.shape != old_contrib_shape
+    assert cache.neighbor_edge_weights_np.shape != old_weights_shape
 
     loop_graph = base.copy()
     loop_graph.graph["vectorized_dnfr"] = False


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

- Replaced the neighbour accumulation kernel with a bincount-based implementation that reuses cached buffers instead of stacking edge contributions.
- Updated ΔNFR vectorization tests to follow the new cache contract and added a dense-graph benchmark comparing bincount performance against the legacy np.add.at path.


------
https://chatgpt.com/codex/tasks/task_e_68f3e35bdfac83219a926da69e255428