### PR TITLE
Deprecate Spanish preset aliases in favour of English identifiers

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,26 @@
 # Release notes
 
+## 6.1.0 (preset alias deprecation window)
+
+- Announced the removal of the Spanish preset identifiers
+  (``arranque_resonante``, ``mutacion_contenida``, ``exploracion_acople``) in
+  **TNFR 7.0**. The engine now emits :class:`FutureWarning` when the legacy
+  names are resolved so pipelines can surface the upcoming breakage.
+- Added the ``tnfr.config.presets.SPANISH_PRESET_ALIASES`` mapping to help
+  audit configurations. Existing presets should switch to the English
+  equivalents (``resonant_bootstrap``, ``contained_mutation``,
+  ``coupling_exploration``) before upgrading to 7.0.
+- Migration helper: update YAML/JSON payloads or CLI arguments with a simple
+  substitution pass. For example, the following Python snippet rewrites a
+  user configuration dictionary in-place::
+
+      from tnfr.config.presets import SPANISH_PRESET_ALIASES
+
+      def normalize_preset_name(name: str) -> str:
+          return SPANISH_PRESET_ALIASES.get(name, name)
+
+      user_config["preset"] = normalize_preset_name(user_config["preset"])
+
 ## 6.0.0 (Nodo aliases removed)
 
 - Removed the Spanish module-level aliases ``tnfr.node.NodoNX`` and

--- a/src/tnfr/config/presets.py
+++ b/src/tnfr/config/presets.py
@@ -1,6 +1,14 @@
-"""Predefined TNFR configuration sequences."""
+"""Predefined TNFR configuration sequences.
+
+The module now exposes **English-only** preset identifiers as the canonical
+surface. Spanish identifiers remain available through
+``SPANISH_PRESET_ALIASES`` during the transition period so existing
+configurations can migrate gradually.
+"""
 
 from __future__ import annotations
+
+import warnings
 
 from ..execution import (
     CANONICAL_PRESET_NAME,
@@ -16,6 +24,7 @@ __all__ = (
     "PREFERRED_PRESET_NAMES",
     "LEGACY_PRESET_NAMES",
     "PRESET_NAME_ALIASES",
+    "SPANISH_PRESET_ALIASES",
 )
 
 
@@ -58,10 +67,14 @@ _PRIMARY_PRESETS: dict[str, PresetTokens] = {
     "canonical_example": list(CANONICAL_PROGRAM_TOKENS),
 }
 
-_LEGACY_PRESET_ALIASES: dict[str, str] = {
+SPANISH_PRESET_ALIASES: dict[str, str] = {
     "arranque_resonante": "resonant_bootstrap",
     "mutacion_contenida": "contained_mutation",
     "exploracion_acople": "coupling_exploration",
+}
+
+_LEGACY_PRESET_ALIASES: dict[str, str] = {
+    **SPANISH_PRESET_ALIASES,
     CANONICAL_PRESET_NAME: "canonical_example",
 }
 
@@ -75,7 +88,22 @@ for alias, target in _LEGACY_PRESET_ALIASES.items():
 
 
 def get_preset(name: str) -> PresetTokens:
+    if name in SPANISH_PRESET_ALIASES:
+        preferred = SPANISH_PRESET_ALIASES[name]
+        warnings.warn(
+            (
+                "Spanish preset identifier '%s' is deprecated and will be removed "
+                "in TNFR 7.0. Use '%s' instead."
+            )
+            % (name, preferred),
+            FutureWarning,
+            stacklevel=2,
+        )
+        name = preferred
+    else:
+        name = _LEGACY_PRESET_ALIASES.get(name, name)
+
     try:
         return _PRESETS[name]
     except KeyError:
-        raise KeyError(f"Preset no encontrado: {name}") from None
+        raise KeyError(f"Preset not found: {name}") from None

--- a/tests/unit/config/test_presets.py
+++ b/tests/unit/config/test_presets.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import pytest
 
 from tnfr.config.presets import (
     LEGACY_PRESET_NAMES,
     PREFERRED_PRESET_NAMES,
     PRESET_NAME_ALIASES,
+    SPANISH_PRESET_ALIASES,
     get_preset,
 )
 
@@ -19,4 +22,23 @@ def test_get_preset_accepts_preferred_names(name: str) -> None:
 @pytest.mark.parametrize("legacy", LEGACY_PRESET_NAMES)
 def test_legacy_aliases_resolve_to_preferred_names(legacy: str) -> None:
     preferred = PRESET_NAME_ALIASES[legacy]
-    assert get_preset(legacy) == get_preset(preferred)
+    context = (
+        pytest.warns(FutureWarning, match="Spanish preset identifier")
+        if legacy in SPANISH_PRESET_ALIASES
+        else nullcontext()
+    )
+    with context:
+        assert get_preset(legacy) == get_preset(preferred)
+
+
+@pytest.mark.parametrize("legacy", SPANISH_PRESET_ALIASES.keys())
+def test_spanish_aliases_announce_removal_timeline(legacy: str) -> None:
+    preferred = SPANISH_PRESET_ALIASES[legacy]
+    warning_message = (
+        f"Spanish preset identifier '{legacy}' is deprecated and will be removed "
+        f"in TNFR 7.0. Use '{preferred}' instead."
+    )
+    with pytest.warns(FutureWarning, match="will be removed in TNFR 7.0") as record:
+        assert get_preset(legacy) == get_preset(preferred)
+
+    assert any(w.message.args[0] == warning_message for w in record)


### PR DESCRIPTION
## Summary
- document the English-only preset identifiers and expose the Spanish compatibility map with deprecation warnings
- translate Spanish preset requests at runtime, emit FutureWarning, and update unit coverage for the legacy aliases
- publish release-note guidance plus a helper snippet to migrate stored configurations away from the Spanish identifiers

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f64c7090788321adcaa3b5bb440b51