### PR TITLE
Enforce English-only phase attributes and add migration helper

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -14,8 +14,10 @@ facades.
 - **Si** — `tnfr.metrics.sense_index.compute_Si`: ability to produce meaningful reorganisation
   combining νf, phase, and topology.
 - **Phase θ** — `tnfr.dynamics.coordinate_global_local_phase` and related helpers.
-- **Compatibility** — legacy node payloads using `"fase"` emit a `DeprecationWarning`
-  and are rewritten to the English `"theta"`/`"phase"` aliases during access.
+- **Compatibility** — legacy node payloads using `"fase"` now raise a
+  :class:`ValueError`. Migrate graphs upfront with
+  :func:`tnfr.utils.migrate_legacy_phase_attributes` so node data stores
+  `"theta"`/`"phase"` exclusively.
 - **Topology** — coupling maps available through operator utilities like
   `tnfr.operators.apply_topological_remesh`.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,18 @@
 # Release notes
 
+## 8.0.0 (phase alias enforcement)
+
+- Finalised the phase attribute migration by rejecting the Spanish ``"fase"``
+  node key. Access helpers in :mod:`tnfr.alias` now operate strictly on the
+  English ``"theta"``/``"phase"`` attributes and raise
+  :class:`ValueError` when the legacy key is encountered.
+- Added :func:`tnfr.utils.migrate_legacy_phase_attributes` to help upgrade
+  stored graphs. The helper rewrites ``"fase"`` and ``"θ"`` payloads in place,
+  populating the canonical English keys before interacting with the alias
+  layer.
+- Updated documentation and tests to reflect the English-only phase contract
+  and removed the automatic ``"fase"`` rewrite shims.
+
 ## 7.0.1 (English deprecation messaging)
 
 - Reworded the remaining deprecation warnings and validation errors that still

--- a/meta.json
+++ b/meta.json
@@ -20,7 +20,7 @@
         "EPI": "Primary Structure of Information (aka PSI): an active coherent form.",
         "νf": "Structural frequency: the node's internal rhythm (unit: Hz_str).",
         "ΔNFR": "Nodal reorganization operator/gradient over time.",
-        "θ": "Structural phase: relative synchrony with the network.",
+        "theta": "Structural phase: relative synchrony with the network.",
         "C(t)": "Total coherence at structural time t."
       }
     },
@@ -44,8 +44,8 @@
     "coherence": "‖EPI‖ or C(t): stability over structural time.",
     "frequency": "νf: internal rhythm (Hz_str).",
     "nodalGradient": "ΔNFR: need for reorganization relative to environment.",
-    "senseIndex": "Si = f(νf, θ, topology): capacity to generate stable, meaningful reorganization.",
-    "phase": "θ: relative synchrony with the network.",
+    "senseIndex": "Si = f(νf, theta, topology): capacity to generate stable, meaningful reorganization.",
+    "phase": "theta: relative synchrony with the network.",
     "topology": "Connection pattern among nodes that influences coupling and propagation."
   },
   "install": {"pip": "pip install tnfr"},

--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -226,12 +226,12 @@ def get_graph_param(
 
 # Claves canónicas con nombres ASCII
 VF_KEY = "νf"
-THETA_KEY = "θ"
+THETA_KEY = "theta"
 
 # Mapa de aliases para atributos nodales
 ALIASES: dict[str, tuple[str, ...]] = {
     "VF": (VF_KEY, "nu_f", "nu-f", "nu", "freq", "frequency"),
-    "THETA": (THETA_KEY, "theta", "phi", "phase"),
+    "THETA": (THETA_KEY, "phase"),
     "DNFR": ("ΔNFR", "delta_nfr", "dnfr"),
     "EPI": ("EPI", "psi", "PSI", "value"),
     "EPI_KIND": ("EPI_kind", "epi_kind", "source_glyph"),

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -25,6 +25,7 @@ from .graph import (
     mark_dnfr_prep_dirty,
     supports_add_edge,
 )
+from .migrations import migrate_legacy_phase_attributes
 from .cache import (
     EdgeCacheManager,
     LockAwareLRUCache,
@@ -93,6 +94,7 @@ __all__ = (
     "get_graph_mapping",
     "mark_dnfr_prep_dirty",
     "supports_add_edge",
+    "migrate_legacy_phase_attributes",
     "JsonDumpsParams",
     "DEFAULT_PARAMS",
     "json_dumps",

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -40,6 +40,7 @@ from .graph import (
     mark_dnfr_prep_dirty,
     supports_add_edge,
 )
+from .migrations import migrate_legacy_phase_attributes
 from .init import (
     EMIT_MAP,
     IMPORT_LOG,
@@ -112,6 +113,7 @@ __all__ = (
     "get_graph_mapping",
     "mark_dnfr_prep_dirty",
     "supports_add_edge",
+    "migrate_legacy_phase_attributes",
     "JsonDumpsParams",
     "DEFAULT_PARAMS",
     "json_dumps",

--- a/src/tnfr/utils/migrations.py
+++ b/src/tnfr/utils/migrations.py
@@ -1,0 +1,62 @@
+"""Utilities for migrating legacy payloads to the English-only contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Hashable, Iterable, cast
+
+from ..types import GraphLike
+
+__all__ = ("migrate_legacy_phase_attributes",)
+
+
+def _iter_node_payloads(
+    obj: GraphLike | Mapping[Hashable, MutableMapping[str, Any]]
+) -> Iterable[MutableMapping[str, Any]]:
+    nodes = getattr(obj, "nodes", None)
+    if nodes is None:
+        if isinstance(obj, Mapping):
+            return (cast(MutableMapping[str, Any], data) for data in obj.values())
+        raise TypeError("Object does not expose node payloads")
+    return (
+        cast(MutableMapping[str, Any], data)
+        for _, data in nodes(data=True)
+        if isinstance(data, MutableMapping)
+    )
+
+
+def migrate_legacy_phase_attributes(
+    obj: GraphLike | Mapping[Hashable, MutableMapping[str, Any]]
+) -> int:
+    """Replace legacy ``"fase"``/``"θ"`` node keys with ``"theta"``/``"phase"``.
+
+    Parameters
+    ----------
+    obj:
+        ``networkx``-style graph or mapping exposing node payloads.
+
+    Returns
+    -------
+    int
+        Number of node payloads updated.
+    """
+
+    updated = 0
+    for data in _iter_node_payloads(obj):
+        if "fase" in data:
+            legacy_value = data.pop("fase")
+        elif "θ" in data:
+            legacy_value = data.pop("θ")
+        else:
+            continue
+        try:
+            coerced = float(legacy_value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("Legacy phase value is not numeric") from exc
+        if "theta" not in data:
+            data["theta"] = coerced
+        else:
+            data["theta"] = float(data["theta"])
+        data["phase"] = float(data["theta"])
+        updated += 1
+    return updated

--- a/src/tnfr/utils/migrations.pyi
+++ b/src/tnfr/utils/migrations.pyi
@@ -1,0 +1,11 @@
+from collections.abc import Mapping, MutableMapping
+from typing import Any, Hashable
+
+from ..types import GraphLike
+
+__all__ = ("migrate_legacy_phase_attributes",)
+
+
+def migrate_legacy_phase_attributes(
+    obj: GraphLike | Mapping[Hashable, MutableMapping[str, Any]]
+) -> int: ...

--- a/tests/unit/alias/test_theta_compat.py
+++ b/tests/unit/alias/test_theta_compat.py
@@ -4,29 +4,39 @@ import networkx as nx
 import pytest
 
 from tnfr.alias import get_theta_attr, set_theta, set_theta_attr
+from tnfr.utils import migrate_legacy_phase_attributes
 
 
-def test_get_theta_attr_warns_and_normalizes_fase() -> None:
+def test_get_theta_attr_rejects_legacy_key() -> None:
     data = {"fase": math.pi / 3}
 
-    with pytest.warns(DeprecationWarning):
-        value = get_theta_attr(data, 0.0)
+    with pytest.raises(ValueError, match="Legacy node attribute \"fase\""):
+        get_theta_attr(data, 0.0)
+
+
+def test_migration_restores_theta_access() -> None:
+    data = {"fase": math.pi / 3}
+
+    assert migrate_legacy_phase_attributes({0: data}) == 1
+    value = get_theta_attr(data, 0.0)
 
     assert value == pytest.approx(math.pi / 3)
-    assert "fase" not in data
     assert data["theta"] == pytest.approx(math.pi / 3)
     assert data["phase"] == pytest.approx(math.pi / 3)
 
 
-def test_set_theta_rewrites_legacy_key_to_english_aliases() -> None:
+def test_migration_converts_symbol_key() -> None:
+    data = {"θ": math.pi / 6}
+
+    assert migrate_legacy_phase_attributes({0: data}) == 1
+    assert data["theta"] == pytest.approx(math.pi / 6)
+    assert data["phase"] == pytest.approx(math.pi / 6)
+
+
+def test_set_theta_keeps_only_english_aliases() -> None:
     graph = nx.Graph()
-    graph.add_node(0, fase=0.0)
+    graph.add_node(0)
 
-    # Ensure the compatibility shim migrates legacy storage.
-    with pytest.warns(DeprecationWarning):
-        assert get_theta_attr(graph.nodes[0], 0.0) == pytest.approx(0.0)
-
-    # Updating the phase should keep only English aliases in the payload.
     set_theta(graph, 0, math.pi / 4)
     set_theta_attr(graph.nodes[0], math.pi / 2)
 

--- a/tests/unit/dynamics/test_gamma.py
+++ b/tests/unit/dynamics/test_gamma.py
@@ -20,7 +20,7 @@ def test_gamma_linear_integration(graph_canon):
     for n in G.nodes():
         G.nodes[n]["νf"] = 1.0
         G.nodes[n]["ΔNFR"] = 0.0
-        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["theta"] = 0.0
         G.nodes[n]["EPI"] = 0.0
     update_epi_via_nodal_equation(G, dt=1.0)
     assert pytest.approx(G.nodes[0]["EPI"], rel=1e-6) == 1.0
@@ -29,7 +29,7 @@ def test_gamma_linear_integration(graph_canon):
 
 def test_eval_gamma_none_returns_zero(graph_canon):
     G = graph_canon()
-    G.add_node(0, θ=0.0)
+    G.add_node(0, theta=0.0)
     inject_defaults(G)
     G.graph["GAMMA"] = {"type": "none"}
 
@@ -42,8 +42,8 @@ def test_gamma_bandpass_eval(graph_canon):
     inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "kuramoto_bandpass", "beta": 1.0})
     for n in [0, 1, 2]:
-        G.nodes[n]["θ"] = 0.0
-    G.nodes[3]["θ"] = math.pi
+        G.nodes[n]["theta"] = 0.0
+    G.nodes[3]["theta"] = math.pi
     g0 = eval_gamma(G, 0, t=0.0)
     g3 = eval_gamma(G, 3, t=0.0)
     assert pytest.approx(g0, rel=1e-6) == 0.25
@@ -58,7 +58,7 @@ def test_gamma_linear_string_params(graph_canon):
         G, GAMMA={"type": "kuramoto_linear", "beta": "1.0", "R0": "0.0"}
     )
     for n in G.nodes():
-        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["theta"] = 0.0
     g0 = eval_gamma(G, 0, t=0.0)
     g1 = eval_gamma(G, 1, t=0.0)
     assert pytest.approx(g0, rel=1e-6) == 1.0
@@ -72,7 +72,7 @@ def test_gamma_inplace_mutation_updates_spec(graph_canon):
     cfg = {"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0}
     G.graph["GAMMA"] = cfg
     for n in G.nodes():
-        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["theta"] = 0.0
 
     g_initial = eval_gamma(G, 0, t=0.0)
     cfg["beta"] = 2.0
@@ -91,8 +91,8 @@ def test_gamma_tanh_eval(graph_canon):
         GAMMA={"type": "kuramoto_tanh", "beta": 1.0, "k": 1.0, "R0": 0.0},
     )
     for n in [0, 1, 2]:
-        G.nodes[n]["θ"] = 0.0
-    G.nodes[3]["θ"] = math.pi
+        G.nodes[n]["theta"] = 0.0
+    G.nodes[3]["theta"] = math.pi
     expected = math.tanh(0.5)
     g0 = eval_gamma(G, 0, t=0.0)
     g3 = eval_gamma(G, 3, t=0.0)
@@ -106,8 +106,8 @@ def test_gamma_bandpass_string_params(graph_canon):
     inject_defaults(G)
     merge_overrides(G, GAMMA={"type": "kuramoto_bandpass", "beta": "1.0"})
     for n in [0, 1, 2]:
-        G.nodes[n]["θ"] = 0.0
-    G.nodes[3]["θ"] = math.pi
+        G.nodes[n]["theta"] = 0.0
+    G.nodes[3]["theta"] = math.pi
     g0 = eval_gamma(G, 0, t=0.0)
     g3 = eval_gamma(G, 3, t=0.0)
     assert pytest.approx(g0, rel=1e-6) == 0.25
@@ -122,7 +122,7 @@ def test_gamma_harmonic_eval(graph_canon):
         G, GAMMA={"type": "harmonic", "beta": 1.0, "omega": 1.0, "phi": 0.0}
     )
     for n in G.nodes():
-        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["theta"] = 0.0
     g0 = eval_gamma(G, 0, t=math.pi / 2)
     g1 = eval_gamma(G, 1, t=math.pi / 2)
     assert pytest.approx(g0, rel=1e-6) == 1.0
@@ -143,8 +143,8 @@ def test_gamma_tanh_string_params(graph_canon):
         },
     )
     for n in [0, 1, 2]:
-        G.nodes[n]["θ"] = 0.0
-    G.nodes[3]["θ"] = math.pi
+        G.nodes[n]["theta"] = 0.0
+    G.nodes[3]["theta"] = math.pi
     expected = math.tanh(0.5)
     g0 = eval_gamma(G, 0, t=0.0)
     g3 = eval_gamma(G, 3, t=0.0)
@@ -154,7 +154,7 @@ def test_gamma_tanh_string_params(graph_canon):
 
 def test_gamma_spec_normalized_once(graph_canon, monkeypatch):
     G = graph_canon()
-    G.add_node(0, θ=0.0)
+    G.add_node(0, theta=0.0)
     G.graph["GAMMA"] = []  # invalid spec
     emitted = []
 
@@ -172,7 +172,7 @@ def test_default_gamma_spec_called_once(graph_canon, monkeypatch):
 
     G = graph_canon()
     G.graph.pop("GAMMA", None)
-    G.add_node(0, θ=0.0)
+    G.add_node(0, theta=0.0)
     calls = []
 
     real = gamma_mod._default_gamma_spec
@@ -191,7 +191,7 @@ def test_kuramoto_cache_reuses_checksum(graph_canon, monkeypatch):
     from tnfr import gamma as gamma_mod
 
     G = graph_canon()
-    G.add_node(0, θ=0.0)
+    G.add_node(0, theta=0.0)
     calls = []
 
     def fake_checksum(G):
@@ -212,7 +212,7 @@ def test_kuramoto_cache_updates_on_time_change(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0])
     inject_defaults(G)
-    G.nodes[0]["θ"] = 0.0
+    G.nodes[0]["theta"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     cache0 = G.graph["_kuramoto_cache"]
     gamma_mod._ensure_kuramoto_cache(G, t=1)
@@ -226,11 +226,11 @@ def test_kuramoto_cache_updates_on_nodes_change(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0])
     inject_defaults(G)
-    G.nodes[0]["θ"] = 0.0
+    G.nodes[0]["theta"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     cache0 = G.graph["_kuramoto_cache"]
     G.add_node(1)
-    G.nodes[1]["θ"] = 0.0
+    G.nodes[1]["theta"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     cache1 = G.graph["_kuramoto_cache"]
     assert cache0 is not cache1
@@ -243,7 +243,7 @@ def test_kuramoto_cache_step_limit(graph_canon):
     G.add_nodes_from([0])
     inject_defaults(G)
     G.graph["KURAMOTO_CACHE_STEPS"] = 2
-    G.nodes[0]["θ"] = 0.0
+    G.nodes[0]["theta"] = 0.0
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     gamma_mod._ensure_kuramoto_cache(G, t=1)
     gamma_mod._ensure_kuramoto_cache(G, t=2)
@@ -260,11 +260,11 @@ def test_kuramoto_cache_invalidation_on_version(graph_canon):
         G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0}
     )
     for n in G.nodes():
-        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["theta"] = 0.0
     g_before = eval_gamma(G, 0, t=0.0)
 
     G.add_node(2)
-    G.nodes[2]["θ"] = math.pi
+    G.nodes[2]["theta"] = math.pi
     increment_edge_version(G)
     g_after = eval_gamma(G, 0, t=0.0)
 
@@ -285,7 +285,7 @@ def test_gamma_harmonic_string_params(graph_canon):
         },
     )
     for n in G.nodes():
-        G.nodes[n]["θ"] = 0.0
+        G.nodes[n]["theta"] = 0.0
     g0 = eval_gamma(G, 0, t=math.pi / 2)
     g1 = eval_gamma(G, 1, t=math.pi / 2)
     assert pytest.approx(g0, rel=1e-6) == 1.0

--- a/tests/unit/dynamics/test_node_sample.py
+++ b/tests/unit/dynamics/test_node_sample.py
@@ -17,7 +17,7 @@ def _build_graph(n, graph_canon=None):
     G = graph_canon() if graph_canon is not None else nx.Graph()
     inject_defaults(G)
     for i in range(n):
-        G.add_node(i, θ=0.0, EPI=0.0)
+        G.add_node(i, theta=0.0, EPI=0.0)
     return G
 
 
@@ -108,7 +108,7 @@ from tnfr.dynamics import _update_node_sample
 G = nx.Graph()
 inject_defaults(G)
 for i in range(80):
-    G.add_node(i, θ=0.0, EPI=0.0)
+    G.add_node(i, theta=0.0, EPI=0.0)
 G.graph["UM_CANDIDATE_COUNT"] = 10
 G.graph["RANDOM_SEED"] = 123
 _update_node_sample(G, step=5)

--- a/tests/unit/dynamics/test_operator_factors.py
+++ b/tests/unit/dynamics/test_operator_factors.py
@@ -51,8 +51,8 @@ def test_op_oz_uses_factor():
 
 def test_op_um_uses_theta_push(graph_canon):
     G = graph_canon()
-    G.add_node(0, **{"θ": 0.0, "EPI": 0.0, "Si": 0.0})
-    G.add_node(1, **{"θ": 1.0, "EPI": 0.0, "Si": 0.0})
+    G.add_node(0, **{"theta": 0.0, "EPI": 0.0, "Si": 0.0})
+    G.add_node(1, **{"theta": 1.0, "EPI": 0.0, "Si": 0.0})
     G.add_edge(0, 1)
     node = NodeNX(G, 0)
     gf = {"UM_theta_push": "0.5"}

--- a/tests/unit/dynamics/test_operators.py
+++ b/tests/unit/dynamics/test_operators.py
@@ -189,7 +189,7 @@ def test_um_candidate_subset_proximity(graph_canon):
     G = graph_canon()
     inject_defaults(G)
     for i, th in enumerate([0.0, 0.1, 0.2, 1.0]):
-        G.add_node(i, **{"θ": th, "EPI": 0.5, "Si": 0.5})
+        G.add_node(i, **{"theta": th, "EPI": 0.5, "Si": 0.5})
 
     G.graph["UM_FUNCTIONAL_LINKS"] = True
     G.graph["UM_COMPAT_THRESHOLD"] = -1.0

--- a/tests/unit/dynamics/test_vf_coherencia.py
+++ b/tests/unit/dynamics/test_vf_coherencia.py
@@ -42,7 +42,7 @@ def test_vf_converge_to_neighbor_average_when_stable(graph_canon):
     G.graph["VF_ADAPT_MU"] = 0.5
     for n in G.nodes():
         nd = G.nodes[n]
-        nd["θ"] = 0.0
+        nd["theta"] = 0.0
         nd["EPI"] = 0.0
     G.nodes[0]["νf"] = 0.2
     G.nodes[1]["νf"] = 1.0

--- a/tests/unit/metrics/test_history_series.py
+++ b/tests/unit/metrics/test_history_series.py
@@ -9,7 +9,7 @@ from tnfr.glyph_history import HistoryDict, ensure_history
 
 def test_history_delta_si_and_B(graph_canon):
     G = graph_canon()
-    G.add_node(0, EPI=0.0, νf=0.5, θ=0.0)
+    G.add_node(0, EPI=0.0, νf=0.5, theta=0.0)
     inject_defaults(G)
     register_metrics_callbacks(G)
     step(G, apply_glyphs=False)
@@ -23,8 +23,8 @@ def test_gamma_kuramoto_tanh_registry(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])
     inject_defaults(G)
-    G.nodes[0]["θ"] = 0.0
-    G.nodes[1]["θ"] = 0.0
+    G.nodes[0]["theta"] = 0.0
+    G.nodes[1]["theta"] = 0.0
     cfg = {"type": "kuramoto_tanh", "beta": 0.5, "k": 2.0, "R0": 0.0}
     gamma_fn = GAMMA_REGISTRY["kuramoto_tanh"].fn
     val = gamma_fn(G, 0, 0.0, cfg)

--- a/tests/unit/structural/test_prepare_network.py
+++ b/tests/unit/structural/test_prepare_network.py
@@ -6,10 +6,10 @@ from tnfr.ontosim import prepare_network
 def test_prepare_network_init_attrs_por_defecto():
     G = nx.path_graph(3)
     prepare_network(G)
-    assert all("θ" in d for _, d in G.nodes(data=True))
+    assert all("theta" in d for _, d in G.nodes(data=True))
 
 
 def test_prepare_network_sin_init_attrs():
     G = nx.path_graph(3)
     prepare_network(G, init_attrs=False)
-    assert all("θ" not in d for _, d in G.nodes(data=True))
+    assert all("theta" not in d for _, d in G.nodes(data=True))


### PR DESCRIPTION
### What it reorganizes
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f6607c40c48321bc54de659d360475