### PR TITLE
Retire preparar_red alias and document TNFR 5.0 upgrade

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -92,9 +92,9 @@ without mutating `G.graph`.
 
 When you build a NetworkX graph outside of `create_nfr`, normalise its configuration with
 `tnfr.prepare_network` before stepping the dynamics. The helper attaches the default
-configuration, telemetry history, ΔNFR hook, and optional observer wiring. The legacy name
-`tnfr.preparar_red` now emits a :class:`DeprecationWarning`, remains available only as a
-bridge, and is scheduled for removal on **2025-06-01**.
+configuration, telemetry history, ΔNFR hook, and optional observer wiring. Versions prior to
+**TNFR 5.0** exposed a Spanish alias (`tnfr.preparar_red`) for the same helper. The alias has
+now been removed; update existing code to call `prepare_network` directly before upgrading.
 
 ```python
 import networkx as nx

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## 5.0.0 (prepare_network alias retired)
+
+- Removed the Spanish helper alias ``tnfr.preparar_red``. The network
+  preparation pipeline now ships exclusively under the English
+  :func:`tnfr.prepare_network` name. Codebases that still relied on the
+  alias must update their imports before upgrading.
+- Updated the typing stubs, integration tests, and documentation to
+  reflect the canonical helper set.
+- Bumped the package version to **5.0.0** to flag the
+  backward-incompatible API change.
+
 ## 2.0.0 (Spanish alias removal)
 
 - Removed the Spanish compatibility tables from :mod:`tnfr.config.operator_names`.
@@ -41,9 +52,9 @@
 
 - Renamed the network preparation helper to `prepare_network` for
   consistency with the English-facing API. The previous Spanish name
-  `preparar_red` now emits a :class:`DeprecationWarning`, is no longer
-  exported via ``__all__`` and will be removed on **2025-06-01**. Use
-  the English helper directly to stay within the supported contract.
+  `preparar_red` emitted a :class:`DeprecationWarning` and has now been
+  removed in **TNFR 5.0**. Use the English helper directly to stay
+  within the supported contract.
 
 - Unified the node wrappers under the English identifiers
   :class:`tnfr.node.NodeNX` and :class:`tnfr.node.NodeProtocol`. Their

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -23,9 +23,7 @@ The imports are grouped as follows:
     :mod:`tnfr.constants`, :mod:`tnfr.dynamics`, :mod:`tnfr.glyph_history`,
     :mod:`tnfr.initialization` and :mod:`tnfr.utils` to assemble the
     graph preparation pipeline.  It also requires ``networkx`` at import
-    time.  A temporary bridge alias :func:`tnfr.preparar_red` is still
-    provided for external callers but is no longer exported from
-    ``__all__``.
+    time.
 
 ``create_nfr`` / ``run_sequence``
     Re-exported from :mod:`tnfr.structural`.  They depend on
@@ -234,10 +232,7 @@ def _assign_exports(module: str, names: tuple[str, ...]) -> bool:
 _assign_exports("dynamics", ("step", "run"))
 
 
-_HAS_PREPARAR_RED = _assign_exports(
-    "ontosim", ("prepare_network", "preparar_red")
-)
-_HAS_PREPARE_NETWORK = _HAS_PREPARAR_RED
+_HAS_PREPARE_NETWORK = _assign_exports("ontosim", ("prepare_network",))
 
 
 _HAS_RUN_SEQUENCE = _assign_exports("structural", ("create_nfr", "run_sequence"))

--- a/src/tnfr/__init__.pyi
+++ b/src/tnfr/__init__.pyi
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import Any, NoReturn
 
 from .dynamics import run, step
-from .ontosim import prepare_network, preparar_red
+from .ontosim import prepare_network
 from .structural import create_nfr, run_sequence
 
 EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]]
@@ -36,6 +36,5 @@ def _assign_exports(module: str, names: tuple[str, ...]) -> bool: ...
 
 def _emit_missing_dependency_warning() -> None: ...
 
-_HAS_PREPARAR_RED: bool
 _HAS_PREPARE_NETWORK: bool
 _HAS_RUN_SEQUENCE: bool

--- a/src/tnfr/_version.py
+++ b/src/tnfr/_version.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.5.2"
+__version__ = "5.0.0"

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -21,9 +20,6 @@ if TYPE_CHECKING:  # pragma: no cover
 __all__ = ("prepare_network", "step", "run")
 
 
-_PREPARAR_RED_REMOVAL_DATE = "2025-06-01"
-
-
 def prepare_network(
     G: "nx.Graph",
     *,
@@ -31,14 +27,7 @@ def prepare_network(
     override_defaults: bool = False,
     **overrides,
 ) -> "nx.Graph":
-    f"""Prepare ``G`` for simulation.
-
-    Notes
-    -----
-    :func:`preparar_red` remains temporarily available for callers that
-    still rely on the Spanish helper name.  The alias now emits a
-    :class:`DeprecationWarning` and will be removed on
-    ``{_PREPARAR_RED_REMOVAL_DATE}``.
+    """Prepare ``G`` for simulation.
 
     Parameters
     ----------
@@ -129,36 +118,6 @@ def prepare_network(
     if init_attrs:
         init_node_attrs(G, override=True)
     return G
-
-
-def preparar_red(
-    G: "nx.Graph",
-    *,
-    init_attrs: bool = True,
-    override_defaults: bool = False,
-    **overrides,
-):
-    f"""Alias en desuso de :func:`prepare_network`.
-
-    El nombre español se retirará definitivamente el
-    ``{_PREPARAR_RED_REMOVAL_DATE}``.  Llama a :func:`prepare_network`
-    directamente en nuevo código.
-    """
-
-    warnings.warn(
-        (
-            "tnfr.preparar_red está en desuso y se retirará el "
-            f"{_PREPARAR_RED_REMOVAL_DATE}. Utiliza tnfr.prepare_network."
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return prepare_network(
-        G,
-        init_attrs=init_attrs,
-        override_defaults=override_defaults,
-        **overrides,
-    )
 
 
 def step(

--- a/src/tnfr/ontosim.pyi
+++ b/src/tnfr/ontosim.pyi
@@ -3,19 +3,9 @@ from __future__ import annotations
 from .types import TNFRConfigValue, TNFRGraph
 
 __all__: tuple[str, ...]
-_PREPARAR_RED_REMOVAL_DATE: str
 
 
 def prepare_network(
-    G: TNFRGraph,
-    *,
-    init_attrs: bool = True,
-    override_defaults: bool = False,
-    **overrides: TNFRConfigValue,
-) -> TNFRGraph: ...
-
-
-def preparar_red(
     G: TNFRGraph,
     *,
     init_attrs: bool = True,

--- a/tests/integration/test_public_api.py
+++ b/tests/integration/test_public_api.py
@@ -30,8 +30,7 @@ def test_public_exports():
 def test_basic_flow():
     G, n = tnfr.create_nfr("n1")
     tnfr.prepare_network(G)
-    with pytest.deprecated_call():
-        tnfr.preparar_red(G)
+    G.graph.setdefault("DIAGNOSIS", {})["enabled"] = False
     register_metrics_callbacks(G)
     tnfr.step(G)
     tnfr.run(G, steps=2)
@@ -98,17 +97,11 @@ def test_public_api_missing_prepare_network_dependency(monkeypatch):
             for message in warning_messages
         )
         assert "prepare_network" in module.__all__
-        assert not getattr(module, "_HAS_PREPARAR_RED", True)
         assert not getattr(module, "_HAS_PREPARE_NETWORK", True)
-        with pytest.raises(ImportError) as excinfo:
-            module.preparar_red(None)
-        assert "networkx" in str(excinfo.value)
+        assert not hasattr(module, "preparar_red")
         with pytest.raises(ImportError) as excinfo:
             module.prepare_network(None)
         assert "networkx" in str(excinfo.value)
-        info = getattr(module.preparar_red, "__tnfr_missing_dependency__", {})
-        assert info.get("export") == "preparar_red"
-        assert info.get("missing") == "networkx"
         prepare_info = getattr(module.prepare_network, "__tnfr_missing_dependency__", {})
         assert prepare_info.get("export") == "prepare_network"
         assert prepare_info.get("missing") == "networkx"

--- a/tests/unit/structural/test_prepare_network.py
+++ b/tests/unit/structural/test_prepare_network.py
@@ -1,7 +1,6 @@
 import networkx as nx
-import pytest
 
-from tnfr.ontosim import prepare_network, preparar_red
+from tnfr.ontosim import prepare_network
 
 
 def test_prepare_network_init_attrs_por_defecto():
@@ -14,10 +13,3 @@ def test_prepare_network_sin_init_attrs():
     G = nx.path_graph(3)
     prepare_network(G, init_attrs=False)
     assert all("θ" not in d for _, d in G.nodes(data=True))
-
-
-def test_preparar_red_alias_emite_deprecated_call():
-    G = nx.path_graph(2)
-    with pytest.deprecated_call():
-        preparar_red(G)
-    assert all("θ" in d for _, d in G.nodes(data=True))


### PR DESCRIPTION
## Summary
- remove the preparar_red compatibility alias so tnfr.ontosim exports only the English helpers
- align package exports, typing stubs, and tests with prepare_network as the sole public network initializer
- document the breaking change, bump the version to 5.0.0, and describe the migration path in the quickstart and release notes

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API (breaking removal of preparar_red)
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f641bcc14c83218e1f9a46cd65b0ba