### PR TITLE
Align benchmark handling in pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 pythonpath = src
-addopts = -m "not slow" --ignore=benchmarks
+addopts = -m "not slow" --benchmark-skip
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    benchmarks: run with 'pytest benchmarks --benchmark-only' to execute the benchmark suite


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Switch pytest benchmark handling to `--benchmark-skip` so benchmark tests stay collected but skipped by default.
- Document how to run the benchmark suite directly via `pytest benchmarks --benchmark-only` within the markers block.

## Testing
- `pytest` *(fails: missing optional dependency `numpy` required by collected tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f60e265fe483218faa41d2e2a1ecaa