### PR TITLE
Align deprecation messaging with English strings

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## 7.0.1 (English deprecation messaging)
+
+- Reworded the remaining deprecation warnings and validation errors that still
+  surfaced Spanish text. Deprecation shims in :mod:`tnfr.constants_glyphs` and
+  :mod:`tnfr.presets` now emit English guidance, and the operator registry plus
+  metrics export helpers raise English-only :class:`ValueError` messages for
+  unsupported usage.
+
 ## 7.0.0 (Spanish identifiers removed)
 
 - Removed the Spanish glyph constants ``ESTABILIZADORES`` and ``DISRUPTIVOS``

--- a/src/tnfr/constants_glyphs.py
+++ b/src/tnfr/constants_glyphs.py
@@ -8,7 +8,7 @@ from .config.constants import *  # noqa: F401,F403 - re-export legacy API
 from .config.constants import __all__ as _CONFIG_ALL
 
 warnings.warn(
-    "'tnfr.constants_glyphs' está en desuso; usa 'tnfr.config.constants'",
+    "'tnfr.constants_glyphs' is deprecated; use 'tnfr.config.constants' instead",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -92,7 +92,7 @@ def export_metrics(G: Graph, base_path: str, fmt: str = "csv") -> None:
     epi_supp: Sequence[Mapping[str, float]] = hist.get("EPI_support", [])
     fmt = fmt.lower()
     if fmt not in {"csv", "json"}:
-        raise ValueError(f"Formato de exportación no soportado: {fmt}")
+        raise ValueError(f"Unsupported export format: {fmt}")
     if fmt == "csv":
         specs: list[tuple[str, Sequence[str], Iterable[Sequence[object]]]] = [
             (

--- a/src/tnfr/operators/registry.py
+++ b/src/tnfr/operators/registry.py
@@ -22,12 +22,12 @@ def register_operator(cls: type["Operador"]) -> type["Operador"]:
     name = getattr(cls, "name", None)
     if not isinstance(name, str) or not name:
         raise ValueError(
-            f"El operador {cls.__name__} debe declarar un atributo 'name' no vacío"
+            f"Operator {cls.__name__} must declare a non-empty 'name' attribute"
         )
 
     existing = OPERATORS.get(name)
     if existing is not None and existing is not cls:
-        raise ValueError(f"El operador '{name}' ya está registrado")
+        raise ValueError(f"Operator '{name}' is already registered")
 
     OPERATORS[name] = cls
     return cls

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -7,7 +7,7 @@ import warnings
 from .config.presets import get_preset
 
 warnings.warn(
-    "'tnfr.presets' está en desuso; usa 'tnfr.config.presets'",
+    "'tnfr.presets' is deprecated; use 'tnfr.config.presets' instead",
     DeprecationWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- translate remaining DeprecationWarning and ValueError messages to English across legacy shims, the operator registry, and metrics export helper
- record the messaging update in the release notes to document the English-only contract

## Testing
- pytest tests/unit/metrics/test_export_metrics.py tests/unit/dynamics/test_operator_names.py -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68f65ba10c588321b33e67eee078f584