### PR TITLE
Enable dynamic registration for TNFR operators

### DIFF
--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -17,22 +17,6 @@ from ..rng import make_rng
 from tnfr import glyph_history
 from ..types import Glyph
 
-from .definitions import (
-    Operador,
-    Emision,
-    Recepcion,
-    Coherencia,
-    Disonancia,
-    Acoplamiento,
-    Resonancia,
-    Silencio,
-    Expansion,
-    Contraccion,
-    Autoorganizacion,
-    Mutacion,
-    Transicion,
-    Recursividad,
-)
 from .jitter import (
     JitterCache,
     JitterCacheManager,
@@ -40,12 +24,22 @@ from .jitter import (
     reset_jitter_manager,
     random_jitter,
 )
-from .registry import OPERADORES
+from .registry import OPERADORES, discover_operators
 from .remesh import (
     apply_network_remesh,
     apply_topological_remesh,
     apply_remesh_if_globally_stable,
 )
+
+discover_operators()
+
+from . import definitions as _definitions
+
+_DEFINITION_EXPORTS = {
+    name: getattr(_definitions, name)
+    for name in getattr(_definitions, "__all__", ())
+}
+globals().update(_DEFINITION_EXPORTS)
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..node import NodoProtocol
@@ -66,22 +60,11 @@ __all__ = [
     "apply_network_remesh",
     "apply_topological_remesh",
     "apply_remesh_if_globally_stable",
-    "Operador",
-    "Emision",
-    "Recepcion",
-    "Coherencia",
-    "Disonancia",
-    "Acoplamiento",
-    "Resonancia",
-    "Silencio",
-    "Expansion",
-    "Contraccion",
-    "Autoorganizacion",
-    "Mutacion",
-    "Transicion",
-    "Recursividad",
     "OPERADORES",
+    "discover_operators",
 ]
+
+__all__.extend(_DEFINITION_EXPORTS.keys())
 
 
 def get_glyph_factors(node: NodoProtocol) -> dict[str, Any]:

--- a/src/tnfr/operators/definitions.py
+++ b/src/tnfr/operators/definitions.py
@@ -22,6 +22,7 @@ from ..config.operator_names import (
     TRANSICION,
     RECURSIVIDAD,
 )
+from .registry import register_operator
 
 __all__ = (
     "Operador",
@@ -62,6 +63,7 @@ class Operador:
         apply_glyph_with_grammar(G, [node], self.glyph, kw.get("window"))
 
 
+@register_operator
 class Emision(Operador):
     """Aplicación del operador de emisión (símbolo ``AL``)."""
 
@@ -70,6 +72,7 @@ class Emision(Operador):
     glyph = Glyph.AL.value
 
 
+@register_operator
 class Recepcion(Operador):
     """Operador de recepción (símbolo ``EN``)."""
 
@@ -78,6 +81,7 @@ class Recepcion(Operador):
     glyph = Glyph.EN.value
 
 
+@register_operator
 class Coherencia(Operador):
     """Operador de coherencia (símbolo ``IL``)."""
 
@@ -86,6 +90,7 @@ class Coherencia(Operador):
     glyph = Glyph.IL.value
 
 
+@register_operator
 class Disonancia(Operador):
     """Operador de disonancia (símbolo ``OZ``)."""
 
@@ -94,6 +99,7 @@ class Disonancia(Operador):
     glyph = Glyph.OZ.value
 
 
+@register_operator
 class Acoplamiento(Operador):
     """Operador de acoplamiento (símbolo ``UM``)."""
 
@@ -102,6 +108,7 @@ class Acoplamiento(Operador):
     glyph = Glyph.UM.value
 
 
+@register_operator
 class Resonancia(Operador):
     """Operador de resonancia (símbolo ``RA``)."""
 
@@ -110,6 +117,7 @@ class Resonancia(Operador):
     glyph = Glyph.RA.value
 
 
+@register_operator
 class Silencio(Operador):
     """Operador de silencio (símbolo ``SHA``)."""
 
@@ -118,6 +126,7 @@ class Silencio(Operador):
     glyph = Glyph.SHA.value
 
 
+@register_operator
 class Expansion(Operador):
     """Operador de expansión (símbolo ``VAL``)."""
 
@@ -126,6 +135,7 @@ class Expansion(Operador):
     glyph = Glyph.VAL.value
 
 
+@register_operator
 class Contraccion(Operador):
     """Operador de contracción (símbolo ``NUL``)."""
 
@@ -134,6 +144,7 @@ class Contraccion(Operador):
     glyph = Glyph.NUL.value
 
 
+@register_operator
 class Autoorganizacion(Operador):
     """Operador de autoorganización (símbolo ``THOL``)."""
 
@@ -142,6 +153,7 @@ class Autoorganizacion(Operador):
     glyph = Glyph.THOL.value
 
 
+@register_operator
 class Mutacion(Operador):
     """Operador de mutación (símbolo ``ZHIR``)."""
 
@@ -150,6 +162,7 @@ class Mutacion(Operador):
     glyph = Glyph.ZHIR.value
 
 
+@register_operator
 class Transicion(Operador):
     """Operador de transición (símbolo ``NAV``)."""
 
@@ -158,6 +171,7 @@ class Transicion(Operador):
     glyph = Glyph.NAV.value
 
 
+@register_operator
 class Recursividad(Operador):
     """Operador de recursividad (símbolo ``REMESH``)."""
 

--- a/src/tnfr/operators/registry.py
+++ b/src/tnfr/operators/registry.py
@@ -2,37 +2,52 @@
 
 from __future__ import annotations
 
-from .definitions import (
-    Operador,
-    Emision,
-    Recepcion,
-    Coherencia,
-    Disonancia,
-    Acoplamiento,
-    Resonancia,
-    Silencio,
-    Expansion,
-    Contraccion,
-    Autoorganizacion,
-    Mutacion,
-    Transicion,
-    Recursividad,
-)
+import importlib
+import pkgutil
+from typing import TYPE_CHECKING
 
-OPERADORES: dict[str, type[Operador]] = {
-    Emision.name: Emision,
-    Recepcion.name: Recepcion,
-    Coherencia.name: Coherencia,
-    Disonancia.name: Disonancia,
-    Acoplamiento.name: Acoplamiento,
-    Resonancia.name: Resonancia,
-    Silencio.name: Silencio,
-    Expansion.name: Expansion,
-    Contraccion.name: Contraccion,
-    Autoorganizacion.name: Autoorganizacion,
-    Mutacion.name: Mutacion,
-    Transicion.name: Transicion,
-    Recursividad.name: Recursividad,
-}
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .definitions import Operador
 
-__all__ = ("OPERADORES",)
+
+OPERADORES: dict[str, type["Operador"]] = {}
+
+
+def register_operator(cls: type["Operador"]) -> type["Operador"]:
+    """Register ``cls`` under its declared ``name`` in :data:`OPERADORES`."""
+
+    name = getattr(cls, "name", None)
+    if not isinstance(name, str) or not name:
+        raise ValueError(
+            f"El operador {cls.__name__} debe declarar un atributo 'name' no vacío"
+        )
+
+    existing = OPERADORES.get(name)
+    if existing is not None and existing is not cls:
+        raise ValueError(f"El operador '{name}' ya está registrado")
+
+    OPERADORES[name] = cls
+    return cls
+
+
+def discover_operators() -> None:
+    """Import all operator submodules so their decorators run."""
+
+    package = importlib.import_module("tnfr.operators")
+    package_path = getattr(package, "__path__", None)
+    if not package_path:
+        return
+
+    if getattr(package, "_operators_discovered", False):  # pragma: no cover - cache
+        return
+
+    prefix = f"{package.__name__}."
+    for module_info in pkgutil.walk_packages(package_path, prefix):
+        if module_info.name == f"{prefix}registry":
+            continue
+        importlib.import_module(module_info.name)
+
+    setattr(package, "_operators_discovered", True)
+
+
+__all__ = ("OPERADORES", "register_operator", "discover_operators")

--- a/tests/test_operator_names.py
+++ b/tests/test_operator_names.py
@@ -1,10 +1,11 @@
 """Tests ensuring operator name constants stay aligned with registry."""
 
 from tnfr.config import operator_names as names
-from tnfr.operators.registry import OPERADORES
+from tnfr.operators.registry import OPERADORES, discover_operators
 
 
 def test_registry_matches_operator_constants() -> None:
+    discover_operators()
     assert set(OPERADORES.keys()) == names.ALL_OPERATOR_NAMES
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add a decorator-based operator registry that guards against duplicate names and discovers operator modules dynamically
- register each canonical operator class via the decorator and load their exports through the package initializer
- ensure operator discovery is triggered in the test suite so the registry matches the configured operator names

## Testing
- pytest tests/test_operator_names.py

------
https://chatgpt.com/codex/tasks/task_e_68f3fd4c740c8321aa96a6625058c6d3