### PR TITLE
Remove deprecated selector norms alias

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,13 +1,21 @@
 # Release notes
 
+## 13.0.0 (selector norms alias removed)
+
+- **Breaking change**: Removed the deprecated
+  :func:`tnfr.selector._norms_para_selector` alias. Callers must import and use
+  :func:`tnfr.selector._selector_norms` directly to fetch ΔNFR and acceleration
+  maxima.
+- Updated selector utilities documentation and tests to reference only the
+  English helper so downstream projects surface the rename during upgrades.
+
 ## 12.1.0 (selector norms helper renamed)
 
-- Renamed :func:`tnfr.selector._norms_para_selector` to the English
-  :func:`tnfr.selector._selector_norms` helper to align selector internals with
-  the ongoing terminology migration.
-- Added a temporary :func:`tnfr.selector._norms_para_selector` compatibility
-  wrapper that emits :class:`DeprecationWarning` so downstream integrations can
-  migrate before the legacy identifier is removed.
+- Renamed the selector norms helper to the English-only
+  :func:`tnfr.selector._selector_norms` identifier to align selector internals
+  with the ongoing terminology migration.
+- Added a temporary compatibility shim for the legacy Spanish helper name that
+  emitted :class:`DeprecationWarning` ahead of its removal in version 13.0.0.
 - Updated :mod:`tnfr.dynamics` and the selector unit tests to consume the new
   helper, keeping the cached norms behaviour unchanged.
 

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -7,7 +7,6 @@ hysteresis when assigning glyphs to nodes.
 from __future__ import annotations
 
 import threading
-import warnings
 from operator import itemgetter
 from typing import Any, Mapping, TYPE_CHECKING, cast
 from weakref import WeakKeyDictionary
@@ -134,22 +133,6 @@ def _selector_norms(G: "nx.Graph") -> SelectorNorms:
     norms = compute_dnfr_accel_max(G)
     G.graph["_sel_norms"] = norms
     return norms
-
-
-def _norms_para_selector(G: "nx.Graph") -> SelectorNorms:
-    """Compatibility alias for :func:`_selector_norms`.
-
-    Emits :class:`DeprecationWarning` advising callers to adopt the English
-    helper name while keeping behaviour identical.
-    """
-
-    warnings.warn(
-        "_norms_para_selector is deprecated and will be removed in a future "
-        "release; use _selector_norms instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _selector_norms(G)
 
 
 def _calc_selector_score(

--- a/src/tnfr/selector.pyi
+++ b/src/tnfr/selector.pyi
@@ -7,5 +7,4 @@ def __getattr__(name: str) -> Any: ...
 _apply_selector_hysteresis: Any
 _calc_selector_score: Any
 _selector_norms: Any
-_norms_para_selector: Any
 _selector_thresholds: Any

--- a/tests/unit/dynamics/test_selector_utils.py
+++ b/tests/unit/dynamics/test_selector_utils.py
@@ -10,7 +10,6 @@ import tnfr.selector as selector
 from tnfr.selector import (
     _selector_thresholds,
     _selector_norms,
-    _norms_para_selector,
     _calc_selector_score,
     _apply_selector_hysteresis,
 )
@@ -105,13 +104,6 @@ def test_selector_norms_computes_max(graph_canon):
     assert norms == G.graph["_sel_norms"]
     assert norms["dnfr_max"] == 3.0
     assert norms["accel_max"] == 1.0
-
-
-def test_norms_para_selector_alias_warns(graph_canon):
-    G = graph_canon()
-    with pytest.deprecated_call():
-        norms = _norms_para_selector(G)
-    assert norms is G.graph["_sel_norms"]
 
 
 def test_calc_selector_score_assumes_normalized_weights():


### PR DESCRIPTION
## Summary
- drop the `_norms_para_selector` compatibility wrapper so selector internals expose only the English helper
- update selector utilities tests and type stubs to import `_selector_norms` directly
- document the alias removal as a breaking change in the release notes

## Testing
- `pytest -o addopts= tests/unit/dynamics/test_selector_utils.py`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f67f3b6da083219fd9f935e346c21d