### PR TITLE
Translate sigma and diagnosis comments to English

### DIFF
--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -796,7 +796,7 @@ def dissonance_events(
     del ctx
 
     hist = ensure_history(G)
-    # eventos de disonancia se registran en ``history['events']``
+    # Dissonance events are recorded in ``history['events']``
     norms = G.graph.get("_sel_norms", {})
     dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
     step_idx = len(hist.get("C_steps", []))

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -130,7 +130,7 @@ def _empty_sigma(fallback_angle: float) -> SigmaVector:
 
 
 # -------------------------
-# σ por nodo y σ global
+# σ per node and global σ
 # -------------------------
 
 
@@ -287,7 +287,7 @@ def sigma_vector_from_graph(
 
 
 # -------------------------
-# Historia / series
+# History / series
 # -------------------------
 
 
@@ -296,7 +296,7 @@ def push_sigma_snapshot(G: TNFRGraph, t: float | None = None) -> None:
     if not cfg.get("enabled", True):
         return
 
-    # Cache local de la historia para evitar llamadas repetidas
+    # Local history cache to avoid repeated lookups
     hist = ensure_history(G)
     key = cfg.get("history_key", "sigma_global")
 


### PR DESCRIPTION
## Summary
- Translate sigma aggregation section headers and the history cache note to English for clarity
- Translate the dissonance event logging comment to English to keep diagnostics documentation consistent

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f87cea4914832198fd51c057e30976