### PR TITLE
Add typed node initialization map alias

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from dataclasses import dataclass
 
 from .constants import VF_KEY, THETA_KEY, get_graph_param
 from .helpers.numeric import clamp
 from .rng import make_rng
+from .types import NodeInitAttrMap
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
@@ -62,7 +63,7 @@ class InitParams:
 
 
 def _init_phase(
-    nd: dict,
+    nd: NodeInitAttrMap,
     rng: random.Random,
     *,
     override: bool,
@@ -82,7 +83,7 @@ def _init_phase(
 
 
 def _init_vf(
-    nd: dict,
+    nd: NodeInitAttrMap,
     rng: random.Random,
     *,
     override: bool,
@@ -118,7 +119,7 @@ def _init_vf(
 
 
 def _init_si_epi(
-    nd: dict,
+    nd: NodeInitAttrMap,
     rng: random.Random,
     *,
     override: bool,
@@ -163,9 +164,10 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
 
     rng = make_rng(params.seed, -1, G)
     for _, nd in G.nodes(data=True):
+        node_attrs = cast(NodeInitAttrMap, nd)
 
         _init_phase(
-            nd,
+            node_attrs,
             rng,
             override=override,
             random_phase=params.init_rand_phase,
@@ -173,7 +175,7 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
             th_max=params.th_max,
         )
         _init_vf(
-            nd,
+            node_attrs,
             rng,
             override=override,
             mode=params.vf_mode,
@@ -186,7 +188,7 @@ def init_node_attrs(G: "nx.Graph", *, override: bool = True) -> "nx.Graph":
             clamp_to_limits=params.clamp_to_limits,
         )
         _init_si_epi(
-            nd,
+            node_attrs,
             rng,
             override=override,
             si_min=params.si_min,

--- a/src/tnfr/initialization.pyi
+++ b/src/tnfr/initialization.pyi
@@ -1,8 +1,73 @@
-from typing import Any
+from __future__ import annotations
 
-__all__: Any
+from dataclasses import dataclass
+import random
 
-def __getattr__(name: str) -> Any: ...
+import networkx as nx
 
-InitParams: Any
-init_node_attrs: Any
+from .types import NodeInitAttrMap
+
+__all__: tuple[str, str] = ("InitParams", "init_node_attrs")
+
+
+@dataclass
+class InitParams:
+    seed: int | None
+    init_rand_phase: bool
+    th_min: float
+    th_max: float
+    vf_mode: str
+    vf_min_lim: float
+    vf_max_lim: float
+    vf_uniform_min: float | None
+    vf_uniform_max: float | None
+    vf_mean: float
+    vf_std: float
+    clamp_to_limits: bool
+    si_min: float
+    si_max: float
+    epi_val: float
+
+    @classmethod
+    def from_graph(cls, G: nx.Graph) -> InitParams: ...
+
+
+def _init_phase(
+    nd: NodeInitAttrMap,
+    rng: random.Random,
+    *,
+    override: bool,
+    random_phase: bool,
+    th_min: float,
+    th_max: float,
+) -> None: ...
+
+
+def _init_vf(
+    nd: NodeInitAttrMap,
+    rng: random.Random,
+    *,
+    override: bool,
+    mode: str,
+    vf_uniform_min: float,
+    vf_uniform_max: float,
+    vf_mean: float,
+    vf_std: float,
+    vf_min_lim: float,
+    vf_max_lim: float,
+    clamp_to_limits: bool,
+) -> None: ...
+
+
+def _init_si_epi(
+    nd: NodeInitAttrMap,
+    rng: random.Random,
+    *,
+    override: bool,
+    si_min: float,
+    si_max: float,
+    epi_val: float,
+) -> None: ...
+
+
+def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph: ...

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Hashable, Mapping, Sequence
+from collections.abc import Callable, Hashable, Mapping, MutableMapping, Sequence
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -76,6 +76,7 @@ __all__ = (
     "SigmaVector",
     "FloatArray",
     "FloatMatrix",
+    "NodeInitAttrMap",
 )
 
 
@@ -107,6 +108,9 @@ NodeId: TypeAlias = Hashable
 
 Node: TypeAlias = NodeId
 #: Backwards-compatible alias for :data:`NodeId`.
+
+NodeInitAttrMap: TypeAlias = MutableMapping[str, float]
+#: Mutable mapping storing scalar node attributes during initialization.
 
 GammaSpec: TypeAlias = Mapping[str, Any]
 #: Mapping describing Γ evaluation parameters for a node or graph.


### PR DESCRIPTION
### Summary
- add the `NodeInitAttrMap` type alias to describe scalar node attribute maps used during initialization
- update initialization helpers to use the new alias and enrich the `.pyi` stub with concrete signatures
- ensure the dataclass stub for `InitParams` mirrors the runtime fields for tighter typing

### Testing
- python -m mypy src/tnfr

------
https://chatgpt.com/codex/tasks/task_e_68f5fba75fcc832187ad2944f1941fbc