### PR TITLE
Move flake8 and pytest config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.flake8]
+max-line-length = 79
+ignore = ["E501", "W503"]
+exclude = ["benchmarks/"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-m \"not slow\" --benchmark-skip"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "benchmarks: run with 'pytest benchmarks --benchmark-only' to execute the benchmark suite",
+]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` with the existing Flake8 and Pytest options migrated from the legacy configuration files

## Testing
- flake8
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f61875bb38832182469e548192170a