### PR TITLE
Translate landing page to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>TNFR Python Engine · Teoría y Motor</title>
+  <title>TNFR Python Engine · Theory and Engine</title>
   <style>
     :root {
       color-scheme: dark;
@@ -177,34 +177,34 @@
     <div class="frame">
       <nav>
         <span class="brand">TNFR · Python Engine</span>
-        <span class="brand" style="opacity: 0.6">Teoría · Resonancia · Simulación</span>
+        <span class="brand" style="opacity: 0.6">Theory · Resonance · Simulation</span>
       </nav>
       <div class="hero">
         <div>
-          <h1 class="tagline">La teoría TNFR, condensada.</h1>
+          <h1 class="tagline">The TNFR theory, distilled.</h1>
           <p class="lead">
-            TNFR explora patrones de resonancia no lineal para describir cómo sistemas complejos se auto-organizan en dominios cuánticos y macroscópicos. Este repositorio es el motor experimental en Python que convierte esas hipótesis en simulaciones reproducibles.
+            TNFR explores nonlinear resonance patterns to describe how complex systems self-organize across quantum and macroscopic domains. This repository is the experimental Python engine that turns those hypotheses into reproducible simulations.
           </p>
           <div class="hero-actions">
-            <a class="btn primary" href="#paquete">Instalar el paquete</a>
-            <a class="btn secondary" href="#innovaciones">Explorar novedades</a>
+            <a class="btn primary" href="#paquete">Install the package</a>
+            <a class="btn secondary" href="#innovaciones">Explore recent work</a>
           </div>
           <div class="metrics">
-            <span class="pill">C(t) · Coherencia global</span>
-            <span class="pill">ΔNFR · Dinámica estructural</span>
-            <span class="pill">Si · Índice de sentido nodal</span>
-            <span class="pill">φ · Control de fase</span>
+            <span class="pill">C(t) · Global coherence</span>
+            <span class="pill">ΔNFR · Structural dynamics</span>
+            <span class="pill">Si · Nodal sense index</span>
+            <span class="pill">φ · Phase control</span>
           </div>
         </div>
         <div class="hero-visual">
           <figure>
-            <img src="img/network.png" alt="Visualización de una red resonante TNFR" />
-            <figcaption>Red TNFR con acoples coherentes y trazabilidad completa.</figcaption>
+            <img src="img/network.png" alt="Visualization of a resonant TNFR network" />
+            <figcaption>TNFR network with coherent couplings and full traceability.</figcaption>
           </figure>
         </div>
         <div class="hero-visual">
           <figure>
-            <img src="img/network.png" alt="Red TNFR" />
+            <img src="img/network.png" alt="TNFR network" />
           </figure>
         </div>
       </div>
@@ -215,25 +215,25 @@
     <div class="frame">
       <div class="cards">
         <article class="card">
-          <h3>Teoría en tres pulsos</h3>
+          <h3>Theory in Three Pulses</h3>
           <ul>
-            <li>Campo tensorial neutro que vincula nodos resonantes sin contacto directo.</li>
-            <li>Escalas acopladas: las métricas locales afectan la estabilidad global de la red.</li>
-            <li>Predicción de ventanas caóticas donde emergen patrones coherentes observables.</li>
+            <li>Neutral tensor field linking resonant nodes without direct contact.</li>
+            <li>Coupled scales where local metrics influence the global stability of the network.</li>
+            <li>Prediction of chaotic windows where observable coherent patterns emerge.</li>
           </ul>
         </article>
         <article class="card">
-          <h3>Qué ofrece el repositorio</h3>
+          <h3>What the Repository Provides</h3>
           <ul>
-            <li>Módulos para generar mallas TNFR y resolver su dinámica temporal.</li>
-            <li>Herramientas de calibración con datos experimentales y registros sintéticos.</li>
-            <li>Scripts de visualización para examinar resonancias, espectros y energía distribuida.</li>
+            <li>Modules to generate TNFR meshes and resolve their temporal dynamics.</li>
+            <li>Calibration tools for experimental data and synthetic records.</li>
+            <li>Visualization scripts to examine resonances, spectra, and distributed energy.</li>
           </ul>
         </article>
         <article class="card">
-          <h3>Cómo empezar</h3>
+          <h3>How to Get Started</h3>
           <p>
-            Clona el proyecto, instala las dependencias de <code>requirements.txt</code> y ejecuta los cuadernos de ejemplo para observar la transición entre fase estable y región caótica.
+            Clone the project, install the dependencies from <code>requirements.txt</code>, and run the example notebooks to observe the transition between the stable phase and the chaotic region.
           </p>
         </article>
       </div>
@@ -241,7 +241,7 @@
   </section>
 
   <footer>
-    <div class="frame">TNFR Python Engine · Laboratorio de Resonancias Fractales</div>
+    <div class="frame">TNFR Python Engine · Fractal Resonance Laboratory</div>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the landing page metadata and navigation copy to English
- translate hero content, calls to action, metrics, and imagery descriptions while preserving scientific intent
- localize section headings, bullet points, onboarding guidance, and footer into natural English

## Testing
- not run (static content changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f61889ef68832180d778c650feb583