### PR TITLE
Add shared SAST workflow for Bandit and Semgrep

### DIFF
--- a/.github/workflows/sast-lint.yml
+++ b/.github/workflows/sast-lint.yml
@@ -1,0 +1,151 @@
+name: SAST Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: "3.11"
+  VENV_PATH: .venv
+  TOOLS_ARTIFACT: sast-tools
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  setup-tools:
+    name: Prepare shared tooling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-sast-${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Create virtual environment
+        run: python -m venv ${{ env.VENV_PATH }}
+
+      - name: Install SAST tooling
+        run: |
+          source ${{ env.VENV_PATH }}/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install --disable-pip-version-check bandit semgrep PyYAML
+
+      - name: Upload tooling environment
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TOOLS_ARTIFACT }}
+          path: ${{ env.VENV_PATH }}
+          if-no-files-found: error
+
+  bandit:
+    name: Bandit scan
+    runs-on: ubuntu-latest
+    needs: setup-tools
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Restore tooling environment
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.TOOLS_ARTIFACT }}
+          path: ${{ env.VENV_PATH }}
+
+      - name: Run Bandit
+        run: |
+          source ${{ env.VENV_PATH }}/bin/activate
+          bandit -r src -ll -f sarif -o bandit.sarif -c bandit.yaml --exit-zero
+
+      - name: Upload Bandit SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: bandit.sarif
+          category: bandit
+
+      - name: Upload Bandit SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-sarif
+          path: bandit.sarif
+          if-no-files-found: error
+
+  semgrep:
+    name: Semgrep scan
+    runs-on: ubuntu-latest
+    needs: setup-tools
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Restore tooling environment
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.TOOLS_ARTIFACT }}
+          path: ${{ env.VENV_PATH }}
+
+      - name: Resolve Semgrep configuration
+        id: semgrep-config
+        run: |
+          source ${{ env.VENV_PATH }}/bin/activate
+          python - <<'PY'
+          import os
+          import pathlib
+          import yaml
+
+          config_path = pathlib.Path(".semgrep.yaml")
+          args: list[str] = []
+          if config_path.exists():
+              data = yaml.safe_load(config_path.read_text()) or {}
+              rules = data.get("exclude", {}).get("rules", [])
+              for entry in rules:
+                  if isinstance(entry, dict):
+                      rule_id = entry.get("id")
+                      if rule_id:
+                          args.append(f"--exclude-rule={rule_id}")
+          message = "Resolved Semgrep excludes: " + ("none" if not args else " ".join(args))
+          print(message)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write("exclude_args=" + " ".join(args) + "\n")
+          PY
+
+      - name: Run Semgrep
+        run: |
+          source ${{ env.VENV_PATH }}/bin/activate
+          semgrep --config auto src --sarif --output semgrep.sarif --no-error ${{ steps.semgrep-config.outputs.exclude_args }}
+
+      - name: Upload Semgrep SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+      - name: Upload Semgrep SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: semgrep-sarif
+          path: semgrep.sarif
+          if-no-files-found: error

--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -1,0 +1,15 @@
+# Semgrep configuration documenting justified exceptions for TNFR.
+exclude:
+  rules:
+    - id: python.lang.security.audit.non-literal-import.non-literal-import
+      justification: >-
+        Dynamic imports only load TNFR-maintained helpers and operator registries.
+        Module names originate from static manifests or package discovery, not user input.
+    - id: python.lang.security.deserialization.pickle.avoid-pickle
+      justification: >-
+        Pickle is invoked solely to verify multiprocessing compatibility for in-memory
+        graph state; no untrusted payloads are deserialised.
+    - id: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+      justification: >-
+        SHA1 digests are used for deterministic topology fingerprints in telemetry and
+        caches and are not relied upon for security guarantees.

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,9 @@
+# Bandit configuration capturing documented exceptions for TNFR.
+#
+# B610 warns about Django's ``QuerySet.extra`` usage, but ``tnfr.alias.set_attr_and_cache``
+# only accepts internal callables used for telemetry hooks; it never builds SQL strings.
+# B324 warns about SHA1 usage; in ``tnfr.operators.remesh`` the hash creates short,
+# deterministic topology fingerprints for logging/caching and is not security-sensitive.
+skips:
+  - B610
+  - B324


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that prepares a reusable virtual environment and runs Bandit and Semgrep with SARIF uploads for code scanning.
- Document the repository-specific rule exclusions for Bandit and Semgrep so the scans focus on actionable findings.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f94bd97d0883218250ccc9e42d2969