### PR TITLE
Improve lazy cached imports and optional I/O dependencies

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Callable
 from functools import partial
 
-from .utils import cached_import, get_logger
+from .utils import LazyImportProxy, cached_import, get_logger
 
 
 def _raise_import_error(name: str, *_: Any, **__: Any) -> Any:
@@ -36,47 +36,72 @@ _MISSING_YAML_ERROR = type(
 )
 
 
+def _resolve_lazy(value: Any) -> Any:
+    if isinstance(value, LazyImportProxy):
+        return value.resolve()
+    return value
+
+
+class _LazyBool:
+    __slots__ = ("_value",)
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def __bool__(self) -> bool:
+        return _resolve_lazy(self._value) is not None
+
+
+_TOMLI_MODULE = cached_import("tomli", emit="log", lazy=True)
 tomllib = cached_import(
     "tomllib",
     emit="log",
-    fallback=cached_import("tomli", emit="log"),
+    lazy=True,
+    fallback=_TOMLI_MODULE,
 )
-has_toml = tomllib is not None
+has_toml = _LazyBool(tomllib)
 
 
+_TOMLI_TOML_ERROR = cached_import(
+    "tomli",
+    "TOMLDecodeError",
+    emit="log",
+    lazy=True,
+    fallback=_MISSING_TOML_ERROR,
+)
 TOMLDecodeError = cached_import(
     "tomllib",
     "TOMLDecodeError",
     emit="log",
-    fallback=cached_import(
-        "tomli",
-        "TOMLDecodeError",
-        emit="log",
-        fallback=_MISSING_TOML_ERROR,
-    ),
+    lazy=True,
+    fallback=_TOMLI_TOML_ERROR,
 )
 
 
+_TOMLI_LOADS = cached_import(
+    "tomli",
+    "loads",
+    emit="log",
+    lazy=True,
+    fallback=partial(_raise_import_error, "tomllib/tomli"),
+)
 _TOML_LOADS: Callable[[str], Any] = cached_import(
     "tomllib",
     "loads",
     emit="log",
-    fallback=cached_import(
-        "tomli",
-        "loads",
-        emit="log",
-        fallback=partial(_raise_import_error, "tomllib/tomli"),
-    ),
+    lazy=True,
+    fallback=_TOMLI_LOADS,
 )
 
 
-yaml = cached_import("yaml", emit="log")
+yaml = cached_import("yaml", emit="log", lazy=True)
 
 
 YAMLError = cached_import(
     "yaml",
     "YAMLError",
     emit="log",
+    lazy=True,
     fallback=_MISSING_YAML_ERROR,
 )
 
@@ -85,6 +110,7 @@ _YAML_SAFE_LOAD: Callable[[str], Any] = cached_import(
     "yaml",
     "safe_load",
     emit="log",
+    lazy=True,
     fallback=partial(_raise_import_error, "pyyaml"),
 )
 
@@ -114,21 +140,66 @@ def _get_parser(suffix: str) -> Callable[[str], Any]:
         raise ValueError(f"Unsupported suffix: {suffix}") from exc
 
 
-ERROR_MESSAGES = {
+_BASE_ERROR_MESSAGES: dict[type[BaseException], str] = {
     OSError: "Could not read {path}: {e}",
     UnicodeDecodeError: "Encoding error while reading {path}: {e}",
     json.JSONDecodeError: "Error parsing JSON file at {path}: {e}",
-    YAMLError: "Error parsing YAML file at {path}: {e}",
     ImportError: "Missing dependency parsing {path}: {e}",
 }
-if has_toml:
-    ERROR_MESSAGES[TOMLDecodeError] = "Error parsing TOML file at {path}: {e}"
+
+
+def _resolve_exception_type(candidate: Any) -> type[BaseException] | None:
+    resolved = _resolve_lazy(candidate)
+    if isinstance(resolved, type) and issubclass(resolved, BaseException):
+        return resolved
+    return None
+
+
+_OPTIONAL_ERROR_MESSAGE_FACTORIES: tuple[
+    tuple[Callable[[], type[BaseException] | None], str],
+    ...,
+] = (
+    (lambda: _resolve_exception_type(YAMLError), "Error parsing YAML file at {path}: {e}"),
+    (lambda: _resolve_exception_type(TOMLDecodeError), "Error parsing TOML file at {path}: {e}"),
+)
+
+
+_BASE_STRUCTURED_EXCEPTIONS = (
+    OSError,
+    UnicodeDecodeError,
+    json.JSONDecodeError,
+    ImportError,
+)
+
+
+def _iter_optional_exceptions() -> list[type[BaseException]]:
+    errors: list[type[BaseException]] = []
+    for resolver, _ in _OPTIONAL_ERROR_MESSAGE_FACTORIES:
+        exc_type = resolver()
+        if exc_type is not None:
+            errors.append(exc_type)
+    return errors
+
+
+def _is_structured_error(exc: Exception) -> bool:
+    if isinstance(exc, _BASE_STRUCTURED_EXCEPTIONS):
+        return True
+    for optional_exc in _iter_optional_exceptions():
+        if isinstance(exc, optional_exc):
+            return True
+    return False
 
 
 def _format_structured_file_error(path: Path, e: Exception) -> str:
-    for exc, msg in ERROR_MESSAGES.items():
+    for exc, msg in _BASE_ERROR_MESSAGES.items():
         if isinstance(e, exc):
             return msg.format(path=path, e=e)
+
+    for resolver, msg in _OPTIONAL_ERROR_MESSAGE_FACTORIES:
+        exc_type = resolver()
+        if exc_type is not None and isinstance(e, exc_type):
+            return msg.format(path=path, e=e)
+
     return f"Error parsing {path}: {e}"
 
 
@@ -150,15 +221,10 @@ def read_structured_file(path: Path) -> Any:
     try:
         text = path.read_text(encoding="utf-8")
         return parser(text)
-    except (
-        OSError,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-        YAMLError,
-        TOMLDecodeError,
-        ImportError,
-    ) as e:
-        raise StructuredFileError(path, e) from e
+    except Exception as e:
+        if _is_structured_error(e):
+            raise StructuredFileError(path, e) from e
+        raise
 
 
 logger = get_logger(__name__)

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -53,6 +53,7 @@ __all__ = (
     "WarnOnce",
     "cached_import",
     "warm_cached_import",
+    "LazyImportProxy",
     "get_logger",
     "get_nodonx",
     "get_numpy",
@@ -110,6 +111,7 @@ __all__ = (
 WarnOnce = _init.WarnOnce
 cached_import = _init.cached_import
 warm_cached_import = _init.warm_cached_import
+LazyImportProxy = _init.LazyImportProxy
 get_logger = _init.get_logger
 get_nodonx = _init.get_nodonx
 get_numpy = _init.get_numpy

--- a/tests/test_io_optional_imports.py
+++ b/tests/test_io_optional_imports.py
@@ -1,0 +1,62 @@
+import importlib
+import types
+
+import pytest
+
+from tnfr import io as io_mod
+from tnfr.utils import LazyImportProxy, cached_import
+
+
+@pytest.fixture
+def fresh_io():
+    cached_import.cache_clear()
+    module = importlib.reload(io_mod)
+    yield module
+    cached_import.cache_clear()
+    importlib.reload(io_mod)
+
+
+def test_io_optional_imports_are_lazy_proxies(fresh_io):
+    assert isinstance(fresh_io.tomllib, LazyImportProxy)
+    assert isinstance(fresh_io._TOML_LOADS, LazyImportProxy)
+    assert isinstance(fresh_io.yaml, LazyImportProxy)
+    assert isinstance(fresh_io._YAML_SAFE_LOAD, LazyImportProxy)
+
+
+def test_yaml_safe_load_proxy_uses_fallback(monkeypatch, fresh_io):
+    calls = {"yaml": 0}
+
+    original_import_module = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "yaml":
+            calls["yaml"] += 1
+            raise ImportError("missing yaml")
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    loader = fresh_io._YAML_SAFE_LOAD
+    with pytest.raises(ImportError):
+        loader("value: 1")
+    assert calls["yaml"] == 1
+
+
+def test_toml_loads_proxy_falls_back_to_tomli(monkeypatch, fresh_io):
+    original_import_module = importlib.import_module
+
+    tomli_module = types.SimpleNamespace(
+        loads=lambda text: {"content": text},
+    )
+
+    def fake_import(name, package=None):
+        if name == "tomllib":
+            raise ImportError("missing tomllib")
+        if name == "tomli":
+            return tomli_module
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    loader = fresh_io._TOML_LOADS
+    assert loader("num = 1") == {"content": "num = 1"}


### PR DESCRIPTION
## Summary
- allow `LazyImportProxy` to retain fallbacks, keep weak references, and expose `resolve()` while threading fallbacks through `cached_import`/`warm_cached_import`
- add an optional `resolve` phase to `warm_cached_import` and update `tnfr.io` to request lazy proxies for YAML/TOML helpers
- extend tests to cover lazy fallback resolution, warm preloading, and the optional dependency helpers

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases (unit coverage of lazy fallback flows)

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f4c41f79908321b6b18cd77fa6d0d6