### PR TITLE
Handle optional glyph selector margins for hysteresis

### DIFF
--- a/src/tnfr/dynamics/selectors.py
+++ b/src/tnfr/dynamics/selectors.py
@@ -183,7 +183,7 @@ def _apply_score_override(
 def _parametric_selector_logic(G: TNFRGraph, n: NodeId) -> GlyphCode:
     nd = G.nodes[n]
     thr = _selector_thresholds(G)
-    margin = get_graph_param(G, "GLYPH_SELECTOR_MARGIN")
+    margin: float | None = get_graph_param(G, "GLYPH_SELECTOR_MARGIN")
 
     norms = cast(Mapping[str, float] | None, G.graph.get("_sel_norms"))
     if norms is None:
@@ -234,7 +234,7 @@ def _build_param_preselection(
 ) -> _SelectorPreselection:
     node_list = list(nodes)
     thresholds = _selector_thresholds(G)
-    margin = get_graph_param(G, "GLYPH_SELECTOR_MARGIN")
+    margin: float | None = get_graph_param(G, "GLYPH_SELECTOR_MARGIN")
     if not node_list:
         return _SelectorPreselection(
             "param", {}, {}, thresholds=thresholds, margin=margin
@@ -507,7 +507,7 @@ def _resolve_preselected_glyph(
     if preselection.kind == "param":
         Si, dnfr, accel = metrics
         thresholds = preselection.thresholds or _selector_thresholds(G)
-        margin = preselection.margin
+        margin: float | None = preselection.margin
         if margin is None:
             margin = get_graph_param(G, "GLYPH_SELECTOR_MARGIN")
 

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -169,7 +169,7 @@ def _apply_selector_hysteresis(
     dnfr: float,
     accel: float,
     thr: dict[str, float],
-    margin: float,
+    margin: float | None,
 ) -> str | None:
     """Apply hysteresis when values are near thresholds.
 
@@ -185,8 +185,10 @@ def _apply_selector_hysteresis(
         Normalised acceleration.
     thr : dict[str, float]
         Thresholds returned by :func:`_selector_thresholds`.
-    margin : float
-        Distance from thresholds below which the previous glyph is reused.
+    margin : float or None
+        When positive, distance from thresholds below which the previous
+        glyph is reused. Falsy margins disable hysteresis entirely, letting
+        selectors bypass the reuse logic.
 
     Returns
     -------
@@ -194,6 +196,9 @@ def _apply_selector_hysteresis(
         Previous glyph if hysteresis applies, otherwise ``None``.
     """
     # Batch extraction reduces dictionary lookups inside loops.
+    if not margin:
+        return None
+
     si_hi, si_lo, dnfr_hi, dnfr_lo, accel_hi, accel_lo = itemgetter(
         "si_hi", "si_lo", "dnfr_hi", "dnfr_lo", "accel_hi", "accel_lo"
     )(thr)

--- a/src/tnfr/selector.pyi
+++ b/src/tnfr/selector.pyi
@@ -1,10 +1,19 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 __all__: Any
 
 def __getattr__(name: str) -> Any: ...
 
-_apply_selector_hysteresis: Any
+def _apply_selector_hysteresis(
+    nd: dict[str, Any],
+    Si: float,
+    dnfr: float,
+    accel: float,
+    thr: Mapping[str, float],
+    margin: float | None,
+) -> str | None: ...
 _calc_selector_score: Any
 _selector_norms: Any
 _selector_thresholds: Any

--- a/tests/unit/dynamics/test_selector_utils.py
+++ b/tests/unit/dynamics/test_selector_utils.py
@@ -18,9 +18,11 @@ from tnfr.selector import (
 from tnfr.constants import DEFAULTS, get_aliases
 from tnfr.utils import normalize_weights
 from tnfr.dynamics import _configure_selector_weights
+from tnfr.dynamics.selectors import ParametricGlyphSelector
 
 ALIAS_DNFR = get_aliases("DNFR")
 ALIAS_D2EPI = get_aliases("D2EPI")
+ALIAS_SI = get_aliases("SI")
 
 
 def test_selector_thresholds_defaults(graph_canon):
@@ -136,3 +138,25 @@ def test_apply_selector_hysteresis_returns_prev():
     # far from thresholds
     none = _apply_selector_hysteresis(nd, 0.5, 0.2, 0.2, thr, 0.05)
     assert none is None
+
+
+def test_parametric_selector_skips_hysteresis_with_none_margin(graph_canon):
+    G = graph_canon()
+    thr = DEFAULTS["SELECTOR_THRESHOLDS"]
+    node = 0
+    G.add_node(
+        node,
+        glyph_history=["IL"],
+        **{
+            ALIAS_SI[0]: thr["si_lo"],
+            ALIAS_DNFR[-1]: 0.9,
+            ALIAS_D2EPI[-1]: 0.0,
+        },
+    )
+    G.graph["GLYPH_SELECTOR_MARGIN"] = None
+    G.graph["_sel_norms"] = {"dnfr_max": 1.0, "accel_max": 1.0}
+
+    selector = ParametricGlyphSelector()
+    glyph = selector.select(G, node)
+
+    assert glyph == "OZ"


### PR DESCRIPTION
## Summary
- Allow selector hysteresis to short-circuit when the glyph margin is disabled and update typing mirrors in the stub and call sites
- Add regression coverage confirming the parametric selector ignores hysteresis when `GLYPH_SELECTOR_MARGIN` is `None`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f9352499488321a174f663293f4331