### PR TITLE
Rename NodeNX jitter seed helper variable

### DIFF
--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -214,10 +214,10 @@ def _node_offset(G: TNFRGraph, n: NodeId) -> int:
 
 
 def _resolve_jitter_seed(node: NodeProtocol) -> tuple[int, int]:
-    nodo_nx_type = get_nodenx()
-    if nodo_nx_type is None:
+    node_nx_type = get_nodenx()
+    if node_nx_type is None:
         raise ImportError("NodeNX is unavailable")
-    if isinstance(node, nodo_nx_type):
+    if isinstance(node, node_nx_type):
         graph = cast(TNFRGraph, getattr(node, "G"))
         node_id = cast(NodeId, getattr(node, "n"))
         return _node_offset(graph, node_id), id(graph)


### PR DESCRIPTION
## Summary
- rename the local variable in `_resolve_jitter_seed` to `node_nx_type` for clearer English naming

## Testing
- pytest tests/unit -k jitter *(fails: expected manager entries per node rather than per scope)*

------
https://chatgpt.com/codex/tasks/task_e_68f877277634832192992b87afffcc47