### PR TITLE
Add telemetry verbosity presets for traces and metrics

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -42,6 +42,34 @@ the graph (default length 100). Adjust or inspect the buffer at runtime with
 `tnfr.callback_utils.callback_manager.set_callback_error_limit` and
 `get_callback_error_limit`.
 
+### Trace verbosity presets
+
+`G.graph["TRACE"]` accepts a `verbosity` knob that determines which field producers execute when
+no explicit `capture` list is provided. The presets are:
+
+- `"basic"` — captures the structural configuration (`gamma`, grammar, selector, ΔNFR/SI weights,
+  callback map, THOL state) while skipping the heavier collectors.
+- `"detailed"` and `"debug"` — include all default collectors (Kuramoto order, Σ⃗ snapshot, glyph
+  counts) to preserve the legacy trace payloads. `"debug"` remains the default level.
+
+If you still need a custom field mix, set `TRACE["capture"]` explicitly; the resolver will honour
+that list (or mapping) and ignore the verbosity preset.
+
+### Metrics verbosity tiers
+
+The metrics orchestrator follows the same pattern via `G.graph["METRICS"]["verbosity"]`:
+
+- `"basic"` keeps the coherence and stability core (C(t), ΔSi, B) while skipping phase sync,
+  Σ⃗ statistics, Si aggregates, glyph timing, and the coherence/diagnosis callback hooks. This is
+  useful for lightweight runs or smoke tests.
+- `"detailed"` and `"debug"` execute the full collector suite (`_update_phase_sync`,
+  `_update_sigma`, `_aggregate_si`, `_compute_advanced_metrics`) and register the auxiliary
+  coherence/diagnosis observers. `"debug"` is the default so existing deployments continue to emit
+  the rich telemetry payloads.
+
+As with traces, an explicit override of `METRICS` parameters (for example `save_by_node` or
+`normalize_series`) still applies regardless of the verbosity preset.
+
 ## Locking policy
 
 The engine centralises reusable process-wide locks in `tnfr.locking`. Obtain named locks with

--- a/src/tnfr/constants/metric.py
+++ b/src/tnfr/constants/metric.py
@@ -35,18 +35,7 @@ class MetricDefaults:
     TRACE: dict[str, Any] = field(
         default_factory=lambda: {
             "enabled": True,
-            "capture": [
-                "gamma",
-                "grammar",
-                "selector",
-                "dnfr_weights",
-                "si_weights",
-                "callbacks",
-                "thol_open_nodes",
-                "sigma",
-                "kuramoto",
-                "glyph_counts",
-            ],
+            "verbosity": "debug",
             "history_key": "trace_meta",
         }
     )
@@ -56,6 +45,7 @@ class MetricDefaults:
             "save_by_node": True,
             "normalize_series": False,
             "n_jobs": 1,
+            "verbosity": "debug",
         }
     )
     GRAMMAR_CANON: dict[str, Any] = field(

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Mapping
+from typing import Any, NamedTuple, cast
 
 from ..types import (
     GlyphSelector,
@@ -63,15 +64,91 @@ __all__ = [
 ]
 
 
+class MetricsVerbositySpec(NamedTuple):
+    """Runtime configuration for metrics verbosity tiers."""
+
+    name: str
+    enable_phase_sync: bool
+    enable_sigma: bool
+    enable_aggregate_si: bool
+    enable_advanced: bool
+    attach_coherence_hooks: bool
+    attach_diagnosis_hooks: bool
+
+
+METRICS_VERBOSITY_DEFAULT = "debug"
+
+_METRICS_VERBOSITY_PRESETS: dict[str, MetricsVerbositySpec] = {}
+
+
+def _register_metrics_preset(spec: MetricsVerbositySpec) -> None:
+    _METRICS_VERBOSITY_PRESETS[spec.name] = spec
+
+
+_register_metrics_preset(
+    MetricsVerbositySpec(
+        name="basic",
+        enable_phase_sync=False,
+        enable_sigma=False,
+        enable_aggregate_si=False,
+        enable_advanced=False,
+        attach_coherence_hooks=False,
+        attach_diagnosis_hooks=False,
+    )
+)
+
+_detailed_spec = MetricsVerbositySpec(
+    name="debug",
+    enable_phase_sync=True,
+    enable_sigma=True,
+    enable_aggregate_si=True,
+    enable_advanced=True,
+    attach_coherence_hooks=True,
+    attach_diagnosis_hooks=True,
+)
+_register_metrics_preset(_detailed_spec)
+_register_metrics_preset(_detailed_spec._replace(name="detailed"))
+
+
+_METRICS_BASE_HISTORY_KEYS = ("C_steps", "stable_frac", "delta_Si", "B")
+_METRICS_PHASE_HISTORY_KEYS = ("phase_sync", "kuramoto_R")
+_METRICS_SIGMA_HISTORY_KEYS = (
+    GLYPH_LOAD_STABILIZERS_KEY,
+    "glyph_load_disr",
+    "sense_sigma_x",
+    "sense_sigma_y",
+    "sense_sigma_mag",
+    "sense_sigma_angle",
+)
+_METRICS_SI_HISTORY_KEYS = ("Si_mean", "Si_hi_frac", "Si_lo_frac")
+
+
+def _resolve_metrics_verbosity(cfg: Mapping[str, Any]) -> MetricsVerbositySpec:
+    """Return the preset matching ``cfg['verbosity']``."""
+
+    raw_value = cfg.get("verbosity", METRICS_VERBOSITY_DEFAULT)
+    key = str(raw_value).lower()
+    spec = _METRICS_VERBOSITY_PRESETS.get(key)
+    if spec is not None:
+        return spec
+    logger.warning(
+        "Unknown METRICS verbosity '%s'; falling back to '%s'",
+        raw_value,
+        METRICS_VERBOSITY_DEFAULT,
+    )
+    return _METRICS_VERBOSITY_PRESETS[METRICS_VERBOSITY_DEFAULT]
+
+
 def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
     """Update operational TNFR metrics per step."""
 
     del ctx
 
-    cfg = get_param(G, "METRICS")
+    cfg = cast(Mapping[str, Any], get_param(G, "METRICS"))
     if not cfg.get("enabled", True):
         return
 
+    spec = _resolve_metrics_verbosity(cfg)
     hist = ensure_history(G)
     if "glyph_load_estab" in hist:
         raise ValueError(
@@ -81,20 +158,17 @@ def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
     metrics_sentinel_key = "_metrics_history_id"
     history_id = id(hist)
     if G.graph.get(metrics_sentinel_key) != history_id:
-        hist.setdefault(GLYPH_LOAD_STABILIZERS_KEY, [])
-
-        for k in (
-            "C_steps",
-            "stable_frac",
-            "phase_sync",
-            "glyph_load_disr",
-            "Si_mean",
-            "Si_hi_frac",
-            "Si_lo_frac",
-            "delta_Si",
-            "B",
-        ):
-            hist.setdefault(k, [])
+        for key in _METRICS_BASE_HISTORY_KEYS:
+            hist.setdefault(key, [])
+        if spec.enable_phase_sync:
+            for key in _METRICS_PHASE_HISTORY_KEYS:
+                hist.setdefault(key, [])
+        if spec.enable_sigma:
+            for key in _METRICS_SIGMA_HISTORY_KEYS:
+                hist.setdefault(key, [])
+        if spec.enable_aggregate_si:
+            for key in _METRICS_SI_HISTORY_KEYS:
+                hist.setdefault(key, [])
         G.graph[metrics_sentinel_key] = history_id
 
     dt = float(get_param(G, "DT"))
@@ -122,36 +196,46 @@ def _metrics_step(G: TNFRGraph, ctx: dict[str, Any] | None = None) -> None:
         eps_depi,
         n_jobs=metrics_jobs,
     )
-    try:
-        _update_phase_sync(G, hist)
-        _update_sigma(G, hist)
-        if hist.get("C_steps") and hist.get("stable_frac"):
-            append_metric(
-                hist,
-                "iota",
-                hist["C_steps"][-1] * hist["stable_frac"][-1],
-            )
-    except (KeyError, AttributeError, TypeError) as exc:
-        logger.debug("observer update failed: %s", exc)
+    if spec.enable_phase_sync or spec.enable_sigma:
+        try:
+            if spec.enable_phase_sync:
+                _update_phase_sync(G, hist)
+            if spec.enable_sigma:
+                _update_sigma(G, hist)
+        except (KeyError, AttributeError, TypeError) as exc:
+            logger.debug("observer update failed: %s", exc)
 
-    _aggregate_si(G, hist, n_jobs=metrics_jobs)
+    if hist.get("C_steps") and hist.get("stable_frac"):
+        append_metric(
+            hist,
+            "iota",
+            hist["C_steps"][-1] * hist["stable_frac"][-1],
+        )
 
-    _compute_advanced_metrics(
-        G,
-        cast(GlyphMetricsHistory, hist),
-        t,
-        dt,
-        cfg,
-        n_jobs=metrics_jobs,
-    )
+    if spec.enable_aggregate_si:
+        _aggregate_si(G, hist, n_jobs=metrics_jobs)
+
+    if spec.enable_advanced:
+        _compute_advanced_metrics(
+            G,
+            cast(GlyphMetricsHistory, hist),
+            t,
+            dt,
+            cfg,
+            n_jobs=metrics_jobs,
+        )
 
 
 def register_metrics_callbacks(G: TNFRGraph) -> None:
+    cfg = cast(Mapping[str, Any], get_param(G, "METRICS"))
+    spec = _resolve_metrics_verbosity(cfg)
     callback_manager.register_callback(
         G,
         event=CallbackEvent.AFTER_STEP.value,
         func=_metrics_step,
         name="metrics_step",
     )
-    register_coherence_callbacks(G)
-    register_diagnosis_callbacks(G)
+    if spec.attach_coherence_hooks:
+        register_coherence_callbacks(G)
+    if spec.attach_diagnosis_hooks:
+        register_diagnosis_callbacks(G)

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -28,6 +28,16 @@ except Exception:  # pragma: no cover - numpy optional dependency
 np: ModuleType | None = cast(ModuleType | None, _np)
 
 
+def _has_numpy_support(np_obj: object) -> bool:
+    """Return ``True`` when ``np_obj`` exposes the required NumPy API."""
+
+    return isinstance(np_obj, ModuleType) or (
+        np_obj is not None
+        and hasattr(np_obj, "fromiter")
+        and hasattr(np_obj, "bincount")
+    )
+
+
 class SigmaTrace(TypedDict):
     """Time-aligned σ(t) trace exported alongside glyphograms."""
 
@@ -194,7 +204,7 @@ def _update_tg(
     if not glyph_sequence:
         return counts, n_total, n_latent
 
-    if isinstance(np, ModuleType):
+    if _has_numpy_support(np):
         glyph_idx = np.fromiter(
             (_GLYPH_TO_INDEX[glyph] for glyph in glyph_sequence),
             dtype=np.int64,
@@ -271,7 +281,7 @@ def _update_epi_support(
     total = 0.0
     count = 0
 
-    if isinstance(np, ModuleType) and node_count:
+    if _has_numpy_support(np) and node_count:
         epi_values = np.fromiter(
             (
                 abs(_coerce_float(get_attr(nd, ALIAS_EPI, 0.0)))

--- a/tests/unit/metrics/test_history_series.py
+++ b/tests/unit/metrics/test_history_series.py
@@ -21,6 +21,22 @@ def test_history_delta_si_and_B(graph_canon):
     assert "B" in hist and len(hist["B"]) >= 2
 
 
+def test_history_basic_metrics_skips_heavy_series(graph_canon):
+    G = graph_canon()
+    G.add_node(0, EPI=0.0, νf=0.5, theta=0.0)
+    inject_defaults(G)
+    G.graph["METRICS"]["verbosity"] = "basic"
+    register_metrics_callbacks(G)
+    step(G, apply_glyphs=False)
+    step(G, apply_glyphs=False)
+    hist = ensure_history(G)
+    assert "delta_Si" in hist
+    assert "B" in hist
+    assert "phase_sync" not in hist
+    assert "glyph_load_stabilizers" not in hist
+    assert "Si_mean" not in hist
+
+
 def test_gamma_kuramoto_tanh_registry(graph_canon):
     G = graph_canon()
     G.add_nodes_from([0, 1])


### PR DESCRIPTION
## Summary
- add configurable verbosity presets for trace capture and metrics collection, defaulting to the legacy debug payloads
- route metrics history initialisation and collectors through the new presets, with optional numpy fallbacks for lightweight runs
- extend unit coverage and documentation to describe basic vs detailed/debug behaviours and capture overrides

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f8ea06422483219cc302cd31debc5d