### PR TITLE
Rename glyph load stabilizer metric history key

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -28,6 +28,8 @@ from .coherence import (
     _update_phase_sync,
     _update_sigma,
     register_coherence_callbacks,
+    GLYPH_LOAD_STABILIZERS_KEY,
+    LEGACY_GLYPH_LOAD_KEY,
 )
 from .diagnosis import register_diagnosis_callbacks
 from .glyph_timing import _compute_advanced_metrics, GlyphMetricsHistory
@@ -75,11 +77,19 @@ def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
     metrics_sentinel_key = "_metrics_history_id"
     history_id = id(hist)
     if G.graph.get(metrics_sentinel_key) != history_id:
+        glyph_series = hist.get(GLYPH_LOAD_STABILIZERS_KEY)
+        legacy_series = hist.get(LEGACY_GLYPH_LOAD_KEY)
+        if glyph_series is None and isinstance(legacy_series, list):
+            glyph_series = list(legacy_series)
+            hist[GLYPH_LOAD_STABILIZERS_KEY] = glyph_series
+        else:
+            glyph_series = cast(list[Any], hist.setdefault(GLYPH_LOAD_STABILIZERS_KEY, []))
+        hist[LEGACY_GLYPH_LOAD_KEY] = glyph_series
+
         for k in (
             "C_steps",
             "stable_frac",
             "phase_sync",
-            "glyph_load_estab",
             "glyph_load_disr",
             "Si_mean",
             "Si_hi_frac",

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -60,7 +60,7 @@ def prepare_network(
         "sense_sigma_mag",
         "sense_sigma_angle",
         "iota",
-        "glyph_load_estab",
+        "glyph_load_stabilizers",
         "glyph_load_disr",
         "Si_mean",
         "Si_hi_frac",
@@ -70,6 +70,7 @@ def prepare_network(
         "phase_kL",
     ]
     history = {k: [] for k in hist_keys}
+    history["glyph_load_estab"] = history["glyph_load_stabilizers"]
     history.update(
         {
             "phase_state": deque(maxlen=ph_len),


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- adopt `glyph_load_stabilizers` as the canonical history key while aliasing the legacy Spanish name with deprecation warnings
- update metrics bootstrap and ontosim history seeding to mirror the new key and migrate any legacy data
- expand sigma metric unit tests to cover the rename and compatibility behaviour

## Testing
- `pytest tests/unit/metrics/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68f87f84cf648321a7ceb94c3417ac4f