### PR TITLE
Align structural tests with English naming

### DIFF
--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -327,7 +327,7 @@ def test_compute_advanced_metrics_populates_history(graph_canon):
 def test_pp_val_zero_when_no_remesh(graph_canon):
     """PP metric should be 0.0 when no REMESH events occur."""
     G = graph_canon()
-    # Nodo en estado SHA, pero sin eventos REMESH
+    # Node in SHA state, but without any REMESH events
     G.add_node(0, EPI_kind=LATENT_GLYPH)
     inject_defaults(G)
 
@@ -340,7 +340,7 @@ def test_pp_val_zero_when_no_remesh(graph_canon):
 def test_pp_val_handles_missing_sha(graph_canon):
     """PP metric handles absence of SHA counts gracefully."""
     G = graph_canon()
-    # Nodo en estado REMESH pero sin nodos SHA
+    # Node in REMESH state but without SHA nodes
     G.add_node(0, EPI_kind="REMESH")
     inject_defaults(G)
 

--- a/tests/unit/structural/test_node_offset.py
+++ b/tests/unit/structural/test_node_offset.py
@@ -4,7 +4,7 @@ from tnfr.utils import ensure_node_offset_map
 from tnfr.node import NodeNX
 
 
-def test_nodonx_offset_uses_cached_mapping(graph_canon):
+def test_node_nx_offset_uses_cached_mapping(graph_canon):
     graph = graph_canon()
     graph.add_nodes_from([0, 1, 2])
     ensure_node_offset_map(graph)
@@ -15,7 +15,7 @@ def test_nodonx_offset_uses_cached_mapping(graph_canon):
     assert node.offset() == expected_offset
 
 
-def test_nodonx_offset_defaults_to_zero():
+def test_node_nx_offset_defaults_to_zero():
     graph = nx.Graph()
     graph.add_node(0)
 

--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -35,7 +35,7 @@ from tnfr.structural import (
 
 
 def test_create_nfr_basic() -> None:
-    G, n = create_nfr("nodo", epi=0.1, vf=2.0, theta=0.3)
+    G, n = create_nfr("node", epi=0.1, vf=2.0, theta=0.3)
     assert isinstance(G, nx.Graph)
     assert n in G
     nd = G.nodes[n]
@@ -82,7 +82,7 @@ def test_validate_sequence_rejects_unknown_tokens() -> None:
         COHERENCE,
         RESONANCE,
         SILENCE,
-        "desconocido",
+        "unknown",
     ]
     ok, msg = validate_sequence(names)
     assert not ok and "unknown tokens" in msg


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Rename the NodeNX offset tests so their names consistently use the `node_nx` identifier.
- Replace the Spanish sample node label and placeholder token in the structural tests with English equivalents.
- Translate the inline comments in the metrics tests that describe node states so the documentation is in English.

## Testing
- `pytest tests/unit/structural/test_node_offset.py tests/unit/structural/test_structural.py tests/unit/metrics/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68f87dc208b88321b51a4f1d259cc14b