### PR TITLE
Refine trace verbosity tiers to skip glyph counts in detailed mode

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -48,9 +48,14 @@ the graph (default length 100). Adjust or inspect the buffer at runtime with
 no explicit `capture` list is provided. The presets are:
 
 - `"basic"` — captures the structural configuration (`gamma`, grammar, selector, ΔNFR/SI weights,
-  callback map, THOL state) while skipping the heavier collectors.
-- `"detailed"` and `"debug"` — include all default collectors (Kuramoto order, Σ⃗ snapshot, glyph
-  counts) to preserve the legacy trace payloads. `"debug"` remains the default level.
+  callback map, THOL state) while skipping the heavier collectors. Use this for smoke tests or
+  performance-sensitive runs where topology snapshots are enough.
+- `"detailed"` — extends the basic payload with the Kuramoto order parameters and Σ⃗ snapshot while
+  omitting glyph counts, avoiding the most expensive history walk. Pick this tier when you need
+  coherence metrics without paying the full glyph audit cost.
+- `"debug"` — executes the full collector suite, including glyph counts, to preserve the legacy
+  trace payload. This remains the default level and is intended for investigations and regression
+  hunts where complete operator coverage matters more than runtime.
 
 If you still need a custom field mix, set `TRACE["capture"]` explicitly; the resolver will honour
 that list (or mapping) and ignore the verbosity preset.

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -82,6 +82,9 @@ _TRACE_ALL_FIELDS = (
     "sigma",
     "glyph_counts",
 )
+_TRACE_DETAILED_FIELDS = tuple(
+    field for field in _TRACE_ALL_FIELDS if field != "glyph_counts"
+)
 TRACE_VERBOSITY_PRESETS: Mapping[str, tuple[str, ...]] = {
     "basic": (
         "gamma",
@@ -92,7 +95,7 @@ TRACE_VERBOSITY_PRESETS: Mapping[str, tuple[str, ...]] = {
         "callbacks",
         "thol_open_nodes",
     ),
-    "detailed": _TRACE_ALL_FIELDS,
+    "detailed": _TRACE_DETAILED_FIELDS,
     "debug": _TRACE_ALL_FIELDS,
 }
 

--- a/tests/unit/structural/test_trace.py
+++ b/tests/unit/structural/test_trace.py
@@ -90,9 +90,25 @@ def test_trace_basic_verbosity_skips_heavy_fields(graph_canon):
     assert "glyphs" not in after
 
 
-def test_trace_detailed_verbosity_preserves_heavy_fields(graph_canon):
+def test_trace_detailed_verbosity_skips_glyph_counts(graph_canon):
     G = graph_canon()
     G.graph["TRACE"]["verbosity"] = "detailed"
+    register_trace(G)
+    callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP.value)
+    callback_manager.invoke_callbacks(G, CallbackEvent.AFTER_STEP.value)
+
+    hist = G.graph["history"]["trace_meta"]
+    after = hist[1]
+
+    assert after["phase"] == "after"
+    assert "kuramoto" in after
+    assert "sigma" in after
+    assert "glyphs" not in after
+
+
+def test_trace_debug_verbosity_includes_all_fields(graph_canon):
+    G = graph_canon()
+    # Debug is the default verbosity; ensure the full capture set executes.
     register_trace(G)
     callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP.value)
     callback_manager.invoke_callbacks(G, CallbackEvent.AFTER_STEP.value)


### PR DESCRIPTION
## Summary
- align the detailed trace preset to skip glyph counts while keeping the debug tier exhaustive
- extend trace tests to assert the capture matrices for basic, detailed, and debug presets
- document the intended usage and field coverage for each trace verbosity level

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f8ef5c6b648321a405bc05cc2559a8