### PR TITLE
Enforce glyph load stabilizer history contract

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,11 +3,11 @@
 ## 16.0.0 (glyph load Spanish history key removed)
 
 - **Breaking change**: Removed the deprecated ``"glyph_load_estab"`` history
-  key. Metrics initialisation and the coherence observers now migrate any
-  persisted payloads by promoting the list to ``"glyph_load_stabilizers"`` once
-  and deleting the Spanish alias instead of keeping both identifiers in sync.
-- Migration guidance: audit stored histories and rename the key before
-  upgrading, for example::
+  key. Metrics initialisation and the coherence observers now raise
+  :class:`ValueError` as soon as the legacy identifier appears in a payload,
+  preventing silent mirroring into ``"glyph_load_stabilizers"``.
+- Migration guidance: audit stored histories and rename the key **before**
+  loading a graph into this release. A minimal preprocessing snippet::
 
       history = payload.get("history", {})
       legacy = history.pop("glyph_load_estab", None)
@@ -15,7 +15,9 @@
           history["glyph_load_stabilizers"] = legacy
 
   Persist the rewritten payloads so downstream tooling only reads the English
-  identifier.
+  identifier. The project does not ship an automated helper for this upgrade;
+  integrators should run the snippet (or an equivalent data migration) on any
+  archived graphs prior to installing version 16.0.0.
 
 ## 14.0.0 (Spanish compatibility messaging retired)
 

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 from typing import Any, cast
 
 from ..types import (
@@ -75,35 +73,15 @@ def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
         return
 
     hist = ensure_history(G)
+    if "glyph_load_estab" in hist:
+        raise ValueError(
+            "History payloads using 'glyph_load_estab' are no longer supported. "
+            "Rename the series to 'glyph_load_stabilizers' before loading the graph."
+        )
     metrics_sentinel_key = "_metrics_history_id"
     history_id = id(hist)
     if G.graph.get(metrics_sentinel_key) != history_id:
-        legacy_series = hist.pop("glyph_load_estab", None)
-        glyph_series = hist.get(GLYPH_LOAD_STABILIZERS_KEY)
-        if glyph_series is None:
-            if isinstance(legacy_series, list):
-                hist[GLYPH_LOAD_STABILIZERS_KEY] = glyph_series = legacy_series
-                warnings.warn(
-                    "'glyph_load_estab' history key is deprecated; use "
-                    "'glyph_load_stabilizers' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            else:
-                glyph_series = cast(
-                    list[Any], hist.setdefault(GLYPH_LOAD_STABILIZERS_KEY, [])
-                )
-        else:
-            glyph_series = cast(list[Any], glyph_series)
-            if isinstance(legacy_series, list):
-                if legacy_series is not glyph_series:
-                    glyph_series[0:0] = legacy_series
-                warnings.warn(
-                    "'glyph_load_estab' history key is deprecated; use "
-                    "'glyph_load_stabilizers' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+        hist.setdefault(GLYPH_LOAD_STABILIZERS_KEY, [])
 
         for k in (
             "C_steps",

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -78,13 +78,6 @@ def prepare_network(
         }
     )
     history_ref = G.graph.setdefault("history", history)
-    if isinstance(history_ref, dict):
-        legacy_series = history_ref.pop("glyph_load_estab", None)
-        if (
-            isinstance(legacy_series, list)
-            and "glyph_load_stabilizers" not in history_ref
-        ):
-            history_ref["glyph_load_stabilizers"] = legacy_series
     # Global REMESH memory
     tau = int(get_param(G, "REMESH_TAU_GLOBAL"))
     maxlen = max(2 * tau + 5, 64)


### PR DESCRIPTION
### Summary
- raise explicit ValueError when legacy `glyph_load_estab` history data appears during metrics setup or sigma updates
- remove the automatic glyph load history rewrite in `prepare_network`
- document the required migration path and adjust metrics tests for the new failure mode

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

### Testing
- pytest --override-ini "addopts=-m 'not slow'" tests/unit/metrics tests/unit/structural/test_remesh.py

------
https://chatgpt.com/codex/tasks/task_e_68f8b670d7208321914f0a3b951192bb