### PR TITLE
docs: document English-only operator classes and drop Spanish aliases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,27 +72,31 @@ When introducing new operators:
 - Update grammar/syntax tables if the operator alters the canonical sequence, ensuring THOL blocks and closure sets remain valid.【F:src/tnfr/validation/syntax.py†L27-L121】【F:src/tnfr/validation/grammar.py†L1-L90】
 - Supply trace fields or telemetry hooks if the operator produces novel metrics, keeping the coherence log consistent.【F:src/tnfr/trace.py†L169-L319】
 
-### Multilingual operator aliases
+### Operator vocabulary (English only)
 
-The engine now recognises bilingual operator identifiers so orchestration code can operate in Spanish (canonical) or English (alias) without sacrificing backwards compatibility. Each token maps to the same glyph binding, and the registry keeps both spellings synchronised:
+TNFR 2.0 completes the transition to **English-only** operator identifiers. The registry,
+validation helpers, CLI, and documentation all use the same canonical ASCII tokens:
 
-| Canonical (ES) | Alias (EN) |
-| --- | --- |
-| `emision` | `emission` |
-| `recepcion` | `reception` |
-| `coherencia` | `coherence` |
-| `disonancia` | `dissonance` |
-| `acoplamiento` | `coupling` |
-| `resonancia` | `resonance` |
-| `silencio` | `silence` |
-| `expansion` | `expansion` |
-| `contraccion` | `contraction` |
-| `autoorganizacion` | `self_organization` |
-| `mutacion` | `mutation` |
-| `transicion` | `transition` |
-| `recursividad` | `recursivity` |
+| Token         | Role summary            |
+| ------------- | ----------------------- |
+| `emission`    | Initiates resonance     |
+| `reception`   | Captures information    |
+| `coherence`   | Stabilises the form     |
+| `dissonance`  | Introduces controlled Δ |
+| `coupling`    | Synchronises nodes      |
+| `resonance`   | Propagates coherence    |
+| `silence`     | Freezes evolution       |
+| `expansion`   | Scales the structure    |
+| `contraction` | Densifies the form      |
+| `self_organization` | Guides self-order |
+| `mutation`    | Adjusts phase safely    |
+| `transition`  | Crosses thresholds      |
+| `recursivity` | Maintains memory        |
 
-Spanish tokens remain the canonical keys for invariants and documentation; English aliases are opt-in helpers for multilingual teams. The validation layer canonicalises input before applying grammar rules, while the registry exposes both spellings via `OPERADORES` and the helper `get_operator_class()` so dispatch works with either vocabulary.【F:src/tnfr/config/operator_names.py†L1-L135】【F:src/tnfr/operators/registry.py†L13-L62】【F:src/tnfr/validation/syntax.py†L1-L121】 Should we ever plan to deprecate the Spanish spellings, emit explicit warnings and update the compatibility tests that currently assert the legacy names remain warning-free.【F:tests/unit/dynamics/test_operator_names.py†L1-L53】
+Legacy Spanish spellings (``emision``, ``recepcion``, …) have been removed from the public
+API, the exported ``__all__`` bindings, and the validation layer. Downstream callers must use
+the canonical names shown above; the registry no longer performs alias canonicalisation and
+``get_operator_class()`` raises :class:`KeyError` for Spanish identifiers.【F:src/tnfr/config/operator_names.py†L1-L77】【F:src/tnfr/operators/registry.py†L13-L45】
 
 ## Enforcing TNFR invariants in runtime orchestration
 

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -6,8 +6,8 @@ reference to plan trajectories for simulations, experiments, or CLI runs.
 ## Canonical operator map
 
 Every trajectory must be composed from the 13 canonical operators and their resonant role.
-Operator tokens remain in Spanish to match the canonical grammar while the descriptions stay
-in technical English.
+Starting in TNFR 2.0 the canonical tokens and class names are aligned on the English
+vocabulary; use the identifiers below when orchestrating pipelines or configuring the CLI.
 
 - **Emission** — initiates a resonant pattern (φ(νf, θ)).
 - **Reception** — captures incoming information (∫ ψ(x, t) dx).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -120,10 +120,8 @@ sequence file matching the Emission → Reception → Coherence → Resonance �
 ]
 ```
 
-> Legacy Spanish tokens (``"emision"``, ``"recepcion"``, …) are still accepted
-> by the parser but now emit :class:`DeprecationWarning` and will be removed in a
-> future release. Migrate automation scripts to the English identifiers to stay
-> within the supported contract.
+Starting with **TNFR 2.0** the CLI accepts **only** the English operator tokens.
+Rewrite existing automation to match the canonical identifiers before upgrading.
 
 Run the sequence on a single node and persist telemetry to `history.json`:
 
@@ -131,13 +129,13 @@ Run the sequence on a single node and persist telemetry to `history.json`:
 tnfr sequence --nodes 1 --sequence-file sequence.json --save-history history.json
 ```
 
-| Canonical token | English operator name |
-| --------------- | --------------------- |
-| `emision`       | Emission              |
-| `recepcion`     | Reception             |
-| `coherencia`    | Coherence             |
-| `resonancia`    | Resonance             |
-| `silencio`      | Silence               |
+| Canonical token | Operator role        |
+| --------------- | -------------------- |
+| `emission`      | Initiates resonance  |
+| `reception`     | Captures information |
+| `coherence`     | Stabilises the form  |
+| `resonance`     | Propagates coherence |
+| `silence`       | Freezes evolution    |
 
 The command updates νf, ΔNFR, and phase using the same hooks as the Python API. Inspect the
 saved history for the series of C(t), mean ΔNFR, and Si.
@@ -146,15 +144,12 @@ saved history for the series of C(t), mean ΔNFR, and Si.
 
 Use the English preset identifiers when invoking `--preset` from the CLI:
 
-| Preferred name         | Legacy alias             |
-| ---------------------- | ------------------------ |
-| `resonant_bootstrap`   | `arranque_resonante`     |
-| `contained_mutation`   | `mutacion_contenida`     |
-| `coupling_exploration` | `exploracion_acople`     |
-| `canonical_example`    | `ejemplo_canonico`       |
-
-The legacy Spanish aliases remain available for backward compatibility throughout the 1.x
-series, but scripts and documentation should migrate to the English identifiers.
+| Preset identifier     | Description (summary)      |
+| --------------------- | -------------------------- |
+| `resonant_bootstrap`  | Balanced start-up profile  |
+| `contained_mutation`  | Mutation with guard rails  |
+| `coupling_exploration` | Coupling sweep for studies |
+| `canonical_example`   | Minimal tutorial sequence  |
 
 ## Next steps
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -9,6 +9,8 @@
   previously emitted :class:`DeprecationWarning`. All structural orchestration
   must now import the English operator classes from
   :mod:`tnfr.operators.definitions` or :mod:`tnfr.structural`.
+- Trimmed Spanish re-exports from :mod:`tnfr.structural` and its typing stubs so
+  only the English operator classes remain in the public ``__all__``.
 - Impacted entry points:
   * Stored operator sequences (YAML/JSON fixtures, CLI configs) must be rewritten
     to use the English identifiers.
@@ -16,11 +18,16 @@
     :func:`tnfr.validation.syntax.validate_sequence`, and
     :func:`tnfr.operators.registry.get_operator_class` will now reject Spanish
     tokens.
+  * Import sites that referenced ``tnfr.operators.compat`` or the Spanish class
+    names exported from :mod:`tnfr.structural` must update their imports to the
+    English equivalents.
   * Diagnostics relying on ``TRANSICION`` should switch to the English
     ``TRANSITION`` constant from :mod:`tnfr.config.operator_names`.
 - Versioning and communication plan:
   * Publish this change as **TNFR 2.0.0** and note the breaking removal in the
     release announcement.
+  * No transition shims remain—migrating to the English tokens is mandatory
+    before adopting 2.0.
   * Ship an upgrade checklist highlighting the required token substitutions and
     the removal of ``tnfr.operators.compat``.
   * Update API docs, tutorials, and CLI references to show only English tokens.

--- a/tests/unit/dynamics/test_operator_names.py
+++ b/tests/unit/dynamics/test_operator_names.py
@@ -1,7 +1,9 @@
 """Tests ensuring operator name constants stay aligned with registry."""
 
+import pytest
+
 from tnfr.config import operator_names as names
-from tnfr.operators.registry import OPERADORES, discover_operators
+from tnfr.operators.registry import OPERADORES, discover_operators, get_operator_class
 
 
 def test_registry_matches_operator_constants() -> None:
@@ -25,3 +27,9 @@ def test_canonical_lookup_is_passthrough_for_english_tokens() -> None:
 def test_operator_display_name_returns_canonical_token() -> None:
     assert names.operator_display_name(names.EMISSION) == names.EMISSION
     assert names.operator_display_name("unknown") == "unknown"
+
+
+def test_get_operator_class_rejects_spanish_tokens() -> None:
+    discover_operators()
+    with pytest.raises(KeyError):
+        get_operator_class("emision")


### PR DESCRIPTION
## Summary
- update architectural and API docs to describe the English-only operator vocabulary
- remove Spanish alias guidance from the quickstart and release notes now that shims are gone
- add a regression test ensuring Spanish tokens are rejected by the operator registry

## Testing
- pytest tests/unit/dynamics/test_operator_names.py

------
https://chatgpt.com/codex/tasks/task_e_68f63daa488c8321983d15267a2cdab4