### PR TITLE
Remove hero visual images from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,17 +300,7 @@
             <span class="pill">φ · Phase control</span>
           </div>
         </div>
-        <div class="hero-visual">
-          <figure>
-            <img src="img/network.png" alt="Visualization of a resonant TNFR network" />
-            <figcaption>TNFR network with coherent couplings and full traceability.</figcaption>
-          </figure>
-        </div>
-        <div class="hero-visual">
-          <figure>
-            <img src="img/network.png" alt="TNFR network" />
-          </figure>
-        </div>
+        
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- remove the redundant hero visual image blocks from the landing page to prevent rendering the images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f61bd573808321b0ad46d45b3d5b96