### PR TITLE
Add TNFR structural aliases and refine typing across node and sense modules

### DIFF
--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -15,7 +15,7 @@ from ..metrics.trig import neighbor_phase_mean
 from ..utils import get_nodonx
 from ..rng import make_rng
 from tnfr import glyph_history
-from ..types import Glyph
+from ..types import EPIValue, Glyph, NodeId, TNFRGraph
 
 from .jitter import (
     JitterCache,
@@ -82,7 +82,7 @@ def get_factor(gf: dict[str, Any], key: str, default: float) -> float:
 # -------------------------
 
 
-def get_neighbor_epi(node: NodoProtocol) -> tuple[list[NodoProtocol], float]:
+def get_neighbor_epi(node: NodoProtocol) -> tuple[list[NodoProtocol], EPIValue]:
     """Return neighbour list and their mean ``EPI`` without mutating ``node``."""
 
     epi = node.EPI
@@ -425,7 +425,7 @@ def apply_glyph_obj(
 
 
 def apply_glyph(
-    G, n, glyph: Glyph | str, *, window: int | None = None
+    G: TNFRGraph, n: NodeId, glyph: Glyph | str, *, window: int | None = None
 ) -> None:
     """Adapter to operate on ``networkx`` graphs."""
     NodoNX = get_nodonx()

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -13,7 +13,11 @@ __all__ = (
     "Node",
     "EPIValue",
     "DeltaNFR",
+    "SecondDerivativeEPI",
     "Phase",
+    "StructuralFrequency",
+    "SenseIndex",
+    "CouplingWeight",
     "CoherenceMetric",
     "DeltaNFRHook",
     "GraphLike",
@@ -44,8 +48,20 @@ EPIValue: TypeAlias = float
 DeltaNFR: TypeAlias = float
 #: Scalar internal reorganisation driver ΔNFR applied to a node.
 
+SecondDerivativeEPI: TypeAlias = float
+#: Second derivative ∂²EPI/∂t² tracking bifurcation pressure.
+
 Phase: TypeAlias = float
 #: Phase (φ) describing a node's synchrony relative to its neighbors.
+
+StructuralFrequency: TypeAlias = float
+#: Structural frequency νf expressed in Hz_str.
+
+SenseIndex: TypeAlias = float
+#: Sense index Si capturing a node's reorganising capacity.
+
+CouplingWeight: TypeAlias = float
+#: Weight attached to edges describing coupling coherence strength.
 
 CoherenceMetric: TypeAlias = float
 #: Aggregated measure of coherence such as C(t) or Si.

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -5,6 +5,7 @@ __all__: Any
 def __getattr__(name: str) -> Any: ...
 
 CoherenceMetric: Any
+CouplingWeight: Any
 DeltaNFR: Any
 EPIValue: Any
 Glyph: Any
@@ -13,4 +14,7 @@ GraphLike: Any
 Node: Any
 NodeId: Any
 Phase: Any
+SecondDerivativeEPI: Any
+SenseIndex: Any
+StructuralFrequency: Any
 TNFRGraph: Any


### PR DESCRIPTION
## Summary
- add TNFR-specific type aliases covering νf, Si, coupling weights and ∂²EPI to clarify structural metrics
- apply the new aliases through node protocols, glyph dispatchers and sigma utilities to eliminate implicit Any usage
- tighten sigma callbacks to require typed TNFR graphs and mappings, reinforcing mypy coverage

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f4fd8e8e588321b64f79181f38d189