### PR TITLE
Fix edge cache miss accounting on version rebuilds

### DIFF
--- a/src/tnfr/cache.pyi
+++ b/src/tnfr/cache.pyi
@@ -165,6 +165,7 @@ class InstrumentedLRUCache(MutableMapping[K, V], Generic[K, V]):
         | None = ...,
         locks: MutableMapping[K, Any] | None = ...,
         getsizeof: Callable[[V], int] | None = ...,
+        count_overwrite_hit: bool = ...,
     ) -> None: ...
 
     @property

--- a/tests/unit/structural/test_edge_version_cache.py
+++ b/tests/unit/structural/test_edge_version_cache.py
@@ -154,3 +154,22 @@ def test_edge_version_cache_metrics(graph_and_manager):
     assert stats.misses == 1
     assert stats.hits == 1
     assert stats.evictions == 0
+
+
+def test_edge_version_cache_version_bump_metrics(graph_and_manager):
+    G, manager = graph_and_manager()
+
+    def builder() -> str:
+        return "payload"
+
+    edge_version_cache(G, "k", builder)
+    edge_version_cache(G, "k", builder)
+
+    stats_before = manager._manager.get_metrics(manager._STATE_KEY)
+
+    increment_edge_version(G)
+    edge_version_cache(G, "k", builder)
+
+    stats_after = manager._manager.get_metrics(manager._STATE_KEY)
+    assert stats_after.misses == stats_before.misses + 1
+    assert stats_after.hits == stats_before.hits

--- a/tests/unit/structural/test_instrumented_lru_cache.py
+++ b/tests/unit/structural/test_instrumented_lru_cache.py
@@ -175,3 +175,23 @@ def test_callback_registration_runtime_updates() -> None:
     cache["p"] = 5
     cache.pop("p")
     assert recorder.events == [("telemetry:gamma", "p", 5)]
+
+
+def test_overwrite_hit_tracking_can_be_disabled() -> None:
+    manager = CacheManager()
+    cache = InstrumentedLRUCache[str, int](
+        4,
+        manager=manager,
+        metrics_key="instrumented",
+        count_overwrite_hit=False,
+    )
+
+    cache["k"] = 1
+    stats_after_insert = manager.get_metrics("instrumented")
+    assert stats_after_insert.misses == 1
+    assert stats_after_insert.hits == 0
+
+    cache["k"] = 2
+    stats_after_overwrite = manager.get_metrics("instrumented")
+    assert stats_after_overwrite.misses == 1
+    assert stats_after_overwrite.hits == 0


### PR DESCRIPTION
## Summary
- disable overwrite-hit accounting in the instrumented LRU cache so edge caches can rebuild entries without inflating hit metrics
- treat stale edge-version entries as misses with optional eviction telemetry instead of counting additional hits
- expand structural cache tests to cover overwrite tracking and regression metrics after edge version bumps

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f8e4574770832193189ceba9985822