### PR TITLE
Refine dynamics phase coordination typing

### DIFF
--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from enum import Enum
-from typing import Any, Iterable, Protocol
+from typing import TYPE_CHECKING, Any, Iterable, Protocol, TypeAlias
 
-__all__ = ("GraphLike", "Glyph")
+__all__ = ("Graph", "Node", "GraphLike", "Glyph")
+
+
+if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
+    import networkx as nx  # type: ignore[import-untyped]
+
+    Graph: TypeAlias = nx.Graph
+else:  # pragma: no cover - runtime fallback without networkx
+    Graph: TypeAlias = Any
+
+Node: TypeAlias = Hashable
 
 
 class GraphLike(Protocol):


### PR DESCRIPTION
## Summary
- import the shared Graph/Node aliases and refine canonical clamp/job helpers so type annotations match TNFR graph usage
- tighten history deque, neighbor map, and NumPy array typing throughout phase coordination to satisfy downstream contracts
- expose Graph and Node aliases from tnfr.types for reuse across dynamics

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f4e123829c8321acb63f7d3198f2da