### PR TITLE
Refine glyph load aggregates to English-only contract

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## 11.1.0 (glyph load Spanish aggregates removed)
+
+- :func:`tnfr.observers.glyph_load` now reports only the English aggregate
+  keys ``"_stabilizers"`` and ``"_disruptors"``. The Spanish compatibility
+  aliases were removed along with the runtime mirroring logic.
+- Consumers in :mod:`tnfr.metrics.coherence` and :mod:`tnfr.dynamics` now read
+  the English keys exclusively. Custom integrations should update any
+  post-processing code that still expected ``"_estabilizadores"`` or
+  ``"_disruptivos"`` entries.
+- Updated the structural and metrics unit tests to enforce the English-only
+  contract and removed the fixtures that patched Spanish aggregate labels.
+
 ## 11.0.0 (Si dispersion legacy keys removed)
 
 - Removed the Spanish ``dSi_ddisp_fase`` attribute from the sense index

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -301,11 +301,7 @@ def _compute_state(G: TNFRGraph, cfg: Mapping[str, Any]) -> tuple[str, float, fl
     """Return the canonical network state and supporting metrics."""
     R = kuramoto_order(G)
     dist = glyph_load(G, window=DEFAULT_GLYPH_LOAD_SPAN)
-    disr = (
-        float(dist.get("_disruptors", dist.get("_disruptivos", 0.0)))
-        if dist
-        else 0.0
-    )
+    disr = float(dist.get("_disruptors", 0.0)) if dist else 0.0
 
     R_hi = float(cfg.get("R_hi", 0.90))
     R_lo = float(cfg.get("R_lo", 0.60))

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -1057,8 +1057,8 @@ def _update_sigma(G: TNFRGraph, hist: HistoryState) -> None:
     """Record glyph load and associated Σ⃗ vector."""
 
     gl: GlyphLoadDistribution = glyph_load(G, window=DEFAULT_GLYPH_LOAD_SPAN)
-    stabilizers = gl.get("_stabilizers", gl.get("_estabilizadores", 0.0))
-    disruptors = gl.get("_disruptors", gl.get("_disruptivos", 0.0))
+    stabilizers = float(gl.get("_stabilizers", 0.0))
+    disruptors = float(gl.get("_disruptors", 0.0))
     _record_metrics(
         hist,
         (stabilizers, "glyph_load_estab"),

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -44,11 +44,6 @@ logger = get_logger(__name__)
 DEFAULT_GLYPH_LOAD_SPAN = 50
 DEFAULT_WBAR_SPAN = 25
 
-_GLYPH_GROUP_COMPAT_KEYS: tuple[tuple[str, str], ...] = (
-    ("_stabilizers", "_estabilizadores"),
-    ("_disruptors", "_disruptivos"),
-)
-
 
 # -------------------------
 # Observador estándar Γ(R)
@@ -150,11 +145,6 @@ def glyph_load(G: TNFRGraph, window: int | None = None) -> GlyphLoadDistribution
     if count == 0:
         return {"_count": 0.0}
     dist = mix_groups(dist_raw, GLYPH_GROUPS)
-    for primary, legacy in _GLYPH_GROUP_COMPAT_KEYS:
-        if primary in dist and legacy not in dist:
-            dist[legacy] = dist[primary]
-        elif legacy in dist and primary not in dist:
-            dist[primary] = dist[legacy]
     glyph_dist: GlyphLoadDistribution = {}
     for key, value in dist.items():
         try:

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -188,9 +188,7 @@ def test_update_sigma_uses_default_window(monkeypatch, graph_canon):
         captured["window"] = window
         return {
             "_stabilizers": 0.25,
-            "_estabilizadores": 0.5,
             "_disruptors": 0.75,
-            "_disruptivos": 0.6,
             "AL": 0.25,
             "RA": 0.75,
         }

--- a/tests/unit/structural/test_observers.py
+++ b/tests/unit/structural/test_observers.py
@@ -145,15 +145,15 @@ def test_glyph_load_uses_module_constants(monkeypatch, graph_canon):
     # Patch constants to custom categories
     monkeypatch.setattr(
         "tnfr.observers.GLYPH_GROUPS",
-        {"estabilizadores": ["A"], "disruptivos": ["B"]},
+        {"stabilizers": ["A"], "disruptors": ["B"]},
     )
 
     dist = glyph_load(G)
 
     assert dist["_stabilizers"] == pytest.approx(0.5)
     assert dist["_disruptors"] == pytest.approx(0.5)
-    assert dist["_estabilizadores"] == pytest.approx(0.5)
-    assert dist["_disruptivos"] == pytest.approx(0.5)
+    assert "_estabilizadores" not in dist
+    assert "_disruptivos" not in dist
 
 
 def test_sigma_vector_consistency():


### PR DESCRIPTION
### Summary
- drop the Spanish glyph load aliases from the observer distribution so only the English aggregates remain
- update the coherence metrics and dynamics state calculator to consume `_stabilizers`/`_disruptors` exclusively
- refresh targeted unit tests and release notes to document the English-only glyph load convention

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

### Testing
- `pytest tests/unit/structural/test_observers.py tests/unit/metrics/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68f6723ab76083219b8b4e5d30f505f7