### PR TITLE
Remove legacy Si dispersion Spanish identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ walkthroughs plus optional dependency caching helpers.
   expectations.
 - [TNFR.pdf](TNFR.pdf) — theoretical background, structural operators, and paradigm glossary.
 
+## Migration notes
+
+- **Si dispersion keys:** Replace any remaining ``dSi_ddisp_fase`` entries in graph payloads
+  or configuration files with the English ``dSi_dphase_disp`` key before upgrading. The
+  runtime now raises :class:`ValueError` when the legacy attribute is encountered and
+  rejects the Spanish ``disp_fase`` keyword argument in
+  :func:`tnfr.metrics.sense_index.compute_Si_node`.
+- Refer to the [release notes](docs/releases.md#1100-si-dispersion-legacy-keys-removed) for
+  a migration snippet that rewrites stored graphs in place prior to running the new version.
+
 ## Licensing
 
 Released under the [MIT License](LICENSE.md). Cite the TNFR paradigm when publishing research

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,25 @@
 # Release notes
 
+## 11.0.0 (Si dispersion legacy keys removed)
+
+- Removed the Spanish ``dSi_ddisp_fase`` attribute from the sense index
+  sensitivity cache. Loading graphs or configuration payloads that still
+  define the legacy key now raises :class:`ValueError` with guidance to use the
+  English ``dSi_dphase_disp`` identifier.
+- Updated :func:`tnfr.metrics.sense_index.compute_Si_node` so the Spanish
+  ``disp_fase`` keyword argument is rejected with :class:`TypeError`. Callers
+  must provide the ``phase_dispersion`` keyword when invoking the helper.
+- Added migration guidance to the README for rewriting stored Si sensitivity
+  mappings and configuration files that still carry the legacy identifiers.
+- Migration snippet for historical graphs::
+
+      sensitivity = G.graph.get("_Si_sensitivity") or {}
+      if "dSi_ddisp_fase" in sensitivity:
+          value = sensitivity.pop("dSi_ddisp_fase")
+          sensitivity.setdefault("dSi_dphase_disp", value)
+
+      # Persist the updated graph payload before upgrading the engine
+
 ## 10.0.0 (remesh stability window keyword removal)
 
 - Removed the Spanish ``pasos_estables_consecutivos`` keyword from

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import warnings
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from typing import Any, Iterable, Mapping
@@ -42,15 +41,11 @@ def _normalise_si_sensitivity_mapping(
     """Return a mapping that only exposes the English Si sensitivity keys."""
 
     normalised = dict(mapping)
-    legacy_value = normalised.pop(LEGACY_PHASE_DISPERSION_KEY, None)
-    if legacy_value is not None:
-        if warn:
-            warnings.warn(
-                "'dSi_ddisp_fase' is deprecated; use 'dSi_dphase_disp' instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-        normalised.setdefault(PHASE_DISPERSION_KEY, legacy_value)
+    if LEGACY_PHASE_DISPERSION_KEY in normalised:
+        raise ValueError(
+            "Si sensitivity mappings must use the English 'dSi_dphase_disp' key; "
+            "found legacy 'dSi_ddisp_fase'."
+        )
     return normalised
 
 
@@ -104,18 +99,11 @@ def compute_Si_node(
 ) -> float:
     """Compute ``Si`` for a single node."""
 
-    legacy_dispersion = kwargs.pop("disp_fase", None)
-    if legacy_dispersion is not None:
-        warnings.warn(
-            "The 'disp_fase' keyword is deprecated; use 'phase_dispersion' instead.",
-            DeprecationWarning,
-            stacklevel=2,
+    if "disp_fase" in kwargs:
+        raise TypeError(
+            "'disp_fase' is no longer supported; use the English 'phase_dispersion' "
+            "keyword."
         )
-        if phase_dispersion is not None:
-            raise TypeError(
-                "Both 'phase_dispersion' and legacy 'disp_fase' were provided."
-            )
-        phase_dispersion = float(legacy_dispersion)
 
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))

--- a/tests/unit/metrics/test_si_helpers.py
+++ b/tests/unit/metrics/test_si_helpers.py
@@ -33,32 +33,29 @@ def test_get_si_weights_normalization(graph_canon):
     }
 
 
-def test_get_si_weights_migrates_legacy_sensitivity(graph_canon):
+def test_get_si_weights_rejects_legacy_sensitivity(graph_canon):
     G = graph_canon()
     G.graph["_Si_sensitivity"] = {
         "dSi_ddisp_fase": -0.5,
         "dSi_dvf_norm": 0.1,
     }
 
-    with pytest.deprecated_call():
+    with pytest.raises(ValueError) as excinfo:
         get_Si_weights(G)
 
-    sensitivity = G.graph["_Si_sensitivity"]
-    assert "dSi_dphase_disp" in sensitivity
-    assert "dSi_ddisp_fase" not in sensitivity
+    assert "dSi_ddisp_fase" in str(excinfo.value)
 
 
-def test_si_sensitivity_field_handles_legacy_key(graph_canon):
+def test_si_sensitivity_field_rejects_legacy_key(graph_canon):
     G = graph_canon()
     G.graph["_Si_sensitivity"] = {
         "dSi_ddisp_fase": -0.25,
     }
 
-    with pytest.deprecated_call():
-        data = _si_sensitivity_field(G)
+    with pytest.raises(ValueError) as excinfo:
+        _si_sensitivity_field(G)
 
-    assert data == {"si_sensitivity": {"dSi_dphase_disp": -0.25}}
-    assert G.graph["_Si_sensitivity"] == {"dSi_dphase_disp": -0.25}
+    assert "dSi_ddisp_fase" in str(excinfo.value)
 
 
 def test_si_sensitivity_field_handles_new_key(graph_canon):
@@ -153,8 +150,8 @@ def test_compute_Si_node_legacy_keyword(graph_canon):
     G = graph_canon()
     nd = {ALIAS_VF[0]: 0.5, ALIAS_DNFR[0]: 0.2}
 
-    with pytest.deprecated_call():
-        result = compute_Si_node(
+    with pytest.raises(TypeError) as excinfo:
+        compute_Si_node(
             1,
             nd,
             alpha=0.5,
@@ -166,4 +163,4 @@ def test_compute_Si_node_legacy_keyword(graph_canon):
             inplace=False,
         )
 
-    assert result == pytest.approx(0.7)
+    assert "disp_fase" in str(excinfo.value)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f671242fd88321914ed4050274032b