### PR TITLE
Add pytest-based performance regression coverage

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Test suite overview
 
-This document describes the purpose of tests in the suite that monitor internal debugging and diagnostic features.
+This document describes the purpose of tests in the suite that monitor internal debugging, diagnostic features, and performance regressions.
 
 ## Debugging and diagnostic tests
 
@@ -11,3 +11,13 @@ This document describes the purpose of tests in the suite that monitor internal 
 - **test_diagnosis_state.py** – validates mapping of coherence metrics into diagnostic states.
 
 Tests that previously covered warning cache pruning and warn-once limits were removed to reduce maintenance overhead.
+
+## Performance regression tests
+
+- **performance/** – covers the NumPy-accelerated ΔNFR pipeline, alias caches, and trigonometric metrics to guard against performance regressions. The tests are marked `slow` and are excluded by default via `pytest.ini`.
+
+  ```bash
+  pytest -m slow tests/performance
+  ```
+
+  The suite requires NumPy for the vectorized branches; `pytest` will skip the affected checks automatically when the dependency is missing.

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance regression tests for TNFR hot paths."""

--- a/tests/performance/test_alias_cache_performance.py
+++ b/tests/performance/test_alias_cache_performance.py
@@ -1,0 +1,113 @@
+"""Performance regression coverage for alias caching utilities."""
+
+from __future__ import annotations
+
+import time
+
+import networkx as nx
+import pytest
+
+import numpy.testing as npt
+
+from tnfr.alias import (
+    collect_attr,
+    get_attr,
+    multi_recompute_abs_max,
+    set_attr,
+    set_attr_with_max,
+)
+from tnfr.constants import get_aliases
+
+pytestmark = pytest.mark.slow
+
+ALIAS_THETA = get_aliases("THETA")
+ALIAS_VF = get_aliases("VF")
+ALIAS_MAP = {"_vfmax": ALIAS_VF}
+
+
+def _seed_graph(num_nodes: int = 280, edge_probability: float = 0.2, *, seed: int = 33) -> nx.Graph:
+    graph = nx.gnp_random_graph(num_nodes, edge_probability, seed=seed)
+    for node in graph.nodes:
+        set_attr(graph.nodes[node], ALIAS_THETA, float(node % 7))
+        set_attr(graph.nodes[node], ALIAS_VF, 0.0)
+    return graph
+
+
+def _measure(callback, loops: int) -> float:
+    start = time.perf_counter()
+    for _ in range(loops):
+        callback()
+    return time.perf_counter() - start
+
+
+def test_collect_attr_numpy_vectorization_is_significantly_faster():
+    np = pytest.importorskip("numpy")
+
+    graph_fast = _seed_graph(seed=41)
+    graph_slow = graph_fast.copy()
+
+    def run_fast() -> None:
+        collect_attr(graph_fast, graph_fast.nodes, ALIAS_THETA, 0.0, np=np)
+
+    def run_slow() -> None:
+        [collect_attr(graph_slow, [node], ALIAS_THETA, 0.0)[0] for node in graph_slow.nodes]
+
+    run_fast()
+    run_slow()
+
+    loops = 6
+    fast_time = _measure(run_fast, loops)
+    slow_time = _measure(run_slow, loops)
+
+    assert fast_time < slow_time
+    assert fast_time <= slow_time * 0.45
+
+    fast_values = collect_attr(graph_fast, graph_fast.nodes, ALIAS_THETA, 0.0, np=np)
+    slow_values = np.array(
+        [collect_attr(graph_fast, [node], ALIAS_THETA, 0.0)[0] for node in graph_fast.nodes],
+        dtype=float,
+    )
+    npt.assert_allclose(fast_values, slow_values, rtol=0.0, atol=0.0)
+
+
+def test_set_attr_with_max_cache_beats_full_recompute():
+    graph_cached = _seed_graph(seed=57)
+    graph_naive = graph_cached.copy()
+
+    for node in graph_cached.nodes:
+        set_attr_with_max(graph_cached, node, ALIAS_VF, 0.0, cache="_vfmax")
+        set_attr(graph_naive.nodes[node], ALIAS_VF, 0.0)
+    multi_recompute_abs_max(graph_naive, ALIAS_MAP)
+
+    nodes = list(graph_cached.nodes)
+    values = [float(index) for index in range(len(nodes))]
+
+    def run_cached() -> None:
+        for node, value in zip(nodes, values):
+            set_attr_with_max(graph_cached, node, ALIAS_VF, value, cache="_vfmax")
+
+    def run_full() -> None:
+        for node, value in zip(nodes, values):
+            set_attr(graph_naive.nodes[node], ALIAS_VF, value)
+            multi_recompute_abs_max(graph_naive, ALIAS_MAP)
+
+    run_cached()
+    run_full()
+
+    loops = 3
+    cached_time = _measure(run_cached, loops)
+    full_time = _measure(run_full, loops)
+
+    assert cached_time < full_time
+    assert cached_time <= full_time * 0.4
+
+    cached_max = float(graph_cached.graph.get("_vfmax", 0.0))
+    cached_node = graph_cached.graph.get("_vfmax_node")
+    expected_values = multi_recompute_abs_max(graph_cached, ALIAS_MAP)
+    expected_max = float(expected_values["_vfmax"])
+    expected_node = max(
+        nodes,
+        key=lambda node: abs(get_attr(graph_cached.nodes[node], ALIAS_VF, 0.0)),
+    )
+    assert cached_max == expected_max
+    assert cached_node == expected_node

--- a/tests/performance/test_dynamics_performance.py
+++ b/tests/performance/test_dynamics_performance.py
@@ -1,0 +1,270 @@
+"""Performance regression coverage for ΔNFR computations."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+import networkx as nx
+import pytest
+
+np = pytest.importorskip("numpy")
+import numpy.testing as npt
+
+from tnfr.alias import collect_attr, set_attr
+from tnfr.constants import get_aliases
+from tnfr.dynamics import default_compute_delta_nfr, _prepare_dnfr_data
+from tnfr.dynamics.dnfr import (
+    _accumulate_neighbors_numpy,
+    _build_edge_index_arrays,
+    _init_neighbor_sums,
+    _resolve_numpy_degree_array,
+)
+from tnfr.utils import cached_nodes_and_A
+
+pytestmark = pytest.mark.slow
+
+ALIAS_THETA = get_aliases("THETA")
+ALIAS_EPI = get_aliases("EPI")
+ALIAS_VF = get_aliases("VF")
+ALIAS_DNFR = get_aliases("DNFR")
+
+DNFR_WEIGHTS = {
+    "phase": 0.4,
+    "epi": 0.3,
+    "vf": 0.2,
+    "topo": 0.1,
+}
+
+
+def _seed_graph(num_nodes: int = 160, edge_probability: float = 0.35, *, seed: int = 42) -> nx.Graph:
+    graph = nx.gnp_random_graph(num_nodes, edge_probability, seed=seed)
+    for node in graph.nodes:
+        set_attr(graph.nodes[node], ALIAS_THETA, 0.1 * (node + 1))
+        set_attr(graph.nodes[node], ALIAS_EPI, 0.05 * (node + 2))
+        set_attr(graph.nodes[node], ALIAS_VF, 0.02 * (node + 3))
+    graph.graph["DNFR_WEIGHTS"] = dict(DNFR_WEIGHTS)
+    return graph
+
+
+def _naive_prepare(graph: nx.Graph):
+    nodes, _ = cached_nodes_and_A(graph, cache_size=1)
+    theta = collect_attr(graph, nodes, ALIAS_THETA, 0.0)
+    epi = collect_attr(graph, nodes, ALIAS_EPI, 0.0)
+    vf = collect_attr(graph, nodes, ALIAS_VF, 0.0)
+    return theta, epi, vf
+
+
+def _legacy_numpy_stack_accumulation(graph, data, *, buffers):
+    x, y, epi_sum, vf_sum, count, deg_sum, _ = buffers
+    nodes = data["nodes"]
+    if not nodes:
+        return buffers
+
+    cache = data.get("cache")
+
+    epi = data.get("epi_np")
+    if epi is None:
+        epi = np.array(data["epi"], dtype=float)
+        data["epi_np"] = epi
+        if cache is not None:
+            cache.epi_np = epi
+
+    cos_th = data.get("cos_theta_np")
+    if cos_th is None:
+        cos_th = np.array(data["cos_theta"], dtype=float)
+        data["cos_theta_np"] = cos_th
+        if cache is not None:
+            cache.cos_theta_np = cos_th
+
+    sin_th = data.get("sin_theta_np")
+    if sin_th is None:
+        sin_th = np.array(data["sin_theta"], dtype=float)
+        data["sin_theta_np"] = sin_th
+        if cache is not None:
+            cache.sin_theta_np = sin_th
+
+    vf = data.get("vf_np")
+    if vf is None:
+        vf = np.array(data["vf"], dtype=float)
+        data["vf_np"] = vf
+        if cache is not None:
+            cache.vf_np = vf
+
+    edge_src = data.get("edge_src")
+    edge_dst = data.get("edge_dst")
+    if edge_src is None or edge_dst is None:
+        edge_src, edge_dst = _build_edge_index_arrays(graph, nodes, data["idx"], np)
+        data["edge_src"] = edge_src
+        data["edge_dst"] = edge_dst
+        if cache is not None:
+            cache.edge_src = edge_src
+            cache.edge_dst = edge_dst
+
+    count.fill(0.0)
+    if edge_src.size:
+        np.add.at(count, edge_src, 1.0)
+
+    component_sources = [cos_th, sin_th, epi, vf]
+    deg_column = None
+    deg_array = None
+    if deg_sum is not None:
+        deg_sum.fill(0.0)
+        deg_array = _resolve_numpy_degree_array(
+            data, count if count is not None else None, cache=cache, np=np
+        )
+        if deg_array is not None:
+            deg_column = len(component_sources)
+            component_sources.append(deg_array)
+
+    stacked = np.empty((len(nodes), len(component_sources)), dtype=float)
+    for col, src_vec in enumerate(component_sources):
+        np.copyto(stacked[:, col], src_vec, casting="unsafe")
+
+    accum = np.zeros_like(stacked)
+    if edge_src.size:
+        edge_values = np.empty((edge_src.size, len(component_sources)), dtype=float)
+        np.copyto(edge_values, stacked[edge_dst], casting="unsafe")
+        np.add.at(accum, edge_src, edge_values)
+
+    np.copyto(x, accum[:, 0], casting="unsafe")
+    np.copyto(y, accum[:, 1], casting="unsafe")
+    np.copyto(epi_sum, accum[:, 2], casting="unsafe")
+    np.copyto(vf_sum, accum[:, 3], casting="unsafe")
+    if deg_column is not None and deg_sum is not None:
+        np.copyto(deg_sum, accum[:, deg_column], casting="unsafe")
+
+    return (
+        x,
+        y,
+        epi_sum,
+        vf_sum,
+        count,
+        deg_sum,
+        deg_array,
+    )
+
+
+def _measure(runtime_fn: Callable[[], None], loops: int) -> float:
+    start = time.perf_counter()
+    for _ in range(loops):
+        runtime_fn()
+    return time.perf_counter() - start
+
+
+def test_default_compute_delta_nfr_vectorized_is_faster_and_equivalent():
+    base_graph = _seed_graph()
+    vectorized_graph = base_graph.copy()
+    fallback_graph = base_graph.copy()
+    fallback_graph.graph["vectorized_dnfr"] = False
+
+    # Warm caches before measuring.
+    default_compute_delta_nfr(vectorized_graph)
+    default_compute_delta_nfr(fallback_graph)
+
+    loops = 2
+    vector_time = _measure(
+        lambda: default_compute_delta_nfr(vectorized_graph),
+        loops,
+    )
+    fallback_time = _measure(
+        lambda: default_compute_delta_nfr(fallback_graph),
+        loops,
+    )
+
+    assert vector_time < fallback_time
+    assert vector_time <= fallback_time * 0.85
+
+    vector_dnfr = [vectorized_graph.nodes[n][ALIAS_DNFR] for n in vectorized_graph.nodes]
+    fallback_dnfr = [fallback_graph.nodes[n][ALIAS_DNFR] for n in fallback_graph.nodes]
+    npt.assert_allclose(vector_dnfr, fallback_dnfr, rtol=1e-9, atol=1e-9)
+
+
+def test_prepare_dnfr_data_stays_faster_than_naive_collector():
+    graph_opt = _seed_graph(seed=7)
+    graph_naive = graph_opt.copy()
+
+    loops = 5
+
+    # Warm up caches so both paths reuse prepared buffers.
+    _ = _prepare_dnfr_data(graph_opt)
+    _ = _prepare_dnfr_data(graph_naive)
+
+    opt_time = _measure(lambda: _prepare_dnfr_data(graph_opt), loops)
+    naive_time = _measure(lambda: _naive_prepare(graph_naive), loops)
+
+    assert opt_time < naive_time
+    assert opt_time <= naive_time * 0.75
+
+    theta, epi, vf = _naive_prepare(graph_opt)
+    optimized_data = _prepare_dnfr_data(graph_opt)
+    npt.assert_allclose(optimized_data["theta"], theta, rtol=0.0, atol=0.0)
+    npt.assert_allclose(optimized_data["epi"], epi, rtol=0.0, atol=0.0)
+    npt.assert_allclose(optimized_data["vf"], vf, rtol=0.0, atol=0.0)
+
+
+def test_neighbor_accumulation_numpy_outperforms_stack_strategy():
+    graph_modern = _seed_graph(seed=9)
+    graph_legacy = graph_modern.copy()
+
+    modern_data = _prepare_dnfr_data(graph_modern)
+    legacy_data = _prepare_dnfr_data(graph_legacy)
+
+    modern_buffers = _init_neighbor_sums(modern_data, np=np)
+    legacy_buffers = _init_neighbor_sums(legacy_data, np=np)
+
+    # Warm up buffers before timing.
+    _accumulate_neighbors_numpy(graph_modern, modern_data, np=np, **{
+        "x": modern_buffers[0],
+        "y": modern_buffers[1],
+        "epi_sum": modern_buffers[2],
+        "vf_sum": modern_buffers[3],
+        "count": modern_buffers[4],
+        "deg_sum": modern_buffers[5],
+    })
+    _legacy_numpy_stack_accumulation(graph_legacy, legacy_data, buffers=legacy_buffers)
+
+    loops = 5
+    modern_time = _measure(
+        lambda: _accumulate_neighbors_numpy(
+            graph_modern,
+            modern_data,
+            x=modern_buffers[0],
+            y=modern_buffers[1],
+            epi_sum=modern_buffers[2],
+            vf_sum=modern_buffers[3],
+            count=modern_buffers[4],
+            deg_sum=modern_buffers[5],
+            np=np,
+        ),
+        loops,
+    )
+    legacy_time = _measure(
+        lambda: _legacy_numpy_stack_accumulation(
+            graph_legacy, legacy_data, buffers=legacy_buffers
+        ),
+        loops,
+    )
+
+    assert modern_time < legacy_time
+    assert modern_time <= legacy_time * 0.65
+
+    modern_result = _accumulate_neighbors_numpy(
+        graph_modern,
+        modern_data,
+        x=modern_buffers[0],
+        y=modern_buffers[1],
+        epi_sum=modern_buffers[2],
+        vf_sum=modern_buffers[3],
+        count=modern_buffers[4],
+        deg_sum=modern_buffers[5],
+        np=np,
+    )
+    legacy_result = _legacy_numpy_stack_accumulation(
+        graph_legacy, legacy_data, buffers=legacy_buffers
+    )
+    for modern_arr, legacy_arr in zip(modern_result, legacy_result):
+        if modern_arr is None or legacy_arr is None:
+            assert modern_arr is legacy_arr is None
+        else:
+            npt.assert_allclose(modern_arr, legacy_arr, rtol=1e-9, atol=1e-9)

--- a/tests/performance/test_metrics_performance.py
+++ b/tests/performance/test_metrics_performance.py
@@ -1,0 +1,77 @@
+"""Performance regression coverage for metric helpers."""
+
+from __future__ import annotations
+
+import math
+import time
+
+import networkx as nx
+import pytest
+
+np = pytest.importorskip("numpy")
+import numpy.testing as npt
+
+from tnfr.alias import set_attr
+from tnfr.constants import get_aliases
+from tnfr.metrics.trig import neighbor_phase_mean
+from tnfr.node import NodoNX
+
+pytestmark = pytest.mark.slow
+
+ALIAS_THETA = get_aliases("THETA")
+
+
+def _seed_graph(num_nodes: int = 220, edge_probability: float = 0.25, *, seed: int = 21) -> nx.Graph:
+    graph = nx.gnp_random_graph(num_nodes, edge_probability, seed=seed)
+    for node in graph.nodes:
+        set_attr(graph.nodes[node], ALIAS_THETA, 0.1 * (node + 1))
+    return graph
+
+
+def _naive_neighbor_phase_mean(G: nx.Graph, node) -> float:
+    wrapper = NodoNX(G, node)
+    x = y = 0.0
+    count = 0
+    for neighbor in wrapper.neighbors():
+        th = NodoNX.from_graph(wrapper.G, neighbor).theta
+        x += math.cos(th)
+        y += math.sin(th)
+        count += 1
+    if count == 0:
+        return wrapper.theta
+    return math.atan2(y, x)
+
+
+def _measure(callback, loops: int) -> float:
+    start = time.perf_counter()
+    for _ in range(loops):
+        callback()
+    return time.perf_counter() - start
+
+
+def test_neighbor_phase_mean_vectorized_outperforms_naive_wrapper():
+    graph_fast = _seed_graph()
+    graph_slow = graph_fast.copy()
+
+    def run_fast() -> None:
+        for node in graph_fast.nodes:
+            neighbor_phase_mean(graph_fast, node)
+
+    def run_slow() -> None:
+        for node in graph_slow.nodes:
+            _naive_neighbor_phase_mean(graph_slow, node)
+
+    # Warm caches to avoid measuring import overhead.
+    run_fast()
+    run_slow()
+
+    loops = 5
+    fast_time = _measure(run_fast, loops)
+    slow_time = _measure(run_slow, loops)
+
+    assert fast_time < slow_time
+    assert fast_time <= slow_time * 0.5
+
+    fast_angles = [neighbor_phase_mean(graph_fast, node) for node in graph_fast.nodes]
+    slow_angles = [_naive_neighbor_phase_mean(graph_slow, node) for node in graph_slow.nodes]
+    npt.assert_allclose(fast_angles, slow_angles, rtol=1e-9, atol=1e-9)


### PR DESCRIPTION
## Summary
- add slow-marked performance regression tests covering the ΔNFR pipeline, trigonometric metrics, and alias caches
- document how to run the performance suite alongside the existing diagnostics overview

## Testing
- pytest -m slow tests/performance *(fails: ImportError due to existing indentation error in tnfr/dynamics/integrators.py)*

------
https://chatgpt.com/codex/tasks/task_e_68f601d9ed808321ac5e26b29f5cf054