### PR TITLE
Add internal architecture checklist to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,56 @@ artifacts (e.g., `node_modules/` or `dist/`) are not committed.
   for quick diagrams, then deep-dive in the
   [TNFR Architecture Guide](ARCHITECTURE.md) to understand orchestration,
   telemetry paths, and invariant enforcement before touching the core layers.
+
+### Internal architecture guide
+
+Use the [TNFR Architecture Guide](ARCHITECTURE.md#layered-responsibilities)
+as the canonical reference for deep dives. The summary below highlights the
+core layers, where they live, and why edits must preserve the invariant and
+telemetry contracts already documented.
+
+- **Structural grammar** — `tnfr.structural`,
+  `tnfr.validation.syntax`, `tnfr.validation.grammar`, `tnfr.flatten`.
+  These modules instantiate nodes, validate operator sequences, and expand
+  THOL blocks so every execution path honours the canonical grammar before
+  mutating EPI.【F:src/tnfr/structural.py†L39-L109】【F:src/tnfr/validation/syntax.py†L27-L121】【F:src/tnfr/validation/grammar.py†L1-L90】【F:src/tnfr/flatten.py†L1-L120】
+- **Operator registry** — `tnfr.operators.definitions`,
+  `tnfr.operators.registry`. They bind glyphs to implementations and enforce
+  closure so the structural layer never executes unknown tokens.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L50】
+- **Dynamics and adaptation** — `tnfr.dynamics.__init__`,
+  `tnfr.dynamics.dnfr`, `tnfr.dynamics.integrators`. These components mix
+  ΔNFR, integrate the nodal equation, and coordinate phase/νf adjustments
+  while keeping stochastic hooks reproducible.【F:src/tnfr/dynamics/__init__.py†L59-L199】【F:src/tnfr/dynamics/dnfr.py†L1958-L2020】【F:src/tnfr/dynamics/integrators.py†L420-L483】
+- **Telemetry and traces** — `tnfr.metrics.common`,
+  `tnfr.metrics.sense_index`, `tnfr.trace`, `tnfr.metrics.trig_cache`. They
+  compute C(t), ΔNFR summaries, Si, and trace history so coherence metrics
+  remain auditable.【F:src/tnfr/metrics/common.py†L32-L149】【F:src/tnfr/metrics/sense_index.py†L1-L200】【F:src/tnfr/trace.py†L169-L319】【F:src/tnfr/metrics/trig_cache.py†L1-L120】
+- **Shared services** — `tnfr.helpers`, `tnfr.cache`, `tnfr.locking`,
+  `tnfr.rng`. These facades provide deterministic caches, locks, and RNG
+  orchestration for every layer that needs shared state.【F:src/tnfr/helpers/__init__.py†L1-L74】【F:src/tnfr/cache.py†L1-L120】【F:src/tnfr/locking.py†L1-L36】【F:src/tnfr/rng.py†L1-L88】
+
+**Checklist before merging changes**
+
+- Structural grammar — Re-run syntax/grammar validation, confirm THOL
+  expansion leaves trace hooks intact, and verify invariants #1, #4, #5, and
+  #7 remain satisfied. Consult
+  [Layered responsibilities](ARCHITECTURE.md#layered-responsibilities) and
+  [Structural loop orchestration](ARCHITECTURE.md#structural-loop-orchestration)
+  for the expected data flow.
+- Operator registry — Ensure new glyph bindings preserve invariants #3, #4,
+  and #10, regenerate registry discovery tests, and cross-check the
+  [Operator registration mechanics](ARCHITECTURE.md#operator-registration-mechanics)
+  guidance for naming and closure rules.
+- Dynamics and adaptation — Validate νf units (Hz_str), ΔNFR semantics, and
+  stochastic clamp hooks against invariants #1, #2, #3, #5, and #8. Inspect
+  the [ΔNFR and telemetry data paths](ARCHITECTURE.md#%CE%94nfr-and-telemetry-data-paths)
+  section to confirm new flows emit required telemetry.
+- Telemetry and traces — Confirm C(t), Si, ΔNFR, and phase metrics still
+  reach the trace buffers, and uphold invariants #8 and #9. Follow the
+  telemetry expectations in the
+  [ΔNFR and telemetry data paths](ARCHITECTURE.md#%CE%94nfr-and-telemetry-data-paths)
+  and [Telemetry exports](ARCHITECTURE.md#layered-responsibilities) notes.
+- Shared services — Keep caches deterministic, lock scopes documented, and
+  RNG seeds reproducible to satisfy invariants #8 and #9. Review the
+  [Layered responsibilities](ARCHITECTURE.md#layered-responsibilities)
+  summary before touching shared state helpers.


### PR DESCRIPTION
## Summary
- add an Internal architecture guide section to CONTRIBUTING.md
- summarize the key engine layers, their responsibilities, and primary modules
- provide a checklist tying invariants and telemetry expectations back to ARCHITECTURE.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4d6735d808321b8044448bbef447b