### PR TITLE
Retire Spanish configuration aliases and document migration

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,24 @@
 # Release notes
 
+## 7.0.0 (Spanish identifiers removed)
+
+- Removed the Spanish glyph constants ``ESTABILIZADORES`` and ``DISRUPTIVOS``
+  from :mod:`tnfr.config.constants`. Import the English
+  :data:`tnfr.config.constants.STABILIZERS` and
+  :data:`tnfr.config.constants.DISRUPTORS` names instead. Accessing the old
+  identifiers now raises :class:`AttributeError` after emitting a final
+  :class:`FutureWarning` explaining the required substitution.
+- Finalised the state token migration. Spanish literals now require an explicit
+  opt-in via :func:`tnfr.constants.enable_spanish_state_tokens` or by setting
+  the :envvar:`TNFR_ENABLE_SPANISH_STATE_TOKENS` environment variable. The shim
+  warns with :class:`FutureWarning` and is scheduled for removal in TNFR 8.0.
+- Removed the ``SPANISH_PRESET_ALIASES`` helper and the runtime resolution of
+  Spanish preset identifiers. Calls such as ``get_preset('arranque_resonante')``
+  now raise :class:`KeyError` indicating the English replacement. Only English
+  preset names remain in the public API.
+- Updated tests and documentation to reflect the English-only contract across
+  glyph constants, preset helpers, and diagnostic state utilities.
+
 ## 6.1.0 (preset alias deprecation window)
 
 - Announced the removal of the Spanish preset identifiers
@@ -9,12 +28,18 @@
 - Added the ``tnfr.config.presets.SPANISH_PRESET_ALIASES`` mapping to help
   audit configurations. Existing presets should switch to the English
   equivalents (``resonant_bootstrap``, ``contained_mutation``,
-  ``coupling_exploration``) before upgrading to 7.0.
+  ``coupling_exploration``) before upgrading to 7.0. The helper was removed in
+  TNFR 7.0 once the migration period ended; downstream projects should now keep
+  a local mapping during the final substitution pass.
 - Migration helper: update YAML/JSON payloads or CLI arguments with a simple
-  substitution pass. For example, the following Python snippet rewrites a
-  user configuration dictionary in-place::
+  substitution pass. The following snippet illustrates how to migrate data once
+  the mapping is defined locally::
 
-      from tnfr.config.presets import SPANISH_PRESET_ALIASES
+      SPANISH_PRESET_ALIASES = {
+          "arranque_resonante": "resonant_bootstrap",
+          "mutacion_contenida": "contained_mutation",
+          "exploracion_acople": "coupling_exploration",
+      }
 
       def normalize_preset_name(name: str) -> str:
           return SPANISH_PRESET_ALIASES.get(name, name)

--- a/src/tnfr/config/constants.pyi
+++ b/src/tnfr/config/constants.pyi
@@ -5,9 +5,7 @@ __all__: Any
 def __getattr__(name: str) -> Any: ...
 
 ANGLE_MAP: Any
-DISRUPTIVOS: Any
 DISRUPTORS: Any
-ESTABILIZADORES: Any
 STABILIZERS: Any
 GLYPHS_CANONICAL: Any
 GLYPHS_CANONICAL_SET: Any

--- a/src/tnfr/config/presets.py
+++ b/src/tnfr/config/presets.py
@@ -1,14 +1,11 @@
 """Predefined TNFR configuration sequences.
 
-The module now exposes **English-only** preset identifiers as the canonical
-surface. Spanish identifiers remain available through
-``SPANISH_PRESET_ALIASES`` during the transition period so existing
-configurations can migrate gradually.
+Spanish preset identifiers were removed in TNFR 7.0. Only the English names
+remain available; attempting to resolve a legacy Spanish identifier will raise
+an explicit :class:`KeyError` pointing to the correct replacement.
 """
 
 from __future__ import annotations
-
-import warnings
 
 from ..execution import (
     CANONICAL_PRESET_NAME,
@@ -24,7 +21,6 @@ __all__ = (
     "PREFERRED_PRESET_NAMES",
     "LEGACY_PRESET_NAMES",
     "PRESET_NAME_ALIASES",
-    "SPANISH_PRESET_ALIASES",
 )
 
 
@@ -67,14 +63,13 @@ _PRIMARY_PRESETS: dict[str, PresetTokens] = {
     "canonical_example": list(CANONICAL_PROGRAM_TOKENS),
 }
 
-SPANISH_PRESET_ALIASES: dict[str, str] = {
+_REMOVED_SPANISH_PRESETS: dict[str, str] = {
     "arranque_resonante": "resonant_bootstrap",
     "mutacion_contenida": "contained_mutation",
     "exploracion_acople": "coupling_exploration",
 }
 
 _LEGACY_PRESET_ALIASES: dict[str, str] = {
-    **SPANISH_PRESET_ALIASES,
     CANONICAL_PRESET_NAME: "canonical_example",
 }
 
@@ -88,20 +83,17 @@ for alias, target in _LEGACY_PRESET_ALIASES.items():
 
 
 def get_preset(name: str) -> PresetTokens:
-    if name in SPANISH_PRESET_ALIASES:
-        preferred = SPANISH_PRESET_ALIASES[name]
-        warnings.warn(
+    preferred = _REMOVED_SPANISH_PRESETS.get(name)
+    if preferred is not None:
+        raise KeyError(
             (
-                "Spanish preset identifier '%s' is deprecated and will be removed "
-                "in TNFR 7.0. Use '%s' instead."
+                "Spanish preset identifier '%s' was removed in TNFR 7.0. "
+                "Use '%s' instead."
             )
-            % (name, preferred),
-            FutureWarning,
-            stacklevel=2,
+            % (name, preferred)
         )
-        name = preferred
-    else:
-        name = _LEGACY_PRESET_ALIASES.get(name, name)
+
+    name = _LEGACY_PRESET_ALIASES.get(name, name)
 
     try:
         return _PRESETS[name]

--- a/src/tnfr/constants/__init__.pyi
+++ b/src/tnfr/constants/__init__.pyi
@@ -50,6 +50,15 @@ __all__ = (
     "dVF_PRIMARY",
     "D2VF_PRIMARY",
     "dSI_PRIMARY",
+    "STATE_STABLE",
+    "STATE_TRANSITION",
+    "STATE_DISSONANT",
+    "CANONICAL_STATE_TOKENS",
+    "SPANISH_STATE_TOKENS_ENV_VAR",
+    "enable_spanish_state_tokens",
+    "disable_spanish_state_tokens",
+    "spanish_state_tokens_enabled",
+    "normalise_state_token",
 )
 
 ensure_node_offset_map: Callable[[GraphLike], None] | None
@@ -69,6 +78,11 @@ D2EPI_PRIMARY: str
 dVF_PRIMARY: str
 D2VF_PRIMARY: str
 dSI_PRIMARY: str
+STATE_STABLE: str
+STATE_TRANSITION: str
+STATE_DISSONANT: str
+CANONICAL_STATE_TOKENS: frozenset[str]
+SPANISH_STATE_TOKENS_ENV_VAR: str
 
 
 def inject_defaults(
@@ -90,3 +104,15 @@ def get_graph_param(
 
 
 def get_aliases(key: str) -> tuple[str, ...]: ...
+
+
+def enable_spanish_state_tokens(*, warn: bool = ...) -> Mapping[str, str]: ...
+
+
+def disable_spanish_state_tokens() -> None: ...
+
+
+def spanish_state_tokens_enabled() -> bool: ...
+
+
+def normalise_state_token(token: str, *, warn: bool = ...) -> str: ...

--- a/src/tnfr/constants_glyphs.pyi
+++ b/src/tnfr/constants_glyphs.pyi
@@ -5,9 +5,7 @@ __all__: Any
 def __getattr__(name: str) -> Any: ...
 
 ANGLE_MAP: Any
-DISRUPTIVOS: Any
 DISRUPTORS: Any
-ESTABILIZADORES: Any
 STABILIZERS: Any
 GLYPHS_CANONICAL: Any
 GLYPHS_CANONICAL_SET: Any

--- a/tests/unit/config/test_presets.py
+++ b/tests/unit/config/test_presets.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
-
 import pytest
 
 from tnfr.config.presets import (
     LEGACY_PRESET_NAMES,
     PREFERRED_PRESET_NAMES,
     PRESET_NAME_ALIASES,
-    SPANISH_PRESET_ALIASES,
     get_preset,
 )
 
@@ -22,23 +19,23 @@ def test_get_preset_accepts_preferred_names(name: str) -> None:
 @pytest.mark.parametrize("legacy", LEGACY_PRESET_NAMES)
 def test_legacy_aliases_resolve_to_preferred_names(legacy: str) -> None:
     preferred = PRESET_NAME_ALIASES[legacy]
-    context = (
-        pytest.warns(FutureWarning, match="Spanish preset identifier")
-        if legacy in SPANISH_PRESET_ALIASES
-        else nullcontext()
+    assert get_preset(legacy) == get_preset(preferred)
+
+
+@pytest.mark.parametrize(
+    ("legacy", "preferred"),
+    (
+        ("arranque_resonante", "resonant_bootstrap"),
+        ("mutacion_contenida", "contained_mutation"),
+        ("exploracion_acople", "coupling_exploration"),
+    ),
+)
+def test_spanish_aliases_are_removed(legacy: str, preferred: str) -> None:
+    with pytest.raises(KeyError) as excinfo:
+        get_preset(legacy)
+
+    message = excinfo.value.args[0]
+    assert message == (
+        f"Spanish preset identifier '{legacy}' was removed in TNFR 7.0. "
+        f"Use '{preferred}' instead."
     )
-    with context:
-        assert get_preset(legacy) == get_preset(preferred)
-
-
-@pytest.mark.parametrize("legacy", SPANISH_PRESET_ALIASES.keys())
-def test_spanish_aliases_announce_removal_timeline(legacy: str) -> None:
-    preferred = SPANISH_PRESET_ALIASES[legacy]
-    warning_message = (
-        f"Spanish preset identifier '{legacy}' is deprecated and will be removed "
-        f"in TNFR 7.0. Use '{preferred}' instead."
-    )
-    with pytest.warns(FutureWarning, match="will be removed in TNFR 7.0") as record:
-        assert get_preset(legacy) == get_preset(preferred)
-
-    assert any(w.message.args[0] == warning_message for w in record)


### PR DESCRIPTION
## Summary
- remove the Spanish glyph aliases from `tnfr.config.constants`, documenting the English replacements and guarding legacy accesses with a final `FutureWarning`
- require an explicit `enable_spanish_state_tokens` opt-in (or environment flag) for Spanish state tokens while updating the unit tests and stubs
- drop the Spanish preset aliases, surface clear `KeyError` guidance, and record the compatibility break in the release notes

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f6581a40988321a7a24c52b96fcc3c