### PR TITLE
Add canonical TNFR type aliases across helpers

### DIFF
--- a/src/tnfr/tokens.py
+++ b/src/tnfr/tokens.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Iterable, Optional, Sequence, Union
 
-from .types import Glyph
+from .types import Glyph, NodeId
 
-Node = Any
+Node = NodeId
+#: Alias maintained for backwards compatibility with historical token helpers.
 
 
 @dataclass(slots=True)

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -6,17 +6,48 @@ from collections.abc import Hashable
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, Protocol, TypeAlias
 
-__all__ = ("Graph", "Node", "GraphLike", "Glyph")
+__all__ = (
+    "TNFRGraph",
+    "Graph",
+    "NodeId",
+    "Node",
+    "EPIValue",
+    "DeltaNFR",
+    "Phase",
+    "CoherenceMetric",
+    "GraphLike",
+    "Glyph",
+)
 
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
     import networkx as nx  # type: ignore[import-untyped]
 
-    Graph: TypeAlias = nx.Graph
+    TNFRGraph: TypeAlias = nx.Graph
 else:  # pragma: no cover - runtime fallback without networkx
-    Graph: TypeAlias = Any
+    TNFRGraph: TypeAlias = Any
+#: Graph container storing TNFR nodes, edges and their coherence telemetry.
 
-Node: TypeAlias = Hashable
+Graph: TypeAlias = TNFRGraph
+#: Backwards-compatible alias for :data:`TNFRGraph`.
+
+NodeId: TypeAlias = Hashable
+#: Hashable identifier for a coherent TNFR node.
+
+Node: TypeAlias = NodeId
+#: Backwards-compatible alias for :data:`NodeId`.
+
+EPIValue: TypeAlias = float
+#: Scalar Primary Information Structure value carried by a node.
+
+DeltaNFR: TypeAlias = float
+#: Scalar internal reorganisation driver ΔNFR applied to a node.
+
+Phase: TypeAlias = float
+#: Phase (φ) describing a node's synchrony relative to its neighbors.
+
+CoherenceMetric: TypeAlias = float
+#: Aggregated measure of coherence such as C(t) or Si.
 
 
 class GraphLike(Protocol):


### PR DESCRIPTION
## Summary
- add canonical TNFR aliases for graphs, node identifiers, and coherence scalars in the shared type module and document their structural meaning
- switch execution helpers, tokens, and dynamics coordination to import the canonical aliases instead of defining local `Any` fallbacks
- annotate dynamics helpers with the new aliases to clarify how EPI, ΔNFR, and phase values propagate through coordination logic

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f4e4da20108321aa65d30e3ecd0680