### PR TITLE
Add warm_cached_import helper for optional imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ safe_load = cached_import("yaml", "safe_load")
 # postpone work until the symbol is first accessed
 safe_lazy = cached_import("yaml", "safe_load", lazy=True)
 
+# warm optional dependencies during application bootstrap
+from tnfr.utils import warm_cached_import
+
+warm_cached_import("numpy", ("yaml", "safe_load"))
+
 # provide a shared cache with an explicit lock
 from cachetools import TTLCache
 import threading

--- a/documentation.txt
+++ b/documentation.txt
@@ -40,9 +40,10 @@ The symbols re-exported by `tnfr.__init__` provide the standard entryway into th
   recomputing ΔNFR after each step.
 - `tnfr.ontosim.preparar_red`: prepares topologies and parameters for multiscale
   simulations.
-- `tnfr.utils.cached_import` / `prune_failed_imports`: manage optional
-  dependencies, obtain lazy proxies (`lazy=True`) when deferring work is useful,
-  and clean shared import caches.
+- `tnfr.utils.cached_import` / `tnfr.utils.warm_cached_import` /
+  `prune_failed_imports`: manage optional dependencies, obtain lazy proxies
+  (`lazy=True`) when deferring work is useful, warm specific modules during
+  bootstrap, and clean shared import caches.
 
 Structural operator map
 -----------------------

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -52,6 +52,7 @@ __all__ = (
     "IMPORT_LOG",
     "WarnOnce",
     "cached_import",
+    "warm_cached_import",
     "get_logger",
     "get_nodonx",
     "get_numpy",
@@ -108,6 +109,7 @@ __all__ = (
 
 WarnOnce = _init.WarnOnce
 cached_import = _init.cached_import
+warm_cached_import = _init.warm_cached_import
 get_logger = _init.get_logger
 get_nodonx = _init.get_nodonx
 get_numpy = _init.get_numpy


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add `warm_cached_import` to preload import cache entries, including multi-spec handling and lazy passthrough
- expose the helper via `tnfr.utils` and document startup warm-up flows
- extend `tests/test_import_utils.py` to cover cache warming success, failure, idempotence, and multi-module scenarios


------
https://chatgpt.com/codex/tasks/task_e_68f4c0f094ec8321b8e6bfcb2cb925ba