### PR TITLE
Add English preset aliases and document CLI transition

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -137,6 +137,20 @@ tnfr sequence --nodes 1 --sequence-file sequence.json --save-history history.jso
 The command updates νf, ΔNFR, and phase using the same hooks as the Python API. Inspect the
 saved history for the series of C(t), mean ΔNFR, and Si.
 
+### Presets
+
+Use the English preset identifiers when invoking `--preset` from the CLI:
+
+| Preferred name         | Legacy alias             |
+| ---------------------- | ------------------------ |
+| `resonant_bootstrap`   | `arranque_resonante`     |
+| `contained_mutation`   | `mutacion_contenida`     |
+| `coupling_exploration` | `exploracion_acople`     |
+| `canonical_example`    | `ejemplo_canonico`       |
+
+The legacy Spanish aliases remain available for backward compatibility throughout the 1.x
+series, but scripts and documentation should migrate to the English identifiers.
+
 ## Next steps
 
 - Explore the [examples](../examples/README.md) for multi-node scenarios and CLI workflows.

--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -3,9 +3,19 @@ from __future__ import annotations
 import argparse
 from typing import Any, Iterable
 
+from ..config.presets import (
+    LEGACY_PRESET_NAMES,
+    PREFERRED_PRESET_NAMES,
+)
 from ..gamma import GAMMA_REGISTRY
 from ..types import ArgSpec
 from .utils import spec
+
+
+_PRESET_HELP = "Nombres preferidos: {}. Claves heredadas: {}.".format(
+    ", ".join(PREFERRED_PRESET_NAMES),
+    ", ".join(LEGACY_PRESET_NAMES),
+)
 
 
 GRAMMAR_ARG_SPECS: tuple[ArgSpec, ...] = (
@@ -116,7 +126,7 @@ def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     add_canon_toggle(p_run)
     add_grammar_selector_args(p_run)
     add_history_export_args(p_run)
-    p_run.add_argument("--preset", type=str, default=None)
+    p_run.add_argument("--preset", type=str, default=None, help=_PRESET_HELP)
     p_run.add_argument("--sequence-file", type=str, default=None)
     p_run.add_argument("--summary", action="store_true")
     p_run.add_argument(
@@ -149,7 +159,7 @@ def _add_sequence_parser(sub: argparse._SubParsersAction) -> None:
         ),
     )
     add_common_args(p_seq)
-    p_seq.add_argument("--preset", type=str, default=None)
+    p_seq.add_argument("--preset", type=str, default=None, help=_PRESET_HELP)
     p_seq.add_argument("--sequence-file", type=str, default=None)
     add_history_export_args(p_seq)
     add_grammar_args(p_seq)

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -24,7 +24,11 @@ from ..dynamics import (
     parametric_glyph_selector,
     validate_canon,
 )
-from ..config.presets import get_preset
+from ..config.presets import (
+    LEGACY_PRESET_NAMES,
+    PREFERRED_PRESET_NAMES,
+    get_preset,
+)
 from ..config import apply_config
 from ..io import read_structured_file, safe_write, StructuredFileError
 from ..glyph_history import ensure_history
@@ -41,6 +45,9 @@ logger = get_logger(__name__)
 # CLI summaries should remain concise by default while allowing callers to
 # inspect the full glyphogram series when needed.
 DEFAULT_SUMMARY_SERIES_LIMIT = 10
+
+_PREFERRED_PRESETS_DISPLAY = ", ".join(PREFERRED_PRESET_NAMES)
+_LEGACY_PRESETS_DISPLAY = ", ".join(LEGACY_PRESET_NAMES)
 
 
 def _save_json(path: str, data: Any) -> None:
@@ -169,8 +176,14 @@ def resolve_program(
             return get_preset(args.preset)
         except KeyError as exc:
             logger.error(
-                "Preset desconocido '%s'. Usa --sequence-file para cargar secuencias personalizadas",
+                (
+                    "Preset desconocido '%s'. Nombres preferidos: %s. "
+                    "Claves heredadas: %s. Usa --sequence-file para cargar "
+                    "secuencias personalizadas"
+                ),
                 args.preset,
+                _PREFERRED_PRESETS_DISPLAY,
+                _LEGACY_PRESETS_DISPLAY,
             )
             raise SystemExit(1) from exc
     if getattr(args, "sequence_file", None):

--- a/src/tnfr/config/presets.py
+++ b/src/tnfr/config/presets.py
@@ -11,11 +11,16 @@ from ..execution import (
 )
 from ..types import Glyph, PresetTokens
 
-__all__ = ("get_preset",)
+__all__ = (
+    "get_preset",
+    "PREFERRED_PRESET_NAMES",
+    "LEGACY_PRESET_NAMES",
+    "PRESET_NAME_ALIASES",
+)
 
 
-_PRESETS: dict[str, PresetTokens] = {
-    "arranque_resonante": seq(
+_PRIMARY_PRESETS: dict[str, PresetTokens] = {
+    "resonant_bootstrap": seq(
         Glyph.AL,
         Glyph.EN,
         Glyph.IL,
@@ -25,14 +30,14 @@ _PRESETS: dict[str, PresetTokens] = {
         wait(3),
         Glyph.SHA,
     ),
-    "mutacion_contenida": seq(
+    "contained_mutation": seq(
         Glyph.AL,
         Glyph.EN,
         block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2),
         Glyph.RA,
         Glyph.SHA,
     ),
-    "exploracion_acople": seq(
+    "coupling_exploration": seq(
         Glyph.AL,
         Glyph.EN,
         Glyph.IL,
@@ -42,8 +47,6 @@ _PRESETS: dict[str, PresetTokens] = {
         Glyph.RA,
         Glyph.SHA,
     ),
-    CANONICAL_PRESET_NAME: list(CANONICAL_PROGRAM_TOKENS),
-    # Topologías fractales: expansión/contracción modular
     "fractal_expand": seq(
         block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL),
         Glyph.RA,
@@ -52,7 +55,23 @@ _PRESETS: dict[str, PresetTokens] = {
         block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA),
         Glyph.RA,
     ),
+    "canonical_example": list(CANONICAL_PROGRAM_TOKENS),
 }
+
+_LEGACY_PRESET_ALIASES: dict[str, str] = {
+    "arranque_resonante": "resonant_bootstrap",
+    "mutacion_contenida": "contained_mutation",
+    "exploracion_acople": "coupling_exploration",
+    CANONICAL_PRESET_NAME: "canonical_example",
+}
+
+PREFERRED_PRESET_NAMES: tuple[str, ...] = tuple(_PRIMARY_PRESETS.keys())
+LEGACY_PRESET_NAMES: tuple[str, ...] = tuple(_LEGACY_PRESET_ALIASES.keys())
+PRESET_NAME_ALIASES: dict[str, str] = dict(_LEGACY_PRESET_ALIASES)
+
+_PRESETS: dict[str, PresetTokens] = {**_PRIMARY_PRESETS}
+for alias, target in _LEGACY_PRESET_ALIASES.items():
+    _PRESETS[alias] = _PRIMARY_PRESETS[target]
 
 
 def get_preset(name: str) -> PresetTokens:

--- a/tests/unit/config/test_presets.py
+++ b/tests/unit/config/test_presets.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from tnfr.config.presets import (
+    LEGACY_PRESET_NAMES,
+    PREFERRED_PRESET_NAMES,
+    PRESET_NAME_ALIASES,
+    get_preset,
+)
+
+
+@pytest.mark.parametrize("name", PREFERRED_PRESET_NAMES)
+def test_get_preset_accepts_preferred_names(name: str) -> None:
+    tokens = get_preset(name)
+    assert tokens, f"El preset '{name}' no debería estar vacío"
+
+
+@pytest.mark.parametrize("legacy", LEGACY_PRESET_NAMES)
+def test_legacy_aliases_resolve_to_preferred_names(legacy: str) -> None:
+    preferred = PRESET_NAME_ALIASES[legacy]
+    assert get_preset(legacy) == get_preset(preferred)


### PR DESCRIPTION
Summary:
- Added English-first preset identifiers and mapped legacy Spanish aliases to preserve compatibility.
- Updated CLI help text and error messaging to advertise the preferred names and flag legacy keys.
- Documented the naming transition and added unit tests that cover both preferred and legacy presets.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f62d69889c832192a97c55f3bb466e