### PR TITLE
Refactor ΔNFR neighbor reductions to reuse cached buffers

### DIFF
--- a/tests/dynamics/test_neighbor_accumulation_vectorized.py
+++ b/tests/dynamics/test_neighbor_accumulation_vectorized.py
@@ -45,6 +45,26 @@ def _dense_weighted_graph(np_module, *, nodes: int, topo_weight: float):
     return graph
 
 
+def _sparse_weighted_graph(np_module, *, nodes: int, topo_weight: float):
+    graph = nx.path_graph(nodes)
+    phases = np_module.linspace(-np_module.pi / 2, np_module.pi / 2, nodes)
+    epi_values = np_module.linspace(-0.2, 0.8, nodes)
+    vf_values = np_module.linspace(0.15, 0.55, nodes)
+
+    for idx, node in enumerate(graph.nodes):
+        set_attr(graph.nodes[node], ALIAS_THETA, float(phases[idx]))
+        set_attr(graph.nodes[node], ALIAS_EPI, float(epi_values[idx]))
+        set_attr(graph.nodes[node], ALIAS_VF, float(vf_values[idx]))
+
+    graph.graph["DNFR_WEIGHTS"] = {
+        "phase": 0.35,
+        "epi": 0.25,
+        "vf": 0.25,
+        "topo": topo_weight,
+    }
+    return graph
+
+
 @pytest.mark.parametrize("topo_weight", [0.0, 0.45])
 def test_vectorized_neighbor_sums_match_loop(topo_weight, monkeypatch):
     np_module = pytest.importorskip("numpy")
@@ -71,6 +91,40 @@ def test_vectorized_neighbor_sums_match_loop(topo_weight, monkeypatch):
         assert vec_degrees is loop_degrees is None
     else:
         np_module.testing.assert_allclose(vec_degrees, loop_degrees, rtol=1e-9, atol=1e-9)
+
+
+@pytest.mark.parametrize("topo_weight", [0.0, 0.5])
+def test_sparse_broadcast_neighbor_sums_match_loop(topo_weight, monkeypatch):
+    np_module = pytest.importorskip("numpy")
+
+    vector_graph = _sparse_weighted_graph(np_module, nodes=48, topo_weight=topo_weight)
+    vector_data = _prepare_dnfr_data(vector_graph)
+    vector_data["prefer_sparse"] = True
+    vector_data["A"] = None
+    vector_result = _build_neighbor_sums_common(vector_graph, vector_data, use_numpy=True)
+
+    loop_graph = _sparse_weighted_graph(np_module, nodes=48, topo_weight=topo_weight)
+    with numpy_disabled(monkeypatch):
+        loop_data = _prepare_dnfr_data(loop_graph)
+        loop_result = _build_neighbor_sums_common(loop_graph, loop_data, use_numpy=False)
+
+    for vector_arr, loop_arr in zip(vector_result[:-1], loop_result[:-1]):
+        if vector_arr is None or loop_arr is None:
+            assert vector_arr is loop_arr is None
+        else:
+            loop_np = np_module.asarray(loop_arr, dtype=float)
+            np_module.testing.assert_allclose(
+                vector_arr, loop_np, rtol=1e-9, atol=1e-9
+            )
+
+    vec_degrees = vector_result[-1]
+    loop_degrees = loop_result[-1]
+    if vec_degrees is None or loop_degrees is None:
+        assert vec_degrees is loop_degrees is None
+    else:
+        np_module.testing.assert_allclose(
+            vec_degrees, loop_degrees, rtol=1e-9, atol=1e-9
+        )
 
 
 def test_vectorized_neighbor_sums_outperform_loop(monkeypatch):

--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -114,7 +114,7 @@ def test_numpy_broadcast_fallback_matches_python(factory, size, monkeypatch):
     assert dnfr_broadcast == pytest.approx(dnfr_loop, rel=1e-9, abs=1e-9)
 
 
-def test_prepare_reuses_neighbor_workspace_vectorized():
+def test_prepare_reuses_neighbor_reduction_buffers_vectorized():
     np = pytest.importorskip("numpy")
     del np
 
@@ -125,13 +125,17 @@ def test_prepare_reuses_neighbor_workspace_vectorized():
     cache = data["cache"]
     assert cache is not None, "Expected ΔNFR cache to be initialised"
 
-    workspace_first = data["neighbor_workspace_np"]
-    assert workspace_first is not None
-    assert cache.neighbor_workspace_np is workspace_first
+    edge_values_first = data["neighbor_edge_values_np"]
+    accum_first = data["neighbor_accum_np"]
+    assert edge_values_first is not None
+    assert accum_first is not None
+    assert cache.neighbor_edge_values_np is edge_values_first
+    assert cache.neighbor_accum_np is accum_first
 
     reused = _prepare_dnfr_data(G)
-    assert reused["neighbor_workspace_np"] is workspace_first
-    assert reused["neighbor_edge_weights_np"] is data["neighbor_edge_weights_np"]
+    assert reused["neighbor_edge_values_np"] is edge_values_first
+    assert reused["neighbor_accum_np"] is accum_first
 
     _compute_dnfr(G, reused)
-    assert reused["neighbor_workspace_np"] is cache.neighbor_workspace_np
+    assert reused["neighbor_edge_values_np"] is cache.neighbor_edge_values_np
+    assert reused["neighbor_accum_np"] is cache.neighbor_accum_np


### PR DESCRIPTION
## Summary
- replace the broadcast workspace with indexed reductions that reuse cached accumulators and edge buffers in `_accumulate_neighbors_broadcasted`
- align ΔNFR preparation code and numpy plumbing with the new buffers while preserving topology-weighted accumulation
- expand vectorization regression tests to cover sparse broadcast paths and updated cache expectations

## Testing
- `pytest tests/test_dnfr_vectorization_flags.py` (skipped: NumPy not available)
- `pytest tests/test_dnfr_precompute.py` (skipped: NumPy not available)
- `pytest tests/test_dynamics_vectorized.py` (partially skipped: NumPy not available)
- `pytest tests/dynamics/test_neighbor_accumulation_vectorized.py` (skipped: NumPy not available)


------
https://chatgpt.com/codex/tasks/task_e_68f3f1c53540832181f90831e19d065a