### PR TITLE
Maintain Si sensitivity alias compatibility

### DIFF
--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -47,6 +47,9 @@ def _cache_weights(G: GraphLike) -> tuple[float, float, float]:
         G.graph["_Si_weights_key"] = cfg_key
         G.graph["_Si_sensitivity"] = {
             "dSi_dvf_norm": alpha,
+            "dSi_dphase_disp": -beta,
+            # ``dSi_ddisp_fase`` is kept temporarily for legacy consumers.
+            # Remove once downstream callers have migrated to the English key.
             "dSi_ddisp_fase": -beta,
             "dSi_ddnfr_norm": -gamma,
         }

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -241,7 +241,29 @@ def _si_weights_field(G: TNFRGraph) -> TraceMetadata:
 
 
 def _si_sensitivity_field(G: TNFRGraph) -> TraceMetadata:
-    return mapping_field(G, "_Si_sensitivity", "si_sensitivity")
+    mapping = get_graph_mapping(
+        G,
+        "_Si_sensitivity",
+        "G.graph['_Si_sensitivity'] no es un mapeo; se ignora",
+    )
+    if mapping is None:
+        return {}
+
+    legacy_key = "dSi_ddisp_fase"
+    english_key = "dSi_dphase_disp"
+
+    normalised = dict(mapping)
+
+    english_value = normalised.get(english_key)
+    legacy_value = normalised.get(legacy_key)
+
+    if english_value is None and legacy_value is not None:
+        english_value = legacy_value
+        normalised[english_key] = legacy_value
+    if legacy_value is None and english_value is not None:
+        normalised[legacy_key] = english_value
+
+    return {"si_sensitivity": normalised}
 
 
 def si_weights_field(G: TNFRGraph) -> TraceMetadata:

--- a/tests/unit/metrics/test_si_helpers.py
+++ b/tests/unit/metrics/test_si_helpers.py
@@ -6,6 +6,7 @@ from tnfr.metrics.sense_index import compute_Si_node, get_Si_weights
 from tnfr.metrics.trig_cache import get_trig_cache
 from tnfr.alias import get_attr, set_attr, set_theta
 from tnfr.utils import increment_edge_version
+from tnfr.trace import _si_sensitivity_field
 
 ALIAS_DNFR = get_aliases("DNFR")
 ALIAS_SI = get_aliases("SI")
@@ -27,8 +28,39 @@ def test_get_si_weights_normalization(graph_canon):
     }
     assert G.graph["_Si_sensitivity"] == {
         "dSi_dvf_norm": alpha,
+        "dSi_dphase_disp": -beta,
         "dSi_ddisp_fase": -beta,
         "dSi_ddnfr_norm": -gamma,
+    }
+
+
+def test_si_sensitivity_field_handles_legacy_key(graph_canon):
+    G = graph_canon()
+    G.graph["_Si_sensitivity"] = {
+        "dSi_ddisp_fase": -0.25,
+    }
+
+    data = _si_sensitivity_field(G)
+    assert data == {
+        "si_sensitivity": {
+            "dSi_dphase_disp": -0.25,
+            "dSi_ddisp_fase": -0.25,
+        }
+    }
+
+
+def test_si_sensitivity_field_handles_new_key(graph_canon):
+    G = graph_canon()
+    G.graph["_Si_sensitivity"] = {
+        "dSi_dphase_disp": -0.75,
+    }
+
+    data = _si_sensitivity_field(G)
+    assert data == {
+        "si_sensitivity": {
+            "dSi_dphase_disp": -0.75,
+            "dSi_ddisp_fase": -0.75,
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- add the english dSi_dphase_disp alias alongside the legacy Si sensitivity key and document the pending removal
- normalise trace Si sensitivity snapshots to backfill missing aliases during the transition
- add regression tests for legacy-only and english-only Si sensitivity mappings

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f656013b1083219a0c21a0f4a1cbe6