### PR TITLE
Centralize flake8 configuration in pyproject

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 79
-ignore = E501,W503
-exclude = benchmarks/

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -33,6 +33,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[test,typecheck]
 
+      - name: Run flake8
+        run: python -m flake8 src
+
       - name: Run pydocstyle
         run: python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,15 @@ dependencies = [
 numpy = ["numpy>=1.24"]
 yaml = ["pyyaml>=6.0"]
 orjson = ["orjson>=3"]
-test = ["pytest>=7", "pytest-benchmark>=4", "pydocstyle>=6", "coverage>=7", "vulture>=2"]
+test = [
+  "pytest>=7",
+  "pytest-benchmark>=4",
+  "pydocstyle>=6",
+  "coverage>=7",
+  "flake8>=5",
+  "flake8-pyproject>=1.2",
+  "vulture>=2",
+]
 typecheck = [
   "mypy>=1.8",
   "networkx-stubs>=0.0.1",
@@ -55,6 +63,11 @@ version = { attr = "tnfr._version.__version__" }
 
 [tool.setuptools.package-data]
 tnfr = ["py.typed"]
+
+[tool.flake8]
+max-line-length = 79
+ignore = ["E501", "W503"]
+exclude = ["benchmarks/"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,6 +4,7 @@ export PYTHONPATH="$PWD/src"
 
 # Keep dependency extras aligned with .github/workflows/type-check.yml.
 python -m pip install --quiet ".[test,typecheck]"
+python -m flake8 src
 python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py
 # Mirrors the mypy invocation in .github/workflows/type-check.yml.
 python -m mypy src/tnfr


### PR DESCRIPTION
## Summary
- move the flake8 configuration into `pyproject.toml` and drop the legacy `.flake8`
- ensure the shared test extras include flake8 with `pyproject.toml` support and run it in local/CI scripts

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f61b4a4c748321a8ab3381ef79338e