### PR TITLE
Add configurable n_jobs overrides to dynamics step/run

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ print(f"C(t)={C:.3f}, ΔNFR̄={delta_nfr_medio:.3f}, dEPI/dt̄={depi_medio:.3f},
 
 La secuencia respeta la ecuación nodal porque `create_nfr` inicializa el nodo con su **νf** y fase, y `run_sequence` valida la gramática TNFR antes de aplicar los operadores en el orden provisto. Tras cada operador invoca el gancho `compute_delta_nfr` del grafo para recalcular únicamente **ΔNFR** (por defecto usa `dnfr_epi_vf_mixed`, que mezcla EPI y νf sin alterar la fase). La fase solo cambiará si los propios operadores la modifican o si se ejecutan pasos dinámicos posteriores (por ejemplo `tnfr.dynamics.step` o `coordinate_global_local_phase`). Cuando necesites sincronización de fase automática, utiliza el ciclo de dinámica completo (`tnfr.dynamics.step`/`tnfr.dynamics.run`) o invoca explícitamente los coordinadores de fase después de `run_sequence`. Esa telemetría permite medir **C(t)** y **Si**, adelantando lo que se desarrolla en [Key concepts (operational summary)](#key-concepts-operational-summary) y [Main metrics](#main-metrics).
 
+Tanto `step` como `run` aceptan un argumento opcional `n_jobs` (diccionario) para
+forzar el número de procesos/hilos a usar en cada etapa paralelizable (ΔNFR,
+Si, integradores, coordinación de fase, adaptación de νf) sin tener que
+persistir esos overrides en `G.graph`.
+
 ### Desde la línea de comandos
 
 Archivo `secuencia.json`:

--- a/documentation.txt
+++ b/documentation.txt
@@ -31,6 +31,9 @@ Primary entry points
 The symbols re-exported by `tnfr.__init__` provide the standard entryway into the engine:
 - `tnfr.dynamics.step` / `tnfr.dynamics.run`: integrators to evolve the network
   stepwise or across full runs, automatically coordinating phase.
+  Both accept an optional ``n_jobs`` mapping to override per-component
+  parallelism (ΔNFR, Si, integrator, phase coordination, VF adaptation) without
+  mutating the graph configuration.
 - `tnfr.structural.create_nfr`: bootstraps resonant nodes with νf, phase, and EPI
   values that comply with the TNFR grammar.
 - `tnfr.structural.run_sequence`: validates and executes operator trajectories,

--- a/tests/test_dynamics_run.py
+++ b/tests/test_dynamics_run.py
@@ -19,7 +19,7 @@ def test_run_stops_early_with_historydict(monkeypatch, graph_canon):
 
     call_count = 0
 
-    def fake_step(G, *, dt=None, use_Si=True, apply_glyphs=True):
+    def fake_step(G, *, dt=None, use_Si=True, apply_glyphs=True, n_jobs=None):
         nonlocal call_count
         call_count += 1
         hist = ensure_history(G)
@@ -52,6 +52,7 @@ def test_step_preserves_since_mappings(monkeypatch, graph_canon):
         apply_glyphs,
         step_idx,
         hist,
+        job_overrides=None,
     ) -> None:
         h_al = hist.setdefault("since_AL", {})
         h_en = hist.setdefault("since_EN", {})
@@ -72,3 +73,148 @@ def test_step_preserves_since_mappings(monkeypatch, graph_canon):
     assert isinstance(since_en, dict)
     assert since_al[0] == 1
     assert since_en[0] == 1
+
+
+def test_step_respects_n_jobs_overrides(monkeypatch, graph_canon):
+    """Explicit ``n_jobs`` overrides should reach every parallel component."""
+
+    G = graph_canon()
+    recorded = {}
+
+    def fake_compute_delta_nfr(G, *, n_jobs=None):
+        recorded["dnfr"] = n_jobs
+
+    G.graph["compute_delta_nfr"] = fake_compute_delta_nfr
+
+    def fake_compute_si(G, *, inplace=True, n_jobs=None):
+        recorded["si"] = n_jobs
+
+    def fake_update_epi_via_nodal_equation(G, *, dt=None, method=None, n_jobs=None):
+        recorded["integrator"] = n_jobs
+
+    def fake_coordinate_global_local_phase(G, *_args, n_jobs=None, **_kwargs):
+        recorded["phase"] = n_jobs
+
+    def fake_adapt_vf_by_coherence(G, *, n_jobs=None):
+        recorded["vf"] = n_jobs
+
+    monkeypatch.setattr(dynamics, "compute_Si", fake_compute_si)
+    monkeypatch.setattr(
+        dynamics, "update_epi_via_nodal_equation", fake_update_epi_via_nodal_equation
+    )
+    monkeypatch.setattr(
+        dynamics, "coordinate_global_local_phase", fake_coordinate_global_local_phase
+    )
+    monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
+    monkeypatch.setattr(dynamics, "_apply_glyphs", lambda G, selector, hist: None)
+    monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)
+    monkeypatch.setattr(dynamics, "_maybe_remesh", lambda G: None)
+    monkeypatch.setattr(dynamics, "_run_validators", lambda G: None)
+    monkeypatch.setattr(dynamics, "_run_after_callbacks", lambda G, step_idx: None)
+
+    overrides = {
+        "dnfr": "3",
+        "SI_N_JOBS": 4,
+        "integrator": 5,
+        "phase": "6",
+        "vf_adapt": 7,
+    }
+
+    dynamics.step(G, n_jobs=overrides)
+
+    assert recorded == {
+        "dnfr": 3,
+        "si": 4,
+        "integrator": 5,
+        "phase": 6,
+        "vf": 7,
+    }
+
+
+def test_step_defaults_to_graph_jobs(monkeypatch, graph_canon):
+    """Graph attributes remain the fallback when overrides are missing."""
+
+    G = graph_canon()
+    G.graph.update(
+        {
+            "DNFR_N_JOBS": "2",
+            "SI_N_JOBS": 3,
+            "INTEGRATOR_N_JOBS": "4",
+            "PHASE_N_JOBS": 5,
+            "VF_ADAPT_N_JOBS": 0,
+        }
+    )
+
+    recorded = {}
+
+    def fake_compute_delta_nfr(G, *, n_jobs=None):
+        recorded["dnfr"] = n_jobs
+
+    G.graph["compute_delta_nfr"] = fake_compute_delta_nfr
+
+    def fake_compute_si(G, *, inplace=True, n_jobs=None):
+        recorded["si"] = n_jobs
+
+    def fake_update_epi_via_nodal_equation(G, *, dt=None, method=None, n_jobs=None):
+        recorded["integrator"] = n_jobs
+
+    def fake_coordinate_global_local_phase(G, *_args, n_jobs=None, **_kwargs):
+        recorded["phase"] = n_jobs
+
+    def fake_adapt_vf_by_coherence(G, *, n_jobs=None):
+        recorded["vf"] = n_jobs
+
+    monkeypatch.setattr(dynamics, "compute_Si", fake_compute_si)
+    monkeypatch.setattr(
+        dynamics, "update_epi_via_nodal_equation", fake_update_epi_via_nodal_equation
+    )
+    monkeypatch.setattr(
+        dynamics, "coordinate_global_local_phase", fake_coordinate_global_local_phase
+    )
+    monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
+    monkeypatch.setattr(dynamics, "_apply_glyphs", lambda G, selector, hist: None)
+    monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)
+    monkeypatch.setattr(dynamics, "_maybe_remesh", lambda G: None)
+    monkeypatch.setattr(dynamics, "_run_validators", lambda G: None)
+    monkeypatch.setattr(dynamics, "_run_after_callbacks", lambda G, step_idx: None)
+
+    dynamics.step(G)
+
+    assert recorded == {
+        "dnfr": 2,
+        "si": 3,
+        "integrator": 4,
+        "phase": 5,
+        "vf": None,
+    }
+
+
+def test_run_reuses_normalized_n_jobs(monkeypatch, graph_canon):
+    """``run`` should normalize ``n_jobs`` once and reuse it across steps."""
+
+    G = graph_canon()
+    seen = []
+
+    def fake_step(
+        G,
+        *,
+        dt=None,
+        use_Si=True,
+        apply_glyphs=True,
+        n_jobs=None,
+    ) -> None:
+        seen.append(n_jobs)
+
+    monkeypatch.setattr(dynamics, "step", fake_step)
+
+    overrides = {"dnfr": "2", "vf_adapt_n_jobs": 3}
+
+    dynamics.run(G, steps=2, n_jobs=overrides)
+
+    assert len(seen) == 2
+    assert seen[0] is seen[1]
+    assert seen[0] == {"DNFR": "2", "VF_ADAPT": 3}


### PR DESCRIPTION
## Summary
- allow tnfr.dynamics.step/run to accept an optional n_jobs mapping and honour overrides before reading graph defaults
- normalize override keys so ΔNFR, Si, integrator, phase and VF adapters share a consistent lookup path
- document the new API surface and add regression tests covering overrides and compatibility fallbacks

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f4b3be9d388321bc1c768b11d5429f