### PR TITLE
Refine ΔNFR preparation typing

### DIFF
--- a/src/tnfr/dynamics/sampling.py
+++ b/src/tnfr/dynamics/sampling.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from ..utils import cached_node_list
+from typing import cast
+
 from ..rng import _rng_for_step, base_seed
+from ..types import NodeId, TNFRGraph
+from ..utils import cached_node_list
 
 __all__ = ("update_node_sample",)
 
 
-def update_node_sample(G, *, step: int) -> None:
+def update_node_sample(G: TNFRGraph, *, step: int) -> None:
     """Refresh ``G.graph['_node_sample']`` with a random subset of nodes.
 
     The sample is limited by ``UM_CANDIDATE_COUNT`` and refreshed every
@@ -20,7 +23,7 @@ def update_node_sample(G, *, step: int) -> None:
     """
     graph = G.graph
     limit = int(graph.get("UM_CANDIDATE_COUNT", 0))
-    nodes = cached_node_list(G)
+    nodes = cast(tuple[NodeId, ...], cached_node_list(G))
     current_n = len(nodes)
     if limit <= 0 or current_n < 50 or limit >= current_n:
         graph["_node_sample"] = nodes


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Annotated `_refresh_dnfr_vectors` with concrete `TNFRGraph` and `NodeId` usage so cached ΔNFR vectors stay type-safe.
- Tightened `_prepare_dnfr_data` to expose typed node tuples, numpy buffers, and graph metadata for downstream consumers.
- Updated `update_node_sample` to accept a typed graph and maintain node cache tuples while sampling.

## Testing
- `mypy src/tnfr/dynamics`


------
https://chatgpt.com/codex/tasks/task_e_68f5352e7c7c832192665585c02c2d21