### PR TITLE
Refine glyph timing and diagnosis type annotations

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from ..types import (
     GlyphSelector,
@@ -30,7 +30,7 @@ from .coherence import (
     register_coherence_callbacks,
 )
 from .diagnosis import register_diagnosis_callbacks
-from .glyph_timing import _compute_advanced_metrics
+from .glyph_timing import _compute_advanced_metrics, GlyphMetricsHistory
 from .reporting import (
     Tg_by_node,
     Tg_global,
@@ -129,7 +129,14 @@ def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
 
     _aggregate_si(G, hist, n_jobs=metrics_jobs)
 
-    _compute_advanced_metrics(G, hist, t, dt, cfg, n_jobs=metrics_jobs)
+    _compute_advanced_metrics(
+        G,
+        cast(GlyphMetricsHistory, hist),
+        t,
+        dt,
+        cfg,
+        n_jobs=metrics_jobs,
+    )
 
 
 def register_metrics_callbacks(G: TNFRGraph) -> None:

--- a/src/tnfr/metrics/diagnosis.pyi
+++ b/src/tnfr/metrics/diagnosis.pyi
@@ -9,9 +9,11 @@ ALIAS_EPI: Any
 ALIAS_SI: Any
 ALIAS_VF: Any
 CallbackEvent: Any
+CoherenceMatrixPayload: Any
 Iterable: Any
 ProcessPoolExecutor: Any
 StatisticsError: Any
+TNFRGraph: Any
 TRANSICION: Any
 VF_KEY: Any
 annotations: Any
@@ -81,4 +83,7 @@ def _state_from_thresholds(Rloc: float, dnfr_n: float, cfg: Mapping[str, Any]) -
 
 def _recommendation(state: str, cfg: Mapping[str, Any]) -> list[Any]: ...
 
-def _get_last_weights(G: Any, hist: Mapping[str, Sequence[Any]]) -> tuple[Any | None, Any | None]: ...
+def _get_last_weights(
+    G: TNFRGraph,
+    hist: Mapping[str, Sequence[CoherenceMatrixPayload | None]],
+) -> tuple[CoherenceMatrixPayload | None, CoherenceMatrixPayload | None]: ...


### PR DESCRIPTION
## Summary
- Narrow glyph timing helpers to work with `GraphLike` graphs and structured metric history aliases.
- Update diagnosis coherence history handling to return typed weight matrices and align call sites and stubs.
- Cast orchestration entry points to the refined history contract so downstream helpers see accurate types.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f5e445a3888321b9f55683e11d0080