### PR TITLE
Align pytest configuration with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,14 @@ max-line-length = 79
 ignore = ["E501", "W503"]
 exclude = ["benchmarks/"]
 
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-m 'not slow' --benchmark-skip"
+markers = [
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "benchmarks: run with 'pytest benchmarks --benchmark-only' to execute the benchmark suite",
+]
+
 [tool.mypy]
 python_version = "3.10"
 warn_unused_configs = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-pythonpath = src
-addopts = -m "not slow" --benchmark-skip
-markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')
-    benchmarks: run with 'pytest benchmarks --benchmark-only' to execute the benchmark suite

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ Tests that previously covered warning cache pruning and warn-once limits were re
 
 ## Performance regression tests
 
-- **performance/** – covers the NumPy-accelerated ΔNFR pipeline, alias caches, and trigonometric metrics to guard against performance regressions. The tests are marked `slow` and are excluded by default via `pytest.ini`.
+- **performance/** – covers the NumPy-accelerated ΔNFR pipeline, alias caches, and trigonometric metrics to guard against performance regressions. The tests are marked `slow` and are excluded by default via the `addopts` setting in `pyproject.toml`.
 
   ```bash
   pytest -m slow tests/performance


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Move pytest path, option, and marker configuration into `pyproject.toml`'s `[tool.pytest.ini_options]` section to consolidate tooling settings.
- Remove the legacy `pytest.ini` file and update the test suite documentation to reference the new configuration location.

## Testing
- `python -m pytest --override-ini=pythonpath=src` *(fails: pre-existing assertions in TNFR core tests; command confirms pytest now reads `pyproject.toml` as its configuration file).*

------
https://chatgpt.com/codex/tasks/task_e_68f61d1a5e008321ba14cab0fcbc4e8b