### PR TITLE
Rename sequence validation parameter to names

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -90,9 +90,9 @@ def run_sequence(G: TNFRGraph, node: NodeId, ops: Iterable[Operator]) -> None:
 
     compute = G.graph.get("compute_delta_nfr")
     ops_list = list(ops)
-    nombres = [op.name for op in ops_list]
+    names = [op.name for op in ops_list]
 
-    ok, msg = validate_sequence(nombres)
+    ok, msg = validate_sequence(names)
     if not ok:
         raise ValueError(f"Invalid sequence: {msg}")
 

--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -127,6 +127,13 @@ def test_sequence_accepts_english_tokens() -> None:
     assert ok, msg
 
 
+def test_validate_sequence_rejects_spanish_keyword() -> None:
+    with pytest.raises(TypeError) as excinfo:
+        validate_sequence(nombres=[EMISSION, RECEPTION, COHERENCE])
+
+    assert "English 'names'" in str(excinfo.value)
+
+
 def test_operator_base_types_exposed() -> None:
     for cls in (
         Emission,


### PR DESCRIPTION
## Summary
- rename the syntax validation API from the Spanish `nombres` to the English `names`
- raise a targeted TypeError when callers still use the deprecated keyword
- update structural sequencing and regression tests to reflect the renamed API

## Testing
- pytest tests/unit/structural/test_structural.py

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f68281b72083219c4f7415490b1e04