### PR TITLE
Add phase alias compatibility shim for deprecated 'fase' key

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -14,6 +14,8 @@ facades.
 - **Si** — `tnfr.metrics.sense_index.compute_Si`: ability to produce meaningful reorganisation
   combining νf, phase, and topology.
 - **Phase θ** — `tnfr.dynamics.coordinate_global_local_phase` and related helpers.
+- **Compatibility** — legacy node payloads using `"fase"` emit a `DeprecationWarning`
+  and are rewritten to the English `"theta"`/`"phase"` aliases during access.
 - **Topology** — coupling maps available through operator utilities like
   `tnfr.operators.apply_topological_remesh`.
 

--- a/src/tnfr/alias.pyi
+++ b/src/tnfr/alias.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Hashable, TypeVar
 
@@ -35,10 +35,29 @@ def get_attr(
 ) -> T | None: ...
 
 
+def get_theta_attr(
+    d: Mapping[str, Any],
+    default: T | None = ...,
+    *,
+    strict: bool = ...,
+    log_level: int | None = ...,
+    conv: Callable[[Any], T] = ...,
+) -> T | None: ...
+
+
 def collect_attr(
     G: "nx.Graph",
     nodes: Iterable[NodeId],
     aliases: Iterable[str],
+    default: float = ...,
+    *,
+    np: ModuleType | None = ...,
+) -> FloatArray | list[float]: ...
+
+
+def collect_theta_attr(
+    G: "nx.Graph",
+    nodes: Iterable[NodeId],
     default: float = ...,
     *,
     np: ModuleType | None = ...,
@@ -71,6 +90,9 @@ def get_attr_str(
 
 
 def set_attr_str(d: dict[str, Any], aliases: Iterable[str], value: Any) -> str: ...
+
+
+def set_theta_attr(d: MutableMapping[str, Any], value: Any) -> float: ...
 
 
 def multi_recompute_abs_max(

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -125,7 +125,7 @@ THETA_KEY = "θ"
 # Mapa de aliases para atributos nodales
 ALIASES: dict[str, tuple[str, ...]] = {
     "VF": (VF_KEY, "nu_f", "nu-f", "nu", "freq", "frequency"),
-    "THETA": (THETA_KEY, "theta", "fase", "phi", "phase"),
+    "THETA": (THETA_KEY, "theta", "phi", "phase"),
     "DNFR": ("ΔNFR", "delta_nfr", "dnfr"),
     "EPI": ("EPI", "psi", "PSI", "value"),
     "EPI_KIND": ("EPI_kind", "epi_kind", "source_glyph"),

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -18,7 +18,7 @@ from types import ModuleType
 from collections.abc import Callable, Iterator, Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
-from ..alias import get_attr, set_dnfr
+from ..alias import get_attr, get_theta_attr, set_dnfr
 from ..constants import DEFAULTS, get_aliases, get_param
 from ..helpers.numeric import angle_diff
 from ..metrics.common import merge_and_normalize_weights
@@ -36,7 +36,6 @@ from ..types import (
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
     import numpy as np
-ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")
 
@@ -2015,7 +2014,8 @@ class _PhaseGradient:
         n: NodeId,
         nd: Mapping[str, Any],
     ) -> float:
-        th_i = get_attr(nd, ALIAS_THETA, 0.0)
+        theta_val = get_theta_attr(nd, 0.0)
+        th_i = float(theta_val if theta_val is not None else 0.0)
         neighbors = list(G.neighbors(n))
         if neighbors:
             th_bar = neighbor_phase_mean_list(

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -9,8 +9,8 @@ from collections.abc import Mapping
 from functools import lru_cache
 from types import MappingProxyType
 
-from .constants import DEFAULTS, get_aliases
-from .alias import get_attr
+from .constants import DEFAULTS
+from .alias import get_theta_attr
 from .types import GammaSpec, NodeId, TNFRGraph
 from .utils import (
     edge_version_cache,
@@ -20,8 +20,6 @@ from .utils import (
     node_set_checksum,
 )
 from .metrics.trig_cache import get_trig_cache
-
-ALIAS_THETA = get_aliases("THETA")
 
 
 logger = get_logger(__name__)
@@ -94,7 +92,8 @@ def _kuramoto_common(
     cache = G.graph.get("_kuramoto_cache", {})
     R = float(cache.get("R", 0.0))
     psi = float(cache.get("psi", 0.0))
-    th_i = get_attr(G.nodes[node], ALIAS_THETA, 0.0)
+    th_val = get_theta_attr(G.nodes[node], 0.0)
+    th_i = float(th_val if th_val is not None else 0.0)
     return th_i, R, psi
 
 

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -16,7 +16,7 @@ from ..constants import (
 )
 from ..callback_utils import CallbackEvent, callback_manager
 from ..glyph_history import append_metric, ensure_history
-from ..alias import collect_attr, set_attr
+from ..alias import collect_attr, collect_theta_attr, set_attr
 from ..helpers.numeric import clamp01
 from ..types import (
     CoherenceMetric,
@@ -47,7 +47,6 @@ from ..utils import (
 
 logger = get_logger(__name__)
 
-ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")
 ALIAS_SI = get_aliases("SI")
@@ -777,7 +776,7 @@ def coherence_matrix(
 
     # Precompute indices to avoid repeated list.index calls within loops
 
-    th_vals = collect_attr(G, nodes, ALIAS_THETA, 0.0, np=np if use_np else None)
+    th_vals = collect_theta_attr(G, nodes, 0.0, np=np if use_np else None)
     epi_vals = collect_attr(G, nodes, ALIAS_EPI, 0.0, np=np if use_np else None)
     vf_vals = collect_attr(G, nodes, ALIAS_VF, 0.0, np=np if use_np else None)
     si_vals = collect_attr(G, nodes, ALIAS_SI, 0.0, np=np if use_np else None)

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -29,8 +29,6 @@ from .trig_cache import get_trig_cache
 ALIAS_VF = get_aliases("VF")
 ALIAS_DNFR = get_aliases("DNFR")
 ALIAS_SI = get_aliases("SI")
-ALIAS_THETA = get_aliases("THETA")
-
 __all__ = ("get_Si_weights", "compute_Si_node", "compute_Si")
 
 

--- a/src/tnfr/metrics/trig_cache.py
+++ b/src/tnfr/metrics/trig_cache.py
@@ -10,12 +10,9 @@ import math
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
-from ..alias import get_attr
-from ..constants import get_aliases
+from ..alias import get_theta_attr
 from ..types import GraphLike
 from ..utils import edge_version_cache, get_numpy
-
-ALIAS_THETA = get_aliases("THETA")
 
 __all__ = ("TrigCache", "compute_theta_trig", "get_trig_cache", "_compute_trig_python")
 
@@ -36,7 +33,7 @@ def _iter_theta_pairs(
 
     for n, data in nodes:
         if isinstance(data, Mapping):
-            yield n, get_attr(data, ALIAS_THETA, 0.0)
+            yield n, get_theta_attr(data, 0.0) or 0.0
         else:
             yield n, float(data)
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from .constants import get_aliases
 from .alias import (
     get_attr,
+    get_theta_attr,
     get_attr_str,
     set_attr,
     set_attr_str,
@@ -98,7 +99,12 @@ class AttrSpec:
 ATTR_SPECS: dict[str, AttrSpec] = {
     "EPI": AttrSpec(aliases=ALIAS_EPI),
     "vf": AttrSpec(aliases=ALIAS_VF, setter=set_vf, use_graph_setter=True),
-    "theta": AttrSpec(aliases=ALIAS_THETA, setter=set_theta, use_graph_setter=True),
+    "theta": AttrSpec(
+        aliases=ALIAS_THETA,
+        getter=get_theta_attr,
+        setter=set_theta,
+        use_graph_setter=True,
+    ),
     "Si": AttrSpec(aliases=ALIAS_SI),
     "epi_kind": AttrSpec(
         aliases=ALIAS_EPI_KIND,

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -7,8 +7,7 @@ from functools import partial
 import statistics
 from statistics import StatisticsError, pvariance
 
-from .constants import get_aliases
-from .alias import get_attr
+from .alias import get_theta_attr
 from .helpers.numeric import angle_diff
 from .callback_utils import CallbackEvent, callback_manager
 from .glyph_history import (
@@ -27,8 +26,6 @@ from .utils import (
 from .config.constants import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
 from .metrics.common import compute_coherence
-
-ALIAS_THETA = get_aliases("THETA")
 
 __all__ = (
     "attach_standard_observer",
@@ -101,10 +98,11 @@ def phase_sync(
             R = R_calc
         if psi is None:
             psi = psi_calc
-    diffs = (
-        angle_diff(get_attr(data, ALIAS_THETA, 0.0), psi)
-        for _, data in G.nodes(data=True)
-    )
+    def _theta(nd: Mapping[str, object]) -> float:
+        value = get_theta_attr(nd, 0.0)
+        return float(value) if value is not None else 0.0
+
+    diffs = (angle_diff(_theta(data), psi) for _, data in G.nodes(data=True))
     # Try NumPy for a vectorised population variance
     np = get_numpy()
     if np is not None:

--- a/tests/unit/alias/test_theta_compat.py
+++ b/tests/unit/alias/test_theta_compat.py
@@ -1,0 +1,36 @@
+import math
+
+import networkx as nx
+import pytest
+
+from tnfr.alias import get_theta_attr, set_theta, set_theta_attr
+
+
+def test_get_theta_attr_warns_and_normalizes_fase() -> None:
+    data = {"fase": math.pi / 3}
+
+    with pytest.warns(DeprecationWarning):
+        value = get_theta_attr(data, 0.0)
+
+    assert value == pytest.approx(math.pi / 3)
+    assert "fase" not in data
+    assert data["theta"] == pytest.approx(math.pi / 3)
+    assert data["phase"] == pytest.approx(math.pi / 3)
+
+
+def test_set_theta_rewrites_legacy_key_to_english_aliases() -> None:
+    graph = nx.Graph()
+    graph.add_node(0, fase=0.0)
+
+    # Ensure the compatibility shim migrates legacy storage.
+    with pytest.warns(DeprecationWarning):
+        assert get_theta_attr(graph.nodes[0], 0.0) == pytest.approx(0.0)
+
+    # Updating the phase should keep only English aliases in the payload.
+    set_theta(graph, 0, math.pi / 4)
+    set_theta_attr(graph.nodes[0], math.pi / 2)
+
+    node_data = graph.nodes[0]
+    assert "fase" not in node_data
+    assert node_data["theta"] == pytest.approx(math.pi / 2)
+    assert node_data["phase"] == pytest.approx(node_data["theta"])


### PR DESCRIPTION
## Summary
- add a compatibility layer in `tnfr.alias` that rewrites legacy `"fase"` node keys while emitting a deprecation warning
- update phase-consuming helpers across dynamics, metrics, observers, and nodes to rely on the new shim
- document the migration and add regression tests covering legacy loads and English-key writes

## Testing
- pytest --override-ini addopts="" tests/unit/alias/test_theta_compat.py

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f648e113a4832185c40c4f5da09a78