### PR TITLE
Remove deprecated remesh stability window alias

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -106,8 +106,8 @@ Use `tnfr.operators.apply_topological_remesh` (`from tnfr.operators import
 apply_topological_remesh`) to reorganise connectivity based on nodal EPI similarity while
 preserving graph connectivity. Pair it with
 `tnfr.operators.apply_remesh_if_globally_stable(G, stable_step_window=...)` to gate
-remeshing on a minimum window of stable steps. The legacy keyword
-`pasos_estables_consecutivos` remains as a deprecated alias during the transition.
+remeshing on a minimum window of stable steps. Only the English
+`stable_step_window` keyword is accepted.
 Modes:
 
 - `"knn"` — connect each node to its `k` nearest neighbours (with optional rewiring).

--- a/docs/getting-started/migrating-remesh-window.md
+++ b/docs/getting-started/migrating-remesh-window.md
@@ -1,0 +1,55 @@
+# Migrating remesh stability window usage
+
+TNFR 10.0.0 removes the transitional Spanish keyword
+``pasos_estables_consecutivos`` from
+:func:`tnfr.operators.apply_remesh_if_globally_stable`. The operator now
+accepts only the English ``stable_step_window`` parameter. Calls that still use
+or forward the Spanish keyword raise :class:`TypeError` immediately so the
+deprecated configuration cannot silently slip through pipelines.
+
+## Who is affected?
+
+- Applications that invoked
+  ``apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=...)``.
+- Configuration loaders that surfaced the Spanish name as part of dynamic
+  keyword expansion.
+- Stored automation artifacts (YAML/JSON, notebooks) that preserved the legacy
+  keyword for reproducibility.
+
+## Migration steps
+
+1. Replace every occurrence of the Spanish keyword with the canonical English
+   parameter. The semantic contract is unchanged::
+
+       # Before (TNFR <= 9.x)
+       apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=5)
+
+       # After (TNFR >= 10.0)
+       apply_remesh_if_globally_stable(G, stable_step_window=5)
+
+2. If you rely on user-provided dictionaries that may contain the legacy
+   identifier, normalise the payload before calling the operator::
+
+       def normalize_remesh_kwargs(kwargs: dict) -> dict:
+           if "pasos_estables_consecutivos" in kwargs:
+               kwargs = dict(kwargs)  # shallow copy if shared
+               kwargs["stable_step_window"] = kwargs.pop("pasos_estables_consecutivos")
+           return kwargs
+
+       apply_remesh_if_globally_stable(G, **normalize_remesh_kwargs(user_kwargs))
+
+3. Audit persisted graphs or configs that reference the Spanish name. Since the
+   operator no longer rewrites the value at runtime, the update must happen in
+   the stored artifact before executing TNFR 10.0.0.
+
+## Verification checklist
+
+- Unit or integration tests that previously asserted a deprecation warning
+  should now expect :class:`TypeError` when the Spanish keyword is passed.
+- Documentation, CLI help, and user-facing guidance must reference only the
+  ``stable_step_window`` parameter.
+- Downstream logs or telemetry that templated the Spanish name should be
+  updated to keep observability messages aligned with the supported API.
+
+Following these steps ensures remesh orchestration remains stable while the
+engine enforces the English-only parameter surface.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## 10.0.0 (remesh stability window keyword removal)
+
+- Removed the Spanish ``pasos_estables_consecutivos`` keyword from
+  :func:`tnfr.operators.apply_remesh_if_globally_stable`. Passing the legacy
+  identifier now raises :class:`TypeError` with guidance to use the English
+  ``stable_step_window`` parameter.
+- Updated :mod:`tnfr.operators` documentation, telemetry guidance, and
+  structural tests to reference only ``stable_step_window``.
+- Published a migration guide covering the required code updates and how to
+  audit stored configurations. See :doc:`getting-started/migrating-remesh-window`
+  for detailed steps.
+
 ## 9.0.0 (canonical preset rename)
 
 - Renamed the canonical tutorial preset to the English-only identifier

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -39,8 +39,7 @@ _remesh_doc = (
     "Parameters\n----------\n"
     "stable_step_window : int | None\n"
     "    Number of consecutive stable steps required before remeshing.\n"
-    "    The legacy keyword 'pasos_estables_consecutivos' is still accepted\n"
-    "    but will be removed after the transition period."
+    "    Only the English keyword 'stable_step_window' is supported."
 )
 if apply_remesh_if_globally_stable.__doc__:
     apply_remesh_if_globally_stable.__doc__ += "\n\n" + _remesh_doc

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import heapq
 import random
-import warnings
 from operator import ge, le
 from functools import cache
 from itertools import combinations
@@ -508,27 +507,17 @@ def apply_remesh_if_globally_stable(
     stable_step_window: int | None = None,
     **kwargs: Any,
 ) -> None:
-    legacy_window = kwargs.pop("pasos_estables_consecutivos", None)
+    if "pasos_estables_consecutivos" in kwargs:
+        raise TypeError(
+            "apply_remesh_if_globally_stable() no longer accepts "
+            "'pasos_estables_consecutivos'; use 'stable_step_window'."
+        )
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(
             "apply_remesh_if_globally_stable() got unexpected keyword argument(s): "
             f"{unexpected}"
         )
-
-    if legacy_window is not None:
-        if stable_step_window is not None and stable_step_window != legacy_window:
-            raise TypeError(
-                "stable_step_window and pasos_estables_consecutivos provide conflicting "
-                "values; use only stable_step_window."
-            )
-        warnings.warn(
-            "'pasos_estables_consecutivos' is deprecated; use 'stable_step_window' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if stable_step_window is None:
-            stable_step_window = legacy_window
 
     params = [
         (

--- a/tests/unit/structural/test_remesh.py
+++ b/tests/unit/structural/test_remesh.py
@@ -43,13 +43,13 @@ def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
     assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
 
 
-def test_aplicar_remesh_legacy_keyword_emite_advertencia(graph_canon):
-    G, hist = _prepare_graph_for_remesh(graph_canon)
+def test_aplicar_remesh_legacy_keyword_lanza_typeerror(graph_canon):
+    G, _ = _prepare_graph_for_remesh(graph_canon)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(TypeError, match="pasos_estables_consecutivos"):
         apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=3)
 
-    assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
+    assert "_last_remesh_step" not in G.graph
 
 
 def test_remesh_alpha_hard_ignores_glyph_factor(graph_canon):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Remove the Spanish `pasos_estables_consecutivos` keyword from `apply_remesh_if_globally_stable` and surface an explicit `TypeError` when it is used.
- Refresh operator docs, telemetry guidance, and structural tests so they reference only the `stable_step_window` parameter.
- Document the API break with new release notes and a migration guide outlining how to audit and update downstream usage.

## Testing
- `pytest tests/unit/structural/test_remesh.py`


------
https://chatgpt.com/codex/tasks/task_e_68f66e62612483218a057a94332a9489