### PR TITLE
Enhance glyph timing metrics parallelism

### DIFF
--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -55,6 +55,7 @@ class MetricDefaults:
             "enabled": True,
             "save_by_node": True,
             "normalize_series": False,
+            "n_jobs": 1,
         }
     )
     GRAMMAR_CANON: dict[str, Any] = field(

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -87,7 +87,18 @@ def _metrics_step(G, ctx: dict[str, Any] | None = None):
         logger.debug("observer update failed: %s", exc)
 
     _aggregate_si(G, hist)
-    _compute_advanced_metrics(G, hist, t, dt, cfg)
+
+    raw_jobs = cfg.get("n_jobs")
+    metrics_jobs: int | None
+    try:
+        metrics_jobs = None if raw_jobs is None else int(raw_jobs)
+    except (TypeError, ValueError):
+        metrics_jobs = None
+    else:
+        if metrics_jobs <= 0:
+            metrics_jobs = None
+
+    _compute_advanced_metrics(G, hist, t, dt, cfg, n_jobs=metrics_jobs)
 
 
 def register_metrics_callbacks(G) -> None:


### PR DESCRIPTION
## Summary
- vectorise glyph timing accumulation when NumPy is present and guard deterministic history updates
- fall back to chunked ProcessPoolExecutor aggregation when NumPy is unavailable but parallel slots are requested
- thread the metrics `n_jobs` configuration through the orchestrator and extend metrics tests to cover both execution paths

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

### Testing
- `pytest tests/test_metrics.py`
- `pytest` *(fails: missing optional numpy dependency in unrelated test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68f49ea7ddd8832198e23da6f9fc7dab