### PR TITLE
Add integrator abstraction and support runtime injection

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -27,7 +27,12 @@ from .dnfr import (
     dnfr_phase_only,
     set_delta_nfr_hook,
 )
-from .integrators import prepare_integration_params, update_epi_via_nodal_equation
+from .integrators import (
+    AbstractIntegrator,
+    DefaultIntegrator,
+    prepare_integration_params,
+    update_epi_via_nodal_equation,
+)
 from .runtime import (
     _maybe_remesh,
     _normalize_job_overrides,
@@ -117,6 +122,8 @@ __all__ = (
     "on_applied_glyph",
     "apply_glyph",
     "parametric_glyph_selector",
+    "AbstractIntegrator",
+    "DefaultIntegrator",
     "prepare_integration_params",
     "run",
     "set_delta_nfr_hook",

--- a/src/tnfr/dynamics/__init__.pyi
+++ b/src/tnfr/dynamics/__init__.pyi
@@ -56,6 +56,9 @@ on_applied_glyph: Any
 apply_glyph: Any
 parametric_glyph_selector: Any
 
+AbstractIntegrator: Any
+DefaultIntegrator: Any
+
 def prepare_integration_params(
     G: TNFRGraph,
     dt: float | None = ...,

--- a/src/tnfr/dynamics/integrators.pyi
+++ b/src/tnfr/dynamics/integrators.pyi
@@ -4,6 +4,20 @@ from tnfr.types import TNFRGraph
 
 __all__: tuple[str, ...]
 
+class AbstractIntegrator:
+    def integrate(
+        self,
+        graph: TNFRGraph,
+        *,
+        dt: float | None = ...,
+        t: float | None = ...,
+        method: str | None = ...,
+        n_jobs: int | None = ...,
+    ) -> None: ...
+
+class DefaultIntegrator(AbstractIntegrator):
+    def __init__(self) -> None: ...
+
 def prepare_integration_params(
     G: TNFRGraph,
     dt: float | None = ...,

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -44,6 +44,7 @@ __all__ = (
     "CoherenceMetric",
     "DeltaNFRHook",
     "GraphLike",
+    "IntegratorProtocol",
     "Glyph",
     "GlyphLoadDistribution",
     "GlyphSelector",
@@ -262,6 +263,21 @@ class GraphLike(Protocol):
         ...
 
     def __iter__(self) -> Iterable[Any]:
+        ...
+
+
+class IntegratorProtocol(Protocol):
+    """Interface describing configurable nodal equation integrators."""
+
+    def integrate(
+        self,
+        graph: TNFRGraph,
+        *,
+        dt: float | None,
+        t: float | None,
+        method: str | None,
+        n_jobs: int | None,
+    ) -> None:
         ...
 
 

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -79,6 +79,17 @@ class GraphLike(Protocol):
     def neighbors(self, n: Any) -> Iterable[Any]: ...
     def __iter__(self) -> Iterable[Any]: ...
 
+class IntegratorProtocol(Protocol):
+    def integrate(
+        self,
+        graph: TNFRGraph,
+        *,
+        dt: float | None = ...,
+        t: float | None = ...,
+        method: str | None = ...,
+        n_jobs: int | None = ...,
+    ) -> None: ...
+
 class Glyph(str, Enum):
     AL = "AL"
     EN = "EN"

--- a/tests/unit/metrics/test_phase_coordination_jobs.py
+++ b/tests/unit/metrics/test_phase_coordination_jobs.py
@@ -15,6 +15,19 @@ from tnfr.constants import get_aliases
 ALIAS_THETA = get_aliases("THETA")
 
 
+class _NoOpIntegrator(integrators.AbstractIntegrator):
+    def integrate(
+        self,
+        graph,
+        *,
+        dt=None,
+        t=None,
+        method=None,
+        n_jobs=None,
+    ) -> None:
+        return None
+
+
 def _build_ring_graph(graph_factory, *, seed: int = 0, size: int = 8):
     rng = random.Random(seed)
     G = graph_factory()
@@ -44,11 +57,7 @@ def test_update_nodes_forwards_phase_jobs(monkeypatch, graph_canon):
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *a, **k: None)
     monkeypatch.setattr(dynamics, "_prepare_dnfr", lambda *a, **k: None)
     monkeypatch.setattr(selectors, "_apply_selector", lambda *a, **k: None)
-    monkeypatch.setattr(
-        integrators,
-        "update_epi_via_nodal_equation",
-        lambda *a, **k: None,
-    )
+    G.graph["integrator"] = _NoOpIntegrator()
     monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", lambda *a, **k: None)
     monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *a, **k: None)
     monkeypatch.setattr(runtime, "apply_canonical_clamps", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- introduce an `AbstractIntegrator` ABC with a `DefaultIntegrator` implementation that wraps the existing Euler/RK4 helpers
- resolve integrator instances inside `_update_nodes` via graph configuration, expose the typing protocol, and keep the legacy facade delegating to the default integrator
- adjust unit tests to exercise integrator injection with custom stubs

## Testing
- pytest tests/unit/dynamics/test_integrators.py tests/unit/dynamics/test_dynamics_run.py tests/unit/metrics/test_phase_coordination_jobs.py


------
https://chatgpt.com/codex/tasks/task_e_68f924e759248321b09456bfbb516faf