### PR TITLE
Refine CLI typing for program execution

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any
+from typing import Any, Iterable
 
 from ..gamma import GAMMA_REGISTRY
+from ..types import ArgSpec
 from .utils import spec
 
 
-GRAMMAR_ARG_SPECS = (
+GRAMMAR_ARG_SPECS: tuple[ArgSpec, ...] = (
     spec("--grammar.enabled", action=argparse.BooleanOptionalAction),
     spec("--grammar.zhir_requires_oz_window", type=int),
     spec("--grammar.zhir_dnfr_min", type=float),
@@ -20,7 +21,7 @@ GRAMMAR_ARG_SPECS = (
 
 
 # Especificaciones para opciones relacionadas con el histórico
-HISTORY_ARG_SPECS = (
+HISTORY_ARG_SPECS: tuple[ArgSpec, ...] = (
     spec("--save-history", type=str),
     spec("--export-history-base", type=str),
     spec("--export-format", choices=["csv", "json"], default="json"),
@@ -28,7 +29,7 @@ HISTORY_ARG_SPECS = (
 
 
 # Argumentos comunes a los subcomandos
-COMMON_ARG_SPECS = (
+COMMON_ARG_SPECS: tuple[ArgSpec, ...] = (
     spec("--nodes", type=int, default=24),
     spec("--topology", choices=["ring", "complete", "erdos"], default="ring"),
     spec("--seed", type=int, default=1),
@@ -48,7 +49,9 @@ COMMON_ARG_SPECS = (
 )
 
 
-def add_arg_specs(parser: argparse._ActionsContainer, specs) -> None:
+def add_arg_specs(
+    parser: argparse._ActionsContainer, specs: Iterable[ArgSpec]
+) -> None:
     """Register arguments from ``specs`` on ``parser``."""
     for opt, kwargs in specs:
         parser.add_argument(opt, **kwargs)

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -29,7 +29,7 @@ from ..config import apply_config
 from ..io import read_structured_file, safe_write, StructuredFileError
 from ..glyph_history import ensure_history
 from ..ontosim import preparar_red
-from ..types import Glyph
+from ..types import Glyph, ProgramTokens
 from ..utils import get_logger, json_dumps
 from ..flatten import parse_program_tokens
 
@@ -148,7 +148,7 @@ def _build_graph_from_args(args: argparse.Namespace) -> "nx.Graph":
     return G
 
 
-def _load_sequence(path: Path) -> list[Any]:
+def _load_sequence(path: Path) -> ProgramTokens:
     try:
         data = read_structured_file(path)
     except (StructuredFileError, OSError) as exc:
@@ -162,8 +162,8 @@ def _load_sequence(path: Path) -> list[Any]:
 
 
 def resolve_program(
-    args: argparse.Namespace, default: Optional[Any] = None
-) -> Optional[Any]:
+    args: argparse.Namespace, default: Optional[ProgramTokens] = None
+) -> Optional[ProgramTokens]:
     if getattr(args, "preset", None):
         try:
             return get_preset(args.preset)
@@ -179,7 +179,9 @@ def resolve_program(
 
 
 def run_program(
-    G: Optional["nx.Graph"], program: Optional[Any], args: argparse.Namespace
+    G: Optional["nx.Graph"],
+    program: Optional[ProgramTokens],
+    args: argparse.Namespace,
 ) -> "nx.Graph":
     if G is None:
         G = _build_graph_from_args(args)
@@ -207,7 +209,7 @@ def run_program(
 def _run_cli_program(
     args: argparse.Namespace,
     *,
-    default_program: Optional[Any] = None,
+    default_program: Optional[ProgramTokens] = None,
     graph: Optional["nx.Graph"] = None,
 ) -> tuple[int, Optional["nx.Graph"]]:
     try:

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -55,6 +55,8 @@ __all__ = (
     "NeighborStats",
     "TimingContext",
     "PresetTokens",
+    "ProgramTokens",
+    "ArgSpec",
     "SigmaVector",
 )
 
@@ -111,8 +113,14 @@ CoherenceMetric: TypeAlias = float
 TimingContext: TypeAlias = ContextManager[None]
 #: Context manager used to measure execution time for cache operations.
 
+ProgramTokens: TypeAlias = Sequence[_Token]
+#: Sequence of execution tokens composing a TNFR program.
+
 PresetTokens: TypeAlias = Sequence[_Token]
 #: Sequence of execution tokens composing a preset program.
+
+ArgSpec: TypeAlias = tuple[str, Mapping[str, Any]]
+#: CLI argument specification pairing an option flag with keyword arguments.
 
 
 class _SigmaVectorRequired(TypedDict):


### PR DESCRIPTION
## Summary
- introduce ProgramTokens and ArgSpec aliases in the shared types module
- tighten CLI execution and argument helpers to use the new aliases

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f54cee9e9c8321856064c55fad167f