### PR TITLE
Centralize cache capacity configuration across caches

### DIFF
--- a/src/tnfr/cache.py
+++ b/src/tnfr/cache.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass
-from typing import Any, Callable, Iterator, MutableMapping
+from typing import Any, Callable, Iterator, Mapping, MutableMapping
 
-__all__ = ["CacheManager"]
+__all__ = ["CacheManager", "CacheCapacityConfig"]
+
+
+@dataclass(frozen=True)
+class CacheCapacityConfig:
+    """Configuration snapshot for cache capacity policies."""
+
+    default_capacity: int | None
+    overrides: dict[str, int | None]
 
 
 @dataclass
@@ -19,7 +27,15 @@ class _CacheEntry:
 class CacheManager:
     """Coordinate named caches guarded by per-entry locks."""
 
-    def __init__(self, storage: MutableMapping[str, Any] | None = None) -> None:
+    _MISSING = object()
+
+    def __init__(
+        self,
+        storage: MutableMapping[str, Any] | None = None,
+        *,
+        default_capacity: int | None = None,
+        overrides: Mapping[str, int | None] | None = None,
+    ) -> None:
         self._storage: MutableMapping[str, Any]
         if storage is None:
             self._storage = {}
@@ -27,6 +43,19 @@ class CacheManager:
             self._storage = storage
         self._entries: dict[str, _CacheEntry] = {}
         self._registry_lock = threading.RLock()
+        self._default_capacity = self._normalise_capacity(default_capacity)
+        self._capacity_overrides: dict[str, int | None] = {}
+        if overrides:
+            self.configure(overrides=overrides)
+
+    @staticmethod
+    def _normalise_capacity(value: int | None) -> int | None:
+        if value is None:
+            return None
+        size = int(value)
+        if size < 0:
+            raise ValueError("capacity must be non-negative or None")
+        return size
 
     def register(
         self,
@@ -52,6 +81,78 @@ class CacheManager:
                 entry.reset = reset
         if create:
             self.get(name)
+
+    def configure(
+        self,
+        *,
+        default_capacity: int | None | object = _MISSING,
+        overrides: Mapping[str, int | None] | None = None,
+        replace_overrides: bool = False,
+    ) -> None:
+        """Update the cache capacity policy shared by registered entries."""
+
+        with self._registry_lock:
+            if default_capacity is not self._MISSING:
+                self._default_capacity = self._normalise_capacity(
+                    default_capacity if default_capacity is not None else None
+                )
+            if overrides is not None:
+                if replace_overrides:
+                    self._capacity_overrides.clear()
+                for key, value in overrides.items():
+                    self._capacity_overrides[key] = self._normalise_capacity(value)
+
+    def configure_from_mapping(self, config: Mapping[str, Any]) -> None:
+        """Load configuration produced by :meth:`export_config`."""
+
+        default = config.get("default_capacity", self._MISSING)
+        overrides = config.get("overrides")
+        overrides_mapping: Mapping[str, int | None] | None
+        overrides_mapping = overrides if isinstance(overrides, Mapping) else None
+        self.configure(default_capacity=default, overrides=overrides_mapping)
+
+    def export_config(self) -> CacheCapacityConfig:
+        """Return a copy of the current capacity configuration."""
+
+        with self._registry_lock:
+            return CacheCapacityConfig(
+                default_capacity=self._default_capacity,
+                overrides=dict(self._capacity_overrides),
+            )
+
+    def get_capacity(
+        self,
+        name: str,
+        *,
+        requested: int | None = None,
+        fallback: int | None = None,
+        use_default: bool = True,
+    ) -> int | None:
+        """Return capacity for ``name`` considering overrides and defaults."""
+
+        with self._registry_lock:
+            override = self._capacity_overrides.get(name, self._MISSING)
+            default = self._default_capacity
+        if override is not self._MISSING:
+            return override
+        values: tuple[int | None, ...]
+        if use_default:
+            values = (requested, default, fallback)
+        else:
+            values = (requested, fallback)
+        for value in values:
+            if value is self._MISSING:
+                continue
+            normalised = self._normalise_capacity(value)
+            if normalised is not None:
+                return normalised
+        return None
+
+    def has_override(self, name: str) -> bool:
+        """Return ``True`` if ``name`` has an explicit capacity override."""
+
+        with self._registry_lock:
+            return name in self._capacity_overrides
 
     def get_lock(self, name: str) -> threading.Lock | threading.RLock:
         entry = self._entries.get(name)

--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -34,7 +34,16 @@ class JitterCache:
         manager: CacheManager | None = None,
     ) -> None:
         self._manager = manager or CacheManager()
-        self._sequence = ScopedCounterCache("jitter", max_entries, manager=self._manager)
+        if not self._manager.has_override("scoped_counter:jitter"):
+            self._manager.configure(
+                overrides={"scoped_counter:jitter": int(max_entries)}
+            )
+        self._sequence = ScopedCounterCache(
+            "jitter",
+            max_entries=None,
+            manager=self._manager,
+            default_max_entries=int(max_entries),
+        )
         self._settings_key = "jitter_settings"
         self._manager.register(
             self._settings_key,

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -37,6 +37,7 @@ from .cache import (
     get_graph_version,
     increment_edge_version,
     increment_graph_version,
+    configure_graph_cache_limits,
     node_set_checksum,
     stable_json,
 )
@@ -81,6 +82,7 @@ __all__ = (
     "get_graph_version",
     "increment_edge_version",
     "increment_graph_version",
+    "configure_graph_cache_limits",
     "node_set_checksum",
     "stable_json",
     "get_graph",


### PR DESCRIPTION
## Summary
- extend `CacheManager` with shared capacity policies and expose a graph-level configuration helper
- route edge, RNG, and jitter caches through the centralized capacity resolver instead of ad-hoc constants
- preserve RNG cache controls while keeping overrides and defaults consistent across callers

## Testing
- pytest tests/test_edge_version_cache.py tests/test_make_rng.py tests/test_make_rng_threadsafe.py tests/test_rng_base_seed.py tests/test_operators.py

------
https://chatgpt.com/codex/tasks/task_e_68f4159645bc8321b4bd2ca0e851e9e1