### PR TITLE
Refactor RNG caches to instrumented wrapper

### DIFF
--- a/tests/unit/structural/test_rng_base_seed.py
+++ b/tests/unit/structural/test_rng_base_seed.py
@@ -181,10 +181,15 @@ def test_scoped_counter_cache_evictions():
     try:
         before = manager.get_metrics(cache._state_key)  # type: ignore[attr-defined]
         cache.bump("a")
+        cache.bump("a")
         cache.bump("b")
         cache.bump("c")
         after = manager.get_metrics(cache._state_key)  # type: ignore[attr-defined]
         assert after.evictions - before.evictions == 1
+        assert after.misses - before.misses == 3
+        assert after.hits - before.hits == 1
+        assert set(cache.cache.keys()) == {"b", "c"}
+        assert set(cache.locks.keys()) == {"b", "c"}
     finally:
         cache.configure(force=True, max_entries=rng_module._DEFAULT_CACHE_MAXSIZE)
         cache.clear()


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

- Replace RNG caches with `InstrumentedLRUCache` to hook cache metrics and lock cleanup.
- Extend `ScopedCounterCache` with per-key lock tracking exposed for diagnostics.
- Update structural RNG tests to verify cache metrics, eviction counts, and lock lifecycle under the new wrapper.


------
https://chatgpt.com/codex/tasks/task_e_68f8dd80ac9c83219ad5f90ed097f88d