### PR TITLE
Add formatting helper script and document local workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ site preserves the canonical TNFR structure. The same steps can be executed loca
 The Netlify build (`netlify.toml`) runs `python -m pip install -r docs/requirements.txt && mkdocs build`
 and publishes the resulting `site/` directory, ensuring the hosted documentation matches local builds.
 
+## Local development
+
+Use the helper scripts to keep formatting aligned with the canonical configuration and to reproduce
+the quality gate locally:
+
+```bash
+./scripts/format.sh           # Apply Black and isort across src/, tests/, scripts/, and benchmarks/
+./scripts/format.sh --check   # Validate formatting without modifying files
+./scripts/run_tests.sh        # Execute the full QA battery (type checks, tests, coverage, linting)
+```
+
+The formatting helper automatically prefers `poetry run` when a Poetry environment is available and
+falls back to `python -m` invocations so local runs mirror the tooling invoked in continuous
+integration.
+
 ## Additional resources
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — orchestration layers and invariant enforcement.

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${REPO_ROOT}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/format.sh [--check]
+
+Run Black and isort with the repository configuration across the core TNFR packages.
+
+Options:
+  --check        Verify formatting without modifying files.
+  -h, --help     Show this help message and exit.
+USAGE
+}
+
+CHECK_MODE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK_MODE=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+declare -a TARGETS=("src" "tests" "scripts" "benchmarks")
+declare -a EXISTING_TARGETS=()
+for target in "${TARGETS[@]}"; do
+  if [[ -d "$target" ]]; then
+    EXISTING_TARGETS+=("$target")
+  fi
+done
+
+if [[ ${#EXISTING_TARGETS[@]} -eq 0 ]]; then
+  echo "No formatting targets found." >&2
+  exit 0
+fi
+
+USE_POETRY=0
+if command -v poetry >/dev/null 2>&1; then
+  if [[ -f "poetry.lock" ]]; then
+    USE_POETRY=1
+  elif [[ -f "pyproject.toml" ]]; then
+    if grep -q "^\\[tool\\.poetry\\]" pyproject.toml; then
+      USE_POETRY=1
+    fi
+  fi
+fi
+
+if [[ $USE_POETRY -eq 1 ]]; then
+  BLACK_CMD=(poetry run black)
+  ISORT_CMD=(poetry run isort)
+else
+  BLACK_CMD=(python -m black)
+  ISORT_CMD=(python -m isort)
+fi
+
+if [[ $CHECK_MODE -eq 1 ]]; then
+  BLACK_CMD+=("--check")
+  ISORT_CMD+=("--check")
+fi
+
+printf 'Running %s on %s\n' "${BLACK_CMD[*]}" "${EXISTING_TARGETS[*]}"
+"${BLACK_CMD[@]}" "${EXISTING_TARGETS[@]}"
+
+printf 'Running %s on %s\n' "${ISORT_CMD[*]}" "${EXISTING_TARGETS[*]}"
+"${ISORT_CMD[@]}" "${EXISTING_TARGETS[@]}"
+


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add `scripts/format.sh` to orchestrate Black/isort across the main packages with a `--check` mode and Poetry fallback
- document the new helper alongside the quality gate script in the README

## Testing
- `./scripts/format.sh --help`
- `bash -n scripts/format.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f9584a68c483219726a0371d67d837