### PR TITLE
Document preparar_red deprecation and remove alias from public exports

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -93,8 +93,8 @@ without mutating `G.graph`.
 When you build a NetworkX graph outside of `create_nfr`, normalise its configuration with
 `tnfr.prepare_network` before stepping the dynamics. The helper attaches the default
 configuration, telemetry history, ΔNFR hook, and optional observer wiring. The legacy name
-`tnfr.preparar_red` remains available throughout the 1.x releases but will be removed in the
-next major version.
+`tnfr.preparar_red` now emits a :class:`DeprecationWarning`, remains available only as a
+bridge, and is scheduled for removal on **2025-06-01**.
 
 ```python
 import networkx as nx

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,11 +13,9 @@
 
 - Renamed the network preparation helper to `prepare_network` for
   consistency with the English-facing API. The previous Spanish name
-  `preparar_red` is still exported as a legacy alias and will keep
-  forwarding to `prepare_network` for every 1.x release.
-- Deprecation timeline: the alias will be removed in the first 2.0.0
-  pre-release. Projects using `preparar_red` should migrate now and
-  monitor the release notes for the final removal date.
+  `preparar_red` now emits a :class:`DeprecationWarning`, is no longer
+  exported via ``__all__`` and will be removed on **2025-06-01**. Use
+  the English helper directly to stay within the supported contract.
 
 All other helpers continue to honour the existing dependency manifest
 and import semantics.

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -17,14 +17,15 @@ The imports are grouped as follows:
     orchestration, validation hooks and metrics integration) and require
     the ``networkx`` package for graph handling.
 
-``prepare_network`` (``preparar_red`` legacy alias)
+``prepare_network``
     Defined in :mod:`tnfr.ontosim`.  Besides :mod:`tnfr.ontosim`
     itself, the helper imports :mod:`tnfr.callback_utils`,
     :mod:`tnfr.constants`, :mod:`tnfr.dynamics`, :mod:`tnfr.glyph_history`,
     :mod:`tnfr.initialization` and :mod:`tnfr.utils` to assemble the
     graph preparation pipeline.  It also requires ``networkx`` at import
-    time.  ``preparar_red`` remains available for backwards compatibility
-    during the 1.x series and forwards to :func:`prepare_network`.
+    time.  A temporary bridge alias :func:`tnfr.preparar_red` is still
+    provided for external callers but is no longer exported from
+    ``__all__``.
 
 ``create_nfr`` / ``run_sequence``
     Re-exported from :mod:`tnfr.structural`.  They depend on
@@ -55,18 +56,6 @@ EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
         "third_party": ("networkx",),
     },
     "prepare_network": {
-        "submodules": (
-            "tnfr.ontosim",
-            "tnfr.callback_utils",
-            "tnfr.constants",
-            "tnfr.dynamics",
-            "tnfr.glyph_history",
-            "tnfr.initialization",
-            "tnfr.utils",
-        ),
-        "third_party": ("networkx",),
-    },
-    "preparar_red": {
         "submodules": (
             "tnfr.ontosim",
             "tnfr.callback_utils",
@@ -276,7 +265,6 @@ __all__ = [
     "step",
     "run",
     "prepare_network",
-    "preparar_red",
     "create_nfr",
 ]
 

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -1,6 +1,8 @@
 """Orchestrate the canonical simulation."""
 
 from __future__ import annotations
+
+import warnings
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -16,7 +18,10 @@ if TYPE_CHECKING:  # pragma: no cover
     import networkx as nx
 
 # API de alto nivel
-__all__ = ("prepare_network", "preparar_red", "step", "run")
+__all__ = ("prepare_network", "step", "run")
+
+
+_PREPARAR_RED_REMOVAL_DATE = "2025-06-01"
 
 
 def prepare_network(
@@ -26,13 +31,14 @@ def prepare_network(
     override_defaults: bool = False,
     **overrides,
 ) -> "nx.Graph":
-    """Prepare ``G`` for simulation.
+    f"""Prepare ``G`` for simulation.
 
     Notes
     -----
-    ``preparar_red`` remains available as a legacy alias for codebases that
-    still rely on the previous Spanish helper name. The alias will be kept
-    until the 1.x compatibility window closes.
+    :func:`preparar_red` remains temporarily available for callers that
+    still rely on the Spanish helper name.  The alias now emits a
+    :class:`DeprecationWarning` and will be removed on
+    ``{_PREPARAR_RED_REMOVAL_DATE}``.
 
     Parameters
     ----------
@@ -125,12 +131,34 @@ def prepare_network(
     return G
 
 
-# Alias legado conservado por compatibilidad externa.
-preparar_red = prepare_network
-preparar_red.__doc__ = (
-    "Alias legado de :func:`prepare_network`. Preferir el nuevo nombre en"
-    " integraciones y código nuevo."
-)
+def preparar_red(
+    G: "nx.Graph",
+    *,
+    init_attrs: bool = True,
+    override_defaults: bool = False,
+    **overrides,
+):
+    f"""Alias en desuso de :func:`prepare_network`.
+
+    El nombre español se retirará definitivamente el
+    ``{_PREPARAR_RED_REMOVAL_DATE}``.  Llama a :func:`prepare_network`
+    directamente en nuevo código.
+    """
+
+    warnings.warn(
+        (
+            "tnfr.preparar_red está en desuso y se retirará el "
+            f"{_PREPARAR_RED_REMOVAL_DATE}. Utiliza tnfr.prepare_network."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return prepare_network(
+        G,
+        init_attrs=init_attrs,
+        override_defaults=override_defaults,
+        **overrides,
+    )
 
 
 def step(

--- a/src/tnfr/ontosim.pyi
+++ b/src/tnfr/ontosim.pyi
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .types import TNFRConfigValue, TNFRGraph
 
 __all__: tuple[str, ...]
+_PREPARAR_RED_REMOVAL_DATE: str
 
 
 def prepare_network(

--- a/tests/integration/test_public_api.py
+++ b/tests/integration/test_public_api.py
@@ -20,7 +20,6 @@ def test_public_exports():
         "step",
         "run",
         "prepare_network",
-        "preparar_red",
         "create_nfr",
     }
     if getattr(tnfr, "_HAS_RUN_SEQUENCE", False):
@@ -31,7 +30,8 @@ def test_public_exports():
 def test_basic_flow():
     G, n = tnfr.create_nfr("n1")
     tnfr.prepare_network(G)
-    assert tnfr.preparar_red is tnfr.prepare_network
+    with pytest.deprecated_call():
+        tnfr.preparar_red(G)
     register_metrics_callbacks(G)
     tnfr.step(G)
     tnfr.run(G, steps=2)
@@ -97,12 +97,7 @@ def test_public_api_missing_prepare_network_dependency(monkeypatch):
             "prepare_network" in message and "networkx" in message
             for message in warning_messages
         )
-        assert any(
-            "preparar_red" in message and "networkx" in message
-            for message in warning_messages
-        )
         assert "prepare_network" in module.__all__
-        assert "preparar_red" in module.__all__
         assert not getattr(module, "_HAS_PREPARAR_RED", True)
         assert not getattr(module, "_HAS_PREPARE_NETWORK", True)
         with pytest.raises(ImportError) as excinfo:

--- a/tests/unit/dynamics/test_export_dependencies.py
+++ b/tests/unit/dynamics/test_export_dependencies.py
@@ -23,12 +23,6 @@ def test_prepare_network_dependencies():
     assert preparar["third_party"] == ("networkx",)
 
 
-def test_preparar_red_alias_dependencies():
-    from tnfr import EXPORT_DEPENDENCIES
-
-    assert EXPORT_DEPENDENCIES["preparar_red"] == EXPORT_DEPENDENCIES["prepare_network"]
-
-
 def test_dynamics_helpers_dependencies():
     from tnfr import EXPORT_DEPENDENCIES
 

--- a/tests/unit/structural/test_preparar_red.py
+++ b/tests/unit/structural/test_preparar_red.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 from tnfr.ontosim import prepare_network, preparar_red
 
@@ -15,8 +16,8 @@ def test_prepare_network_sin_init_attrs():
     assert all("θ" not in d for _, d in G.nodes(data=True))
 
 
-def test_preparar_red_alias_sigue_activo():
+def test_preparar_red_alias_emite_deprecated_call():
     G = nx.path_graph(2)
-    preparar_red(G)
+    with pytest.deprecated_call():
+        preparar_red(G)
     assert all("θ" in d for _, d in G.nodes(data=True))
-    assert preparar_red is prepare_network


### PR DESCRIPTION
## Summary
- stop exporting `preparar_red` while keeping a DeprecationWarning bridge to `prepare_network`
- update docs and tests to highlight the 2025-06-01 removal deadline for the Spanish alias
- adjust the export dependency manifest to match the trimmed public API

## Testing
- `pytest tests/integration/test_public_api.py tests/unit/structural/test_preparar_red.py tests/unit/dynamics/test_export_dependencies.py`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f63380cec08321af93ab7fce76d060