### PR TITLE
Add format check workflow to CI matrix

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,36 @@
+name: Format Check
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  pre-commit:
+    name: Python ${{ matrix.python-version }} format check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs pre-commit formatting hooks across the existing Python 3.9-3.12 matrix on push and pull requests

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f9597a4d2c8321a34212ca6f7b1c80