### PR TITLE
Clarify ontosim callback documentation

### DIFF
--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -111,8 +111,8 @@ def prepare_network(
     )
     G.graph.setdefault(
         "_CALLBACKS_DOC",
-        "Interfaz Γ(R): registrar pares (name, func) con firma (G, ctx) "
-        "en callbacks['before_step'|'after_step'|'on_remesh']",
+        "Γ(R) interface: register (name, func) pairs with signature (G, ctx) "
+        "in callbacks['before_step'|'after_step'|'on_remesh']",
     )
 
     if init_attrs:


### PR DESCRIPTION
## Summary
- translate the `_CALLBACKS_DOC` guidance in `ontosim.prepare_network` to English while preserving the existing structure

## Testing
- pytest tests/unit/dynamics/test_export_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68f72a6978b083219ab237ae8981a275