### PR TITLE
Remove legacy remesh keyword guard in favor of generic handling

### DIFF
--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -475,11 +475,6 @@ def apply_remesh_if_globally_stable(
     stable_step_window: int | None = None,
     **kwargs: Any,
 ) -> None:
-    if "pasos_estables_consecutivos" in kwargs:
-        raise TypeError(
-            "apply_remesh_if_globally_stable() no longer accepts "
-            "'pasos_estables_consecutivos'; use 'stable_step_window'."
-        )
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(

--- a/tests/unit/structural/test_remesh.py
+++ b/tests/unit/structural/test_remesh.py
@@ -47,7 +47,7 @@ def test_apply_remesh_uses_custom_parameter(graph_canon):
 def test_apply_remesh_legacy_keyword_raises_typeerror(graph_canon):
     G, _ = _prepare_graph_for_remesh(graph_canon)
 
-    with pytest.raises(TypeError, match="pasos_estables_consecutivos"):
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
         apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=3)
 
     assert "_last_remesh_step" not in G.graph


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Summary:
- Rely on the generic unexpected keyword argument guard in the remesh stability gate by removing the dedicated legacy keyword branch.
- Align the structural remesh test with the new error messaging expectations for unexpected keywords.
- Validate the guard behaviour with the structural remesh pytest target.


------
https://chatgpt.com/codex/tasks/task_e_68f726483f008321ad318bcc4c6eaf28