### PR TITLE
Tighten coherence telemetry typing

### DIFF
--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -20,11 +20,12 @@ ALIAS_EPI = get_aliases("EPI")
 LATENT_GLYPH: str = "SHA"
 DEFAULT_EPI_SUPPORT_LIMIT = 0.05
 
-np: ModuleType | None
 try:  # pragma: no cover - import guard exercised via tests
-    import numpy as np  # type: ignore[import-not-found]
+    import numpy as _np  # type: ignore[import-not-found]
 except Exception:  # pragma: no cover - numpy optional dependency
-    np = None
+    _np = None
+
+np: ModuleType | None = cast(ModuleType | None, _np)
 
 
 class SigmaTrace(TypedDict):

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -1,9 +1,8 @@
-from typing import Any, Callable, ContextManager, Iterable, Protocol, TypeAlias
+from typing import Any, Callable, ContextManager, Iterable, Protocol, TypeAlias, cast
 from collections.abc import Hashable, Mapping, Sequence
 from enum import Enum
 from typing import TypedDict
 
-nx: Any
 try:
     import networkx as nx  # type: ignore[import-not-found]
 except Exception:
@@ -12,9 +11,8 @@ except Exception:
     class _FallbackNetworkX:
         Graph = _FallbackGraph
 
-    nx = _FallbackNetworkX()
+    nx = cast(Any, _FallbackNetworkX())
 
-np: Any
 try:
     import numpy as np  # type: ignore[import-not-found]
 except Exception:
@@ -23,7 +21,7 @@ except Exception:
     class _FallbackNumpy:
         ndarray = _FallbackNdArray
 
-    np = _FallbackNumpy()
+    np = cast(Any, _FallbackNumpy())
 
 from .tokens import Token
 from .trace import TraceMetadata


### PR DESCRIPTION
## Summary
- annotate coherence observers with TNFRGraph, NodeId, and HistoryState to clarify metric payloads
- support dense coherence matrices when computing local phase synchrony
- normalise optional NumPy fallbacks so stricter mypy checks succeed

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f5698fcac88321b43bb1f47a560078