### PR TITLE
Strengthen metrics typing for TNFR graphs

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -4,6 +4,19 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..types import (
+    GlyphSelector,
+    NodeId,
+    SelectorPreselectionChoices,
+    SelectorPreselectionMetrics,
+    SelectorPreselectionPayload,
+    TNFRGraph,
+    TraceCallback,
+    TraceFieldFn,
+    TraceFieldMap,
+    TraceFieldRegistry,
+)
+
 from ..callback_utils import CallbackEvent, callback_manager
 from ..constants import get_param
 from ..glyph_history import append_metric, ensure_history
@@ -29,6 +42,16 @@ from .reporting import (
 logger = get_logger(__name__)
 
 __all__ = [
+    "TNFRGraph",
+    "NodeId",
+    "GlyphSelector",
+    "SelectorPreselectionMetrics",
+    "SelectorPreselectionChoices",
+    "SelectorPreselectionPayload",
+    "TraceCallback",
+    "TraceFieldFn",
+    "TraceFieldMap",
+    "TraceFieldRegistry",
     "_metrics_step",
     "register_metrics_callbacks",
     "Tg_global",
@@ -39,7 +62,7 @@ __all__ = [
 ]
 
 
-def _metrics_step(G, ctx: dict[str, Any] | None = None):
+def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
     """Update operational TNFR metrics per step."""
 
     del ctx
@@ -109,7 +132,7 @@ def _metrics_step(G, ctx: dict[str, Any] | None = None):
     _compute_advanced_metrics(G, hist, t, dt, cfg, n_jobs=metrics_jobs)
 
 
-def register_metrics_callbacks(G) -> None:
+def register_metrics_callbacks(G: TNFRGraph) -> None:
     callback_manager.register_callback(
         G,
         event=CallbackEvent.AFTER_STEP.value,

--- a/src/tnfr/metrics/reporting.py
+++ b/src/tnfr/metrics/reporting.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from heapq import nlargest
 from statistics import mean, fmean, StatisticsError
 
 from ..glyph_history import ensure_history
+from ..types import NodeId, TNFRGraph
 from ..sense import sigma_rose
 from .glyph_timing import for_each_glyph
 
@@ -26,7 +28,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-def Tg_global(G, normalize: bool = True) -> dict[str, float]:
+def Tg_global(G: TNFRGraph, normalize: bool = True) -> dict[str, float]:
     """Total glyph dwell time per class."""
 
     hist = ensure_history(G)
@@ -42,7 +44,9 @@ def Tg_global(G, normalize: bool = True) -> dict[str, float]:
     return out
 
 
-def Tg_by_node(G, n, normalize: bool = False) -> dict[str, float | list[float]]:
+def Tg_by_node(
+    G: TNFRGraph, n: NodeId, normalize: bool = False
+) -> dict[str, float] | dict[str, list[float]]:
     """Per-node glyph dwell summary."""
 
     hist = ensure_history(G)
@@ -65,7 +69,7 @@ def Tg_by_node(G, n, normalize: bool = False) -> dict[str, float | list[float]]:
     return out
 
 
-def latency_series(G) -> dict[str, list[float]]:
+def latency_series(G: TNFRGraph) -> dict[str, list[float]]:
     hist = ensure_history(G)
     xs = hist.get("latency_index", [])
     return {
@@ -74,7 +78,7 @@ def latency_series(G) -> dict[str, list[float]]:
     }
 
 
-def glyphogram_series(G) -> dict[str, list[float]]:
+def glyphogram_series(G: TNFRGraph) -> dict[str, list[float]]:
     hist = ensure_history(G)
     xs = hist.get("glyphogram", [])
     if not xs:
@@ -88,7 +92,7 @@ def glyphogram_series(G) -> dict[str, list[float]]:
     return out
 
 
-def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
+def glyph_top(G: TNFRGraph, k: int = 3) -> list[tuple[str, float]]:
     """Top-k structural operators by ``Tg_global`` fraction."""
 
     k = int(k)
@@ -99,8 +103,8 @@ def glyph_top(G, k: int = 3) -> list[tuple[str, float]]:
 
 
 def build_metrics_summary(
-    G, *, series_limit: int | None = None
-) -> tuple[dict[str, Any], bool]:
+    G: TNFRGraph, *, series_limit: int | None = None
+) -> tuple[dict[str, float | dict[str, float] | dict[str, list[float]] | dict[str, int]], bool]:
     """Collect a compact metrics summary for CLI reporting.
 
     Parameters
@@ -131,7 +135,7 @@ def build_metrics_summary(
         if limit <= 0:
             limit = None
 
-    def _trim(values: list[Any]) -> list[Any]:
+    def _trim(values: Sequence[Any]) -> list[Any]:
         seq = list(values)
         if limit is None:
             return seq


### PR DESCRIPTION
## Summary
- annotate the metrics orchestrator with explicit TNFRGraph contexts and re-export selector/trace aliases
- tighten reporting helpers and neighbor phase computation with concrete graph/node typing
- verify the stronger annotations by running `mypy src/tnfr/metrics`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f5386e90b483218ae57031eaa7142a