### PR TITLE
Route phase coordination through dedicated module

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
 
-from . import dnfr, integrators
+from . import coordination, dnfr, integrators
 from .adaptation import adapt_vf_by_coherence
 from .aliases import (
     ALIAS_D2EPI,
@@ -58,10 +58,12 @@ from .selectors import (
     parametric_glyph_selector,
 )
 from ..operators import apply_glyph
+from ..metrics.sense_index import compute_Si
 from ..utils import get_numpy
 from ..validation.grammar import enforce_canonical_grammar, on_applied_glyph
 
 __all__ = (
+    "coordination",
     "dnfr",
     "integrators",
     "ALIAS_D2EPI",
@@ -98,6 +100,7 @@ __all__ = (
     "adapt_vf_by_coherence",
     "apply_canonical_clamps",
     "coordinate_global_local_phase",
+    "compute_Si",
     "default_compute_delta_nfr",
     "default_glyph_selector",
     "dnfr_epi_vf_mixed",

--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -28,6 +28,7 @@ from .aliases import ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_VF
 from .dnfr import default_compute_delta_nfr
 from .sampling import update_node_sample as _update_node_sample
 from ..operators import apply_remesh_if_globally_stable
+from . import coordination
 
 HistoryLog = MutableSequence[MutableMapping[str, object]]
 
@@ -292,7 +293,7 @@ def _update_nodes(
         G.graph.get("PHASE_N_JOBS"),
         allow_non_positive=True,
     )
-    facade.coordinate_global_local_phase(G, None, None, n_jobs=phase_jobs)
+    coordination.coordinate_global_local_phase(G, None, None, n_jobs=phase_jobs)
     vf_jobs = _resolve_jobs_override(
         overrides,
         "VF_ADAPT",

--- a/tests/unit/dynamics/test_dynamics_run.py
+++ b/tests/unit/dynamics/test_dynamics_run.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections import deque
 
 import tnfr.dynamics as dynamics
+import tnfr.dynamics.runtime as runtime
+import tnfr.dynamics.coordination as coordination
 from tnfr.glyph_history import ensure_history
 
 
@@ -27,6 +29,7 @@ def test_run_stops_early_with_historydict(monkeypatch, graph_canon):
         series.append(0.95)
 
     monkeypatch.setattr(dynamics, "step", fake_step)
+    monkeypatch.setattr(runtime, "step", fake_step)
 
     dynamics.run(G, steps=5)
 
@@ -60,9 +63,13 @@ def test_step_preserves_since_mappings(monkeypatch, graph_canon):
         h_en[0] = h_en.get(0, 0) + 1
 
     monkeypatch.setattr(dynamics, "_update_nodes", fake_update_nodes)
+    monkeypatch.setattr(runtime, "_update_nodes", fake_update_nodes)
     monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)
+    monkeypatch.setattr(runtime, "_update_epi_hist", lambda G: None)
     monkeypatch.setattr(dynamics, "_maybe_remesh", lambda G: None)
+    monkeypatch.setattr(runtime, "_maybe_remesh", lambda G: None)
     monkeypatch.setattr(dynamics, "_run_validators", lambda G: None)
+    monkeypatch.setattr(runtime, "_run_validators", lambda G: None)
 
     dynamics.step(G)
 
@@ -99,20 +106,28 @@ def test_step_respects_n_jobs_overrides(monkeypatch, graph_canon):
         recorded["vf"] = n_jobs
 
     monkeypatch.setattr(dynamics, "compute_Si", fake_compute_si)
+    monkeypatch.setattr(runtime, "compute_Si", fake_compute_si)
     monkeypatch.setattr(
         dynamics, "update_epi_via_nodal_equation", fake_update_epi_via_nodal_equation
     )
     monkeypatch.setattr(
-        dynamics, "coordinate_global_local_phase", fake_coordinate_global_local_phase
+        coordination,
+        "coordinate_global_local_phase",
+        fake_coordinate_global_local_phase,
     )
     monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
     monkeypatch.setattr(dynamics, "_apply_glyphs", lambda G, selector, hist: None)
     monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runtime, "_update_node_sample", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)
+    monkeypatch.setattr(runtime, "_update_epi_hist", lambda G: None)
     monkeypatch.setattr(dynamics, "_maybe_remesh", lambda G: None)
+    monkeypatch.setattr(runtime, "_maybe_remesh", lambda G: None)
     monkeypatch.setattr(dynamics, "_run_validators", lambda G: None)
+    monkeypatch.setattr(runtime, "_run_validators", lambda G: None)
     monkeypatch.setattr(dynamics, "_run_after_callbacks", lambda G, step_idx: None)
+    monkeypatch.setattr(runtime, "_run_after_callbacks", lambda G, step_idx: None)
 
     overrides = {
         "dnfr": "3",
@@ -167,20 +182,28 @@ def test_step_defaults_to_graph_jobs(monkeypatch, graph_canon):
         recorded["vf"] = n_jobs
 
     monkeypatch.setattr(dynamics, "compute_Si", fake_compute_si)
+    monkeypatch.setattr(runtime, "compute_Si", fake_compute_si)
     monkeypatch.setattr(
         dynamics, "update_epi_via_nodal_equation", fake_update_epi_via_nodal_equation
     )
     monkeypatch.setattr(
-        dynamics, "coordinate_global_local_phase", fake_coordinate_global_local_phase
+        coordination,
+        "coordinate_global_local_phase",
+        fake_coordinate_global_local_phase,
     )
     monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
     monkeypatch.setattr(dynamics, "_apply_glyphs", lambda G, selector, hist: None)
     monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runtime, "_update_node_sample", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)
+    monkeypatch.setattr(runtime, "_update_epi_hist", lambda G: None)
     monkeypatch.setattr(dynamics, "_maybe_remesh", lambda G: None)
+    monkeypatch.setattr(runtime, "_maybe_remesh", lambda G: None)
     monkeypatch.setattr(dynamics, "_run_validators", lambda G: None)
+    monkeypatch.setattr(runtime, "_run_validators", lambda G: None)
     monkeypatch.setattr(dynamics, "_run_after_callbacks", lambda G, step_idx: None)
+    monkeypatch.setattr(runtime, "_run_after_callbacks", lambda G, step_idx: None)
 
     dynamics.step(G)
 
@@ -210,6 +233,7 @@ def test_run_reuses_normalized_n_jobs(monkeypatch, graph_canon):
         seen.append(n_jobs)
 
     monkeypatch.setattr(dynamics, "step", fake_step)
+    monkeypatch.setattr(runtime, "step", fake_step)
 
     overrides = {"dnfr": "2", "vf_adapt_n_jobs": 3}
 

--- a/tests/unit/metrics/test_phase_coordination_jobs.py
+++ b/tests/unit/metrics/test_phase_coordination_jobs.py
@@ -4,6 +4,7 @@ import random
 import pytest
 
 import tnfr.dynamics as dynamics
+import tnfr.dynamics.coordination as coordination
 from tnfr.alias import get_attr, set_attr
 from tnfr.constants import get_aliases
 
@@ -33,7 +34,9 @@ def test_update_nodes_forwards_phase_jobs(monkeypatch, graph_canon):
     def fake_coordinate(G_inner, global_force, local_force, *, n_jobs=None):
         captured["n_jobs"] = n_jobs
 
-    monkeypatch.setattr(dynamics, "coordinate_global_local_phase", fake_coordinate)
+    monkeypatch.setattr(
+        coordination, "coordinate_global_local_phase", fake_coordinate
+    )
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *a, **k: None)
     monkeypatch.setattr(dynamics, "_prepare_dnfr", lambda *a, **k: None)
     monkeypatch.setattr(dynamics, "_apply_selector", lambda *a, **k: None)
@@ -70,8 +73,8 @@ def test_coordinate_phase_parallel_matches_serial(
     baseline = _build_ring_graph(graph_factory, seed=42, size=10)
     parallel = _build_ring_graph(graph_factory, seed=42, size=10)
 
-    dynamics.coordinate_global_local_phase(baseline, n_jobs=None)
-    dynamics.coordinate_global_local_phase(parallel, n_jobs=phase_jobs)
+    coordination.coordinate_global_local_phase(baseline, n_jobs=None)
+    coordination.coordinate_global_local_phase(parallel, n_jobs=phase_jobs)
 
     for node in baseline.nodes:
         th_serial = get_attr(baseline.nodes[node], ALIAS_THETA, 0.0)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Import the coordination helpers as a module within the runtime so phase updates use the relocated helpers directly.
- Re-export `coordinate_global_local_phase` and `compute_Si` from the dynamics facade and expose the coordination module itself.
- Update phase coordination and dynamics tests to patch the new module path and runtime hooks explicitly.

## Testing
- `pytest -o addopts= tests/unit/metrics/test_phase_coordination_jobs.py tests/unit/dynamics/test_dynamics_run.py`


------
https://chatgpt.com/codex/tasks/task_e_68f908d528288321ae4b06ebfdc76eea