### PR TITLE
Refactor runtime module wiring to dedicated dynamics submodules

### DIFF
--- a/tests/unit/dynamics/test_dynamics_run.py
+++ b/tests/unit/dynamics/test_dynamics_run.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from collections import deque
 
 import tnfr.dynamics as dynamics
-import tnfr.dynamics.runtime as runtime
+import tnfr.dynamics.adaptation as adaptation
 import tnfr.dynamics.coordination as coordination
+import tnfr.dynamics.integrators as integrators
+import tnfr.dynamics.runtime as runtime
+import tnfr.dynamics.selectors as selectors
 from tnfr.glyph_history import ensure_history
 
 
@@ -108,16 +111,21 @@ def test_step_respects_n_jobs_overrides(monkeypatch, graph_canon):
     monkeypatch.setattr(dynamics, "compute_Si", fake_compute_si)
     monkeypatch.setattr(runtime, "compute_Si", fake_compute_si)
     monkeypatch.setattr(
-        dynamics, "update_epi_via_nodal_equation", fake_update_epi_via_nodal_equation
+        integrators,
+        "update_epi_via_nodal_equation",
+        fake_update_epi_via_nodal_equation,
     )
     monkeypatch.setattr(
         coordination,
         "coordinate_global_local_phase",
         fake_coordinate_global_local_phase,
     )
-    monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
-    monkeypatch.setattr(dynamics, "_apply_glyphs", lambda G, selector, hist: None)
+    monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
+    monkeypatch.setattr(selectors, "_apply_glyphs", lambda G, selector, hist: None)
     monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runtime, "apply_canonical_clamps", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
     monkeypatch.setattr(runtime, "_update_node_sample", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)
@@ -184,16 +192,21 @@ def test_step_defaults_to_graph_jobs(monkeypatch, graph_canon):
     monkeypatch.setattr(dynamics, "compute_Si", fake_compute_si)
     monkeypatch.setattr(runtime, "compute_Si", fake_compute_si)
     monkeypatch.setattr(
-        dynamics, "update_epi_via_nodal_equation", fake_update_epi_via_nodal_equation
+        integrators,
+        "update_epi_via_nodal_equation",
+        fake_update_epi_via_nodal_equation,
     )
     monkeypatch.setattr(
         coordination,
         "coordinate_global_local_phase",
         fake_coordinate_global_local_phase,
     )
-    monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
-    monkeypatch.setattr(dynamics, "_apply_glyphs", lambda G, selector, hist: None)
+    monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
+    monkeypatch.setattr(selectors, "_apply_glyphs", lambda G, selector, hist: None)
     monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runtime, "apply_canonical_clamps", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
     monkeypatch.setattr(runtime, "_update_node_sample", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_epi_hist", lambda G: None)

--- a/tests/unit/metrics/test_phase_coordination_jobs.py
+++ b/tests/unit/metrics/test_phase_coordination_jobs.py
@@ -4,7 +4,11 @@ import random
 import pytest
 
 import tnfr.dynamics as dynamics
+import tnfr.dynamics.adaptation as adaptation
 import tnfr.dynamics.coordination as coordination
+import tnfr.dynamics.integrators as integrators
+import tnfr.dynamics.runtime as runtime
+import tnfr.dynamics.selectors as selectors
 from tnfr.alias import get_attr, set_attr
 from tnfr.constants import get_aliases
 
@@ -39,14 +43,15 @@ def test_update_nodes_forwards_phase_jobs(monkeypatch, graph_canon):
     )
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *a, **k: None)
     monkeypatch.setattr(dynamics, "_prepare_dnfr", lambda *a, **k: None)
-    monkeypatch.setattr(dynamics, "_apply_selector", lambda *a, **k: None)
+    monkeypatch.setattr(selectors, "_apply_selector", lambda *a, **k: None)
     monkeypatch.setattr(
-        dynamics,
+        integrators,
         "update_epi_via_nodal_equation",
         lambda *a, **k: None,
     )
-    monkeypatch.setattr(dynamics, "adapt_vf_by_coherence", lambda *a, **k: None)
+    monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", lambda *a, **k: None)
     monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *a, **k: None)
+    monkeypatch.setattr(runtime, "apply_canonical_clamps", lambda *a, **k: None)
 
     dynamics._update_nodes(
         G,


### PR DESCRIPTION
## Summary
- route `_update_nodes` through `dynamics.selectors`, `dynamics.integrators`, and `dynamics.adaptation`
- update glyph-selection and νf adaptation tests to monkeypatch the relocated helpers

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68f90eb669c083218a5ca02222b6f9eb