### PR TITLE
Update Autoorganizacion descriptor in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ documentation or prose is written in English. When contributing:
 When documenting operators in English prose, pair the canonical identifier with
 its English descriptor so readers can follow along without altering the API.
 For example, write “apply the Emision operator (Emission)” or “the
-Autoorganizacion (`Auto-organization`) step”. The canonical mapping is:
+Autoorganizacion (`Self-organization`) step”. The canonical mapping is:
 
 | Canonical identifier | English descriptor |
 | --- | --- |


### PR DESCRIPTION
## Summary
- align the contributing guide example with the canonical Self-organization descriptor and confirm no other mismatches remain

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f4d7d91b1083219fb16fcddc3c37d4