### PR TITLE
Set up MkDocs Netlify documentation build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyc
 dist/
 build/
+site/
 *.egg-info/
 *.egg
 .venv/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ walkthroughs plus optional dependency caching helpers.
   and helper facades.
 - [Examples](docs/examples/README.md) — runnable scenarios, CLI artefacts, and token legend.
 
+## Documentation build workflow
+
+Netlify publishes the documentation with [MkDocs](https://www.mkdocs.org/) so the generated
+site preserves the canonical TNFR structure. The same steps can be executed locally:
+
+1. Create and activate a virtual environment (e.g. `python -m venv .venv && source .venv/bin/activate`).
+2. Install the documentation toolchain: `python -m pip install -r docs/requirements.txt`.
+3. Preview changes live with `mkdocs serve` or reproduce the Netlify pipeline with
+   `mkdocs build`, which writes the static site to the `site/` directory.
+
+The Netlify build (`netlify.toml`) runs `python -m pip install -r docs/requirements.txt && mkdocs build`
+and publishes the resulting `site/` directory, ensuring the hosted documentation matches local builds.
+
 ## Additional resources
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — orchestration layers and invariant enforcement.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,9 @@ $\partial EPI/\partial t = \nu_f \cdot \Delta NFR(t)$.
 
 ## Canonical references
 
-- [Architecture guide](../ARCHITECTURE.md) for orchestration layers and invariants.
-- [Contribution guidelines](../CONTRIBUTING.md) with the structural test suite contract.
-- [TNFR paradigm PDF](../TNFR.pdf) detailing the theoretical background and operator grammar.
+- [Architecture guide](https://github.com/fermga/TNFR-Python-Engine/blob/main/ARCHITECTURE.md) for orchestration layers and invariants.
+- [Contribution guidelines](https://github.com/fermga/TNFR-Python-Engine/blob/main/CONTRIBUTING.md) with the structural test suite contract.
+- [TNFR paradigm PDF](https://github.com/fermga/TNFR-Python-Engine/raw/main/TNFR.pdf) detailing the theoretical background and operator grammar.
 
 ## Navigating the docs
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.5,<2.0
+mkdocs-material>=9.5,<10.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+site_name: TNFR Python Engine
+site_description: Canonical TNFR structural dynamics engine documentation
+repo_url: https://github.com/fermga/TNFR-Python-Engine
+repo_name: TNFR Python Engine
+docs_dir: docs
+site_dir: site
+nav:
+  - Home: index.md
+  - Getting started:
+      - Quickstart: getting-started/quickstart.md
+      - Migrating from Remesh Window: getting-started/migrating-remesh-window.md
+  - API:
+      - Overview: api/overview.md
+      - Structural operators: api/operators.md
+      - Telemetry & utilities: api/telemetry.md
+  - Examples: examples/README.md
+  - Security:
+      - Monitoring: security/monitoring.md
+      - Dependency auditing: security/dependency-auditing.md
+      - CodeQL: security/codeql.md
+      - Dependabot: security/dependabot.md
+  - Releases: releases.md
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - toc.integrate
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences
+plugins:
+  - search

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+command = "python -m pip install -r docs/requirements.txt && mkdocs build"
+publish = "site"


### PR DESCRIPTION
## Summary
- add a Netlify build configuration that installs the MkDocs toolchain and publishes the generated site
- introduce MkDocs project metadata and dependencies so the documentation can be rendered locally and in CI
- document the MkDocs workflow in the README and ignore the generated site directory

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

### Testing
- `python -m mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68f952e666f08321831b8d261cface07