### PR TITLE
Clarify metrics verbosity tiers to lighten detailed preset

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -67,10 +67,12 @@ The metrics orchestrator follows the same pattern via `G.graph["METRICS"]["verbo
 - `"basic"` keeps the coherence and stability core (C(t), ΔSi, B) while skipping phase sync,
   Σ⃗ statistics, Si aggregates, glyph timing, and the coherence/diagnosis callback hooks. This is
   useful for lightweight runs or smoke tests.
-- `"detailed"` and `"debug"` execute the full collector suite (`_update_phase_sync`,
-  `_update_sigma`, `_aggregate_si`, `_compute_advanced_metrics`) and register the auxiliary
-  coherence/diagnosis observers. `"debug"` is the default so existing deployments continue to emit
-  the rich telemetry payloads.
+- `"detailed"` enables `_update_phase_sync`, `_update_sigma`, and `_aggregate_si` while attaching
+  the coherence observers. It deliberately skips `_compute_advanced_metrics` and the diagnosis
+  callbacks so you get richer stability traces without the most expensive glyph timing jobs.
+- `"debug"` retains the entire collector suite, including `_compute_advanced_metrics` and the
+  diagnosis callbacks, to mirror the legacy payload. This remains the default verbosity for
+  investigations that require a full glyph and diagnosis audit trail.
 
 As with traces, an explicit override of `METRICS` parameters (for example `save_by_node` or
 `normalize_series`) still applies regardless of the verbosity preset.

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -98,16 +98,22 @@ _register_metrics_preset(
 )
 
 _detailed_spec = MetricsVerbositySpec(
-    name="debug",
+    name="detailed",
     enable_phase_sync=True,
     enable_sigma=True,
     enable_aggregate_si=True,
-    enable_advanced=True,
+    enable_advanced=False,
     attach_coherence_hooks=True,
-    attach_diagnosis_hooks=True,
+    attach_diagnosis_hooks=False,
 )
 _register_metrics_preset(_detailed_spec)
-_register_metrics_preset(_detailed_spec._replace(name="detailed"))
+_register_metrics_preset(
+    _detailed_spec._replace(
+        name="debug",
+        enable_advanced=True,
+        attach_diagnosis_hooks=True,
+    )
+)
 
 
 _METRICS_BASE_HISTORY_KEYS = ("C_steps", "stable_frac", "delta_Si", "B")


### PR DESCRIPTION
## Summary
- split the detailed and debug metrics presets so only debug triggers advanced glyph timing and diagnosis hooks
- refreshed unit expectations and docs to describe the collectors enabled by each verbosity tier

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f8f08455408321bd758b395d88c583