### PR TITLE
Add pre-commit configuration for Black and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        args: ["--config=pyproject.toml"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--settings-path=pyproject.toml"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,22 @@ The canonical operator identifiers are:
 | `transition` | Transition |
 | `recursivity` | Recursivity |
 
+## Pre-commit hooks
+
+Run the repository's pre-commit hooks to keep formatting aligned with the
+canonical configuration:
+
+```bash
+python -m pip install --upgrade pre-commit
+pre-commit install
+```
+
+The hooks execute [Black](https://github.com/psf/black) and
+[isort](https://github.com/PyCQA/isort) using the shared settings in
+`pyproject.toml`. They run automatically on each commit after installation, but
+you can also trigger them manually with `pre-commit run --all-files` before
+submitting changes.
+
 ## Commit message format
 
 Every commit **must** follow the `AGENT_COMMIT_TEMPLATE` documented for this


### PR DESCRIPTION
## Summary
- Add a `.pre-commit-config.yaml` with Black and isort hooks bound to the shared formatting settings.
- Document hook installation and manual execution guidance in `CONTRIBUTING.md`.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f9579b2e088321b105905218ad5050