### PR TITLE
Align formatting tooling configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,17 @@ version = { attr = "tnfr._version.__version__" }
 [tool.setuptools.package-data]
 tnfr = ["py.typed"]
 
+[tool.black]
+line-length = 88
+target-version = ["py39", "py310", "py311", "py312"]
+
+[tool.isort]
+profile = "black"
+line_length = 88
+skip = ["benchmarks"]
+
 [tool.flake8]
-max-line-length = 79
+max-line-length = 88
 ignore = ["E501", "W503"]
 exclude = ["benchmarks/"]
 


### PR DESCRIPTION
## Summary
- add a Black configuration with a shared 88 character line length and supported Python targets
- configure isort to follow the Black profile while skipping benchmark assets
- raise the Flake8 max line length to 88 so linters and formatters agree

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f956f878388321b40c764079839799