### PR TITLE
Add return annotations to structured IO helpers

### DIFF
--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -206,7 +206,7 @@ def _format_structured_file_error(path: Path, e: Exception) -> str:
 class StructuredFileError(Exception):
     """Error while reading or parsing a structured file."""
 
-    def __init__(self, path: Path, original: Exception):
+    def __init__(self, path: Path, original: Exception) -> None:
         super().__init__(_format_structured_file_error(path, original))
         self.path = path
 

--- a/src/tnfr/utils/init.py
+++ b/src/tnfr/utils/init.py
@@ -15,7 +15,7 @@ import warnings
 import weakref
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Any, Callable, Hashable, Iterable, Literal, Mapping
+from typing import Any, Callable, Hashable, Iterable, Iterator, Literal, Mapping
 
 __all__ = (
     "_configure_root",
@@ -495,7 +495,7 @@ class LazyImportProxy:
     def __str__(self) -> str:  # pragma: no cover - representation helper
         return str(self._resolve())
 
-    def __iter__(self):  # pragma: no cover - passthrough helper
+    def __iter__(self) -> Iterator[Any]:  # pragma: no cover - passthrough helper
         return iter(self._resolve())
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- declare StructuredFileError.__init__ as returning None without altering behaviour
- ensure LazyImportProxy.__iter__ exposes an Iterator[Any] typing for downstream tooling

## Testing
- `python -m mypy src/tnfr`


------
https://chatgpt.com/codex/tasks/task_e_68f5497da9f88321bfb5d92461614a40