### PR TITLE
Align operator registry typing with canonical Operator export

### DIFF
--- a/src/tnfr/operators/definitions.pyi
+++ b/src/tnfr/operators/definitions.pyi
@@ -2,6 +2,23 @@ from typing import Any, ClassVar
 
 from ..types import Glyph, TNFRGraph
 
+__all__ = (
+    "Operator",
+    "Emission",
+    "Reception",
+    "Coherence",
+    "Dissonance",
+    "Coupling",
+    "Resonance",
+    "Silence",
+    "Expansion",
+    "Contraction",
+    "SelfOrganization",
+    "Mutation",
+    "Transition",
+    "Recursivity",
+)
+
 
 class Operator:
     name: ClassVar[str]

--- a/src/tnfr/operators/registry.py
+++ b/src/tnfr/operators/registry.py
@@ -9,13 +9,13 @@ from typing import TYPE_CHECKING
 from ..config.operator_names import canonical_operator_name
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from .definitions import Operador
+    from .definitions import Operator
 
 
-OPERATORS: dict[str, type["Operador"]] = {}
+OPERATORS: dict[str, type["Operator"]] = {}
 
 
-def register_operator(cls: type["Operador"]) -> type["Operador"]:
+def register_operator(cls: type["Operator"]) -> type["Operator"]:
     """Register ``cls`` under its declared ``name`` in :data:`OPERATORS`."""
 
     name = getattr(cls, "name", None)
@@ -32,7 +32,7 @@ def register_operator(cls: type["Operador"]) -> type["Operador"]:
     return cls
 
 
-def get_operator_class(name: str) -> type["Operador"]:
+def get_operator_class(name: str) -> type["Operator"]:
     """Return the operator class registered for ``name`` or its canonical alias."""
 
     try:

--- a/src/tnfr/operators/registry.pyi
+++ b/src/tnfr/operators/registry.pyi
@@ -1,13 +1,15 @@
-from typing import Any, Literal
+from typing import Any
 
-from .definitions import Operador
+from .definitions import Operator
 
 __all__: Any
 
-def __getattr__(name: Literal["OPERADORES"]) -> dict[str, type[Operador]]: ...
 def __getattr__(name: str) -> Any: ...
 
-OPERATORS: dict[str, type[Operador]]
-discover_operators: Any
-register_operator: Any
-get_operator_class: Any
+OPERATORS: dict[str, type[Operator]]
+
+def discover_operators() -> None: ...
+
+def register_operator(cls: type[Operator]) -> type[Operator]: ...
+
+def get_operator_class(name: str) -> type[Operator]: ...

--- a/tests/unit/dynamics/test_operator_names.py
+++ b/tests/unit/dynamics/test_operator_names.py
@@ -56,4 +56,6 @@ def test_get_operator_class_rejects_spanish_tokens() -> None:
 def test_registry_exposes_only_english_collection_name() -> None:
     with pytest.raises(AttributeError) as exc_info:
         getattr(registry_module, "OPERADORES")
-    assert "OPERADORES" in str(exc_info.value)
+    message = str(exc_info.value)
+    assert "OPERADORES" in message
+    assert "OPERATORS" in message


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Replace lingering ``Operador`` forward references in the operator registry with the exported ``Operator`` type.
- Update registry and definitions stubs to expose ``Operator`` and remove the legacy ``OPERADORES`` typing surface.
- Extend the registry unit test to assert the English-only guidance in the ``OPERADORES`` AttributeError message.

## Testing
- `pytest tests/unit/dynamics/test_operator_names.py`


------
https://chatgpt.com/codex/tasks/task_e_68f6803c4278832187b1897a72669174