### PR TITLE
Translate Spanish guidance in tests to English

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Utilidades de pruebas."""
+"""Test utilities."""
 
 import pytest
 import networkx as nx

--- a/tests/unit/dynamics/test_dnfr_cache.py
+++ b/tests/unit/dynamics/test_dnfr_cache.py
@@ -234,7 +234,7 @@ def test_cache_invalidated_on_graph_change(vectorized, monkeypatch):
         default_compute_delta_nfr(G, cache_size=2)
         nodes1, _ = cached_nodes_and_A(G, cache_size=2)
 
-        G.add_edge(2, 3)  # Cambia número de nodos y aristas
+        G.add_edge(2, 3)  # Changes the number of nodes and edges
         for attr, scale in ((THETA_PRIMARY, 0.1), (EPI_PRIMARY, 0.2), (VF_PRIMARY, 0.3)):
             G.nodes[3][attr] = scale * 4
         increment_edge_version(G)

--- a/tests/unit/dynamics/test_grammar.py
+++ b/tests/unit/dynamics/test_grammar.py
@@ -152,14 +152,14 @@ def test_apply_glyph_with_grammar_equivalence(graph_canon):
     G_func.add_node(0)
     inject_defaults(G_func)
 
-    # Aplicación manual
+    # Manual application
     g_eff = enforce_canonical_grammar(G_manual, 0, Glyph.ZHIR)
     from tnfr.operators import apply_glyph
 
     apply_glyph(G_manual, 0, g_eff, window=1)
     on_applied_glyph(G_manual, 0, g_eff)
 
-    # Aplicación mediante helper
+    # Application via helper
     apply_glyph_with_grammar(G_func, [0], Glyph.ZHIR, 1)
 
     assert G_manual.nodes[0] == G_func.nodes[0]

--- a/tests/unit/structural/test_glyph_helpers.py
+++ b/tests/unit/structural/test_glyph_helpers.py
@@ -23,5 +23,5 @@ def test_mix_groups():
     groups = {"ab": ("A", "B")}
     mixed = mix_groups(dist, groups)
     assert mixed["_ab"] == 1.0
-    # se conserva la distribución original
+    # The original distribution is preserved
     assert mixed["A"] == 0.5

--- a/tests/unit/structural/test_observers.py
+++ b/tests/unit/structural/test_observers.py
@@ -159,13 +159,13 @@ def test_glyph_load_uses_module_constants(monkeypatch, graph_canon):
 
 
 def test_sigma_vector_consistency():
-    # Distribución ficticia de glyphs
+    # Fictional glyph distribution
     dist = {"IL": 0.4, "RA": 0.3, "ZHIR": 0.1, "AL": 0.2}
 
     res = sigma_vector(dist)
     n = res["n"]
 
-    # Cálculo esperado con el mapa de ángulos canónico
+    # Expected calculation using the canonical angle map
     keys = list(dist.keys())
     angles = {k: ANGLE_MAP[k] for k in keys}
     x = sum(dist[k] * math.cos(angles[k]) for k in keys) / len(keys)

--- a/tests/unit/structural/test_remesh.py
+++ b/tests/unit/structural/test_remesh.py
@@ -32,19 +32,19 @@ def _prepare_graph_for_remesh(graph_canon, stable_steps: int = 3):
     return G, hist
 
 
-def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
+def test_apply_remesh_uses_custom_parameter(graph_canon):
     G, hist = _prepare_graph_for_remesh(graph_canon)
 
-    # Sin parámetro personalizado no se debería activar
+    # Without a custom parameter it should not trigger
     apply_remesh_if_globally_stable(G)
     assert "_last_remesh_step" not in G.graph
 
-    # Con parámetro personalizado se activa con 3 pasos estables
+    # With the custom parameter it triggers after 3 stable steps
     apply_remesh_if_globally_stable(G, stable_step_window=3)
     assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
 
 
-def test_aplicar_remesh_legacy_keyword_lanza_typeerror(graph_canon):
+def test_apply_remesh_legacy_keyword_raises_typeerror(graph_canon):
     G, _ = _prepare_graph_for_remesh(graph_canon)
 
     with pytest.raises(TypeError, match="pasos_estables_consecutivos"):

--- a/tests/unit/structural/test_sense.py
+++ b/tests/unit/structural/test_sense.py
@@ -45,7 +45,7 @@ def test_sigma_vector_from_graph_paths(graph_canon):
 
 
 def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
-    """Referencia que recalcula ``glyph_unit(g) * w`` en cada paso."""
+    """Reference implementation recomputing ``glyph_unit(g) * w`` at each step."""
     pairs = []
     for _, nd in G.nodes(data=True):
         nw = _node_weight(nd, weight_mode)
@@ -59,8 +59,7 @@ def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
 
 
 def test_sigma_vector_from_graph_matches_naive(graph_canon):
-    """La versión optimizada coincide con el cálculo ingenuo y no es
-    más lenta."""
+    """The optimized version matches the naive computation and is not slower."""
     G_opt = graph_canon()
     glyphs = list(Glyph)
     for i in range(1000):

--- a/tests/unit/structural/test_topological_remesh.py
+++ b/tests/unit/structural/test_topological_remesh.py
@@ -67,9 +67,9 @@ def test_remesh_community_adds_exact_k_connections_per_cluster(graph_canon):
     apply_topological_remesh(G, mode="community", k=2, p_rewire=0.0, seed=7)
 
     events = ensure_history(G).get("remesh_events", [])
-    assert events, "Se esperaba evento de remesh en modo comunidad"
+    assert events, "Expected a remesh event in community mode"
     extra_attempts = events[-1].get("extra_edge_attempts")
-    assert extra_attempts, "La telemetría debe registrar intentos por comunidad"
+    assert extra_attempts, "Telemetry should record attempts for each community"
     assert set(extra_attempts.values()) == {2}
 
 
@@ -90,7 +90,7 @@ def test_remesh_community_rewire_changes_destinations(graph_canon):
 
     assert events_no[-1].get("rewired_edges") == []
     rewired_edges = events_yes[-1].get("rewired_edges")
-    assert rewired_edges, "Con p_rewire=1.0 deben registrarse aristas reubicadas"
+    assert rewired_edges, "With p_rewire=1.0 there must be rewired edges recorded"
     assert any(edge["from"] != edge["to"] for edge in rewired_edges)
 
 


### PR DESCRIPTION
## Summary
- Rename remeshing tests and translate their comments so the suite uses English identifiers while still checking for rejected Spanish keywords
- Convert remaining Spanish docstrings and inline comments in the test tree to English to keep guidance consistent

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f722836570832197dc6a0b031451ca