### PR TITLE
Add lazy proxies for cached optional imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,20 @@ pip install tnfr
 Use ``tnfr.utils.cached_import`` to load optional dependencies and cache the
 result via a process-wide LRU cache. Missing modules (or attributes) yield
 ``None`` without triggering repeated imports. The helper records failures and
-emits a single warning per module to keep logs tidy. When optional packages are
-installed at runtime call ``tnfr.utils.prune_failed_imports`` to clear the
-consolidated failure/warning registry before retrying:
+emits a single warning per module to keep logs tidy. Set ``lazy=True`` to obtain
+a lightweight proxy that postpones the real import until the object is first
+used—handy when optional dependencies are rarely touched. When optional
+packages are installed at runtime call ``tnfr.utils.prune_failed_imports`` to
+clear the consolidated failure/warning registry before retrying:
 
 ```python
 from tnfr.utils import cached_import, prune_failed_imports
 
 np = cached_import("numpy")
 safe_load = cached_import("yaml", "safe_load")
+
+# postpone work until the symbol is first accessed
+safe_lazy = cached_import("yaml", "safe_load", lazy=True)
 
 # provide a shared cache with an explicit lock
 from cachetools import TTLCache

--- a/documentation.txt
+++ b/documentation.txt
@@ -41,7 +41,8 @@ The symbols re-exported by `tnfr.__init__` provide the standard entryway into th
 - `tnfr.ontosim.preparar_red`: prepares topologies and parameters for multiscale
   simulations.
 - `tnfr.utils.cached_import` / `prune_failed_imports`: manage optional
-  dependencies and clean shared import caches.
+  dependencies, obtain lazy proxies (`lazy=True`) when deferring work is useful,
+  and clean shared import caches.
 
 Structural operator map
 -----------------------


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Introduced a `LazyImportProxy` that defers optional imports while reusing the existing cache and warning registry.
- Extended `cached_import` with a `lazy` flag and shared cache of resolved objects so repeated calls receive the concrete module.
- Documented the lazy option and expanded the import utility tests to cover deferred resolution, fallback handling, and identity guarantees.

## Testing
- pytest tests/test_import_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68f4bd8de21c83219519b70eecd03d67