### PR TITLE
Centralize telemetry verbosity presets

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable
 
 from ..config.presets import PREFERRED_PRESET_NAMES
 from ..gamma import GAMMA_REGISTRY
+from ..telemetry.verbosity import TELEMETRY_VERBOSITY_LEVELS
 from ..types import ArgSpec
 from .utils import spec
 
@@ -13,7 +14,7 @@ _PRESET_HELP = "Available presets: {}.".format(
     ", ".join(PREFERRED_PRESET_NAMES),
 )
 
-TELEMETRY_VERBOSITY_CHOICES = ("basic", "detailed", "debug")
+TELEMETRY_VERBOSITY_CHOICES = TELEMETRY_VERBOSITY_LEVELS
 
 
 GRAMMAR_ARG_SPECS: tuple[ArgSpec, ...] = (

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -22,6 +22,11 @@ from ..callback_utils import CallbackEvent, callback_manager
 from ..constants import get_param
 from ..glyph_history import append_metric, ensure_history
 from ..utils import get_logger
+from ..telemetry.verbosity import (
+    TelemetryVerbosity,
+    TELEMETRY_VERBOSITY_DEFAULT,
+    TELEMETRY_VERBOSITY_LEVELS,
+)
 from .coherence import (
     _aggregate_si,
     _track_stability,
@@ -76,18 +81,25 @@ class MetricsVerbositySpec(NamedTuple):
     attach_diagnosis_hooks: bool
 
 
-METRICS_VERBOSITY_DEFAULT = "debug"
+METRICS_VERBOSITY_DEFAULT = TELEMETRY_VERBOSITY_DEFAULT
 
 _METRICS_VERBOSITY_PRESETS: dict[str, MetricsVerbositySpec] = {}
 
 
 def _register_metrics_preset(spec: MetricsVerbositySpec) -> None:
+    if spec.name not in TELEMETRY_VERBOSITY_LEVELS:
+        raise ValueError(
+            "Unknown metrics verbosity '%s'; use %s" % (
+                spec.name,
+                ", ".join(TELEMETRY_VERBOSITY_LEVELS),
+            )
+        )
     _METRICS_VERBOSITY_PRESETS[spec.name] = spec
 
 
 _register_metrics_preset(
     MetricsVerbositySpec(
-        name="basic",
+        name=TelemetryVerbosity.BASIC.value,
         enable_phase_sync=False,
         enable_sigma=False,
         enable_aggregate_si=False,
@@ -98,7 +110,7 @@ _register_metrics_preset(
 )
 
 _detailed_spec = MetricsVerbositySpec(
-    name="detailed",
+    name=TelemetryVerbosity.DETAILED.value,
     enable_phase_sync=True,
     enable_sigma=True,
     enable_aggregate_si=True,
@@ -109,7 +121,7 @@ _detailed_spec = MetricsVerbositySpec(
 _register_metrics_preset(_detailed_spec)
 _register_metrics_preset(
     _detailed_spec._replace(
-        name="debug",
+        name=TelemetryVerbosity.DEBUG.value,
         enable_advanced=True,
         attach_diagnosis_hooks=True,
     )

--- a/src/tnfr/telemetry/__init__.py
+++ b/src/tnfr/telemetry/__init__.py
@@ -1,0 +1,13 @@
+"""Telemetry helpers for shared observability settings."""
+
+from .verbosity import (
+    TelemetryVerbosity,
+    TELEMETRY_VERBOSITY_DEFAULT,
+    TELEMETRY_VERBOSITY_LEVELS,
+)
+
+__all__ = [
+    "TelemetryVerbosity",
+    "TELEMETRY_VERBOSITY_DEFAULT",
+    "TELEMETRY_VERBOSITY_LEVELS",
+]

--- a/src/tnfr/telemetry/verbosity.py
+++ b/src/tnfr/telemetry/verbosity.py
@@ -1,0 +1,37 @@
+"""Canonical telemetry verbosity presets for TNFR structures.
+
+Each level expresses how much structural context is exported in traces and
+metrics:
+
+* ``basic`` preserves lightweight coherence checks for quick health probes.
+* ``detailed`` adds phase alignment and coupling diagnostics to map resonance.
+* ``debug`` captures the full glyph narrative for deep structural forensics.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TelemetryVerbosity(str, Enum):
+    """Enumerated verbosity tiers shared by trace and metrics pipelines."""
+
+    BASIC = "basic"
+    DETAILED = "detailed"
+    DEBUG = "debug"
+
+
+TELEMETRY_VERBOSITY_LEVELS: tuple[str, ...] = tuple(
+    level.value for level in TelemetryVerbosity
+)
+"""Ordered tuple of canonical telemetry verbosity identifiers."""
+
+TELEMETRY_VERBOSITY_DEFAULT: str = TelemetryVerbosity.DEBUG.value
+"""Default telemetry verbosity preserving complete structural capture."""
+
+
+__all__ = [
+    "TelemetryVerbosity",
+    "TELEMETRY_VERBOSITY_LEVELS",
+    "TELEMETRY_VERBOSITY_DEFAULT",
+]

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -17,6 +17,10 @@ from .constants import TRACE
 from .glyph_history import ensure_history, count_glyphs, append_metric
 from .utils import cached_import, get_graph_mapping, is_non_string_sequence
 from .metrics.sense_index import _normalise_si_sensitivity_mapping
+from .telemetry.verbosity import (
+    TelemetryVerbosity,
+    TELEMETRY_VERBOSITY_DEFAULT,
+)
 from .types import (
     SigmaVector,
     TNFRGraph,
@@ -69,7 +73,7 @@ class TraceSnapshot(TraceMetadata, total=False):
     phase: str
 
 
-TRACE_VERBOSITY_DEFAULT = "debug"
+TRACE_VERBOSITY_DEFAULT = TELEMETRY_VERBOSITY_DEFAULT
 _TRACE_ALL_FIELDS = (
     "gamma",
     "grammar",
@@ -91,7 +95,7 @@ _TRACE_CAPTURE_ALIASES: Mapping[str, str] = MappingProxyType(
     }
 )
 TRACE_VERBOSITY_PRESETS: Mapping[str, tuple[str, ...]] = {
-    "basic": (
+    TelemetryVerbosity.BASIC.value: (
         "gamma",
         "grammar",
         "selector",
@@ -100,8 +104,8 @@ TRACE_VERBOSITY_PRESETS: Mapping[str, tuple[str, ...]] = {
         "callbacks",
         "thol_open_nodes",
     ),
-    "detailed": _TRACE_DETAILED_FIELDS,
-    "debug": _TRACE_ALL_FIELDS,
+    TelemetryVerbosity.DETAILED.value: _TRACE_DETAILED_FIELDS,
+    TelemetryVerbosity.DEBUG.value: _TRACE_ALL_FIELDS,
 }
 
 

--- a/tests/unit/metrics/test_metrics.py
+++ b/tests/unit/metrics/test_metrics.py
@@ -27,6 +27,16 @@ from tnfr.metrics.glyph_timing import (
 )
 from tnfr.metrics.glyph_timing import DEFAULT_EPI_SUPPORT_LIMIT
 from tnfr.metrics.reporting import build_metrics_summary
+from tnfr.telemetry.verbosity import (
+    TELEMETRY_VERBOSITY_DEFAULT,
+    TELEMETRY_VERBOSITY_LEVELS,
+)
+from tnfr.metrics.core import (
+    METRICS_VERBOSITY_DEFAULT,
+    _METRICS_VERBOSITY_PRESETS,
+    MetricsVerbositySpec,
+    _register_metrics_preset,
+)
 
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_DNFR = get_aliases("DNFR")
@@ -36,6 +46,25 @@ ALIAS_DSI = get_aliases("DSI")
 ALIAS_VF = get_aliases("VF")
 ALIAS_DVF = get_aliases("DVF")
 ALIAS_D2VF = get_aliases("D2VF")
+
+
+def test_metrics_verbosity_presets_match_shared_levels():
+    assert METRICS_VERBOSITY_DEFAULT == TELEMETRY_VERBOSITY_DEFAULT
+    assert set(_METRICS_VERBOSITY_PRESETS) == set(TELEMETRY_VERBOSITY_LEVELS)
+
+
+def test_register_metrics_preset_rejects_unknown_levels():
+    spec = MetricsVerbositySpec(
+        name="custom",
+        enable_phase_sync=False,
+        enable_sigma=False,
+        enable_aggregate_si=False,
+        enable_advanced=False,
+        attach_coherence_hooks=False,
+        attach_diagnosis_hooks=False,
+    )
+    with pytest.raises(ValueError):
+        _register_metrics_preset(spec)
 
 
 def test_track_stability_updates_hist(graph_canon):

--- a/tests/unit/structural/test_trace.py
+++ b/tests/unit/structural/test_trace.py
@@ -4,6 +4,11 @@
 
 import pytest
 
+from tnfr.telemetry.verbosity import (
+    TelemetryVerbosity,
+    TELEMETRY_VERBOSITY_DEFAULT,
+    TELEMETRY_VERBOSITY_LEVELS,
+)
 from tnfr.trace import (
     register_trace,
     register_trace_field,
@@ -17,6 +22,13 @@ from tnfr import trace
 from tnfr.utils import get_graph_mapping
 from tnfr.callback_utils import CallbackEvent, callback_manager
 from types import MappingProxyType
+
+
+def test_trace_verbosity_presets_align_with_shared_levels():
+    assert trace.TRACE_VERBOSITY_DEFAULT == TELEMETRY_VERBOSITY_DEFAULT
+    assert set(trace.TRACE_VERBOSITY_PRESETS) == set(TELEMETRY_VERBOSITY_LEVELS)
+    for level in TelemetryVerbosity:
+        assert trace.TRACE_VERBOSITY_PRESETS[level.value]
 
 
 def test_register_trace_idempotent(graph_canon):


### PR DESCRIPTION
## Summary
- Introduced a shared telemetry verbosity module that documents the canonical basic/detailed/debug presets.
- Updated trace and metrics pipelines to import the shared defaults, enforcing valid verbosity names when registering presets.
- Synced CLI choices and telemetry tests so both trace and metrics expose exactly the shared verbosity tiers.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f8fab483108321b83111b0c704c912