### PR TITLE
Add prepare_network helper and document preparar_red alias

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -88,6 +88,23 @@ Both `tnfr.dynamics.step` and `tnfr.dynamics.run` accept an optional `n_jobs` di
 pin process/thread counts for ΔNFR, Si, integrators, phase coordination, and νf adaptation
 without mutating `G.graph`.
 
+### Preparing existing graphs
+
+When you build a NetworkX graph outside of `create_nfr`, normalise its configuration with
+`tnfr.prepare_network` before stepping the dynamics. The helper attaches the default
+configuration, telemetry history, ΔNFR hook, and optional observer wiring. The legacy name
+`tnfr.preparar_red` remains available throughout the 1.x releases but will be removed in the
+next major version.
+
+```python
+import networkx as nx
+from tnfr import prepare_network
+
+G = nx.path_graph(4)
+G.graph["ATTACH_STD_OBSERVER"] = True
+prepare_network(G)
+```
+
 ## CLI quickstart
 
 The CLI mirrors the Python API while enforcing the canonical operator tokens. Create a

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ $\partial EPI/\partial t = \nu_f \cdot \Delta NFR(t)$.
   helper facades for reproducible experiments.
 - [Examples library](examples/README.md): runnable scenarios (controlled dissonance loop and
   optical cavity feedback) with CLI counterparts.
+- [Release notes](releases.md): API transitions, compatibility windows, and deprecation timelines.
 
 ## Canonical references
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,14 @@
+# Release notes
+
+## Upcoming (1.x compatibility window)
+
+- Renamed the network preparation helper to `prepare_network` for
+  consistency with the English-facing API. The previous Spanish name
+  `preparar_red` is still exported as a legacy alias and will keep
+  forwarding to `prepare_network` for every 1.x release.
+- Deprecation timeline: the alias will be removed in the first 2.0.0
+  pre-release. Projects using `preparar_red` should migrate now and
+  monitor the release notes for the final removal date.
+
+All other helpers continue to honour the existing dependency manifest
+and import semantics.

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -17,13 +17,14 @@ The imports are grouped as follows:
     orchestration, validation hooks and metrics integration) and require
     the ``networkx`` package for graph handling.
 
-``preparar_red``
+``prepare_network`` (``preparar_red`` legacy alias)
     Defined in :mod:`tnfr.ontosim`.  Besides :mod:`tnfr.ontosim`
     itself, the helper imports :mod:`tnfr.callback_utils`,
     :mod:`tnfr.constants`, :mod:`tnfr.dynamics`, :mod:`tnfr.glyph_history`,
     :mod:`tnfr.initialization` and :mod:`tnfr.utils` to assemble the
     graph preparation pipeline.  It also requires ``networkx`` at import
-    time.
+    time.  ``preparar_red`` remains available for backwards compatibility
+    during the 1.x series and forwards to :func:`prepare_network`.
 
 ``create_nfr`` / ``run_sequence``
     Re-exported from :mod:`tnfr.structural`.  They depend on
@@ -51,6 +52,18 @@ EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "run": {
         "submodules": ("tnfr.dynamics",),
+        "third_party": ("networkx",),
+    },
+    "prepare_network": {
+        "submodules": (
+            "tnfr.ontosim",
+            "tnfr.callback_utils",
+            "tnfr.constants",
+            "tnfr.dynamics",
+            "tnfr.glyph_history",
+            "tnfr.initialization",
+            "tnfr.utils",
+        ),
         "third_party": ("networkx",),
     },
     "preparar_red": {
@@ -232,7 +245,10 @@ def _assign_exports(module: str, names: tuple[str, ...]) -> bool:
 _assign_exports("dynamics", ("step", "run"))
 
 
-_HAS_PREPARAR_RED = _assign_exports("ontosim", ("preparar_red",))
+_HAS_PREPARAR_RED = _assign_exports(
+    "ontosim", ("prepare_network", "preparar_red")
+)
+_HAS_PREPARE_NETWORK = _HAS_PREPARAR_RED
 
 
 _HAS_RUN_SEQUENCE = _assign_exports("structural", ("create_nfr", "run_sequence"))
@@ -259,6 +275,7 @@ __all__ = [
     "__version__",
     "step",
     "run",
+    "prepare_network",
     "preparar_red",
     "create_nfr",
 ]

--- a/src/tnfr/__init__.pyi
+++ b/src/tnfr/__init__.pyi
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import Any, NoReturn
 
 from .dynamics import run, step
-from .ontosim import preparar_red
+from .ontosim import prepare_network, preparar_red
 from .structural import create_nfr, run_sequence
 
 EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]]
@@ -37,4 +37,5 @@ def _assign_exports(module: str, names: tuple[str, ...]) -> bool: ...
 def _emit_missing_dependency_warning() -> None: ...
 
 _HAS_PREPARAR_RED: bool
+_HAS_PREPARE_NETWORK: bool
 _HAS_RUN_SEQUENCE: bool

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -28,7 +28,7 @@ from ..config.presets import get_preset
 from ..config import apply_config
 from ..io import read_structured_file, safe_write, StructuredFileError
 from ..glyph_history import ensure_history
-from ..ontosim import preparar_red
+from ..ontosim import prepare_network
 from ..types import ProgramTokens
 from ..utils import get_logger, json_dumps
 from ..flatten import parse_program_tokens
@@ -143,7 +143,7 @@ def _build_graph_from_args(args: argparse.Namespace) -> "nx.Graph":
     apply_cli_config(G, args)
     if getattr(args, "observer", False):
         G.graph["ATTACH_STD_OBSERVER"] = True
-    preparar_red(G)
+    prepare_network(G)
     register_callbacks_and_observer(G)
     return G
 

--- a/src/tnfr/cli/execution.pyi
+++ b/src/tnfr/cli/execution.pyi
@@ -24,7 +24,7 @@ from ..metrics import (
     build_metrics_summary,
 )
 from ..metrics.core import _metrics_step
-from ..ontosim import preparar_red
+from ..ontosim import prepare_network
 from ..sense import register_sigma_callback
 from ..trace import register_trace
 from ..types import Glyph, ProgramTokens

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -16,10 +16,10 @@ if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
 
 # API de alto nivel
-__all__ = ("preparar_red", "step", "run")
+__all__ = ("prepare_network", "preparar_red", "step", "run")
 
 
-def preparar_red(
+def prepare_network(
     G: "nx.Graph",
     *,
     init_attrs: bool = True,
@@ -27,6 +27,12 @@ def preparar_red(
     **overrides,
 ) -> "nx.Graph":
     """Prepare ``G`` for simulation.
+
+    Notes
+    -----
+    ``preparar_red`` remains available as a legacy alias for codebases that
+    still rely on the previous Spanish helper name. The alias will be kept
+    until the 1.x compatibility window closes.
 
     Parameters
     ----------
@@ -117,6 +123,14 @@ def preparar_red(
     if init_attrs:
         init_node_attrs(G, override=True)
     return G
+
+
+# Alias legado conservado por compatibilidad externa.
+preparar_red = prepare_network
+preparar_red.__doc__ = (
+    "Alias legado de :func:`prepare_network`. Preferir el nuevo nombre en"
+    " integraciones y código nuevo."
+)
 
 
 def step(

--- a/src/tnfr/ontosim.pyi
+++ b/src/tnfr/ontosim.pyi
@@ -5,6 +5,15 @@ from .types import TNFRConfigValue, TNFRGraph
 __all__: tuple[str, ...]
 
 
+def prepare_network(
+    G: TNFRGraph,
+    *,
+    init_attrs: bool = True,
+    override_defaults: bool = False,
+    **overrides: TNFRConfigValue,
+) -> TNFRGraph: ...
+
+
 def preparar_red(
     G: TNFRGraph,
     *,

--- a/tests/unit/dynamics/test_export_dependencies.py
+++ b/tests/unit/dynamics/test_export_dependencies.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 
-def test_preparar_red_dependencies():
+def test_prepare_network_dependencies():
     from tnfr import EXPORT_DEPENDENCIES
 
     expected = {
@@ -18,9 +18,15 @@ def test_preparar_red_dependencies():
         "tnfr.utils",
     }
 
-    preparar = EXPORT_DEPENDENCIES["preparar_red"]
+    preparar = EXPORT_DEPENDENCIES["prepare_network"]
     assert set(preparar["submodules"]) == expected
     assert preparar["third_party"] == ("networkx",)
+
+
+def test_preparar_red_alias_dependencies():
+    from tnfr import EXPORT_DEPENDENCIES
+
+    assert EXPORT_DEPENDENCIES["preparar_red"] == EXPORT_DEPENDENCIES["prepare_network"]
 
 
 def test_dynamics_helpers_dependencies():

--- a/tests/unit/structural/test_preparar_red.py
+++ b/tests/unit/structural/test_preparar_red.py
@@ -1,15 +1,22 @@
 import networkx as nx
 
-from tnfr.ontosim import preparar_red
+from tnfr.ontosim import prepare_network, preparar_red
 
 
-def test_preparar_red_init_attrs_por_defecto():
+def test_prepare_network_init_attrs_por_defecto():
     G = nx.path_graph(3)
-    preparar_red(G)
+    prepare_network(G)
     assert all("θ" in d for _, d in G.nodes(data=True))
 
 
-def test_preparar_red_sin_init_attrs():
+def test_prepare_network_sin_init_attrs():
     G = nx.path_graph(3)
-    preparar_red(G, init_attrs=False)
+    prepare_network(G, init_attrs=False)
     assert all("θ" not in d for _, d in G.nodes(data=True))
+
+
+def test_preparar_red_alias_sigue_activo():
+    G = nx.path_graph(2)
+    preparar_red(G)
+    assert all("θ" in d for _, d in G.nodes(data=True))
+    assert preparar_red is prepare_network


### PR DESCRIPTION
### Summary
- introduce `prepare_network` as the primary graph preparation helper and keep `preparar_red` as a documented legacy alias
- update exports, CLI consumers, and tests to rely on `prepare_network` while asserting the alias remains wired
- refresh quickstart guidance and add release notes covering the rename and 2.0 removal timeline

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f624d4394c83219666b6c7f8c89310