### PR TITLE
Improve hero call-to-action styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,110 @@
       z-index: 1;
     }
 
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.85rem;
+      align-items: center;
+      margin-top: 2rem;
+    }
+
+    .hero-actions .btn {
+      flex: 0 1 auto;
+    }
+
+    .metrics {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 1.75rem;
+    }
+
+    @media (min-width: 720px) {
+      .metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.9rem;
+      }
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.75rem 1.55rem;
+      border-radius: 999px;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      text-decoration: none;
+      color: var(--fg);
+      border: 1px solid transparent;
+      position: relative;
+      transition: transform 0.22s ease, box-shadow 0.22s ease, background-color 0.22s ease,
+        border-color 0.22s ease;
+      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+    }
+
+    .btn::after {
+      content: "";
+      position: absolute;
+      inset: -2px;
+      border-radius: 999px;
+      border: 1px solid rgba(90, 216, 255, 0.22);
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.22s ease;
+    }
+
+    .btn:hover,
+    .btn:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 26px 36px rgba(0, 0, 0, 0.4);
+    }
+
+    .btn:focus-visible::after {
+      opacity: 1;
+    }
+
+    .btn.primary {
+      background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+      border-color: rgba(90, 216, 255, 0.32);
+      color: #05060d;
+    }
+
+    .btn.primary:hover,
+    .btn.primary:focus-visible {
+      background: linear-gradient(135deg, #7d76ff, #74e2ff);
+    }
+
+    .btn.secondary {
+      background: rgba(15, 20, 44, 0.78);
+      border-color: rgba(90, 216, 255, 0.28);
+      color: var(--fg);
+    }
+
+    .btn.secondary:hover,
+    .btn.secondary:focus-visible {
+      background: rgba(27, 35, 68, 0.9);
+      border-color: rgba(90, 216, 255, 0.45);
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(90, 216, 255, 0.12);
+      border: 1px solid rgba(90, 216, 255, 0.3);
+      color: var(--fg);
+      font-size: 0.85rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      box-shadow: 0 0 16px rgba(90, 216, 255, 0.18);
+      backdrop-filter: blur(6px);
+    }
+
     .hero-visual {
       justify-self: center;
     }


### PR DESCRIPTION
## Summary
- add responsive flex/grid layouts for hero action and metric groups to keep content aligned
- introduce button variants with contrastful hover and focus states for the hero calls to action
- style metric pills as badge-like chips with soft glow for visual hierarchy

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68f6198c18d48321913ad6eb939e99d3