### PR TITLE
Clarify typing for THOL evaluators

### DIFF
--- a/src/tnfr/flatten.py
+++ b/src/tnfr/flatten.py
@@ -126,7 +126,7 @@ class THOLEvaluator:
     def __iter__(self) -> "THOLEvaluator":
         return self
 
-    def __next__(self):
+    def __next__(self) -> Token | object:
         if not self._started:
             self._started = True
             return THOL_SENTINEL
@@ -235,7 +235,7 @@ def parse_program_tokens(
 
     sequence = _iter_source(obj, max_materialize=max_materialize)
 
-    def _expand(item: Any):
+    def _expand(item: Any) -> Iterable[Any] | None:
         if isinstance(item, Mapping):
             return (_coerce_mapping_token(item, max_materialize=max_materialize),)
         return None
@@ -259,7 +259,7 @@ def _flatten(
     ops: list[tuple[OpTag, Any]] = []
     sequence = _iter_source(seq, max_materialize=max_materialize)
 
-    def _expand(item: Any):
+    def _expand(item: Any) -> Iterable[Any] | None:
         if isinstance(item, THOL):
             return THOLEvaluator(item, max_materialize=max_materialize)
         if isinstance(item, Mapping):


### PR DESCRIPTION
## Summary
- annotate `THOLEvaluator.__next__` with the sentinel-aware return type to mirror its runtime behaviour
- add explicit `Iterable[Any] | None` return annotations to the flattening closures so they no longer default to implicit `Any`
- validate the typing adjustments by running `python -m mypy src/tnfr`

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f5315d9b10832195eadfa27fb8c901