### PR TITLE
Align run_tests.sh comments with workflow configuration

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 export PYTHONPATH="$PWD/src"
 
+# Keep dependency extras aligned with .github/workflows/type-check.yml.
 python -m pip install --quiet ".[test,typecheck]"
 python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py
+# Mirrors the mypy invocation in .github/workflows/type-check.yml.
 python -m mypy src/tnfr
 python -m coverage run --source=src -m pytest "$@"
 python -m coverage report -m


### PR DESCRIPTION
## Summary
- document that the dependency extras and mypy invocation mirror the type-check workflow

## Testing
- `./scripts/run_tests.sh` *(fails: existing suite failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f4f32aba9083218e71f492334c29eb