### PR TITLE
Clarify NodeNX cache lock identifier

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -228,7 +228,7 @@ class NodeNX(NodeProtocol):
     @classmethod
     def from_graph(cls, G: TNFRGraph, n: NodeId) -> "NodeNX":
         """Return cached ``NodeNX`` for ``(G, n)`` with thread safety."""
-        lock = get_lock(f"nodonx_cache_{id(G)}")
+        lock = get_lock(f"node_nx_cache_{id(G)}")
         with lock:
             cache = G.graph.setdefault("_node_cache", {})
             node = cache.get(n)


### PR DESCRIPTION
## Summary
- rename the NodeNX lock cache identifier to an English phrase for clarity and consistent access

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f87abede848321829e843b05d172a7