### PR TITLE
Refine sigma vector typing across sense utilities

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -14,6 +14,7 @@ from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
 from .utils import cached_import, get_graph_mapping, is_non_string_sequence
 from .types import (
+    SigmaVector,
     TNFRGraph,
     TraceCallback,
     TraceFieldFn,
@@ -29,7 +30,7 @@ class _KuramotoFn(Protocol):
 class _SigmaVectorFn(Protocol):
     def __call__(
         self, G: TNFRGraph, weight_mode: str | None = None
-    ) -> Mapping[str, float]: ...
+    ) -> SigmaVector: ...
 
 
 class CallbackSpec(NamedTuple):
@@ -74,7 +75,7 @@ kuramoto_R_psi: _KuramotoFn = cast(
 
 def _sigma_fallback(
     G: TNFRGraph, _weight_mode: str | None = None
-) -> dict[str, float]:
+) -> SigmaVector:
     """Return a null sigma vector regardless of ``_weight_mode``."""
 
     return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -55,6 +55,7 @@ __all__ = (
     "NeighborStats",
     "TimingContext",
     "PresetTokens",
+    "SigmaVector",
 )
 
 
@@ -112,6 +113,28 @@ TimingContext: TypeAlias = ContextManager[None]
 
 PresetTokens: TypeAlias = Sequence[_Token]
 #: Sequence of execution tokens composing a preset program.
+
+
+class _SigmaVectorRequired(TypedDict):
+    """Mandatory components for a σ-vector in the sense plane."""
+
+    x: float
+    y: float
+    mag: float
+    angle: float
+    n: int
+
+
+class _SigmaVectorOptional(TypedDict, total=False):
+    """Optional metadata captured when tracking σ-vectors."""
+
+    glyph: str
+    w: float
+    t: float
+
+
+class SigmaVector(_SigmaVectorRequired, _SigmaVectorOptional):
+    """Typed dictionary describing σ-vector telemetry."""
 
 
 class SelectorThresholds(TypedDict):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f54a2549748321b34d3252260d2a38