### PR TITLE
Enforce canonical preset naming

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,21 @@
 # Release notes
 
+## 9.0.0 (canonical preset rename)
+
+- Renamed the canonical tutorial preset to the English-only identifier
+  ``"canonical_example"``. The Spanish ``"ejemplo_canonico"`` alias now raises a
+  :class:`KeyError` pointing to the supported name instead of being silently
+  resolved.
+- Updated :mod:`tnfr.execution` so :data:`tnfr.execution.CANONICAL_PRESET_NAME`
+  exposes the English identifier, aligning the helper with
+  :mod:`tnfr.config.presets`.
+- Simplified the preset resolution layer by removing the remaining runtime
+  aliases. ``get_preset()`` now rejects the retired identifiers with explicit
+  guidance and the CLI surfaces the same migration message.
+- Revised the CLI help strings, error handling, and documentation to mention
+  only the English preset names. Downstream automation should update any stored
+  configuration that still references ``"ejemplo_canonico"``.
+
 ## 8.1.0 (remesh cooldown alias removal)
 
 - Removed the Spanish ``"REMESH_COOLDOWN_VENTANA"`` alias from

--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -3,18 +3,14 @@ from __future__ import annotations
 import argparse
 from typing import Any, Iterable
 
-from ..config.presets import (
-    LEGACY_PRESET_NAMES,
-    PREFERRED_PRESET_NAMES,
-)
+from ..config.presets import PREFERRED_PRESET_NAMES
 from ..gamma import GAMMA_REGISTRY
 from ..types import ArgSpec
 from .utils import spec
 
 
-_PRESET_HELP = "Preferred names: {}. Legacy keys: {}.".format(
+_PRESET_HELP = "Available presets: {}.".format(
     ", ".join(PREFERRED_PRESET_NAMES),
-    ", ".join(LEGACY_PRESET_NAMES),
 )
 
 

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -25,7 +25,6 @@ from ..dynamics import (
     validate_canon,
 )
 from ..config.presets import (
-    LEGACY_PRESET_NAMES,
     PREFERRED_PRESET_NAMES,
     get_preset,
 )
@@ -47,7 +46,6 @@ logger = get_logger(__name__)
 DEFAULT_SUMMARY_SERIES_LIMIT = 10
 
 _PREFERRED_PRESETS_DISPLAY = ", ".join(PREFERRED_PRESET_NAMES)
-_LEGACY_PRESETS_DISPLAY = ", ".join(LEGACY_PRESET_NAMES)
 
 
 def _save_json(path: str, data: Any) -> None:
@@ -175,15 +173,15 @@ def resolve_program(
         try:
             return get_preset(args.preset)
         except KeyError as exc:
+            details = exc.args[0] if exc.args else "Legacy preset identifier rejected."
             logger.error(
                 (
-                    "Preset desconocido '%s'. Nombres preferidos: %s. "
-                    "Claves heredadas: %s. Usa --sequence-file para cargar "
-                    "secuencias personalizadas"
+                    "Unknown preset '%s'. Available presets: %s. %s "
+                    "Use --sequence-file to execute custom sequences."
                 ),
                 args.preset,
                 _PREFERRED_PRESETS_DISPLAY,
-                _LEGACY_PRESETS_DISPLAY,
+                details,
             )
             raise SystemExit(1) from exc
     if getattr(args, "sequence_file", None):

--- a/src/tnfr/config/presets.py
+++ b/src/tnfr/config/presets.py
@@ -1,8 +1,8 @@
 """Predefined TNFR configuration sequences.
 
-Spanish preset identifiers were removed in TNFR 7.0. Only the English names
-remain available; attempting to resolve a legacy Spanish identifier will raise
-an explicit :class:`KeyError` pointing to the correct replacement.
+Legacy preset identifiers are no longer accepted. Requests for Spanish or
+otherwise retired names raise :class:`KeyError` with guidance pointing to the
+canonical English identifier.
 """
 
 from __future__ import annotations
@@ -19,8 +19,7 @@ from ..types import Glyph, PresetTokens
 __all__ = (
     "get_preset",
     "PREFERRED_PRESET_NAMES",
-    "LEGACY_PRESET_NAMES",
-    "PRESET_NAME_ALIASES",
+    "REMOVED_PRESET_NAMES",
 )
 
 
@@ -60,40 +59,33 @@ _PRIMARY_PRESETS: dict[str, PresetTokens] = {
         block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA),
         Glyph.RA,
     ),
-    "canonical_example": list(CANONICAL_PROGRAM_TOKENS),
+    CANONICAL_PRESET_NAME: list(CANONICAL_PROGRAM_TOKENS),
 }
 
-_REMOVED_SPANISH_PRESETS: dict[str, str] = {
-    "arranque_resonante": "resonant_bootstrap",
-    "mutacion_contenida": "contained_mutation",
-    "exploracion_acople": "coupling_exploration",
-}
-
-_LEGACY_PRESET_ALIASES: dict[str, str] = {
-    CANONICAL_PRESET_NAME: "canonical_example",
+_REMOVED_PRESETS: dict[str, tuple[str, str]] = {
+    "arranque_resonante": ("resonant_bootstrap", "TNFR 7.0"),
+    "mutacion_contenida": ("contained_mutation", "TNFR 7.0"),
+    "exploracion_acople": ("coupling_exploration", "TNFR 7.0"),
+    "ejemplo_canonico": (CANONICAL_PRESET_NAME, "TNFR 9.0"),
 }
 
 PREFERRED_PRESET_NAMES: tuple[str, ...] = tuple(_PRIMARY_PRESETS.keys())
-LEGACY_PRESET_NAMES: tuple[str, ...] = tuple(_LEGACY_PRESET_ALIASES.keys())
-PRESET_NAME_ALIASES: dict[str, str] = dict(_LEGACY_PRESET_ALIASES)
+REMOVED_PRESET_NAMES: tuple[str, ...] = tuple(_REMOVED_PRESETS.keys())
 
 _PRESETS: dict[str, PresetTokens] = {**_PRIMARY_PRESETS}
-for alias, target in _LEGACY_PRESET_ALIASES.items():
-    _PRESETS[alias] = _PRIMARY_PRESETS[target]
 
 
 def get_preset(name: str) -> PresetTokens:
-    preferred = _REMOVED_SPANISH_PRESETS.get(name)
-    if preferred is not None:
+    removed = _REMOVED_PRESETS.get(name)
+    if removed is not None:
+        replacement, version = removed
         raise KeyError(
             (
-                "Spanish preset identifier '%s' was removed in TNFR 7.0. "
+                "Legacy preset identifier '%s' was removed in %s. "
                 "Use '%s' instead."
             )
-            % (name, preferred)
+            % (name, version, replacement)
         )
-
-    name = _LEGACY_PRESET_ALIASES.get(name, name)
 
     try:
         return _PRESETS[name]

--- a/src/tnfr/execution.py
+++ b/src/tnfr/execution.py
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 
-CANONICAL_PRESET_NAME = "ejemplo_canonico"
+CANONICAL_PRESET_NAME = "canonical_example"
 CANONICAL_PROGRAM_TOKENS: tuple[Token, ...] = (
     Glyph.SHA,
     Glyph.AL,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -74,8 +74,26 @@ def test_cli_invalid_preset_exits_gracefully(capsys, command):
     captured = capsys.readouterr()
 
     assert rc == 1
-    assert "Preset desconocido" in captured.out
-    assert "nope" in captured.out
+    assert "Unknown preset 'nope'." in captured.out
+    assert "Available presets" in captured.out
+    assert "Use --sequence-file" in captured.out
+
+
+@pytest.mark.parametrize("command", ["run", "sequence"])
+def test_cli_legacy_preset_rejected_with_guidance(capsys, command):
+    legacy = "ejemplo_canonico"
+    args = [command, "--preset", legacy]
+    if command == "run":
+        args.extend(["--steps", "0"])
+
+    rc = main(args)
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert (
+        "Legacy preset identifier 'ejemplo_canonico' was removed in TNFR 9.0. "
+        "Use 'canonical_example' instead."
+    ) in captured.out
 
 
 def test_cli_sequence_file_missing(tmp_path, capsys):

--- a/tests/unit/config/test_presets.py
+++ b/tests/unit/config/test_presets.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from tnfr.execution import CANONICAL_PRESET_NAME
 from tnfr.config.presets import (
-    LEGACY_PRESET_NAMES,
     PREFERRED_PRESET_NAMES,
-    PRESET_NAME_ALIASES,
     get_preset,
 )
 
@@ -16,26 +15,23 @@ def test_get_preset_accepts_preferred_names(name: str) -> None:
     assert tokens, f"El preset '{name}' no debería estar vacío"
 
 
-@pytest.mark.parametrize("legacy", LEGACY_PRESET_NAMES)
-def test_legacy_aliases_resolve_to_preferred_names(legacy: str) -> None:
-    preferred = PRESET_NAME_ALIASES[legacy]
-    assert get_preset(legacy) == get_preset(preferred)
-
-
 @pytest.mark.parametrize(
-    ("legacy", "preferred"),
+    ("legacy", "preferred", "version"),
     (
-        ("arranque_resonante", "resonant_bootstrap"),
-        ("mutacion_contenida", "contained_mutation"),
-        ("exploracion_acople", "coupling_exploration"),
+        ("arranque_resonante", "resonant_bootstrap", "TNFR 7.0"),
+        ("mutacion_contenida", "contained_mutation", "TNFR 7.0"),
+        ("exploracion_acople", "coupling_exploration", "TNFR 7.0"),
+        ("ejemplo_canonico", CANONICAL_PRESET_NAME, "TNFR 9.0"),
     ),
 )
-def test_spanish_aliases_are_removed(legacy: str, preferred: str) -> None:
+def test_removed_presets_raise_with_guidance(
+    legacy: str, preferred: str, version: str
+) -> None:
     with pytest.raises(KeyError) as excinfo:
         get_preset(legacy)
 
     message = excinfo.value.args[0]
     assert message == (
-        f"Spanish preset identifier '{legacy}' was removed in TNFR 7.0. "
+        f"Legacy preset identifier '{legacy}' was removed in {version}. "
         f"Use '{preferred}' instead."
     )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f6686999e08321b6c393e5ff3ec43c