### PR TITLE
Add TypeAlias compatibility shim for Python 3.9 environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 ]
 dependencies = [
   "networkx>=2.6",
-  "cachetools>=5"
+  "cachetools>=5",
+  "typing-extensions>=4.4; python_version < \"3.10\"",
 ]
 
 [project.optional-dependencies]

--- a/src/tnfr/_compat.py
+++ b/src/tnfr/_compat.py
@@ -1,0 +1,11 @@
+"""Compatibility helpers for bridging typing features across Python versions."""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - exercised implicitly by importers
+    from typing import TypeAlias  # type: ignore[attr-defined]
+except (ImportError, AttributeError):  # pragma: no cover - Python < 3.10
+    from typing_extensions import TypeAlias  # type: ignore[assignment]
+
+__all__ = ["TypeAlias"]
+

--- a/src/tnfr/dynamics/coordination.py
+++ b/src/tnfr/dynamics/coordination.py
@@ -6,7 +6,7 @@ import math
 from collections import deque
 from collections.abc import Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from ..alias import get_theta_attr, set_theta
 from ..constants import (
@@ -25,6 +25,7 @@ from ..metrics.trig_cache import get_trig_cache
 from ..observers import DEFAULT_GLYPH_LOAD_SPAN, glyph_load, kuramoto_order
 from ..types import NodeId, Phase, TNFRGraph
 from ..utils import get_numpy
+from .._compat import TypeAlias
 
 if TYPE_CHECKING:  # pragma: no cover - typing imports only
     try:

--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import get_context
-from typing import Any, Literal, TypeAlias, cast
+from typing import Any, Literal, cast
 
 import networkx as nx
 
@@ -17,6 +17,7 @@ from ..gamma import _get_gamma_spec, eval_gamma
 from ..alias import collect_attr, get_attr, get_attr_str, set_attr, set_attr_str
 from ..utils import get_numpy
 from ..types import NodeId, TNFRGraph
+from .._compat import TypeAlias
 
 ALIAS_VF = get_aliases("VF")
 ALIAS_DNFR = get_aliases("DNFR")

--- a/src/tnfr/dynamics/selectors.py
+++ b/src/tnfr/dynamics/selectors.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import Any, TypeAlias, cast
+from typing import Any, cast
 
 from ..alias import collect_attr, get_attr
 from ..constants import get_graph_param, get_param
@@ -26,6 +26,7 @@ from ..types import Glyph, GlyphSelector, HistoryState, NodeId, TNFRGraph
 from ..utils import get_numpy
 from ..validation.grammar import enforce_canonical_grammar, on_applied_glyph
 from .aliases import ALIAS_D2EPI, ALIAS_DNFR, ALIAS_DSI, ALIAS_SI
+from .._compat import TypeAlias
 
 GlyphCode: TypeAlias = Glyph | str
 

--- a/src/tnfr/execution.py
+++ b/src/tnfr/execution.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Optional, TypeAlias, cast
+from typing import Any, Optional, cast
+
+from ._compat import TypeAlias
 
 from .utils import MAX_MATERIALIZE_DEFAULT, ensure_collection, is_non_string_sequence
 from .constants import get_param

--- a/src/tnfr/execution.pyi
+++ b/src/tnfr/execution.pyi
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, Optional, TypeAlias
+from typing import Any, Optional
+
+from ._compat import TypeAlias
 
 from .tokens import OpTag, TARGET, THOL, WAIT, Token
 from .types import Glyph, NodeId, TNFRGraph

--- a/src/tnfr/immutable.py
+++ b/src/tnfr/immutable.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
 from functools import lru_cache, partial, singledispatch, wraps
-from typing import Any, Callable, Iterable, Iterator, TypeAlias, cast
+from typing import Any, Callable, Iterable, Iterator, cast
 from collections.abc import Mapping
 from types import MappingProxyType
 import threading
 import weakref
+
+from ._compat import TypeAlias
 
 # Types considered immutable without further inspection
 IMMUTABLE_SIMPLE = frozenset(

--- a/src/tnfr/immutable.pyi
+++ b/src/tnfr/immutable.pyi
@@ -1,4 +1,6 @@
-from typing import Any, Callable, Iterator, Mapping, TypeAlias
+from typing import Any, Callable, Iterator, Mapping
+
+from ._compat import TypeAlias
 
 FrozenPrimitive: TypeAlias = int | float | complex | str | bool | bytes | None
 FrozenCollectionItems: TypeAlias = tuple["FrozenSnapshot", ...]

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -7,7 +7,9 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any, MutableMapping, TypedDict, TypeAlias, cast
+from typing import Any, MutableMapping, TypedDict, cast
+
+from .._compat import TypeAlias
 
 
 from ..constants import (

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -11,7 +11,9 @@ from collections import deque
 from collections.abc import Hashable, Iterable, Mapping, MutableMapping, Sequence
 from statistics import fmean, StatisticsError
 from types import ModuleType
-from typing import Any, TypedDict, TypeAlias, cast
+from typing import Any, TypedDict, cast
+
+from .._compat import TypeAlias
 
 from ..constants import DEFAULTS, REMESH_DEFAULTS, get_aliases, get_param
 from ..helpers.numeric import kahan_sum_nd

--- a/src/tnfr/tokens.pyi
+++ b/src/tnfr/tokens.pyi
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterable, Optional, Sequence, TypeAlias
+from typing import Iterable, Optional, Sequence
 
 from .types import Glyph, NodeId
+from ._compat import TypeAlias
 
 __all__: tuple[str, ...]
 

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -4,16 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Hashable, Mapping, MutableMapping, Sequence
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ContextManager,
-    Iterable,
-    Protocol,
-    TypeAlias,
-    TypedDict,
-)
+from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Protocol, TypedDict
 from types import SimpleNamespace
+
+from ._compat import TypeAlias
 
 try:  # pragma: no cover - optional dependency for typing only
     import numpy as np

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -1,7 +1,9 @@
-from typing import Any, Callable, ContextManager, Iterable, Protocol, TypeAlias, cast
+from typing import Any, Callable, ContextManager, Iterable, Protocol, cast
 from collections.abc import Hashable, Mapping, Sequence
 from enum import Enum
 from typing import TypedDict
+
+from ._compat import TypeAlias
 
 try:
     import networkx as nx  # type: ignore[import-not-found]

--- a/src/tnfr/utils/validators.py
+++ b/src/tnfr/utils/validators.py
@@ -6,7 +6,9 @@ import numbers
 import sys
 
 from collections.abc import Mapping
-from typing import Callable, Sequence, TypeAlias
+from typing import Callable, Sequence
+
+from .._compat import TypeAlias
 
 from ..alias import get_attr
 from ..config.constants import GLYPHS_CANONICAL_SET

--- a/src/tnfr/utils/validators.pyi
+++ b/src/tnfr/utils/validators.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Mapping
-from typing import Callable, Sequence, TypeAlias
+from typing import Callable, Sequence
 
 from ..types import TNFRGraph
+from .._compat import TypeAlias
 
 ValidatorFunc: TypeAlias = Callable[[TNFRGraph], None]
 NodeData: TypeAlias = Mapping[str, object]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add `tnfr._compat.TypeAlias` to defer to `typing` when available or fall back to `typing_extensions`
- switch runtime modules and type stubs to import `TypeAlias` from the compatibility shim
- declare a conditional `typing-extensions` dependency for Python <3.10 so the fallback is installable in CI

## Testing
- `pytest` *(fails under Python 3.9: dataclass() does not accept the ``slots`` argument)*

------
https://chatgpt.com/codex/tasks/task_e_68f93fae76408321b0757f7653a1842b