### PR TITLE
Rename operator registry export to OPERATORS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,9 @@ The following table highlights how ΔNFR values propagate through the engine and
 
 ## Operator registration mechanics
 
-Operator classes apply the `@register_operator` decorator, which verifies unique ASCII names, binds glyphs, and inserts implementations into the shared `OPERADORES` map used by syntax validators and dynamic dispatch.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L31】 The discovery routine scans the `tnfr.operators` package exactly once per interpreter session, importing every submodule except the registry itself so that registration side effects run reliably before the structural loop accesses them.【F:src/tnfr/operators/registry.py†L33-L50】
+Operator classes apply the `@register_operator` decorator, which verifies unique ASCII names, binds glyphs, and inserts implementations into the shared `OPERATORS` map used by syntax validators and dynamic dispatch.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L58】 The discovery routine scans the `tnfr.operators` package exactly once per interpreter session, importing every submodule except the registry itself so that registration side effects run reliably before the structural loop accesses them.【F:src/tnfr/operators/registry.py†L33-L58】
+
+> **Compatibility note**: The previous `OPERADORES` export now resolves through a deprecated module attribute. Existing consumers that import `tnfr.operators.registry.OPERADORES` continue to receive the same mapping but will emit a `DeprecationWarning`; new code should use `OPERATORS` instead.【F:src/tnfr/operators/registry.py†L44-L58】
 
 When introducing new operators:
 

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -27,7 +27,7 @@ from .jitter import (
     reset_jitter_manager,
     random_jitter,
 )
-from .registry import OPERADORES, discover_operators, get_operator_class
+from .registry import OPERATORS, discover_operators, get_operator_class
 from .remesh import (
     apply_network_remesh,
     apply_topological_remesh,
@@ -64,7 +64,7 @@ __all__ = [
     "apply_network_remesh",
     "apply_topological_remesh",
     "apply_remesh_if_globally_stable",
-    "OPERADORES",
+    "OPERATORS",
     "discover_operators",
     "get_operator_class",
 ]

--- a/src/tnfr/operators/__init__.pyi
+++ b/src/tnfr/operators/__init__.pyi
@@ -17,7 +17,7 @@ Recursivity: Any
 GLYPH_OPERATIONS: Any
 JitterCache: Any
 JitterCacheManager: Any
-OPERADORES: Any
+OPERATORS: Any
 apply_glyph: Any
 apply_glyph_obj: Any
 apply_network_remesh: Any

--- a/src/tnfr/operators/registry.pyi
+++ b/src/tnfr/operators/registry.pyi
@@ -1,9 +1,13 @@
-from typing import Any
+from typing import Any, Literal
+
+from .definitions import Operador
 
 __all__: Any
 
+def __getattr__(name: Literal["OPERADORES"]) -> dict[str, type[Operador]]: ...
 def __getattr__(name: str) -> Any: ...
 
-OPERADORES: Any
+OPERATORS: dict[str, type[Operador]]
 discover_operators: Any
 register_operator: Any
+get_operator_class: Any

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -28,7 +28,7 @@ from .operators.definitions import (
     Transition,
     Recursivity,
 )
-from .operators.registry import OPERADORES
+from .operators.registry import OPERATORS
 from .validation import validate_sequence
 
 
@@ -79,7 +79,7 @@ __all__ = (
     "Mutation",
     "Transition",
     "Recursivity",
-    "OPERADORES",
+    "OPERATORS",
     "validate_sequence",
     "run_sequence",
 )

--- a/src/tnfr/structural.pyi
+++ b/src/tnfr/structural.pyi
@@ -37,7 +37,7 @@ def create_nfr(
 ) -> tuple["nx.Graph", str]: ...
 
 
-OPERADORES: dict[str, Operator]
+OPERATORS: dict[str, Operator]
 
 
 def validate_sequence(names: Iterable[str]) -> tuple[bool, str]: ...

--- a/src/tnfr/validation/syntax.py
+++ b/src/tnfr/validation/syntax.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..operators.registry import OPERADORES
+from ..operators.registry import OPERATORS
 from ..config.operator_names import (
     CIERRE_VALIDO,
     COHERENCE,
@@ -77,7 +77,7 @@ def _validate_known_tokens(
     unknown_tokens = {
         alias
         for alias, canonical in token_to_canonical.items()
-        if canonical not in OPERADORES
+        if canonical not in OPERATORS
     }
     if unknown_tokens:
         ordered = ", ".join(sorted(unknown_tokens))

--- a/tests/unit/dynamics/test_operator_names.py
+++ b/tests/unit/dynamics/test_operator_names.py
@@ -3,12 +3,12 @@
 import pytest
 
 from tnfr.config import operator_names as names
-from tnfr.operators.registry import OPERADORES, discover_operators, get_operator_class
+from tnfr.operators.registry import OPERATORS, discover_operators, get_operator_class
 
 
 def test_registry_matches_operator_constants() -> None:
     discover_operators()
-    assert set(OPERADORES.keys()) == names.ALL_OPERATOR_NAMES
+    assert set(OPERATORS.keys()) == names.ALL_OPERATOR_NAMES
 
 
 def test_validation_sets_are_subsets() -> None:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- rename the operator registry mapping to `OPERATORS` across runtime modules and stubs, adjusting public exports
- retain a deprecated `OPERADORES` attribute via `__getattr__` to warn external consumers while keeping compatibility
- refresh documentation and tests to reference the English name and describe the alias deprecation path


------
https://chatgpt.com/codex/tasks/task_e_68f63f0042888321ba792441153a954d