### PR TITLE
Tighten ΔNFR hook typing for TNFRGraph entry points

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -11,6 +11,7 @@ from .dynamics import (
     set_delta_nfr_hook,
     dnfr_epi_vf_mixed,
 )
+from .types import DeltaNFRHook, NodeId, TNFRGraph
 from .operators.definitions import (
     Operador,
     Emision,
@@ -42,9 +43,9 @@ def create_nfr(
     epi: float = 0.0,
     vf: float = 1.0,
     theta: float = 0.0,
-    graph: nx.Graph | None = None,
-    dnfr_hook=dnfr_epi_vf_mixed,
-) -> tuple[nx.Graph, str]:
+    graph: TNFRGraph | None = None,
+    dnfr_hook: DeltaNFRHook = dnfr_epi_vf_mixed,
+) -> tuple[TNFRGraph, str]:
     """Create a graph with an initialised NFR node.
 
     Returns the tuple ``(G, name)`` for convenience.
@@ -84,7 +85,7 @@ __all__ = (
 )
 
 
-def run_sequence(G: nx.Graph, node, ops: Iterable[Operador]) -> None:
+def run_sequence(G: TNFRGraph, node: NodeId, ops: Iterable[Operador]) -> None:
     """Execute a sequence of operators on ``node`` after validation."""
 
     compute = G.graph.get("compute_delta_nfr")

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -15,6 +15,7 @@ __all__ = (
     "DeltaNFR",
     "Phase",
     "CoherenceMetric",
+    "DeltaNFRHook",
     "GraphLike",
     "Glyph",
 )
@@ -48,6 +49,30 @@ Phase: TypeAlias = float
 
 CoherenceMetric: TypeAlias = float
 #: Aggregated measure of coherence such as C(t) or Si.
+
+
+class _DeltaNFRHookProtocol(Protocol):
+    """Callable signature expected for ΔNFR update hooks.
+
+    Hooks receive the graph instance and may expose optional keyword
+    arguments such as ``n_jobs`` or cache controls. Additional positional
+    arguments are reserved for future extensions and ignored by the core
+    engine, keeping compatibility with user-provided hooks that only need the
+    graph reference.
+    """
+
+    def __call__(
+        self,
+        graph: TNFRGraph,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        ...
+
+
+DeltaNFRHook: TypeAlias = _DeltaNFRHookProtocol
+#: Callable hook invoked to compute ΔNFR for a :data:`TNFRGraph`.
 
 
 class GraphLike(Protocol):


### PR DESCRIPTION
## Summary
- add a DeltaNFRHook type alias describing graph-first callable hooks with optional keyword arguments
- annotate ΔNFR dynamics helpers and structural utilities with TNFRGraph, NodeId, and the new hook alias to satisfy mypy
- refine NumPy module handling and job distribution helpers to keep typing precise in vectorised and parallel paths

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f4fbdbd39c832188651a9f66186835