### PR TITLE
Strengthen typing for trace helpers

### DIFF
--- a/src/tnfr/trace.pyi
+++ b/src/tnfr/trace.pyi
@@ -1,14 +1,68 @@
-from typing import Any
+from typing import Any, Callable, NamedTuple, TypedDict
+from collections.abc import Iterable, Mapping
 
-__all__: Any
+from .types import TNFRGraph, TraceFieldFn, TraceFieldMap, TraceFieldRegistry
+
+__all__: tuple[str, ...]
 
 def __getattr__(name: str) -> Any: ...
 
-CallbackSpec: Any
-TraceMetadata: Any
-TraceSnapshot: Any
-_callback_names: Any
-gamma_field: Any
-grammar_field: Any
-register_trace: Any
-register_trace_field: Any
+
+class CallbackSpec(NamedTuple):
+    name: str | None
+    func: Callable[..., Any]
+
+
+class TraceMetadata(TypedDict, total=False):
+    gamma: Mapping[str, Any]
+    grammar: Mapping[str, Any]
+    selector: str | None
+    dnfr_weights: Mapping[str, Any]
+    si_weights: Mapping[str, Any]
+    si_sensitivity: Mapping[str, Any]
+    callbacks: Mapping[str, list[str] | None]
+    thol_open_nodes: int
+    kuramoto: Mapping[str, float]
+    sigma: Mapping[str, float]
+    glyphs: Mapping[str, int]
+
+
+class TraceSnapshot(TraceMetadata, total=False):
+    t: float
+    phase: str
+
+
+kuramoto_R_psi: Callable[[TNFRGraph], tuple[float, float]]
+TRACE_FIELDS: TraceFieldRegistry
+
+def _callback_names(
+    callbacks: Mapping[str, CallbackSpec] | Iterable[CallbackSpec],
+) -> list[str]: ...
+
+def mapping_field(G: TNFRGraph, graph_key: str, out_key: str) -> TraceMetadata: ...
+
+def _trace_capture(G: TNFRGraph, phase: str, fields: TraceFieldMap) -> None: ...
+
+def register_trace_field(phase: str, name: str, func: TraceFieldFn) -> None: ...
+
+def gamma_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def grammar_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def dnfr_weights_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def selector_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def si_weights_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def callbacks_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def thol_state_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def kuramoto_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def sigma_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def glyph_counts_field(G: TNFRGraph) -> TraceMetadata: ...
+
+def register_trace(G: TNFRGraph) -> None: ...

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Mapping
+from collections.abc import Callable, Hashable, Mapping
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, Protocol, TypeAlias
 
@@ -24,11 +24,16 @@ __all__ = (
     "GraphLike",
     "Glyph",
     "GlyphLoadDistribution",
+    "TraceCallback",
+    "TraceFieldFn",
+    "TraceFieldMap",
+    "TraceFieldRegistry",
 )
 
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
     import networkx as nx
+    from .trace import TraceMetadata
 
     TNFRGraph: TypeAlias = nx.Graph
 else:  # pragma: no cover - runtime fallback without networkx
@@ -134,3 +139,15 @@ class Glyph(str, Enum):
 
 GlyphLoadDistribution: TypeAlias = dict[Glyph | str, float]
 #: Normalised glyph load proportions keyed by :class:`Glyph` or aggregate labels.
+
+TraceFieldFn: TypeAlias = Callable[[TNFRGraph], "TraceMetadata"]
+#: Callable producing :class:`tnfr.trace.TraceMetadata` from a :data:`TNFRGraph`.
+
+TraceFieldMap: TypeAlias = Mapping[str, "TraceFieldFn"]
+#: Mapping of trace field names to their producers for a given phase.
+
+TraceFieldRegistry: TypeAlias = dict[str, dict[str, "TraceFieldFn"]]
+#: Registry grouping trace field producers by capture phase.
+
+TraceCallback: TypeAlias = Callable[[TNFRGraph, dict[str, Any]], None]
+#: Callback signature used by :func:`tnfr.trace.register_trace`.

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -1,20 +1,41 @@
-from typing import Any
+from typing import Any, Callable, Iterable, Protocol, TypeAlias
+from collections.abc import Hashable, Mapping
 
-__all__: Any
+__all__: tuple[str, ...]
 
 def __getattr__(name: str) -> Any: ...
 
-CoherenceMetric: Any
-CouplingWeight: Any
-DeltaNFR: Any
-EPIValue: Any
-Glyph: Any
-Graph: Any
-GraphLike: Any
-Node: Any
-NodeId: Any
-Phase: Any
-SecondDerivativeEPI: Any
-SenseIndex: Any
-StructuralFrequency: Any
-TNFRGraph: Any
+TNFRGraph: TypeAlias = Any
+Graph: TypeAlias = TNFRGraph
+NodeId: TypeAlias = Hashable
+Node: TypeAlias = NodeId
+GammaSpec: TypeAlias = Mapping[str, Any]
+EPIValue: TypeAlias = float
+DeltaNFR: TypeAlias = float
+SecondDerivativeEPI: TypeAlias = float
+Phase: TypeAlias = float
+StructuralFrequency: TypeAlias = float
+SenseIndex: TypeAlias = float
+CouplingWeight: TypeAlias = float
+CoherenceMetric: TypeAlias = float
+
+class _DeltaNFRHookProtocol(Protocol):
+    def __call__(self, graph: TNFRGraph, /, *args: Any, **kwargs: Any) -> None: ...
+
+DeltaNFRHook: TypeAlias = _DeltaNFRHookProtocol
+
+class GraphLike(Protocol):
+    graph: dict[str, Any]
+
+    def nodes(self, data: bool = ...) -> Iterable[Any]: ...
+    def number_of_nodes(self) -> int: ...
+    def neighbors(self, n: Any) -> Iterable[Any]: ...
+    def __iter__(self) -> Iterable[Any]: ...
+
+class Glyph(str): ...
+
+GlyphLoadDistribution: TypeAlias = dict[Glyph | str, float]
+TraceFieldFn: TypeAlias = Callable[[TNFRGraph], Any]
+TraceFieldMap: TypeAlias = Mapping[str, TraceFieldFn]
+TraceFieldRegistry: TypeAlias = dict[str, dict[str, TraceFieldFn]]
+TraceCallback: TypeAlias = Callable[[TNFRGraph, dict[str, Any]], None]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

- Improved trace helpers to operate on concrete `TNFRGraph` inputs and structured metadata snapshots.
- Added shared aliases for trace field callables and callback signatures to keep typing intent consistent across modules.

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

- Static typing (`python -m mypy src/tnfr`) now passes with the refined hints, ensuring trace capture remains verifiable.

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f5055787d0832182b83cf6701610e0