### PR TITLE
Add typing annotations for selector metric workers

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import math
 from collections import deque
-from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import Iterator, Mapping, MutableMapping, MutableSequence, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from operator import itemgetter
@@ -1113,7 +1113,9 @@ def _collect_selector_metrics(
             dnfr_seq: list[float] = []
             accel_seq: list[float] = []
 
-            def _args_iter():
+            def _args_iter() -> Iterator[
+                tuple[list[float], list[float], list[float], float, float]
+            ]:
                 for start, end in chunk_bounds:
                     yield (
                         si_values[start:end],
@@ -1157,7 +1159,9 @@ def _compute_default_base_choices(
     return base
 
 
-def _param_base_worker(args: tuple[dict[str, float], list[tuple[Any, tuple[float, float, float]]]]):
+def _param_base_worker(
+    args: tuple[dict[str, float], list[tuple[Any, tuple[float, float, float]]]]
+) -> list[tuple[Any, str]]:
     """Worker used to evaluate base rules for the parametric selector."""
     thresholds, chunk = args
     return [


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f5401136f08321af75b5e03d671c53