### PR TITLE
Adjust validate_sequence keyword error handling

### DIFF
--- a/src/tnfr/validation/syntax.py
+++ b/src/tnfr/validation/syntax.py
@@ -138,11 +138,6 @@ def validate_sequence(
 ) -> tuple[bool, str]:
     """Validate minimal TNFR syntax rules."""
 
-    if "nombres" in kwargs:
-        raise TypeError(
-            "validate_sequence() no longer accepts 'nombres'; use the English 'names' instead"
-        )
-
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(

--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -131,7 +131,7 @@ def test_validate_sequence_rejects_spanish_keyword() -> None:
     with pytest.raises(TypeError) as excinfo:
         validate_sequence(nombres=[EMISSION, RECEPTION, COHERENCE])
 
-    assert "English 'names'" in str(excinfo.value)
+    assert "unexpected keyword argument" in str(excinfo.value)
 
 
 def test_operator_base_types_exposed() -> None:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Remove the bespoke Spanish keyword guard from `validate_sequence` so unexpected arguments share a single error path.
- Update the structural test to assert the generic TypeError message for unsupported keyword usage.

## Testing
- `python -m pytest tests/unit/structural/test_structural.py`


------
https://chatgpt.com/codex/tasks/task_e_68f8aac547088321a0c24c7f1f368ded