### PR TITLE
Adopt stable_step_window for remesh gating

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -102,7 +102,11 @@ instantiate ad-hoc locks when they are not shared.
 
 Use `tnfr.operators.apply_topological_remesh` (`from tnfr.operators import
 apply_topological_remesh`) to reorganise connectivity based on nodal EPI similarity while
-preserving graph connectivity. Modes:
+preserving graph connectivity. Pair it with
+`tnfr.operators.apply_remesh_if_globally_stable(G, stable_step_window=...)` to gate
+remeshing on a minimum window of stable steps. The legacy keyword
+`pasos_estables_consecutivos` remains as a deprecated alias during the transition.
+Modes:
 
 - `"knn"` — connect each node to its `k` nearest neighbours (with optional rewiring).
 - `"mst"` — retain only a minimum spanning tree.

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -34,6 +34,19 @@ from .remesh import (
     apply_remesh_if_globally_stable,
 )
 
+_remesh_doc = (
+    "Trigger a remesh once the stability window is satisfied.\n\n"
+    "Parameters\n----------\n"
+    "stable_step_window : int | None\n"
+    "    Number of consecutive stable steps required before remeshing.\n"
+    "    The legacy keyword 'pasos_estables_consecutivos' is still accepted\n"
+    "    but will be removed after the transition period."
+)
+if apply_remesh_if_globally_stable.__doc__:
+    apply_remesh_if_globally_stable.__doc__ += "\n\n" + _remesh_doc
+else:
+    apply_remesh_if_globally_stable.__doc__ = _remesh_doc
+
 discover_operators()
 
 _DEFINITION_EXPORTS = {

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import heapq
 import random
+import warnings
 from operator import ge, le
 from functools import cache
 from itertools import combinations
@@ -468,8 +469,32 @@ def _extra_gating_ok(
 
 
 def apply_remesh_if_globally_stable(
-    G: CommunityGraph, pasos_estables_consecutivos: int | None = None
+    G: CommunityGraph,
+    stable_step_window: int | None = None,
+    **kwargs: Any,
 ) -> None:
+    legacy_window = kwargs.pop("pasos_estables_consecutivos", None)
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(
+            "apply_remesh_if_globally_stable() got unexpected keyword argument(s): "
+            f"{unexpected}"
+        )
+
+    if legacy_window is not None:
+        if stable_step_window is not None and stable_step_window != legacy_window:
+            raise TypeError(
+                "stable_step_window and pasos_estables_consecutivos provide conflicting "
+                "values; use only stable_step_window."
+            )
+        warnings.warn(
+            "'pasos_estables_consecutivos' is deprecated; use 'stable_step_window' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if stable_step_window is None:
+            stable_step_window = legacy_window
+
     params = [
         (
             "REMESH_STABILITY_WINDOW",
@@ -518,8 +543,8 @@ def apply_remesh_if_globally_stable(
         cfg[key] = conv(get_param(G, key))
     frac_req = _as_float(get_param(G, "FRACTION_STABLE_REMESH"))
     w_estab = (
-        pasos_estables_consecutivos
-        if pasos_estables_consecutivos is not None
+        stable_step_window
+        if stable_step_window is not None
         else cfg["REMESH_STABILITY_WINDOW"]
     )
 

--- a/tests/unit/structural/test_remesh.py
+++ b/tests/unit/structural/test_remesh.py
@@ -12,48 +12,51 @@ from tnfr.operators import apply_remesh_if_globally_stable
 from tnfr.operators.remesh import apply_network_remesh
 
 
-def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
+def _prepare_graph_for_remesh(graph_canon, stable_steps: int = 3):
     G = graph_canon()
     G.add_node(0)
     inject_defaults(G)
     G.graph["REMESH_REQUIRE_STABILITY"] = False
 
-    # Historial suficiente para el parámetro personalizado
     hist = G.graph.setdefault("history", {})
-    hist["stable_frac"] = [1.0, 1.0, 1.0]
+    hist["stable_frac"] = [1.0] * stable_steps
 
-    # Historial de EPI necesario para apply_network_remesh
     tau = G.graph["REMESH_TAU_GLOBAL"]
     maxlen = max(2 * tau + 5, 64)
     G.graph["_epi_hist"] = deque(
         [{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen
     )
+
+    return G, hist
+
+
+def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
+    G, hist = _prepare_graph_for_remesh(graph_canon)
 
     # Sin parámetro personalizado no se debería activar
     apply_remesh_if_globally_stable(G)
     assert "_last_remesh_step" not in G.graph
 
     # Con parámetro personalizado se activa con 3 pasos estables
-    apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=3)
+    apply_remesh_if_globally_stable(G, stable_step_window=3)
+    assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
+
+
+def test_aplicar_remesh_legacy_keyword_emite_advertencia(graph_canon):
+    G, hist = _prepare_graph_for_remesh(graph_canon)
+
+    with pytest.warns(DeprecationWarning):
+        apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=3)
+
     assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
 
 
 def test_remesh_alpha_hard_ignores_glyph_factor(graph_canon):
-    G = graph_canon()
-    G.add_node(0)
-    inject_defaults(G)
-    G.graph["REMESH_REQUIRE_STABILITY"] = False
-    hist = G.graph.setdefault("history", {})
-    hist["stable_frac"] = [1.0, 1.0, 1.0]
-    tau = G.graph["REMESH_TAU_GLOBAL"]
-    maxlen = max(2 * tau + 5, 64)
-    G.graph["_epi_hist"] = deque(
-        [{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen
-    )
+    G, _ = _prepare_graph_for_remesh(graph_canon)
     G.graph["REMESH_ALPHA"] = 0.7
     G.graph["REMESH_ALPHA_HARD"] = True
     G.graph["GLYPH_FACTORS"]["REMESH_alpha"] = 0.1
-    apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=3)
+    apply_remesh_if_globally_stable(G, stable_step_window=3)
     meta = G.graph.get("_REMESH_META", {})
     assert meta.get("alpha") == 0.7
     assert G.graph.get("_REMESH_ALPHA_SRC") == "REMESH_ALPHA"


### PR DESCRIPTION
## Summary
- add the `stable_step_window` keyword to `apply_remesh_if_globally_stable` with a deprecation warning for `pasos_estables_consecutivos`
- document the preferred keyword in the operator export facade and API guide
- update tests to exercise both the new keyword and the legacy alias during the transition period

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f65002562c8321bb8d992635042666