### PR TITLE
Add cache telemetry counters and instrumentation

### DIFF
--- a/tests/test_edge_version_cache.py
+++ b/tests/test_edge_version_cache.py
@@ -120,3 +120,21 @@ def test_edge_version_cache_thread_safety(graph_and_manager):
     assert all(r is second for r in results2)
     assert second is not first
     assert calls > calls_after_first
+
+
+def test_edge_version_cache_metrics(graph_and_manager):
+    G, manager = graph_and_manager()
+    calls = 0
+
+    def builder():
+        nonlocal calls
+        calls += 1
+        return calls
+
+    assert edge_version_cache(G, "k", builder) == 1
+    assert edge_version_cache(G, "k", builder) == 1
+
+    stats = manager._manager.get_metrics(manager._STATE_KEY)
+    assert stats.misses == 1
+    assert stats.hits == 1
+    assert stats.evictions == 0

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -37,6 +37,24 @@ def test_random_jitter_deterministic(graph_canon):
     assert [j3, j4] == [j1, j2]
 
 
+def test_jitter_cache_metrics(graph_canon):
+    reset_jitter_manager()
+    G = graph_canon()
+    G.add_node(0)
+    node = NodoNX(G, 0)
+
+    manager = get_jitter_manager()
+    telemetry = manager.cache.manager
+    before = telemetry.get_metrics("scoped_counter:jitter")
+
+    random_jitter(node, 0.5)
+    random_jitter(node, 0.5)
+
+    after = telemetry.get_metrics("scoped_counter:jitter")
+    assert after.misses - before.misses == 1
+    assert after.hits - before.hits == 1
+
+
 def test_random_jitter_zero_amplitude(graph_canon):
     G = graph_canon()
     G.add_node(0)

--- a/tests/test_rng_base_seed.py
+++ b/tests/test_rng_base_seed.py
@@ -124,3 +124,26 @@ def test_manual_disable_blocks_graph_override(graph_canon):
         set_cache_maxsize(original_size)
         rng_module._CACHE_LOCKED = original_locked
         clear_rng_cache()
+
+
+def test_seed_hash_metrics():
+    import tnfr.rng as rng_module
+
+    original_size = rng_module._CACHE_MAXSIZE
+    original_locked = rng_module._CACHE_LOCKED
+    try:
+        set_cache_maxsize(4)
+        seed_hash.cache_clear()
+        manager = rng_module._RNG_CACHE_MANAGER
+        before = manager.get_metrics("seed_hash_cache")
+
+        seed_hash(1, 1)
+        seed_hash(1, 1)
+
+        after = manager.get_metrics("seed_hash_cache")
+        assert after.misses - before.misses == 1
+        assert after.hits - before.hits == 1
+    finally:
+        set_cache_maxsize(original_size)
+        rng_module._CACHE_LOCKED = original_locked
+        clear_rng_cache()


### PR DESCRIPTION
## Summary
- extend `CacheManager` with hit/miss/eviction counters, timing utilities, and publisher/logging hooks for telemetry reuse
- instrument edge version, RNG seed hash, and jitter scoped counter caches to record metrics and evictions via the shared manager
- add regression tests covering cache metric deltas for edge caches, seed hashes, and jitter sequences

## Testing
- `pytest tests/test_edge_version_cache.py tests/test_rng_base_seed.py tests/test_operators.py`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f4198552f08321b8bbd0a126e03f5f