### PR TITLE
Refine gamma typing to use TNFR graph aliases

### DIFF
--- a/src/tnfr/gamma.pyi
+++ b/src/tnfr/gamma.pyi
@@ -1,15 +1,40 @@
-from typing import Any
+from typing import Callable, NamedTuple
 
-__all__: Any
+from .types import GammaSpec, NodeId, TNFRGraph
 
-def __getattr__(name: str) -> Any: ...
+__all__: tuple[str, ...]
 
-GAMMA_REGISTRY: Any
-GammaEntry: Any
-eval_gamma: Any
-gamma_harmonic: Any
-gamma_kuramoto_bandpass: Any
-gamma_kuramoto_linear: Any
-gamma_kuramoto_tanh: Any
-gamma_none: Any
-kuramoto_R_psi: Any
+class GammaEntry(NamedTuple):
+    fn: Callable[[TNFRGraph, NodeId, float | int, GammaSpec], float]
+    needs_kuramoto: bool
+
+GAMMA_REGISTRY: dict[str, GammaEntry]
+
+def kuramoto_R_psi(G: TNFRGraph) -> tuple[float, float]: ...
+
+def gamma_none(G: TNFRGraph, node: NodeId, t: float | int, cfg: GammaSpec) -> float: ...
+
+def gamma_kuramoto_linear(
+    G: TNFRGraph, node: NodeId, t: float | int, cfg: GammaSpec
+) -> float: ...
+
+def gamma_kuramoto_bandpass(
+    G: TNFRGraph, node: NodeId, t: float | int, cfg: GammaSpec
+) -> float: ...
+
+def gamma_kuramoto_tanh(
+    G: TNFRGraph, node: NodeId, t: float | int, cfg: GammaSpec
+) -> float: ...
+
+def gamma_harmonic(
+    G: TNFRGraph, node: NodeId, t: float | int, cfg: GammaSpec
+) -> float: ...
+
+def eval_gamma(
+    G: TNFRGraph,
+    node: NodeId,
+    t: float | int,
+    *,
+    strict: bool = ...,
+    log_level: int | None = ...,
+) -> float: ...

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Mapping
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, Protocol, TypeAlias
 
@@ -11,6 +11,7 @@ __all__ = (
     "Graph",
     "NodeId",
     "Node",
+    "GammaSpec",
     "EPIValue",
     "DeltaNFR",
     "SecondDerivativeEPI",
@@ -42,6 +43,9 @@ NodeId: TypeAlias = Hashable
 
 Node: TypeAlias = NodeId
 #: Backwards-compatible alias for :data:`NodeId`.
+
+GammaSpec: TypeAlias = Mapping[str, Any]
+#: Mapping describing Γ evaluation parameters for a node or graph.
 
 EPIValue: TypeAlias = float
 #: Scalar Primary Information Structure value carried by a node.


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

---
- add a shared `GammaSpec` alias so gamma evaluators share a consistent mapping type
- annotate gamma helpers, implementations and the registry with `TNFRGraph`/`NodeId` aware signatures and mirror them in `gamma.pyi`
- confirm the stricter typing with `python -m mypy src/tnfr`


------
https://chatgpt.com/codex/tasks/task_e_68f504a917f083218a59590e5ed87d10