### PR TITLE
Improve TNFR public stubs for accurate typing

### DIFF
--- a/src/tnfr/__init__.pyi
+++ b/src/tnfr/__init__.pyi
@@ -1,14 +1,40 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Callable
+from typing import Any, NoReturn
 
-def __getattr__(name: str) -> Any: ...
+from .dynamics import run, step
+from .ontosim import preparar_red
+from .structural import create_nfr, run_sequence
 
-ExportDependencyError: Any
-Names: Any
-__version__: Any
-create_nfr: Any
-preparar_red: Any
-run: Any
-run_sequence: Any
-step: Any
+EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]]
+"""Manifest describing required submodules and third-party packages."""
+
+_MISSING_EXPORTS: dict[str, dict[str, Any]]
+
+__version__: str
+__all__: list[str]
+
+
+class ExportDependencyError(RuntimeError):
+    """Raised when the export dependency manifest is inconsistent."""
+
+
+def _is_internal_import_error(exc: ImportError) -> bool: ...
+
+def _missing_dependency(
+    name: str,
+    exc: ImportError,
+    *,
+    module: str | None = ...,
+) -> Callable[..., NoReturn]: ...
+
+
+def _validate_export_dependencies() -> None: ...
+
+def _assign_exports(module: str, names: tuple[str, ...]) -> bool: ...
+
+def _emit_missing_dependency_warning() -> None: ...
+
+_HAS_PREPARAR_RED: bool
+_HAS_RUN_SEQUENCE: bool

--- a/src/tnfr/node.pyi
+++ b/src/tnfr/node.pyi
@@ -1,9 +1,159 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Hashable, Iterable, MutableMapping
+from typing import Any, Callable, Optional, Protocol, SupportsFloat, TypeVar
 
-def __getattr__(name: str) -> Any: ...
+from .types import (
+    CouplingWeight,
+    DeltaNFR,
+    EPIValue,
+    NodeId,
+    Phase,
+    SecondDerivativeEPI,
+    SenseIndex,
+    StructuralFrequency,
+    TNFRGraph,
+)
 
-NodoNX: Any
-NodoProtocol: Any
-add_edge: Any
+T = TypeVar("T")
+
+__all__ = ("NodoNX", "NodoProtocol", "add_edge")
+
+
+class AttrSpec:
+    aliases: tuple[str, ...]
+    default: Any
+    getter: Callable[[MutableMapping[str, Any], tuple[str, ...], Any], Any]
+    setter: Callable[..., None]
+    to_python: Callable[[Any], Any]
+    to_storage: Callable[[Any], Any]
+    use_graph_setter: bool
+
+    def build_property(self) -> property: ...
+
+
+ALIAS_EPI: tuple[str, ...]
+ALIAS_VF: tuple[str, ...]
+ALIAS_THETA: tuple[str, ...]
+ALIAS_SI: tuple[str, ...]
+ALIAS_EPI_KIND: tuple[str, ...]
+ALIAS_DNFR: tuple[str, ...]
+ALIAS_D2EPI: tuple[str, ...]
+
+ATTR_SPECS: dict[str, AttrSpec]
+
+
+def _add_edge_common(
+    n1: NodeId,
+    n2: NodeId,
+    weight: CouplingWeight | SupportsFloat | str,
+) -> Optional[CouplingWeight]: ...
+
+
+def add_edge(
+    graph: TNFRGraph,
+    n1: NodeId,
+    n2: NodeId,
+    weight: CouplingWeight | SupportsFloat | str,
+    overwrite: bool = ...,
+) -> None: ...
+
+
+class NodoProtocol(Protocol):
+    EPI: EPIValue
+    vf: StructuralFrequency
+    theta: Phase
+    Si: SenseIndex
+    epi_kind: str
+    dnfr: DeltaNFR
+    d2EPI: SecondDerivativeEPI
+    graph: MutableMapping[str, Any]
+
+    def neighbors(self) -> Iterable["NodoProtocol" | Hashable]: ...
+
+    def _glyph_storage(self) -> MutableMapping[str, object]: ...
+
+    def has_edge(self, other: "NodoProtocol") -> bool: ...
+
+    def add_edge(
+        self,
+        other: "NodoProtocol",
+        weight: CouplingWeight,
+        *,
+        overwrite: bool = ...,
+    ) -> None: ...
+
+    def offset(self) -> int: ...
+
+    def all_nodes(self) -> Iterable["NodoProtocol"]: ...
+
+
+class NodoNX(NodoProtocol):
+    G: TNFRGraph
+    n: NodeId
+    graph: MutableMapping[str, Any]
+
+    def __init__(self, G: TNFRGraph, n: NodeId) -> None: ...
+
+    @classmethod
+    def from_graph(cls, G: TNFRGraph, n: NodeId) -> "NodoNX": ...
+
+    def _glyph_storage(self) -> MutableMapping[str, Any]: ...
+
+    @property
+    def EPI(self) -> EPIValue: ...
+
+    @EPI.setter
+    def EPI(self, value: EPIValue) -> None: ...
+
+    @property
+    def vf(self) -> StructuralFrequency: ...
+
+    @vf.setter
+    def vf(self, value: StructuralFrequency) -> None: ...
+
+    @property
+    def theta(self) -> Phase: ...
+
+    @theta.setter
+    def theta(self, value: Phase) -> None: ...
+
+    @property
+    def Si(self) -> SenseIndex: ...
+
+    @Si.setter
+    def Si(self, value: SenseIndex) -> None: ...
+
+    @property
+    def epi_kind(self) -> str: ...
+
+    @epi_kind.setter
+    def epi_kind(self, value: str) -> None: ...
+
+    @property
+    def dnfr(self) -> DeltaNFR: ...
+
+    @dnfr.setter
+    def dnfr(self, value: DeltaNFR) -> None: ...
+
+    @property
+    def d2EPI(self) -> SecondDerivativeEPI: ...
+
+    @d2EPI.setter
+    def d2EPI(self, value: SecondDerivativeEPI) -> None: ...
+
+    def neighbors(self) -> Iterable[NodeId]: ...
+
+    def has_edge(self, other: NodoProtocol) -> bool: ...
+
+    def add_edge(
+        self,
+        other: NodoProtocol,
+        weight: CouplingWeight,
+        *,
+        overwrite: bool = ...,
+    ) -> None: ...
+
+    def offset(self) -> int: ...
+
+    def all_nodes(self) -> Iterable[NodoProtocol]: ...

--- a/src/tnfr/utils/data.pyi
+++ b/src/tnfr/utils/data.pyi
@@ -1,17 +1,73 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
+from typing import Any, Callable, TypeVar
 
-def __getattr__(name: str) -> Any: ...
+T = TypeVar("T")
 
-MAX_MATERIALIZE_DEFAULT: Any
-STRING_TYPES: Any
-convert_value: Any
-ensure_collection: Any
-flatten_structure: Any
-is_non_string_sequence: Any
-mix_groups: Any
-negative_weights_warn_once: Any
-normalize_counter: Any
-normalize_materialize_limit: Any
-normalize_weights: Any
+STRING_TYPES: tuple[type[str] | type[bytes] | type[bytearray], ...]
+MAX_MATERIALIZE_DEFAULT: int
+NEGATIVE_WEIGHTS_MSG: str
+
+__all__: tuple[str, ...]
+
+
+def convert_value(
+    value: Any,
+    conv: Callable[[Any], T],
+    *,
+    strict: bool = ...,
+    key: str | None = ...,
+    log_level: int | None = ...,
+) -> tuple[bool, T | None]: ...
+
+
+def negative_weights_warn_once(
+    *,
+    maxsize: int = ...,
+) -> Callable[[Mapping[str, float]], None]: ...
+
+
+def is_non_string_sequence(obj: Any) -> bool: ...
+
+
+def flatten_structure(
+    obj: Any,
+    *,
+    expand: Callable[[Any], Iterable[Any] | None] | None = ...,
+) -> Iterator[Any]: ...
+
+
+def normalize_materialize_limit(max_materialize: int | None) -> int | None: ...
+
+
+def ensure_collection(
+    it: Iterable[T],
+    *,
+    max_materialize: int | None = ...,
+    error_msg: str | None = ...,
+) -> Collection[T]: ...
+
+
+def normalize_weights(
+    dict_like: Mapping[str, Any],
+    keys: Iterable[str] | Sequence[str],
+    default: float = ...,
+    *,
+    error_on_negative: bool = ...,
+    warn_once: bool | Callable[[Mapping[str, float]], None] = ...,
+    error_on_conversion: bool = ...,
+) -> dict[str, float]: ...
+
+
+def normalize_counter(
+    counts: Mapping[str, float | int],
+) -> tuple[dict[str, float], float]: ...
+
+
+def mix_groups(
+    dist: Mapping[str, float],
+    groups: Mapping[str, Iterable[str]],
+    *,
+    prefix: str = ...,
+) -> dict[str, float]: ...


### PR DESCRIPTION
## Summary
- replace the placeholder tnfr.__init__ stub with explicit type declarations and re-exports
- document NodoNX protocol members and helpers within tnfr.node.pyi
- describe tnfr.utils.data helpers so typed callers see concrete signatures

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f5474ab6ec8321b72dfa7e1d6c341d