### PR TITLE
Normalize TNFR state telemetry to canonical tokens

### DIFF
--- a/tests/unit/metrics/test_diagnosis_state.py
+++ b/tests/unit/metrics/test_diagnosis_state.py
@@ -1,7 +1,17 @@
 """Tests for _state_from_thresholds."""
 
+import warnings
+
+import pytest
+
+from tnfr.constants import (
+    LEGACY_STATE_TOKENS,
+    STATE_DISSONANT,
+    STATE_STABLE,
+    STATE_TRANSITION,
+    normalise_state_token,
+)
 from tnfr.metrics.diagnosis import _state_from_thresholds
-from tnfr.config.operator_names import TRANSITION
 
 
 def test_state_from_thresholds_checks_all_conditions():
@@ -9,6 +19,20 @@ def test_state_from_thresholds_checks_all_conditions():
         "stable": {"Rloc_hi": 0.8, "dnfr_lo": 0.2},
         "dissonance": {"Rloc_lo": 0.4, "dnfr_hi": 0.5},
     }
-    assert _state_from_thresholds(0.9, 0.1, cfg) == "estable"
-    assert _state_from_thresholds(0.3, 0.6, cfg) == "disonante"
-    assert _state_from_thresholds(0.5, 0.3, cfg) == TRANSITION
+    assert _state_from_thresholds(0.9, 0.1, cfg) == STATE_STABLE
+    assert _state_from_thresholds(0.3, 0.6, cfg) == STATE_DISSONANT
+    assert _state_from_thresholds(0.5, 0.3, cfg) == STATE_TRANSITION
+
+
+def test_normalise_state_token_accepts_canonical_tokens_without_warning():
+    for token in (STATE_STABLE, STATE_DISSONANT, STATE_TRANSITION):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("error")
+            assert normalise_state_token(token) == token
+        assert caught == []
+
+
+def test_normalise_state_token_maps_legacy_values_with_warning():
+    for legacy_token, canonical in LEGACY_STATE_TOKENS.items():
+        with pytest.warns(UserWarning):
+            assert normalise_state_token(legacy_token) == canonical


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Introduced canonical English state constants with normalization helpers and warnings for legacy Spanish tokens.
- Normalized phase adaptation, telemetry history, and diagnostics to emit canonical state labels while preserving compatibility with historical data.
- Updated unit tests to assert canonical states and verify that legacy values still parse correctly.

## Testing
- pytest -o addopts='' tests/unit/metrics/test_diagnosis_state.py


------
https://chatgpt.com/codex/tasks/task_e_68f65328affc8321a3717e8ad8a61fa6