### PR TITLE
Improve typing coverage for cache-related stubs

### DIFF
--- a/src/tnfr/cache.pyi
+++ b/src/tnfr/cache.pyi
@@ -1,9 +1,138 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+import logging
+import threading
+from collections.abc import Callable, Iterator, Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any, ClassVar
 
-def __getattr__(name: str) -> Any: ...
+from .types import TimingContext
 
-CacheCapacityConfig: Any
-CacheManager: Any
-CacheStatistics: Any
+__all__ = ["CacheManager", "CacheCapacityConfig", "CacheStatistics"]
+
+
+@dataclass(frozen=True)
+class CacheCapacityConfig:
+    default_capacity: int | None
+    overrides: dict[str, int | None]
+
+
+@dataclass(frozen=True)
+class CacheStatistics:
+    hits: int = ...
+    misses: int = ...
+    evictions: int = ...
+    total_time: float = ...
+    timings: int = ...
+
+    def merge(self, other: CacheStatistics) -> CacheStatistics: ...
+
+
+class CacheManager:
+    _MISSING: ClassVar[object]
+
+    def __init__(
+        self,
+        storage: MutableMapping[str, Any] | None = ...,
+        *,
+        default_capacity: int | None = ...,
+        overrides: Mapping[str, int | None] | None = ...,
+    ) -> None: ...
+
+    @staticmethod
+    def _normalise_capacity(value: int | None) -> int | None: ...
+
+    def register(
+        self,
+        name: str,
+        factory: Callable[[], Any],
+        *,
+        lock_factory: Callable[[], threading.Lock | threading.RLock] | None = ...,
+        reset: Callable[[Any], Any] | None = ...,
+        create: bool = ...,
+    ) -> None: ...
+
+    def configure(
+        self,
+        *,
+        default_capacity: int | None | object = ...,
+        overrides: Mapping[str, int | None] | None = ...,
+        replace_overrides: bool = ...,
+    ) -> None: ...
+
+    def configure_from_mapping(self, config: Mapping[str, Any]) -> None: ...
+
+    def export_config(self) -> CacheCapacityConfig: ...
+
+    def get_capacity(
+        self,
+        name: str,
+        *,
+        requested: int | None = ...,
+        fallback: int | None = ...,
+        use_default: bool = ...,
+    ) -> int | None: ...
+
+    def has_override(self, name: str) -> bool: ...
+
+    def get_lock(self, name: str) -> threading.Lock | threading.RLock: ...
+
+    def names(self) -> Iterator[str]: ...
+
+    def get(self, name: str, *, create: bool = ...) -> Any: ...
+
+    def peek(self, name: str) -> Any: ...
+
+    def store(self, name: str, value: Any) -> None: ...
+
+    def update(
+        self,
+        name: str,
+        updater: Callable[[Any], Any],
+        *,
+        create: bool = ...,
+    ) -> Any: ...
+
+    def clear(self, name: str | None = ...) -> None: ...
+
+    def increment_hit(
+        self,
+        name: str,
+        *,
+        amount: int = ...,
+        duration: float | None = ...,
+    ) -> None: ...
+
+    def increment_miss(
+        self,
+        name: str,
+        *,
+        amount: int = ...,
+        duration: float | None = ...,
+    ) -> None: ...
+
+    def increment_eviction(self, name: str, *, amount: int = ...) -> None: ...
+
+    def record_timing(self, name: str, duration: float) -> None: ...
+
+    def timer(self, name: str) -> TimingContext: ...
+
+    def get_metrics(self, name: str) -> CacheStatistics: ...
+
+    def iter_metrics(self) -> Iterator[tuple[str, CacheStatistics]]: ...
+
+    def aggregate_metrics(self) -> CacheStatistics: ...
+
+    def register_metrics_publisher(
+        self, publisher: Callable[[str, CacheStatistics], None]
+    ) -> None: ...
+
+    def publish_metrics(
+        self,
+        *,
+        publisher: Callable[[str, CacheStatistics], None] | None = ...,
+    ) -> None: ...
+
+    def log_metrics(
+        self, logger: logging.Logger, *, level: int = ...
+    ) -> None: ...

--- a/src/tnfr/constants/__init__.pyi
+++ b/src/tnfr/constants/__init__.pyi
@@ -1,37 +1,92 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Mapping
+from typing import Any, Callable, TypeVar
 
-def __getattr__(name: str) -> Any: ...
+from .core import CORE_DEFAULTS as CORE_DEFAULTS, REMESH_DEFAULTS as REMESH_DEFAULTS
+from .init import INIT_DEFAULTS as INIT_DEFAULTS
+from .metric import (
+    COHERENCE as COHERENCE,
+    DIAGNOSIS as DIAGNOSIS,
+    GRAMMAR_CANON as GRAMMAR_CANON,
+    METRICS as METRICS,
+    METRIC_DEFAULTS as METRIC_DEFAULTS,
+    SIGMA as SIGMA,
+    TRACE as TRACE,
+)
+from ..types import GraphLike
 
-ALIASES: Any
-COHERENCE: Any
-CORE_DEFAULTS: Any
-D2EPI_PRIMARY: Any
-D2VF_PRIMARY: Any
-DEFAULTS: Any
-DEFAULT_SECTIONS: Any
-DIAGNOSIS: Any
-DNFR_PRIMARY: Any
-EPI_KIND_PRIMARY: Any
-EPI_PRIMARY: Any
-GRAMMAR_CANON: Any
-INIT_DEFAULTS: Any
-METRICS: Any
-METRIC_DEFAULTS: Any
-REMESH_DEFAULTS: Any
-SIGMA: Any
-SI_PRIMARY: Any
-THETA_KEY: Any
-THETA_PRIMARY: Any
-TRACE: Any
-VF_KEY: Any
-VF_PRIMARY: Any
-dEPI_PRIMARY: Any
-dSI_PRIMARY: Any
-dVF_PRIMARY: Any
-get_aliases: Any
-get_graph_param: Any
-get_param: Any
-inject_defaults: Any
-merge_overrides: Any
+T = TypeVar("T")
+
+__all__ = (
+    "CORE_DEFAULTS",
+    "INIT_DEFAULTS",
+    "REMESH_DEFAULTS",
+    "METRIC_DEFAULTS",
+    "SIGMA",
+    "TRACE",
+    "METRICS",
+    "GRAMMAR_CANON",
+    "COHERENCE",
+    "DIAGNOSIS",
+    "DEFAULTS",
+    "DEFAULT_SECTIONS",
+    "ALIASES",
+    "inject_defaults",
+    "merge_overrides",
+    "get_param",
+    "get_graph_param",
+    "get_aliases",
+    "VF_KEY",
+    "THETA_KEY",
+    "VF_PRIMARY",
+    "THETA_PRIMARY",
+    "DNFR_PRIMARY",
+    "EPI_PRIMARY",
+    "EPI_KIND_PRIMARY",
+    "SI_PRIMARY",
+    "dEPI_PRIMARY",
+    "D2EPI_PRIMARY",
+    "dVF_PRIMARY",
+    "D2VF_PRIMARY",
+    "dSI_PRIMARY",
+)
+
+ensure_node_offset_map: Callable[[GraphLike], None] | None
+DEFAULT_SECTIONS: Mapping[str, Mapping[str, Any]]
+DEFAULTS: Mapping[str, Any]
+ALIASES: dict[str, tuple[str, ...]]
+VF_KEY: str
+THETA_KEY: str
+VF_PRIMARY: str
+THETA_PRIMARY: str
+DNFR_PRIMARY: str
+EPI_PRIMARY: str
+EPI_KIND_PRIMARY: str
+SI_PRIMARY: str
+dEPI_PRIMARY: str
+D2EPI_PRIMARY: str
+dVF_PRIMARY: str
+D2VF_PRIMARY: str
+dSI_PRIMARY: str
+
+
+def inject_defaults(
+    G: GraphLike,
+    defaults: Mapping[str, Any] = ...,
+    override: bool = ...,
+) -> None: ...
+
+
+def merge_overrides(G: GraphLike, **overrides: Any) -> None: ...
+
+
+def get_param(G: GraphLike, key: str) -> Any: ...
+
+
+def get_graph_param(
+    G: GraphLike, key: str, cast: Callable[[Any], T] = ...
+) -> T | None: ...
+
+
+def get_aliases(key: str) -> tuple[str, ...]: ...

--- a/src/tnfr/helpers/__init__.pyi
+++ b/src/tnfr/helpers/__init__.pyi
@@ -1,29 +1,66 @@
+from __future__ import annotations
+
 from typing import Any
 
-__all__: Any
+from ..cache import CacheManager as CacheManager
+from ..glyph_history import (
+    HistoryDict,
+    count_glyphs as count_glyphs,
+    ensure_history as ensure_history,
+    last_glyph as last_glyph,
+    push_glyph as push_glyph,
+    recent_glyph as recent_glyph,
+)
+from ..utils.cache import (
+    EdgeCacheManager as EdgeCacheManager,
+    cached_node_list as cached_node_list,
+    cached_nodes_and_A as cached_nodes_and_A,
+    edge_version_cache as edge_version_cache,
+    edge_version_update as edge_version_update,
+    ensure_node_index_map as ensure_node_index_map,
+    ensure_node_offset_map as ensure_node_offset_map,
+    node_set_checksum as node_set_checksum,
+    stable_json as stable_json,
+)
+from ..utils.graph import (
+    get_graph as get_graph,
+    get_graph_mapping as get_graph_mapping,
+    increment_edge_version as increment_edge_version,
+    mark_dnfr_prep_dirty as mark_dnfr_prep_dirty,
+)
+from .numeric import (
+    angle_diff as angle_diff,
+    clamp as clamp,
+    clamp01 as clamp01,
+    kahan_sum_nd as kahan_sum_nd,
+)
+
+__all__ = (
+    "CacheManager",
+    "EdgeCacheManager",
+    "angle_diff",
+    "cached_node_list",
+    "cached_nodes_and_A",
+    "clamp",
+    "clamp01",
+    "edge_version_cache",
+    "edge_version_update",
+    "ensure_node_index_map",
+    "ensure_node_offset_map",
+    "get_graph",
+    "get_graph_mapping",
+    "increment_edge_version",
+    "kahan_sum_nd",
+    "mark_dnfr_prep_dirty",
+    "node_set_checksum",
+    "stable_json",
+    "count_glyphs",
+    "ensure_history",
+    "last_glyph",
+    "push_glyph",
+    "recent_glyph",
+    "__getattr__",
+)
+
 
 def __getattr__(name: str) -> Any: ...
-
-CacheManager: Any
-EdgeCacheManager: Any
-angle_diff: Any
-cached_node_list: Any
-cached_nodes_and_A: Any
-clamp: Any
-clamp01: Any
-count_glyphs: Any
-edge_version_cache: Any
-edge_version_update: Any
-ensure_history: Any
-ensure_node_index_map: Any
-ensure_node_offset_map: Any
-get_graph: Any
-get_graph_mapping: Any
-increment_edge_version: Any
-kahan_sum_nd: Any
-last_glyph: Any
-mark_dnfr_prep_dirty: Any
-node_set_checksum: Any
-push_glyph: Any
-recent_glyph: Any
-stable_json: Any

--- a/src/tnfr/utils/cache.pyi
+++ b/src/tnfr/utils/cache.pyi
@@ -1,22 +1,169 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+import threading
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, MutableMapping
+from typing import Any, ContextManager, Generic, TypeVar
 
-def __getattr__(name: str) -> Any: ...
+import networkx as nx
 
-EdgeCacheManager: Any
-LockAwareLRUCache: Any
-NODE_SET_CHECKSUM_KEY: Any
-cached_node_list: Any
-cached_nodes_and_A: Any
-clear_node_repr_cache: Any
-configure_graph_cache_limits: Any
-edge_version_cache: Any
-edge_version_update: Any
-ensure_node_index_map: Any
-ensure_node_offset_map: Any
-get_graph_version: Any
-increment_edge_version: Any
-increment_graph_version: Any
-node_set_checksum: Any
-stable_json: Any
+from ..cache import CacheCapacityConfig, CacheManager
+from ..types import NodeId, TNFRGraph, TimingContext
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+T = TypeVar("T")
+
+__all__ = (
+    "EdgeCacheManager",
+    "LockAwareLRUCache",
+    "NODE_SET_CHECKSUM_KEY",
+    "cached_node_list",
+    "cached_nodes_and_A",
+    "clear_node_repr_cache",
+    "configure_graph_cache_limits",
+    "edge_version_cache",
+    "edge_version_update",
+    "ensure_node_index_map",
+    "ensure_node_offset_map",
+    "get_graph_version",
+    "increment_edge_version",
+    "increment_graph_version",
+    "node_set_checksum",
+    "stable_json",
+)
+
+NODE_SET_CHECKSUM_KEY: str
+
+
+class LRUCache(MutableMapping[K, V], Generic[K, V]):
+    def __init__(self, maxsize: int = ...) -> None: ...
+
+    def __getitem__(self, __key: K) -> V: ...
+
+    def __setitem__(self, __key: K, __value: V) -> None: ...
+
+    def __delitem__(self, __key: K) -> None: ...
+
+    def __iter__(self) -> Iterator[K]: ...
+
+    def __len__(self) -> int: ...
+
+
+class LockAwareLRUCache(LRUCache[Hashable, Any]):
+    def __init__(
+        self,
+        maxsize: int,
+        locks: dict[Hashable, threading.RLock],
+        *,
+        on_evict: Callable[[Hashable, Any], None] | None = ...,
+    ) -> None: ...
+
+    def popitem(self) -> tuple[Hashable, Any]: ...
+
+
+class EdgeCacheState:
+    cache: MutableMapping[Hashable, Any]
+    locks: MutableMapping[Hashable, threading.RLock]
+    max_entries: int | None
+
+
+class EdgeCacheManager:
+    _STATE_KEY: str
+
+    def __init__(self, graph: Any) -> None: ...
+
+    def record_hit(self) -> None: ...
+
+    def record_miss(self) -> None: ...
+
+    def record_eviction(self) -> None: ...
+
+    def timer(self) -> TimingContext: ...
+
+    def _default_state(self) -> EdgeCacheState: ...
+
+    def resolve_max_entries(self, max_entries: int | None | object) -> int | None: ...
+
+    def _build_state(self, max_entries: int | None) -> EdgeCacheState: ...
+
+    def _ensure_state(
+        self, state: EdgeCacheState | None, max_entries: int | None | object
+    ) -> EdgeCacheState: ...
+
+    def _reset_state(self, state: EdgeCacheState | None) -> EdgeCacheState: ...
+
+    def get_cache(
+        self,
+        max_entries: int | None | object,
+        *,
+        create: bool = ...,
+    ) -> tuple[
+        MutableMapping[Hashable, Any] | None,
+        MutableMapping[Hashable, threading.RLock] | None,
+    ]: ...
+
+    def clear(self) -> None: ...
+
+
+def get_graph_version(graph: Any, key: str, default: int = ...) -> int: ...
+
+
+def increment_graph_version(graph: Any, key: str) -> int: ...
+
+
+def stable_json(obj: Any) -> str: ...
+
+
+def clear_node_repr_cache() -> None: ...
+
+
+def node_set_checksum(
+    G: nx.Graph,
+    nodes: Iterable[Any] | None = ...,
+    *,
+    presorted: bool = ...,
+    store: bool = ...,
+) -> str: ...
+
+
+def cached_node_list(G: nx.Graph) -> tuple[Any, ...]: ...
+
+
+def ensure_node_index_map(G: TNFRGraph) -> dict[NodeId, int]: ...
+
+
+def ensure_node_offset_map(G: TNFRGraph) -> dict[NodeId, int]: ...
+
+
+def configure_graph_cache_limits(
+    G: Any,
+    *,
+    default_capacity: int | None | object = CacheManager._MISSING,
+    overrides: Mapping[str, int | None] | None = ...,
+    replace_overrides: bool = ...,
+) -> CacheCapacityConfig: ...
+
+
+def increment_edge_version(G: Any) -> None: ...
+
+
+def edge_version_cache(
+    G: Any,
+    key: Hashable,
+    builder: Callable[[], T],
+    *,
+    max_entries: int | None | object = CacheManager._MISSING,
+) -> T: ...
+
+
+def cached_nodes_and_A(
+    G: nx.Graph,
+    *,
+    cache_size: int | None = ...,
+    require_numpy: bool = ...,
+    prefer_sparse: bool = ...,
+    nodes: tuple[Any, ...] | None = ...,
+) -> tuple[tuple[Any, ...], Any]: ...
+
+
+def edge_version_update(G: TNFRGraph) -> ContextManager[None]: ...


### PR DESCRIPTION
### Summary
- replace `Any` placeholders in `tnfr.cache` stubs with dataclass fields and CacheManager method signatures
- type the cache utilities stub so LockAwareLRUCache, EdgeCacheManager, and graph cache helpers expose precise interfaces
- align helpers and constants stubs with their runtime `__all__` exports for consistent IDE visibility

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f578288cc083218dcd7f4c0eae8c23