### PR TITLE
Translate CLI help messaging to English

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -129,6 +129,9 @@ Run the sequence on a single node and persist telemetry to `history.json`:
 tnfr sequence --nodes 1 --sequence-file sequence.json --save-history history.json
 ```
 
+Use `--summary-limit` to bound the number of samples per series in CLI summaries.
+Pass `0` or a negative value to disable trimming altogether when exporting metrics.
+
 | Canonical token | Operator role        |
 | --------------- | -------------------- |
 | `emission`      | Initiates resonance  |

--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -61,8 +61,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         prog="tnfr",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Ejemplo: tnfr sequence --sequence-file secuencia.json\n"
-            "secuencia.json:\n"
+            "Example: tnfr sequence --sequence-file sequence.json\n"
+            "sequence.json:\n"
             '[\n  {"WAIT": 1},\n  {"TARGET": "A"}\n]'
         ),
     )
@@ -70,7 +70,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--version",
         action="store_true",
         help=(
-            "muestra versión real y sale (lee pyproject.toml en desarrollo)"
+            "show the actual version and exit (reads pyproject.toml in development)"
         ),
     )
     sub = p.add_subparsers(dest="cmd")

--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -12,7 +12,7 @@ from ..types import ArgSpec
 from .utils import spec
 
 
-_PRESET_HELP = "Nombres preferidos: {}. Claves heredadas: {}.".format(
+_PRESET_HELP = "Preferred names: {}. Legacy keys: {}.".format(
     ", ".join(PREFERRED_PRESET_NAMES),
     ", ".join(LEGACY_PRESET_NAMES),
 )
@@ -46,9 +46,9 @@ COMMON_ARG_SPECS: tuple[ArgSpec, ...] = (
     spec(
         "--p",
         type=float,
-        help="Probabilidad de arista si topology=erdos",
+        help="Edge probability when topology=erdos",
     ),
-    spec("--observer", action="store_true", help="Adjunta observador estándar"),
+    spec("--observer", action="store_true", help="Attach standard observer"),
     spec("--config", type=str),
     spec("--dt", type=float),
     spec("--integrator", choices=["euler", "rk4"]),
@@ -107,7 +107,7 @@ def add_canon_toggle(parser: argparse.ArgumentParser) -> None:
         dest="grammar_canon",
         action="store_false",
         default=True,
-        help="Desactiva gramática canónica",
+        help="Disable canonical grammar",
     )
 
 
@@ -118,7 +118,7 @@ def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     p_run = sub.add_parser(
         "run",
         help=(
-            "Correr escenario libre o preset y opcionalmente exportar history"
+            "Run a free scenario or preset and optionally export history"
         ),
     )
     add_common_args(p_run)
@@ -134,8 +134,8 @@ def _add_run_parser(sub: argparse._SubParsersAction) -> None:
         type=int,
         default=DEFAULT_SUMMARY_SERIES_LIMIT,
         help=(
-            "Número máximo de muestras por serie en el resumen (<=0 para"
-            " desactivar el recorte)"
+            "Maximum number of samples per series in the summary (<=0 to"
+            " disable trimming)"
         ),
     )
     p_run.set_defaults(func=cmd_run)
@@ -147,10 +147,10 @@ def _add_sequence_parser(sub: argparse._SubParsersAction) -> None:
 
     p_seq = sub.add_parser(
         "sequence",
-        help="Ejecutar una secuencia (preset o YAML/JSON)",
+        help="Execute a sequence (preset or YAML/JSON)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Ejemplo de secuencia JSON:\n"
+            "JSON sequence example:\n"
             "[\n"
             '  "A",\n'
             '  {"WAIT": 1},\n'
@@ -171,7 +171,7 @@ def _add_metrics_parser(sub: argparse._SubParsersAction) -> None:
     from .execution import cmd_metrics
 
     p_met = sub.add_parser(
-        "metrics", help="Correr breve y volcar métricas clave"
+        "metrics", help="Run briefly and export key metrics"
     )
     add_common_args(p_met)
     p_met.add_argument("--steps", type=int, default=None)
@@ -183,8 +183,8 @@ def _add_metrics_parser(sub: argparse._SubParsersAction) -> None:
         type=int,
         default=None,
         help=(
-            "Número máximo de muestras por serie en el resumen (<=0 para"
-            " desactivar el recorte)"
+            "Maximum number of samples per series in the summary (<=0 to"
+            " disable trimming)"
         ),
     )
     p_met.set_defaults(func=cmd_metrics)


### PR DESCRIPTION
## Summary
- translate CLI help strings and epilog text to English across argument builders and the main entry point
- document the CLI summary limit behaviour in the quickstart guide so user docs mirror the updated help text

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f65aa9ba5c8321a787bfb78e3a0ab2