### PR TITLE
Improve CLI typing stubs and callback annotations

### DIFF
--- a/src/tnfr/callback_utils.pyi
+++ b/src/tnfr/callback_utils.pyi
@@ -1,10 +1,105 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+import threading
+import traceback
+from collections import defaultdict, deque
+from collections.abc import Callable, Iterable, Mapping
+from enum import Enum
+from typing import Any, TypedDict
 
-def __getattr__(name: str) -> Any: ...
+import networkx as nx
 
-CallbackError: Any
-CallbackEvent: Any
-CallbackManager: Any
-callback_manager: Any
+from .constants import DEFAULTS
+from .locking import get_lock
+from .trace import CallbackSpec
+from .utils import get_logger, is_non_string_sequence
+
+__all__ = (
+    "CallbackEvent",
+    "CallbackManager",
+    "callback_manager",
+    "CallbackError",
+)
+
+logger: Any
+
+
+class CallbackEvent(str, Enum):
+    BEFORE_STEP = "before_step"
+    AFTER_STEP = "after_step"
+    ON_REMESH = "on_remesh"
+
+
+Callback = Callable[[nx.Graph, dict[str, Any]], None]
+CallbackRegistry = dict[str, dict[str, CallbackSpec]]
+
+
+class CallbackError(TypedDict):
+    event: str
+    step: int | None
+    error: str
+    traceback: str
+    fn: str
+    name: str | None
+
+
+class CallbackManager:
+    def __init__(self) -> None: ...
+
+    def get_callback_error_limit(self) -> int: ...
+
+    def set_callback_error_limit(self, limit: int) -> int: ...
+
+    def register_callback(
+        self,
+        G: nx.Graph,
+        event: CallbackEvent | str,
+        func: Callback,
+        *,
+        name: str | None = ...,
+    ) -> Callback: ...
+
+    def invoke_callbacks(
+        self,
+        G: nx.Graph,
+        event: CallbackEvent | str,
+        ctx: dict[str, Any] | None = ...,
+    ) -> None: ...
+
+    def _record_callback_error(
+        self,
+        G: nx.Graph,
+        event: str,
+        ctx: dict[str, Any],
+        spec: CallbackSpec,
+        err: Exception,
+    ) -> None: ...
+
+    def _ensure_callbacks_nolock(self, G: nx.Graph) -> CallbackRegistry: ...
+
+    def _ensure_callbacks(self, G: nx.Graph) -> CallbackRegistry: ...
+
+
+callback_manager: CallbackManager
+
+
+def _func_id(fn: Callable[..., Any]) -> str: ...
+
+def _validate_registry(G: nx.Graph, cbs: Any, dirty: set[str]) -> CallbackRegistry: ...
+
+def _normalize_callbacks(entries: Any) -> dict[str, CallbackSpec]: ...
+
+def _normalize_event(event: CallbackEvent | str) -> str: ...
+
+def _is_known_event(event: str) -> bool: ...
+
+def _ensure_known_event(event: str) -> None: ...
+
+def _normalize_callback_entry(entry: Any) -> CallbackSpec | None: ...
+
+def _reconcile_callback(
+    event: str,
+    existing_map: dict[str, CallbackSpec],
+    spec: CallbackSpec,
+    strict: bool,
+) -> str: ...

--- a/src/tnfr/cli/arguments.pyi
+++ b/src/tnfr/cli/arguments.pyi
@@ -1,19 +1,33 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+import argparse
+from typing import Any, Iterable
 
-def __getattr__(name: str) -> Any: ...
+from ..gamma import GAMMA_REGISTRY
+from ..types import ArgSpec
+from .utils import spec
 
-COMMON_ARG_SPECS: Any
-GAMMA_REGISTRY: Any
-GRAMMAR_ARG_SPECS: Any
-HISTORY_ARG_SPECS: Any
-add_arg_specs: Any
-add_canon_toggle: Any
-add_common_args: Any
-add_grammar_args: Any
-add_grammar_selector_args: Any
-add_history_export_args: Any
-annotations: Any
-argparse: Any
-spec: Any
+GRAMMAR_ARG_SPECS: tuple[ArgSpec, ...]
+HISTORY_ARG_SPECS: tuple[ArgSpec, ...]
+COMMON_ARG_SPECS: tuple[ArgSpec, ...]
+
+
+def add_arg_specs(parser: argparse._ActionsContainer, specs: Iterable[ArgSpec]) -> None: ...
+
+def _args_to_dict(args: argparse.Namespace, prefix: str) -> dict[str, Any]: ...
+
+def add_common_args(parser: argparse.ArgumentParser) -> None: ...
+
+def add_grammar_args(parser: argparse.ArgumentParser) -> None: ...
+
+def add_grammar_selector_args(parser: argparse.ArgumentParser) -> None: ...
+
+def add_history_export_args(parser: argparse.ArgumentParser) -> None: ...
+
+def add_canon_toggle(parser: argparse.ArgumentParser) -> None: ...
+
+def _add_run_parser(sub: argparse._SubParsersAction) -> None: ...
+
+def _add_sequence_parser(sub: argparse._SubParsersAction) -> None: ...
+
+def _add_metrics_parser(sub: argparse._SubParsersAction) -> None: ...

--- a/src/tnfr/cli/execution.pyi
+++ b/src/tnfr/cli/execution.pyi
@@ -1,46 +1,80 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+import argparse
+from pathlib import Path
+from typing import Any, Optional
 
-def __getattr__(name: str) -> Any: ...
+import networkx as nx
 
-CANONICAL_PRESET_NAME: Any
-DEFAULT_SUMMARY_SERIES_LIMIT: Any
-Glyph: Any
-METRIC_DEFAULTS: Any
-Optional: Any
-Path: Any
-StructuredFileError: Any
-annotations: Any
-apply_cli_config: Any
-apply_config: Any
-argparse: Any
-build_basic_graph: Any
-build_metrics_summary: Any
-cmd_metrics: Any
-cmd_run: Any
-cmd_sequence: Any
-default_glyph_selector: Any
-ensure_history: Any
-export_metrics: Any
-get_logger: Any
-get_preset: Any
-glyph_top: Any
-json_dumps: Any
+from ..constants import METRIC_DEFAULTS
+from ..dynamics import (
+    run,
+    default_glyph_selector,
+    parametric_glyph_selector,
+    validate_canon,
+)
+from ..execution import CANONICAL_PRESET_NAME, play, seq
+from ..flatten import parse_program_tokens
+from ..glyph_history import ensure_history
+from ..io import read_structured_file, safe_write, StructuredFileError
+from ..metrics import (
+    register_metrics_callbacks,
+    glyph_top,
+    export_metrics,
+    build_metrics_summary,
+)
+from ..metrics.core import _metrics_step
+from ..ontosim import preparar_red
+from ..sense import register_sigma_callback
+from ..trace import register_trace
+from ..types import Glyph, ProgramTokens
+from ..utils import get_logger, json_dumps
+from ..config import apply_config
+from ..config.presets import get_preset
+
+from .arguments import _args_to_dict
+
+DEFAULT_SUMMARY_SERIES_LIMIT: int
 logger: Any
-nx: Any
-parametric_glyph_selector: Any
-parse_program_tokens: Any
-play: Any
-preparar_red: Any
-read_structured_file: Any
-register_callbacks_and_observer: Any
-register_metrics_callbacks: Any
-register_sigma_callback: Any
-register_trace: Any
-resolve_program: Any
-run: Any
-run_program: Any
-safe_write: Any
-seq: Any
-validate_canon: Any
+
+
+def _save_json(path: str, data: Any) -> None: ...
+
+def _attach_callbacks(G: nx.Graph) -> None: ...
+
+def _persist_history(G: nx.Graph, args: argparse.Namespace) -> None: ...
+
+def build_basic_graph(args: argparse.Namespace) -> nx.Graph: ...
+
+def apply_cli_config(G: nx.Graph, args: argparse.Namespace) -> None: ...
+
+def register_callbacks_and_observer(G: nx.Graph) -> None: ...
+
+def _build_graph_from_args(args: argparse.Namespace) -> nx.Graph: ...
+
+def _load_sequence(path: Path) -> ProgramTokens: ...
+
+def resolve_program(
+    args: argparse.Namespace, default: Optional[ProgramTokens] = ...
+) -> Optional[ProgramTokens]: ...
+
+def run_program(
+    G: Optional[nx.Graph],
+    program: Optional[ProgramTokens],
+    args: argparse.Namespace,
+) -> nx.Graph: ...
+
+def _run_cli_program(
+    args: argparse.Namespace,
+    *,
+    default_program: Optional[ProgramTokens] = ...,
+    graph: Optional[nx.Graph] = ...,
+) -> tuple[int, Optional[nx.Graph]]: ...
+
+def _log_run_summaries(G: nx.Graph, args: argparse.Namespace) -> None: ...
+
+def cmd_run(args: argparse.Namespace) -> int: ...
+
+def cmd_sequence(args: argparse.Namespace) -> int: ...
+
+def cmd_metrics(args: argparse.Namespace) -> int: ...

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -12,6 +12,7 @@ from ..config.constants import GLYPHS_CANONICAL
 from ..glyph_history import ensure_history
 from ..io import safe_write
 from ..utils import json_dumps
+from ..types import Graph
 from .core import glyphogram_series
 from .glyph_timing import GlyphogramRow, SigmaTrace
 
@@ -44,7 +45,7 @@ def _iter_glif_rows(
         yield [t] + [col[i] for col in cols]
 
 
-def export_metrics(G: object, base_path: str, fmt: str = "csv") -> None:
+def export_metrics(G: Graph, base_path: str, fmt: str = "csv") -> None:
     """Dump glyphogram and σ(t) trace to compact CSV or JSON files."""
     hist = ensure_history(G)
     glyph = glyphogram_series(G)

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -20,6 +20,7 @@ ALIAS_EPI = get_aliases("EPI")
 LATENT_GLYPH: str = "SHA"
 DEFAULT_EPI_SUPPORT_LIMIT = 0.05
 
+np: ModuleType | None
 try:  # pragma: no cover - import guard exercised via tests
     import numpy as np  # type: ignore[import-not-found]
 except Exception:  # pragma: no cover - numpy optional dependency

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -3,6 +3,7 @@ from collections.abc import Hashable, Mapping, Sequence
 from enum import Enum
 from typing import TypedDict
 
+nx: Any
 try:
     import networkx as nx  # type: ignore[import-not-found]
 except Exception:
@@ -13,6 +14,7 @@ except Exception:
 
     nx = _FallbackNetworkX()
 
+np: Any
 try:
     import numpy as np  # type: ignore[import-not-found]
 except Exception:


### PR DESCRIPTION
## Summary
- replace the CLI execution and argument stubs with precise signatures that surface ProgramTokens and ArgSpec aliases
- expand the callback utilities stub to expose the callback manager API, callback types, and concrete event enums
- tighten glyph timing, export, and core type aliases so downstream modules satisfy the stricter stub contracts

## Testing
- python -m mypy src/tnfr
- ./scripts/run_tests.sh *(fails: ImportError from tnfr.dynamics.integrators IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_68f54f4fe9f883219a91aab359326bb7