### PR TITLE
Translate TNFR warnings to English and fix DNFR pool updates

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1986,8 +1986,8 @@ def _apply_dnfr_hook(
                     total += w * float(func(G, n, nd))
             results.append((n, total))
 
-        for node, value in results:
-            set_dnfr(G, node, float(value))
+    for node, value in results:
+        set_dnfr(G, node, float(value))
 
     _write_dnfr_metadata(G, weights=weights, hook_name=hook_name, note=note)
 
@@ -2084,7 +2084,7 @@ def dnfr_phase_only(G: TNFRGraph, *, n_jobs: int | None = None) -> None:
         {"phase": g_phase},
         weights={"phase": 1.0},
         hook_name="dnfr_phase_only",
-        note="Hook de ejemplo.",
+        note="Example hook.",
         n_jobs=n_jobs,
     )
 
@@ -2112,7 +2112,7 @@ def dnfr_epi_vf_mixed(G: TNFRGraph, *, n_jobs: int | None = None) -> None:
         grads,
         weights={"phase": 0.0, "epi": 0.5, "vf": 0.5},
         hook_name="dnfr_epi_vf_mixed",
-        note="Hook de ejemplo.",
+        note="Example hook.",
         n_jobs=n_jobs,
     )
 
@@ -2144,6 +2144,6 @@ def dnfr_laplacian(G: TNFRGraph, *, n_jobs: int | None = None) -> None:
         grads,
         weights={"epi": wE, "vf": wV},
         hook_name="dnfr_laplacian",
-        note="Gradiente topológico",
+        note="Topological gradient",
         n_jobs=n_jobs,
     )

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -109,7 +109,9 @@ def _read_gamma_raw(G: TNFRGraph) -> GammaSpec | None:
     if raw is None or isinstance(raw, Mapping):
         return raw
     return get_graph_mapping(
-        G, "GAMMA", "G.graph['GAMMA'] no es un mapeo; se usa {'type': 'none'}"
+        G,
+        "GAMMA",
+        "G.graph['GAMMA'] is not a mapping; using {'type': 'none'}",
     )
 
 


### PR DESCRIPTION
## Summary
- translate gamma fallback messages, trace mapping warnings, and DNFR hook notes to clear English equivalents
- provide immutable empty fallbacks for Si trace fields when graph state lacks a mapping
- ensure the ΔNFR process-pool path writes computed totals back to nodes before persisting metadata

## Testing
- pytest -o addopts='' tests/unit/structural/test_trace.py tests/unit/dynamics/test_dnfr_hooks.py tests/unit/metrics/test_si_helpers.py


------
https://chatgpt.com/codex/tasks/task_e_68f67b0c4e6c832195a3320de4d6ef7f