### PR TITLE
Remove Spanish diagnosis state shim

### DIFF
--- a/src/tnfr/constants/__init__.pyi
+++ b/src/tnfr/constants/__init__.pyi
@@ -54,10 +54,6 @@ __all__ = (
     "STATE_TRANSITION",
     "STATE_DISSONANT",
     "CANONICAL_STATE_TOKENS",
-    "SPANISH_STATE_TOKENS_ENV_VAR",
-    "enable_spanish_state_tokens",
-    "disable_spanish_state_tokens",
-    "spanish_state_tokens_enabled",
     "normalise_state_token",
 )
 
@@ -82,7 +78,6 @@ STATE_STABLE: str
 STATE_TRANSITION: str
 STATE_DISSONANT: str
 CANONICAL_STATE_TOKENS: frozenset[str]
-SPANISH_STATE_TOKENS_ENV_VAR: str
 
 
 def inject_defaults(
@@ -106,13 +101,4 @@ def get_graph_param(
 def get_aliases(key: str) -> tuple[str, ...]: ...
 
 
-def enable_spanish_state_tokens(*, warn: bool = ...) -> Mapping[str, str]: ...
-
-
-def disable_spanish_state_tokens() -> None: ...
-
-
-def spanish_state_tokens_enabled() -> bool: ...
-
-
-def normalise_state_token(token: str, *, warn: bool = ...) -> str: ...
+def normalise_state_token(token: str) -> str: ...


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

### Summary
- Remove the diagnosis state Spanish migration shim and environment hook, enforcing English-only identifiers.
- Update the state normalisation tests to expect ValueError for legacy tokens and cover unknown identifiers.
- Document the breaking change in the 12.0.0 release notes with guidance for rewriting stored payloads.

### Testing
- `pytest tests/unit/metrics/test_diagnosis_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68f675559e448321b81e09737785d283