### PR TITLE
Refine graph cache type handling

### DIFF
--- a/src/tnfr/utils/cache.py
+++ b/src/tnfr/utils/cache.py
@@ -12,7 +12,14 @@ from __future__ import annotations
 import hashlib
 import threading
 from collections import defaultdict
-from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
+from collections.abc import (
+    Callable,
+    Hashable,
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+)
 from contextlib import contextmanager
 from functools import lru_cache
 from dataclasses import dataclass
@@ -22,7 +29,7 @@ from cachetools import LRUCache
 import networkx as nx
 
 from ..cache import CacheCapacityConfig, CacheManager
-from ..types import NodeId, TNFRGraph, TimingContext
+from ..types import GraphLike, NodeId, TNFRGraph, TimingContext
 from .graph import get_graph, mark_dnfr_prep_dirty
 from .init import get_logger, get_numpy
 from .io import json_dumps
@@ -402,7 +409,7 @@ _GRAPH_CACHE_MANAGER_KEY = "_tnfr_cache_manager"
 _GRAPH_CACHE_CONFIG_KEY = "_tnfr_cache_config"
 
 
-def _graph_cache_manager(graph: Any) -> CacheManager:
+def _graph_cache_manager(graph: MutableMapping[str, Any]) -> CacheManager:
     manager = graph.get(_GRAPH_CACHE_MANAGER_KEY)
     if not isinstance(manager, CacheManager):
         manager = CacheManager(default_capacity=128)
@@ -414,7 +421,7 @@ def _graph_cache_manager(graph: Any) -> CacheManager:
 
 
 def configure_graph_cache_limits(
-    G: Any,
+    G: GraphLike | TNFRGraph | MutableMapping[str, Any],
     *,
     default_capacity: int | None | object = CacheManager._MISSING,
     overrides: Mapping[str, int | None] | None = None,
@@ -442,8 +449,8 @@ class EdgeCacheManager:
 
     _STATE_KEY = "_edge_version_state"
 
-    def __init__(self, graph: Any) -> None:
-        self.graph = graph
+    def __init__(self, graph: MutableMapping[str, Any]) -> None:
+        self.graph: MutableMapping[str, Any] = graph
         self._manager = _graph_cache_manager(graph)
         self._manager.register(
             self._STATE_KEY,

--- a/src/tnfr/utils/cache.pyi
+++ b/src/tnfr/utils/cache.pyi
@@ -7,7 +7,7 @@ from typing import Any, ContextManager, Generic, TypeVar
 import networkx as nx
 
 from ..cache import CacheCapacityConfig, CacheManager
-from ..types import NodeId, TNFRGraph, TimingContext
+from ..types import GraphLike, NodeId, TNFRGraph, TimingContext
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
@@ -70,7 +70,7 @@ class EdgeCacheState:
 class EdgeCacheManager:
     _STATE_KEY: str
 
-    def __init__(self, graph: Any) -> None: ...
+    def __init__(self, graph: MutableMapping[str, Any]) -> None: ...
 
     def record_hit(self) -> None: ...
 
@@ -136,7 +136,7 @@ def ensure_node_offset_map(G: TNFRGraph) -> dict[NodeId, int]: ...
 
 
 def configure_graph_cache_limits(
-    G: Any,
+    G: GraphLike | TNFRGraph | MutableMapping[str, Any],
     *,
     default_capacity: int | None | object = CacheManager._MISSING,
     overrides: Mapping[str, int | None] | None = ...,


### PR DESCRIPTION
## Summary
- tighten graph cache helpers to operate on mutable metadata mappings
- extend cache configuration entry point to normalise GraphLike inputs before applying limits
- align typing stubs with new MutableMapping expectations for edge cache managers

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f5e666c37483218a210a01de9d4ba2