### PR TITLE
Add return annotation to glyph history proxy closure

### DIFF
--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -129,7 +129,7 @@ def _glyph_history_proxy(name: str) -> Callable[..., Any]:
 
     target: dict[str, Callable[..., Any] | None] = {"func": None}
 
-    def _call(*args: Any, **kwargs: Any):
+    def _call(*args: Any, **kwargs: Any) -> Any:
         func = target["func"]
         if func is None:
             from .. import glyph_history as _glyph_history


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Adds an explicit `Any` return annotation to the glyph history proxy closure so the helper satisfies `mypy` type checking.


------
https://chatgpt.com/codex/tasks/task_e_68f5412ecaa083218817bd40cc20bc01