### PR TITLE
Add optional n_jobs parallelism for ΔNFR pure Python path

### DIFF
--- a/tests/test_dnfr_neighbor_means.py
+++ b/tests/test_dnfr_neighbor_means.py
@@ -88,3 +88,28 @@ def test_neighbor_mean_workspaces_reused(monkeypatch):
     assert cache_after.neighbor_mean_tmp_np is tmp_first
     assert cache_after.neighbor_mean_length_np is length_first
 
+
+def test_pure_python_parallel_matches_serial(monkeypatch):
+    G_serial = _build_graph()
+    G_parallel = _build_graph()
+
+    with numpy_disabled(monkeypatch):
+        default_compute_delta_nfr(G_serial, n_jobs=1)
+        default_compute_delta_nfr(G_parallel, n_jobs=3)
+
+    assert _collect_dnfr(G_parallel) == pytest.approx(_collect_dnfr(G_serial))
+
+
+def test_vectorized_n_jobs_argument():
+    pytest.importorskip("numpy")
+
+    G_reference = _build_graph()
+    G_vectorized = _build_graph()
+
+    default_compute_delta_nfr(G_reference)
+    default_compute_delta_nfr(G_vectorized, n_jobs=4)
+
+    assert _collect_dnfr(G_vectorized) == pytest.approx(
+        _collect_dnfr(G_reference)
+    )
+


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f41fc4b7ec8321bd17098b93f347f4