### PR TITLE
Improve ΔNFR hook parallelism and add regression tests

### DIFF
--- a/tests/test_dnfr_hooks.py
+++ b/tests/test_dnfr_hooks.py
@@ -1,5 +1,12 @@
+import math
+
 from tnfr.constants import get_aliases
-from tnfr.dynamics import dnfr_phase_only, dnfr_epi_vf_mixed, dnfr_laplacian
+from tnfr.dynamics import (
+    dnfr_phase_only,
+    dnfr_epi_vf_mixed,
+    dnfr_laplacian,
+    set_delta_nfr_hook,
+)
 from tnfr.alias import get_attr
 
 ALIAS_THETA = get_aliases("THETA")
@@ -39,3 +46,54 @@ def test_dnfr_laplacian_respects_weights(graph_canon):
     dnfr_laplacian(G)
     assert get_attr(G.nodes[0], ALIAS_DNFR, 0.0) == -1.0
     assert get_attr(G.nodes[1], ALIAS_DNFR, 0.0) == 1.0
+
+
+def test_dnfr_phase_only_parallel_matches_serial(graph_canon, monkeypatch):
+    G_serial = graph_canon()
+    G_serial.add_edge(0, 1)
+    G_serial.nodes[0][ALIAS_THETA[0]] = 0.0
+    G_serial.nodes[1][ALIAS_THETA[0]] = math.pi / 2
+    dnfr_phase_only(G_serial)
+    serial = {
+        node: get_attr(data, ALIAS_DNFR, 0.0)
+        for node, data in G_serial.nodes(data=True)
+    }
+
+    G_parallel = graph_canon()
+    G_parallel.add_edge(0, 1)
+    G_parallel.nodes[0][ALIAS_THETA[0]] = 0.0
+    G_parallel.nodes[1][ALIAS_THETA[0]] = math.pi / 2
+    monkeypatch.setattr("tnfr.dynamics.dnfr.get_numpy", lambda: None)
+    dnfr_phase_only(G_parallel, n_jobs=2)
+    parallel = {
+        node: get_attr(data, ALIAS_DNFR, 0.0)
+        for node, data in G_parallel.nodes(data=True)
+    }
+
+    assert parallel == serial
+
+
+def test_set_delta_nfr_hook_forwards_jobs(graph_canon):
+    G = graph_canon()
+    recorded: list[int | None] = []
+
+    def hook(graph, *, n_jobs=None):
+        recorded.append(n_jobs)
+
+    set_delta_nfr_hook(G, hook)
+    compute = G.graph["compute_delta_nfr"]
+    compute(G, n_jobs=3)
+    assert recorded == [3]
+
+
+def test_set_delta_nfr_hook_ignores_jobs_when_missing(graph_canon):
+    G = graph_canon()
+    calls: list[bool] = []
+
+    def hook(graph):
+        calls.append(True)
+
+    set_delta_nfr_hook(G, hook)
+    compute = G.graph["compute_delta_nfr"]
+    compute(G, n_jobs=5)
+    assert calls == [True]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add a NumPy-aware ΔNFR hook helper with multiprocessing fallback when vectorisation is unavailable
- extend bundled ΔNFR hooks to accept optional n_jobs hints and reuse cached neighbour statistics
- expand the hook test suite with serial versus parallel regression coverage and wrapper forwarding checks

## Testing
- `pytest tests/test_dnfr_hooks.py`


------
https://chatgpt.com/codex/tasks/task_e_68f4a0977e0c8321b0197b840039c2e2