### PR TITLE
Add precise type information to key TNFR stubs

### DIFF
--- a/src/tnfr/alias.pyi
+++ b/src/tnfr/alias.pyi
@@ -1,21 +1,116 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Callable, Iterable, Mapping
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, Hashable, TypeVar
+
+if TYPE_CHECKING:
+    import networkx as nx
+
+T = TypeVar("T")
+
+__all__: list[str]
 
 def __getattr__(name: str) -> Any: ...
 
-AbsMaxResult: Any
-SCALAR_SETTERS: Any
-collect_attr: Any
-get_attr: Any
-get_attr_str: Any
-multi_recompute_abs_max: Any
-set_attr: Any
-set_attr_and_cache: Any
-set_attr_generic: Any
-set_attr_str: Any
-set_attr_with_max: Any
-set_dnfr: Any
-set_scalar: Any
-set_theta: Any
-set_vf: Any
+
+class AbsMaxResult:
+    max_value: float
+    node: Hashable | None
+
+
+SCALAR_SETTERS: dict[str, dict[str, Any]]
+
+
+def get_attr(
+    d: dict[str, Any],
+    aliases: Iterable[str],
+    default: T | None = ...,
+    *,
+    strict: bool = ...,
+    log_level: int | None = ...,
+    conv: Callable[[Any], T] = ...,
+) -> T | None: ...
+
+
+def collect_attr(
+    G: "nx.Graph",
+    nodes: Iterable[Any],
+    aliases: Iterable[str],
+    default: float = ...,
+    *,
+    np: ModuleType | None = ...,
+) -> list[float] | Any: ...
+
+
+def set_attr_generic(
+    d: dict[str, Any],
+    aliases: Iterable[str],
+    value: Any,
+    *,
+    conv: Callable[[Any], T],
+) -> T: ...
+
+
+def set_attr(
+    d: dict[str, Any], aliases: Iterable[str], value: Any, conv: Callable[[Any], T] = ...
+) -> T: ...
+
+
+def get_attr_str(
+    d: dict[str, Any],
+    aliases: Iterable[str],
+    default: str | None = ...,
+    *,
+    strict: bool = ...,
+    log_level: int | None = ...,
+    conv: Callable[[Any], str] = ...,
+) -> str | None: ...
+
+
+def set_attr_str(d: dict[str, Any], aliases: Iterable[str], value: Any) -> str: ...
+
+
+def multi_recompute_abs_max(
+    G: "nx.Graph", alias_map: Mapping[str, tuple[str, ...]]
+) -> dict[str, float]: ...
+
+
+def set_attr_and_cache(
+    G: "nx.Graph",
+    n: Hashable,
+    aliases: tuple[str, ...],
+    value: float,
+    *,
+    cache: str | None = ...,
+    extra: Callable[["nx.Graph", Hashable, float], None] | None = ...,
+) -> AbsMaxResult | None: ...
+
+
+def set_attr_with_max(
+    G: "nx.Graph", n: Hashable, aliases: tuple[str, ...], value: float, *, cache: str
+) -> AbsMaxResult: ...
+
+
+def set_scalar(
+    G: "nx.Graph",
+    n: Hashable,
+    alias: tuple[str, ...],
+    value: float,
+    *,
+    cache: str | None = ...,
+    extra: Callable[["nx.Graph", Hashable, float], None] | None = ...,
+) -> AbsMaxResult | None: ...
+
+
+def set_vf(
+    G: "nx.Graph", n: Hashable, value: float, *, update_max: bool = ...
+) -> AbsMaxResult | None: ...
+
+
+def set_dnfr(G: "nx.Graph", n: Hashable, value: float) -> AbsMaxResult | None: ...
+
+
+def set_theta(
+    G: "nx.Graph", n: Hashable, value: float
+) -> AbsMaxResult | None: ...

--- a/src/tnfr/execution.pyi
+++ b/src/tnfr/execution.pyi
@@ -1,19 +1,63 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections import deque
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any, Optional, TypeAlias
+
+from .tokens import OpTag, TARGET, THOL, WAIT, Token
+from .types import Glyph, NodeId, TNFRGraph
+
+__all__: list[str]
+
 
 def __getattr__(name: str) -> Any: ...
 
-AdvanceFn: Any
-CANONICAL_PRESET_NAME: Any
-CANONICAL_PROGRAM_TOKENS: Any
-HANDLERS: Any
-_apply_glyph_to_targets: Any
-_record_trace: Any
-basic_canonical_example: Any
-block: Any
-compile_sequence: Any
-play: Any
-seq: Any
-target: Any
-wait: Any
+
+AdvanceFn = Callable[[TNFRGraph], None]
+TraceEntry = dict[str, Any]
+ProgramTrace: TypeAlias = deque[TraceEntry]
+HandlerFn = Callable[
+    [TNFRGraph, Any, Sequence[NodeId] | None, ProgramTrace, AdvanceFn],
+    Sequence[NodeId] | None,
+]
+
+CANONICAL_PRESET_NAME: str
+CANONICAL_PROGRAM_TOKENS: tuple[Token, ...]
+HANDLERS: dict[OpTag, HandlerFn]
+
+
+def _apply_glyph_to_targets(
+    G: TNFRGraph, g: Glyph | str, nodes: Iterable[NodeId] | None = ...
+) -> None: ...
+
+
+def _record_trace(trace: ProgramTrace, G: TNFRGraph, op: OpTag, **data: Any) -> None: ...
+
+
+def compile_sequence(
+    sequence: Iterable[Token] | Sequence[Token] | Any,
+    *,
+    max_materialize: int | None = ...,
+) -> list[tuple[OpTag, Any]]: ...
+
+
+def play(
+    G: TNFRGraph, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = ...
+) -> None: ...
+
+
+def seq(*tokens: Token) -> list[Token]: ...
+
+
+def block(
+    *tokens: Token, repeat: int = ..., close: Glyph | None = ...
+) -> THOL: ...
+
+
+def target(nodes: Iterable[NodeId] | None = ...) -> TARGET: ...
+
+
+def wait(steps: int = ...) -> WAIT: ...
+
+
+def basic_canonical_example() -> list[Token]: ...

--- a/src/tnfr/flatten.pyi
+++ b/src/tnfr/flatten.pyi
@@ -1,8 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
 
-__all__: Any
+from .tokens import THOL, Token
+
+__all__: list[str]
+
 
 def __getattr__(name: str) -> Any: ...
 
-THOLEvaluator: Any
-parse_program_tokens: Any
+
+class THOLEvaluator(Iterator[Token | object]):
+    def __init__(
+        self, item: THOL, *, max_materialize: int | None = ...
+    ) -> None: ...
+
+    def __iter__(self) -> THOLEvaluator: ...
+
+    def __next__(self) -> Token | object: ...
+
+
+def parse_program_tokens(
+    obj: Iterable[Any] | Sequence[Any] | Any,
+    *,
+    max_materialize: int | None = ...,
+) -> list[Token]: ...

--- a/src/tnfr/structural.pyi
+++ b/src/tnfr/structural.pyi
@@ -1,24 +1,49 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Callable, Hashable
+
+from .operators.definitions import (
+    Acoplamiento,
+    Autoorganizacion,
+    Coherencia,
+    Contraccion,
+    Disonancia,
+    Emision,
+    Expansion,
+    Mutacion,
+    Operador,
+    Recepcion,
+    Recursividad,
+    Resonancia,
+    Silencio,
+    Transicion,
+)
+
+if TYPE_CHECKING:
+    import networkx as nx
+
+__all__: tuple[str, ...]
+
 
 def __getattr__(name: str) -> Any: ...
 
-Acoplamiento: Any
-Autoorganizacion: Any
-Coherencia: Any
-Contraccion: Any
-Disonancia: Any
-Emision: Any
-Expansion: Any
-Mutacion: Any
-OPERADORES: Any
-Operador: Any
-Recepcion: Any
-Recursividad: Any
-Resonancia: Any
-Silencio: Any
-Transicion: Any
-create_nfr: Any
-run_sequence: Any
-validate_sequence: Any
+
+def create_nfr(
+    name: str,
+    *,
+    epi: float = ...,
+    vf: float = ...,
+    theta: float = ...,
+    graph: "nx.Graph" | None = ...,
+    dnfr_hook: Callable[..., None] = ...,
+) -> tuple["nx.Graph", str]: ...
+
+
+OPERADORES: dict[str, Operador]
+
+
+def validate_sequence(names: Iterable[str]) -> tuple[bool, str]: ...
+
+
+def run_sequence(G: "nx.Graph", node: Hashable, ops: Iterable[Operador]) -> None: ...


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

---
- Replace the placeholder `Any` stubs for `alias`, `flatten`, `execution`, and `structural` with concrete signatures that mirror their Python implementations so mypy can follow the real APIs.
- Ensure exported helper types (e.g., THOLEvaluator iterators, program handler callables, graph setters) are accurately described and reference shared TNFR graph types.

**Testing**
- `python -m mypy src/tnfr`


------
https://chatgpt.com/codex/tasks/task_e_68f4f8896c70832194daef999d0e3e45