### PR TITLE
Add optional parallel coherence computation and tests

### DIFF
--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -76,6 +76,7 @@ class MetricDefaults:
             "self_on_diag": True,
             "store_mode": "sparse",
             "threshold": 0.0,
+            "n_jobs": 1,
             "history_key": "W_sparse",
             "Wi_history_key": "W_i",
             "stats_history_key": "W_stats",


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add an optional `n_jobs` argument to `coherence_matrix` that drives parallel worker usage for the Python fallback while keeping the NumPy path unchanged
- fan out pure-Python `wij` assembly and aggregation through a shared `ProcessPoolExecutor` and expose a default `n_jobs` in the coherence metric configuration
- extend the coherence cache tests to validate serial/parallel equivalence and configuration-driven worker selection

## Testing
- `pytest tests/test_coherence_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68f42218756c8321969eaa4ef1f28ae0