### PR TITLE
Refine TNFR configuration typing

### DIFF
--- a/src/tnfr/constants/__init__.pyi
+++ b/src/tnfr/constants/__init__.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Callable, TypeVar
+from typing import Callable, TypeVar
 
 from .core import CORE_DEFAULTS as CORE_DEFAULTS, REMESH_DEFAULTS as REMESH_DEFAULTS
 from .init import INIT_DEFAULTS as INIT_DEFAULTS
@@ -14,7 +14,7 @@ from .metric import (
     SIGMA as SIGMA,
     TRACE as TRACE,
 )
-from ..types import GraphLike
+from ..types import GraphLike, TNFRConfigValue
 
 T = TypeVar("T")
 
@@ -53,8 +53,8 @@ __all__ = (
 )
 
 ensure_node_offset_map: Callable[[GraphLike], None] | None
-DEFAULT_SECTIONS: Mapping[str, Mapping[str, Any]]
-DEFAULTS: Mapping[str, Any]
+DEFAULT_SECTIONS: Mapping[str, Mapping[str, TNFRConfigValue]]
+DEFAULTS: Mapping[str, TNFRConfigValue]
 ALIASES: dict[str, tuple[str, ...]]
 VF_KEY: str
 THETA_KEY: str
@@ -73,19 +73,19 @@ dSI_PRIMARY: str
 
 def inject_defaults(
     G: GraphLike,
-    defaults: Mapping[str, Any] = ...,
+    defaults: Mapping[str, TNFRConfigValue] = ...,
     override: bool = ...,
 ) -> None: ...
 
 
-def merge_overrides(G: GraphLike, **overrides: Any) -> None: ...
+def merge_overrides(G: GraphLike, **overrides: TNFRConfigValue) -> None: ...
 
 
-def get_param(G: GraphLike, key: str) -> Any: ...
+def get_param(G: GraphLike, key: str) -> TNFRConfigValue: ...
 
 
 def get_graph_param(
-    G: GraphLike, key: str, cast: Callable[[Any], T] = ...
+    G: GraphLike, key: str, cast: Callable[[object], T] = ...
 ) -> T | None: ...
 
 

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -57,6 +57,7 @@ __all__ = (
     "PresetTokens",
     "ProgramTokens",
     "ArgSpec",
+    "TNFRConfigValue",
     "SigmaVector",
 )
 
@@ -121,6 +122,24 @@ PresetTokens: TypeAlias = Sequence[_Token]
 
 ArgSpec: TypeAlias = tuple[str, Mapping[str, Any]]
 #: CLI argument specification pairing an option flag with keyword arguments.
+
+
+TNFRConfigScalar: TypeAlias = bool | int | float | str | None
+"""Primitive value allowed within TNFR configuration stores."""
+
+TNFRConfigSequence: TypeAlias = Sequence[TNFRConfigScalar]
+"""Homogeneous sequence of scalar TNFR configuration values."""
+
+TNFRConfigValue: TypeAlias = (
+    TNFRConfigScalar | TNFRConfigSequence | Mapping[str, "TNFRConfigValue"]
+)
+"""Permissible configuration entry for TNFR coherence defaults.
+
+The alias captures the recursive structure used by TNFR defaults: scalars
+express structural thresholds, booleans toggle operators, and nested mappings
+or sequences describe coherent parameter bundles such as γ grammars,
+selector advice or trace capture lists.
+"""
 
 
 class _SigmaVectorRequired(TypedDict):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- document the recursive `TNFRConfigValue` alias describing allowable coherence defaults
- update constants helpers and stubs to use the new alias, deep copying mutable branches with typed casts

## Testing
- `python -m mypy src/tnfr`


------
https://chatgpt.com/codex/tasks/task_e_68f579e8b0dc832186bd14c2d5443fa4