### PR TITLE
Add shared LRU cache wrapper for telemetry and lock hygiene

### DIFF
--- a/src/tnfr/rng.py
+++ b/src/tnfr/rng.py
@@ -13,7 +13,7 @@ from typing import Any, Generic, Hashable, TypeVar, cast
 
 from cachetools import LRUCache, cached  # type: ignore[import-untyped]
 from .constants import DEFAULTS, get_param
-from .cache import CacheManager
+from .cache import CacheManager, ManagedLRUCache
 from .utils import get_graph
 from .locking import get_lock
 from .types import GraphLike, TNFRGraph
@@ -29,29 +29,15 @@ K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
 
-class _TelemetryLRUCache(LRUCache[K, V], Generic[K, V]):
-    """LRU cache that reports evictions through the shared manager."""
-
-    def __init__(self, maxsize: int, *, manager: CacheManager, metrics_key: str) -> None:
-        super().__init__(maxsize)
-        self._manager = manager
-        self._metrics_key = metrics_key
-
-    def popitem(self) -> tuple[K, V]:  # type: ignore[override]
-        key, value = super().popitem()
-        self._manager.increment_eviction(self._metrics_key)
-        return key, value
-
-
 @dataclass
 class _SeedCacheState:
-    cache: LRUCache[tuple[int, int], int] | None
+    cache: ManagedLRUCache[tuple[int, int], int] | None
     maxsize: int
 
 
 @dataclass
 class _CounterState(Generic[K]):
-    cache: LRUCache[K, int]
+    cache: ManagedLRUCache[K, int]
     max_entries: int
 
 
@@ -96,8 +82,8 @@ class _SeedHashCache(MutableMapping[tuple[int, int], int]):
         if size <= 0:
             return _SeedCacheState(cache=None, maxsize=0)
         return _SeedCacheState(
-            cache=_TelemetryLRUCache(
-                maxsize=size,
+            cache=ManagedLRUCache(
+                size,
                 manager=self._manager,
                 metrics_key=self._state_key,
             ),
@@ -221,8 +207,8 @@ class ScopedCounterCache(Generic[K]):
     def _create_state(self, requested: int | None = None) -> _CounterState[K]:
         size = self._resolved_entries(requested)
         return _CounterState(
-            cache=_TelemetryLRUCache(
-                maxsize=size,
+            cache=ManagedLRUCache(
+                size,
                 manager=self._manager,
                 metrics_key=self._state_key,
             ),
@@ -274,8 +260,8 @@ class ScopedCounterCache(Generic[K]):
         def _update(state: _CounterState[K] | None) -> _CounterState[K]:
             if not isinstance(state, _CounterState) or force or state.max_entries != size:
                 return _CounterState(
-                    cache=_TelemetryLRUCache(
-                        maxsize=size,
+                    cache=ManagedLRUCache(
+                        size,
                         manager=self._manager,
                         metrics_key=self._state_key,
                     ),

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -27,7 +27,6 @@ from .graph import (
 )
 from .cache import (
     EdgeCacheManager,
-    LockAwareLRUCache,
     NODE_SET_CHECKSUM_KEY,
     cached_node_list,
     cached_nodes_and_A,
@@ -74,7 +73,6 @@ __all__ = (
     "mix_groups",
     "CacheManager",
     "EdgeCacheManager",
-    "LockAwareLRUCache",
     "NODE_SET_CHECKSUM_KEY",
     "cached_node_list",
     "cached_nodes_and_A",

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -5,7 +5,6 @@ from typing import Any, Final
 from ..cache import CacheManager
 from .cache import (
     EdgeCacheManager,
-    LockAwareLRUCache,
     NODE_SET_CHECKSUM_KEY,
     cached_node_list,
     cached_nodes_and_A,
@@ -93,7 +92,6 @@ __all__ = (
     "mix_groups",
     "CacheManager",
     "EdgeCacheManager",
-    "LockAwareLRUCache",
     "NODE_SET_CHECKSUM_KEY",
     "cached_node_list",
     "cached_nodes_and_A",

--- a/src/tnfr/utils/cache.pyi
+++ b/src/tnfr/utils/cache.pyi
@@ -15,7 +15,6 @@ T = TypeVar("T")
 
 __all__ = (
     "EdgeCacheManager",
-    "LockAwareLRUCache",
     "NODE_SET_CHECKSUM_KEY",
     "cached_node_list",
     "cached_nodes_and_A",
@@ -47,18 +46,6 @@ class LRUCache(MutableMapping[K, V], Generic[K, V]):
     def __iter__(self) -> Iterator[K]: ...
 
     def __len__(self) -> int: ...
-
-
-class LockAwareLRUCache(LRUCache[Hashable, Any]):
-    def __init__(
-        self,
-        maxsize: int,
-        locks: dict[Hashable, threading.RLock],
-        *,
-        on_evict: Callable[[Hashable, Any], None] | None = ...,
-    ) -> None: ...
-
-    def popitem(self) -> tuple[Hashable, Any]: ...
 
 
 class EdgeCacheState:

--- a/tests/unit/structural/test_edge_version_cache.py
+++ b/tests/unit/structural/test_edge_version_cache.py
@@ -38,13 +38,18 @@ def test_edge_version_cache_disable(graph_and_manager):
 
 
 def test_edge_version_cache_limit(graph_and_manager):
-    G, _ = graph_and_manager()
+    G, manager = graph_and_manager()
+    baseline = manager._manager.get_metrics(manager._STATE_KEY)
     edge_version_cache(G, "a", lambda: 1, max_entries=2)
     edge_version_cache(G, "b", lambda: 2, max_entries=2)
     edge_version_cache(G, "c", lambda: 3, max_entries=2)
-    cache, _ = EdgeCacheManager(G.graph).get_cache(2)
+    cache, locks = EdgeCacheManager(G.graph).get_cache(2)
     assert "a" not in cache
     assert "b" in cache and "c" in cache
+    assert set(locks) == set(cache)
+
+    stats = manager._manager.get_metrics(manager._STATE_KEY)
+    assert stats.evictions - baseline.evictions == 1
 
 
 @pytest.mark.parametrize("max_entries", [2, None])


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Introduced a ManagedLRUCache wrapper in `tnfr.cache` with telemetry callbacks and optional lock pruning utilities.
- Refactored `EdgeCacheManager`, `_SeedHashCache`, and `ScopedCounterCache` to adopt the shared wrapper and cleaned related exports.
- Extended edge cache and RNG unit tests to assert eviction metrics and lock hygiene under bounded caches.

## Testing
- `pytest tests/unit/structural/test_edge_version_cache.py tests/unit/structural/test_rng_base_seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68f8ca35a1d88321b0e00be8d635d5aa