### PR TITLE
Type glyph selector helpers and export shared aliases

### DIFF
--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -31,6 +31,10 @@ __all__ = (
     "GraphLike",
     "Glyph",
     "GlyphLoadDistribution",
+    "GlyphSelector",
+    "SelectorPreselectionMetrics",
+    "SelectorPreselectionChoices",
+    "SelectorPreselectionPayload",
     "SelectorMetrics",
     "SelectorNorms",
     "SelectorThresholds",
@@ -39,6 +43,7 @@ __all__ = (
     "TraceFieldFn",
     "TraceFieldMap",
     "TraceFieldRegistry",
+    "HistoryState",
     "DiagnosisNodeData",
     "DiagnosisSharedState",
     "DiagnosisPayload",
@@ -55,10 +60,12 @@ __all__ = (
 if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
     import networkx as nx
     from .trace import TraceMetadata
+    from .glyph_history import HistoryDict as _HistoryDict
 
     TNFRGraph: TypeAlias = nx.Graph
 else:  # pragma: no cover - runtime fallback without networkx
     TNFRGraph: TypeAlias = Any
+    _HistoryDict = Any  # type: ignore[assignment]
 #: Graph container storing TNFR nodes, edges and their coherence telemetry.
 
 Graph: TypeAlias = TNFRGraph
@@ -190,6 +197,21 @@ class Glyph(str, Enum):
 GlyphLoadDistribution: TypeAlias = dict[Glyph | str, float]
 #: Normalised glyph load proportions keyed by :class:`Glyph` or aggregate labels.
 
+GlyphSelector: TypeAlias = Callable[[TNFRGraph, NodeId], Glyph | str]
+#: Callable returning the glyph to apply for ``NodeId`` within a graph.
+
+SelectorPreselectionMetrics: TypeAlias = Mapping[Any, SelectorMetrics]
+#: Mapping of nodes to their normalised selector metrics.
+
+SelectorPreselectionChoices: TypeAlias = Mapping[Any, Glyph | str]
+#: Mapping of nodes to their preferred glyph choices prior to grammar filters.
+
+SelectorPreselectionPayload: TypeAlias = tuple[
+    SelectorPreselectionMetrics,
+    SelectorPreselectionChoices,
+]
+#: Tuple grouping selector metrics and base decisions for preselection steps.
+
 TraceFieldFn: TypeAlias = Callable[[TNFRGraph], "TraceMetadata"]
 #: Callable producing :class:`tnfr.trace.TraceMetadata` from a :data:`TNFRGraph`.
 
@@ -198,6 +220,9 @@ TraceFieldMap: TypeAlias = Mapping[str, "TraceFieldFn"]
 
 TraceFieldRegistry: TypeAlias = dict[str, dict[str, "TraceFieldFn"]]
 #: Registry grouping trace field producers by capture phase.
+
+HistoryState: TypeAlias = _HistoryDict | dict[str, Any]
+#: History container used to accumulate glyph metrics and logs for the graph.
 
 TraceCallback: TypeAlias = Callable[[TNFRGraph, dict[str, Any]], None]
 #: Callback signature used by :func:`tnfr.trace.register_trace`.


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Export glyph selector, preselection, and history aliases for reuse across the engine.
- Annotate dynamics selector helpers and VF adaptation routines with explicit TNFRGraph-aware signatures.
- Ensure selector preselection dataclass and glyph proposal workers rely on shared alias types for clarity.

## Testing
- `mypy src/tnfr`


------
https://chatgpt.com/codex/tasks/task_e_68f533c682e083219faa7bf594270805