### PR TITLE
Support glyphs alias for trace capture configuration

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -60,7 +60,19 @@ manual API configuration. The presets are:
   hunts where complete operator coverage matters more than runtime.
 
 If you still need a custom field mix, set `TRACE["capture"]` explicitly; the resolver will honour
-that list (or mapping) and ignore the verbosity preset.
+that list (or mapping) and ignore the verbosity preset. Identifiers are case-sensitive and the
+following capture names are recognised:
+
+- `"gamma"` — canonical Γ specification snapshot.
+- `"grammar"` — canonical grammar configuration.
+- `"selector"` — active glyph selector name.
+- `"dnfr_weights"` — ΔNFR mixing weights.
+- `"si_weights"` — Si weighting and sensitivity payload.
+- `"callbacks"` — registered callback names per phase.
+- `"thol_open_nodes"` — count of nodes with an open THOL block.
+- `"kuramoto"` — network Kuramoto order parameters.
+- `"sigma"` — global sense-plane vector Σ⃗.
+- `"glyph_counts"` (alias `"glyphs"`) — per-step glyph/operator count audit.
 
 ### Metrics verbosity tiers
 

--- a/tests/unit/structural/test_trace.py
+++ b/tests/unit/structural/test_trace.py
@@ -218,3 +218,15 @@ def test_trace_capture_override_takes_priority(graph_canon):
     assert "kuramoto" in meta
     assert "sigma" not in meta
     assert "glyphs" not in meta
+
+
+def test_trace_capture_accepts_glyph_alias(graph_canon):
+    G = graph_canon()
+    G.graph["TRACE"] = {"capture": ["glyphs"]}
+
+    register_trace(G)
+    callback_manager.invoke_callbacks(G, CallbackEvent.AFTER_STEP.value)
+
+    meta = G.graph["history"]["trace_meta"][0]
+    assert "glyphs" in meta
+    assert isinstance(meta["glyphs"], dict)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- normalise trace capture names so the glyph audit can be requested via the `"glyphs"` alias
- document the accepted trace capture identifiers and note the glyph count alias
- add regression coverage to ensure the glyph alias populates glyph counts in snapshots

## Testing
- python -m pytest -o addopts='' tests/unit/structural/test_trace.py

------
https://chatgpt.com/codex/tasks/task_e_68f8f7cc66648321a2a160eb5104220d