### PR TITLE
Annotate neighbor buffer reset helper to return float lists

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1229,7 +1229,7 @@ def _init_neighbor_sums(
     w_topo = data["w_topo"]
     cache: DnfrCache | None = data.get("cache")
 
-    def _reset_list(buffer, value=0.0):
+    def _reset_list(buffer: list[float] | None, value: float = 0.0) -> list[float]:
         if buffer is None or len(buffer) != n:
             return [value] * n
         for i in range(n):
@@ -1731,7 +1731,7 @@ def _init_neighbor_sums(
     w_topo = data["w_topo"]
     cache: DnfrCache | None = data.get("cache")
 
-    def _reset_list(buffer, value=0.0):
+    def _reset_list(buffer: list[float] | None, value: float = 0.0) -> list[float]:
         if buffer is None or len(buffer) != n:
             return [value] * n
         for i in range(n):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- annotate the `_reset_list` closures in `_init_neighbor_sums` so cached buffers are typed as `list[float]`
- keep buffer reset behavior intact while aligning the implementation with the declared return type

------
https://chatgpt.com/codex/tasks/task_e_68f5409dd57c832195e3750b742eb7e5