### PR TITLE
Align type stubs with runtime signatures for CLI, sense, ontosim, and tokens

### DIFF
--- a/src/tnfr/cli/__init__.pyi
+++ b/src/tnfr/cli/__init__.pyi
@@ -1,17 +1,47 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+import argparse
+from typing import Optional
 
-def __getattr__(name: str) -> Any: ...
+from ..types import ProgramTokens, TNFRGraph
 
-add_canon_toggle: Any
-add_common_args: Any
-add_grammar_args: Any
-add_grammar_selector_args: Any
-add_history_export_args: Any
-apply_cli_config: Any
-build_basic_graph: Any
-main: Any
-register_callbacks_and_observer: Any
-resolve_program: Any
-run_program: Any
+__all__: tuple[str, ...]
+
+
+def main(argv: Optional[list[str]] = None) -> int: ...
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None: ...
+
+
+def add_grammar_args(parser: argparse.ArgumentParser) -> None: ...
+
+
+def add_grammar_selector_args(parser: argparse.ArgumentParser) -> None: ...
+
+
+def add_history_export_args(parser: argparse.ArgumentParser) -> None: ...
+
+
+def add_canon_toggle(parser: argparse.ArgumentParser) -> None: ...
+
+
+def build_basic_graph(args: argparse.Namespace) -> TNFRGraph: ...
+
+
+def apply_cli_config(G: TNFRGraph, args: argparse.Namespace) -> None: ...
+
+
+def register_callbacks_and_observer(G: TNFRGraph) -> None: ...
+
+
+def resolve_program(
+    args: argparse.Namespace, default: Optional[ProgramTokens] = None
+) -> Optional[ProgramTokens]: ...
+
+
+def run_program(
+    G: Optional[TNFRGraph],
+    program: Optional[ProgramTokens],
+    args: argparse.Namespace,
+) -> TNFRGraph: ...

--- a/src/tnfr/ontosim.pyi
+++ b/src/tnfr/ontosim.pyi
@@ -1,9 +1,33 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from .types import TNFRConfigValue, TNFRGraph
 
-def __getattr__(name: str) -> Any: ...
+__all__: tuple[str, ...]
 
-preparar_red: Any
-run: Any
-step: Any
+
+def preparar_red(
+    G: TNFRGraph,
+    *,
+    init_attrs: bool = True,
+    override_defaults: bool = False,
+    **overrides: TNFRConfigValue,
+) -> TNFRGraph: ...
+
+
+def step(
+    G: TNFRGraph,
+    *,
+    dt: float | None = None,
+    use_Si: bool = True,
+    apply_glyphs: bool = True,
+) -> None: ...
+
+
+def run(
+    G: TNFRGraph,
+    steps: int,
+    *,
+    dt: float | None = None,
+    use_Si: bool = True,
+    apply_glyphs: bool = True,
+) -> None: ...

--- a/src/tnfr/sense.pyi
+++ b/src/tnfr/sense.pyi
@@ -1,15 +1,30 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from collections.abc import Mapping
+from typing import Optional
 
-def __getattr__(name: str) -> Any: ...
+from .types import NodeId, SigmaVector, TNFRGraph
 
-GLYPH_UNITS: Any
-glyph_angle: Any
-glyph_unit: Any
-push_sigma_snapshot: Any
-register_sigma_callback: Any
-sigma_rose: Any
-sigma_vector: Any
-sigma_vector_from_graph: Any
-sigma_vector_node: Any
+__all__: tuple[str, ...]
+
+GLYPH_UNITS: dict[str, complex]
+
+def glyph_angle(g: str) -> float: ...
+
+def glyph_unit(g: str) -> complex: ...
+
+def push_sigma_snapshot(G: TNFRGraph, t: Optional[float] = None) -> None: ...
+
+def register_sigma_callback(G: TNFRGraph) -> None: ...
+
+def sigma_rose(G: TNFRGraph, steps: Optional[int] = None) -> dict[str, int]: ...
+
+def sigma_vector(dist: Mapping[str, float]) -> SigmaVector: ...
+
+def sigma_vector_from_graph(
+    G: TNFRGraph, weight_mode: Optional[str] = None
+) -> SigmaVector: ...
+
+def sigma_vector_node(
+    G: TNFRGraph, n: NodeId, weight_mode: Optional[str] = None
+) -> Optional[SigmaVector]: ...

--- a/src/tnfr/tokens.pyi
+++ b/src/tnfr/tokens.pyi
@@ -1,13 +1,40 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Optional, Sequence, TypeAlias
 
-def __getattr__(name: str) -> Any: ...
+from .types import Glyph, NodeId
 
-Node: Any
-OpTag: Any
-TARGET: Any
-THOL: Any
-THOL_SENTINEL: Any
-Token: Any
-WAIT: Any
+__all__: tuple[str, ...]
+
+Node: TypeAlias = NodeId
+
+
+@dataclass(slots=True)
+class WAIT:
+    steps: int = 1
+
+
+@dataclass(slots=True)
+class TARGET:
+    nodes: Optional[Iterable[Node]] = None
+
+
+@dataclass(slots=True)
+class THOL:
+    body: Sequence["Token"]
+    repeat: int = 1
+    force_close: Optional[Glyph] = None
+
+
+Token: TypeAlias = Glyph | WAIT | TARGET | THOL | str
+
+THOL_SENTINEL: object
+
+
+class OpTag(Enum):
+    TARGET = ...
+    WAIT = ...
+    GLYPH = ...
+    THOL = ...


### PR DESCRIPTION
## Summary
- replace catch-all Any exports in CLI, sense, ontosim, and token stubs with precise signatures that mirror the runtime modules
- expose existing TNFR type aliases (TNFRGraph, ProgramTokens, SigmaVector, Glyph, Node) in the stubs and define the Token union explicitly
- drop generic __getattr__ fallbacks in favour of concrete typed definitions for the public API

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f5e8eecb9083219df6cbc5a0185b21