### PR TITLE
Vectorize sense index computation with configurable parallel fallback

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -539,7 +539,15 @@ def _prepare_dnfr(G, *, use_Si: bool) -> None:
                 raise
     G.graph.pop("_sel_norms", None)
     if use_Si:
-        compute_Si(G, inplace=True)
+        raw_si_jobs = G.graph.get("SI_N_JOBS")
+        try:
+            si_jobs = None if raw_si_jobs is None else int(raw_si_jobs)
+        except (TypeError, ValueError):
+            si_jobs = None
+        else:
+            if si_jobs is not None and si_jobs <= 0:
+                si_jobs = None
+        compute_Si(G, inplace=True, n_jobs=si_jobs)
 
 
 def _apply_selector(G):

--- a/tests/test_compute_Si_numpy_usage.py
+++ b/tests/test_compute_Si_numpy_usage.py
@@ -1,5 +1,7 @@
 import math
 
+import pytest
+
 from tnfr.alias import set_attr
 from tnfr.constants import get_aliases
 from tnfr.metrics.sense_index import compute_Si
@@ -52,3 +54,84 @@ def test_compute_Si_uses_module_numpy_and_propagates(monkeypatch, graph_canon):
     compute_Si(G, inplace=False)
 
     assert captured == [sentinel] * G.number_of_nodes()
+
+
+def _configure_graph(graph):
+    graph.add_nodes_from(range(4))
+    graph.add_edges_from(((0, 1), (1, 2), (2, 3)))
+    phases = [0.0, math.pi / 5, math.pi / 3, math.pi / 2]
+    vf_values = [0.2, 0.5, 0.8, 1.1]
+    dnfr_values = [0.1, 0.3, 0.4, 0.6]
+    for node in graph.nodes:
+        set_attr(graph.nodes[node], ALIAS_THETA, phases[node])
+        set_attr(graph.nodes[node], ALIAS_VF, vf_values[node])
+        set_attr(graph.nodes[node], ALIAS_DNFR, dnfr_values[node])
+
+
+def test_compute_Si_vectorized_matches_python(monkeypatch, graph_canon):
+    pytest.importorskip("numpy")
+
+    G_vec = graph_canon()
+    G_py = graph_canon()
+    _configure_graph(G_vec)
+    _configure_graph(G_py)
+
+    vectorized = compute_Si(G_vec, inplace=False)
+
+    monkeypatch.setattr("tnfr.metrics.sense_index.get_numpy", lambda: None)
+    python = compute_Si(G_py, inplace=False)
+
+    assert set(vectorized) == set(python)
+    for node in vectorized:
+        assert python[node] == pytest.approx(vectorized[node])
+
+
+def test_compute_Si_python_parallel_matches(monkeypatch, graph_canon):
+    monkeypatch.setattr("tnfr.metrics.sense_index.get_numpy", lambda: None)
+
+    G = graph_canon()
+    _configure_graph(G)
+
+    sequential = compute_Si(G, inplace=False, n_jobs=1)
+    parallel = compute_Si(G, inplace=False, n_jobs=2)
+
+    assert set(sequential) == set(parallel)
+    for node in sequential:
+        assert parallel[node] == pytest.approx(sequential[node])
+
+
+def test_compute_Si_reads_jobs_from_graph(monkeypatch, graph_canon):
+    monkeypatch.setattr("tnfr.metrics.sense_index.get_numpy", lambda: None)
+
+    captured = []
+
+    class DummyExecutor:
+        def __init__(self, max_workers):
+            captured.append(max_workers)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def submit(self, fn, *args, **kwargs):
+            result = fn(*args, **kwargs)
+
+            class DummyFuture:
+                def result(self_inner):
+                    return result
+
+            return DummyFuture()
+
+    monkeypatch.setattr(
+        "tnfr.metrics.sense_index.ProcessPoolExecutor", DummyExecutor
+    )
+
+    G = graph_canon()
+    _configure_graph(G)
+    G.graph["SI_N_JOBS"] = "3"
+
+    compute_Si(G, inplace=False)
+
+    assert captured == [3]


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Vectorized `compute_Si` when NumPy is available and added a chunked `ProcessPoolExecutor` fallback for Python-only environments.
- Normalized `n_jobs` handling for the sense index, including reading `SI_N_JOBS` from graph configuration and propagating it through `_prepare_dnfr`.
- Added regression tests covering vectorized versus Python/parallel equivalence and verifying sense-index job propagation.

## Testing
- `pytest tests/test_compute_Si_numpy_usage.py tests/test_dynamics_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68f42887321883219bf86191207eb059