### PR TITLE
Propagate n_jobs through Si aggregation metrics

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -104,7 +104,7 @@ def _metrics_step(G, ctx: dict[str, Any] | None = None):
     except (KeyError, AttributeError, TypeError) as exc:
         logger.debug("observer update failed: %s", exc)
 
-    _aggregate_si(G, hist)
+    _aggregate_si(G, hist, n_jobs=metrics_jobs)
 
     _compute_advanced_metrics(G, hist, t, dt, cfg, n_jobs=metrics_jobs)
 


### PR DESCRIPTION
## Summary
- Extend `_aggregate_si` to accept `n_jobs`, leverage NumPy vectorization, and provide multiprocessing fallback when NumPy is absent.
- Forward the metrics configuration `n_jobs` value to Si aggregation and add targeted tests for vectorized, sequential, and parallel aggregation paths.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f4a6080a608321a1bc0923ff15e9fe