### PR TITLE
Remove legacy Spanish operator and preset alias guidance

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -28,7 +28,6 @@ from ..dynamics import (
 from ..config.presets import (
     PREFERRED_PRESET_NAMES,
     get_preset,
-    legacy_preset_guidance,
 )
 from ..config import apply_config
 from ..io import read_structured_file, safe_write, StructuredFileError
@@ -187,15 +186,7 @@ def resolve_program(
         try:
             return get_preset(args.preset)
         except KeyError as exc:
-            guidance = legacy_preset_guidance(args.preset)
-            if guidance is not None:
-                details = guidance
-            else:
-                details = (
-                    exc.args[0]
-                    if exc.args
-                    else "Legacy preset identifier rejected."
-                )
+            details = exc.args[0] if exc.args else "Preset lookup failed."
             logger.error(
                 (
                     "Unknown preset '%s'. Available presets: %s. %s "

--- a/src/tnfr/config/operator_names.py
+++ b/src/tnfr/config/operator_names.py
@@ -49,14 +49,6 @@ INTERMEDIATE_OPERATORS = frozenset({DISSONANCE, COUPLING, RESONANCE})
 VALID_END_OPERATORS = frozenset({SILENCE, TRANSITION, RECURSIVITY})
 SELF_ORGANIZATION_CLOSURES = frozenset({SILENCE, CONTRACTION})
 
-
-_LEGACY_COLLECTION_ALIASES: dict[str, str] = {
-    "INICIO_VALIDOS": "VALID_START_OPERATORS",
-    "TRAMO_INTERMEDIO": "INTERMEDIATE_OPERATORS",
-    "CIERRE_VALIDO": "VALID_END_OPERATORS",
-    "AUTOORGANIZACION_CIERRES": "SELF_ORGANIZATION_CLOSURES",
-}
-
 def canonical_operator_name(name: str) -> str:
     """Return the canonical operator token for ``name``."""
 
@@ -96,11 +88,6 @@ __all__ = [
 
 
 def __getattr__(name: str) -> Any:
-    """Provide guidance for legacy operator collection aliases."""
+    """Provide a consistent ``AttributeError`` when names are missing."""
 
-    canonical = _LEGACY_COLLECTION_ALIASES.get(name)
-    if canonical is not None:
-        raise AttributeError(
-            f"module '{__name__}' has no attribute '{name}'; use '{canonical}' instead."
-        )
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/tnfr/config/presets.py
+++ b/src/tnfr/config/presets.py
@@ -65,36 +65,14 @@ PREFERRED_PRESET_NAMES: tuple[str, ...] = tuple(_PRIMARY_PRESETS.keys())
 _PRESETS: dict[str, PresetTokens] = {**_PRIMARY_PRESETS}
 
 
-_LEGACY_PRESET_ALIASES: dict[str, str] = {
-    "arranque_resonante": "resonant_bootstrap",
-    "mutacion_contenida": "contained_mutation",
-    "exploracion_acople": "coupling_exploration",
-    "ejemplo_canonico": CANONICAL_PRESET_NAME,
-}
-
-
 def legacy_preset_guidance(name: str) -> str | None:
-    """Return CLI guidance for historical preset aliases.
+    """Return CLI guidance for preset lookups.
 
-    Parameters
-    ----------
-    name:
-        Identifier received from the CLI.
-
-    Returns
-    -------
-    str | None
-        A human readable guidance string when ``name`` matches a removed
-        alias. ``None`` when no dedicated guidance is available.
+    Legacy aliases were removed; the function now always returns ``None``.
+    ``name`` is accepted to preserve the public helper signature.
     """
 
-    canonical = _LEGACY_PRESET_ALIASES.get(name)
-    if canonical is None:
-        return None
-    return (
-        f"Legacy preset identifier '{name}' was removed in TNFR 9.0. "
-        f"Use '{canonical}' instead."
-    )
+    return None
 
 
 def get_preset(name: str) -> PresetTokens:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -92,10 +92,8 @@ def test_cli_legacy_preset_rejected_with_guidance(capsys, command):
     captured = capsys.readouterr()
 
     assert rc == 1
-    assert (
-        "Legacy preset identifier 'ejemplo_canonico' was removed in TNFR 9.0. "
-        "Use 'canonical_example' instead."
-    ) in captured.out
+    assert "Preset not found: ejemplo_canonico" in captured.out
+    assert "Legacy preset identifier" not in captured.out
 
 
 def test_cli_sequence_file_missing(tmp_path, capsys):

--- a/tests/unit/dynamics/test_operator_names.py
+++ b/tests/unit/dynamics/test_operator_names.py
@@ -21,20 +21,20 @@ def test_validation_sets_are_subsets() -> None:
 
 
 @pytest.mark.parametrize(
-    ("legacy_name", "preferred_name"),
+    "legacy_name",
     (
-        ("INICIO_VALIDOS", "VALID_START_OPERATORS"),
-        ("TRAMO_INTERMEDIO", "INTERMEDIATE_OPERATORS"),
-        ("CIERRE_VALIDO", "VALID_END_OPERATORS"),
-        ("AUTOORGANIZACION_CIERRES", "SELF_ORGANIZATION_CLOSURES"),
+        "INICIO_VALIDOS",
+        "TRAMO_INTERMEDIO",
+        "CIERRE_VALIDO",
+        "AUTOORGANIZACION_CIERRES",
     ),
 )
-def test_spanish_aliases_raise_attribute_error(legacy_name: str, preferred_name: str) -> None:
+def test_spanish_aliases_raise_plain_attribute_error(legacy_name: str) -> None:
     with pytest.raises(AttributeError) as exc_info:
         getattr(names, legacy_name)
     message = str(exc_info.value)
     assert legacy_name in message
-    assert preferred_name in message
+    assert "VALID_" not in message
 
 
 def test_canonical_lookup_is_passthrough_for_english_tokens() -> None:


### PR DESCRIPTION
## Summary
- remove legacy alias handling from operator and preset configuration modules
- simplify CLI preset guidance to rely solely on canonical English identifiers
- refresh unit and integration tests to assert the new plain error messaging

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f95e40a5448321bd641c3b48c9e058