### PR TITLE
Expose telemetry verbosity flags in CLI defaults

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -45,7 +45,9 @@ the graph (default length 100). Adjust or inspect the buffer at runtime with
 ### Trace verbosity presets
 
 `G.graph["TRACE"]` accepts a `verbosity` knob that determines which field producers execute when
-no explicit `capture` list is provided. The presets are:
+no explicit `capture` list is provided. The CLI mirrors these presets through the
+`--trace-verbosity {basic,detailed,debug}` switch so scripted runs can stay in sync with
+manual API configuration. The presets are:
 
 - `"basic"` — captures the structural configuration (`gamma`, grammar, selector, ΔNFR/SI weights,
   callback map, THOL state) while skipping the heavier collectors. Use this for smoke tests or
@@ -62,7 +64,8 @@ that list (or mapping) and ignore the verbosity preset.
 
 ### Metrics verbosity tiers
 
-The metrics orchestrator follows the same pattern via `G.graph["METRICS"]["verbosity"]`:
+The metrics orchestrator follows the same pattern via `G.graph["METRICS"]["verbosity"]`,
+which is exposed on the CLI as `--metrics-verbosity {basic,detailed,debug}`:
 
 - `"basic"` keeps the coherence and stability core (C(t), ΔSi, B) while skipping phase sync,
   Σ⃗ statistics, Si aggregates, glyph timing, and the coherence/diagnosis callback hooks. This is

--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -13,6 +13,8 @@ _PRESET_HELP = "Available presets: {}.".format(
     ", ".join(PREFERRED_PRESET_NAMES),
 )
 
+TELEMETRY_VERBOSITY_CHOICES = ("basic", "detailed", "debug")
+
 
 GRAMMAR_ARG_SPECS: tuple[ArgSpec, ...] = (
     spec("--grammar.enabled", action=argparse.BooleanOptionalAction),
@@ -45,6 +47,16 @@ COMMON_ARG_SPECS: tuple[ArgSpec, ...] = (
         help="Edge probability when topology=erdos",
     ),
     spec("--observer", action="store_true", help="Attach standard observer"),
+    spec(
+        "--trace-verbosity",
+        choices=TELEMETRY_VERBOSITY_CHOICES,
+        help="Select the trace capture preset",
+    ),
+    spec(
+        "--metrics-verbosity",
+        choices=TELEMETRY_VERBOSITY_CHOICES,
+        help="Select the metrics capture preset",
+    ),
     spec("--config", type=str),
     spec("--dt", type=float),
     spec("--integrator", choices=["euler", "rk4"]),

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Optional
 
@@ -136,6 +137,18 @@ def apply_cli_config(G: "nx.Graph", args: argparse.Namespace) -> None:
             "beta": args.gamma_beta,
             "R0": args.gamma_R0,
         }
+
+    for attr, key in (
+        ("trace_verbosity", "TRACE"),
+        ("metrics_verbosity", "METRICS"),
+    ):
+        cfg = G.graph.get(key)
+        if not isinstance(cfg, dict):
+            cfg = deepcopy(METRIC_DEFAULTS[key])
+            G.graph[key] = cfg
+        value = getattr(args, attr, None)
+        if value is not None:
+            cfg["verbosity"] = value
 
 
 def register_callbacks_and_observer(G: "nx.Graph") -> None:

--- a/tests/unit/cli/test_apply_cli_config.py
+++ b/tests/unit/cli/test_apply_cli_config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import argparse
+
+import networkx as nx
+
+from tnfr.cli.execution import apply_cli_config
+from tnfr.constants import METRIC_DEFAULTS
+
+
+def test_apply_cli_config_sets_requested_telemetry_verbosity() -> None:
+    args = argparse.Namespace(
+        config=None,
+        dt=None,
+        integrator=None,
+        remesh_mode=None,
+        glyph_hysteresis_window=None,
+        grammar_canon=None,
+        trace_verbosity="detailed",
+        metrics_verbosity="basic",
+        gamma_type="none",
+        gamma_beta=0.0,
+        gamma_R0=0.0,
+    )
+    G = nx.Graph()
+    G.graph["TRACE"] = {"enabled": False}
+
+    apply_cli_config(G, args)
+
+    trace_cfg = G.graph["TRACE"]
+    assert trace_cfg["verbosity"] == "detailed"
+    assert trace_cfg["enabled"] is False
+
+    metrics_cfg = G.graph["METRICS"]
+    assert metrics_cfg["verbosity"] == "basic"
+    assert metrics_cfg is not METRIC_DEFAULTS["METRICS"]
+    assert METRIC_DEFAULTS["TRACE"]["verbosity"] == "debug"
+    assert METRIC_DEFAULTS["METRICS"]["verbosity"] == "debug"


### PR DESCRIPTION
## Summary
- add `--trace-verbosity` and `--metrics-verbosity` to the shared CLI arguments
- ensure `apply_cli_config` seeds trace/metrics configs and applies requested presets
- document the CLI switches and cover the behaviour with a focused unit test

## Testing
- `pytest -o addopts="" tests/unit/cli/test_apply_cli_config.py`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f8f63e8d188321886494216d2a988b