### PR TITLE
Add English-only language guard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,7 +66,7 @@ The following table highlights how ΔNFR values propagate through the engine and
 
 Operator classes apply the `@register_operator` decorator, which verifies unique ASCII names, binds glyphs, and inserts implementations into the shared `OPERATORS` map used by syntax validators and dynamic dispatch.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L58】 The discovery routine scans the `tnfr.operators` package exactly once per interpreter session, importing every submodule except the registry itself so that registration side effects run reliably before the structural loop accesses them.【F:src/tnfr/operators/registry.py†L33-L58】
 
-> **Compatibility note**: The previous `OPERADORES` export now resolves through a deprecated module attribute. Existing consumers that import `tnfr.operators.registry.OPERADORES` continue to receive the same mapping but will emit a `DeprecationWarning`; new code should use `OPERATORS` instead.【F:src/tnfr/operators/registry.py†L44-L58】
+> **Compatibility note**: The previous `OPERAD<span></span>ORES` export now resolves through a deprecated module attribute. Existing consumers that import `tnfr.operators.registry.OPERAD<span></span>ORES` continue to receive the same mapping but will emit a `DeprecationWarning`; new code should use `OPERATORS` instead.【F:src/tnfr/operators/registry.py†L44-L58】
 
 When introducing new operators:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,9 @@ captured in `pyproject.toml`, so local runs match CI expectations:
 - `python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py`
   applies the docstring linter with the single extra ignore used in automation,
   keeping the docstring style gate aligned with the workflow.
+- `python scripts/check_language.py` enforces the English-only policy by
+  flagging tracked files that contain the retired Spanish compatibility tokens
+  or accented characters.
 - `python -m mypy src/tnfr` enforces the TNFR-aware typing contracts with
   `allow_untyped_defs = false`, `allow_untyped_globals = false`,
   `allow_untyped_calls = false`, and `show_error_codes = true` so every
@@ -131,6 +134,23 @@ To forward additional flags to `pytest`, append them after `--`, e.g.
 
 The [README Tests section](README.md#tests) repeats these instructions so that
 contributors can find them quickly while browsing the project overview.
+
+### English-only lint
+
+The `scripts/check_language.py` helper powers the Spanish language guard that
+CI now runs alongside Flake8 and the other quality gates. It scans the tracked
+files for a configurable set of disallowed Spanish keywords and accented
+characters, exiting with a non-zero status when any matches are found. The
+default list targets the legacy compatibility tokens (`est<span></span>able`, `trans<span></span>icion`,
+`transici&oacute;n`, `diso<span></span>nante`, etc.) that must never re-enter the codebase. You
+can extend or override the defaults by editing the
+`[tool.tnfr.language_check]` table in `pyproject.toml`.
+
+When the guard reports violations, rewrite the offending strings to their
+English equivalents before committing. For documentation or tests that need to
+mention the historical tokens for migration guidance, use escaped sequences
+(`\u00f3`, HTML entities, or string literal concatenation) so the underlying
+files stay ASCII-only.
 
 Make sure to honor the patterns in `.gitignore` so that dependency and build
 artifacts (e.g., `node_modules/` or `dist/`) are not committed.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2025 TNFR - Teoría de la naturaleza fractral resonante
+Copyright (c) 2025 TNFR - Teoria de la naturaleza fractral resonante
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/getting-started/migrating-remesh-window.md
+++ b/docs/getting-started/migrating-remesh-window.md
@@ -1,7 +1,7 @@
 # Migrating remesh stability window usage
 
 TNFR 10.0.0 removes the transitional Spanish keyword
-``pasos_estables_consecutivos`` from
+``"pasos_" "est" "ables_consecutivos"`` from
 :func:`tnfr.operators.apply_remesh_if_globally_stable`. The operator now
 accepts only the English ``stable_step_window`` parameter. Calls that still use
 or forward the Spanish keyword raise :class:`TypeError` immediately so the
@@ -17,7 +17,7 @@ keys.
 ## Who is affected?
 
 - Applications that invoked
-  ``apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=...)``.
+  ``apply_remesh_if_globally_stable(G, **{"pasos_" "est" "ables_consecutivos": ...})``.
 - Configuration loaders that surfaced the Spanish name as part of dynamic
   keyword expansion.
 - Stored automation artifacts (YAML/JSON, notebooks) that preserved the legacy
@@ -29,7 +29,10 @@ keys.
    parameter. The semantic contract is unchanged::
 
        # Before (TNFR <= 9.x)
-       apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=5)
+       apply_remesh_if_globally_stable(
+           G,
+           **{"pasos_" "est" "ables_consecutivos": 5},
+       )
 
        # After (TNFR >= 10.0)
        apply_remesh_if_globally_stable(G, stable_step_window=5)
@@ -37,10 +40,12 @@ keys.
 2. If you rely on user-provided dictionaries that may contain the legacy
    identifier, normalise the payload before calling the operator::
 
+       LEGACY_KEY = "pasos_" "est" "ables_consecutivos"
+
        def normalize_remesh_kwargs(kwargs: dict) -> dict:
-           if "pasos_estables_consecutivos" in kwargs:
+           if LEGACY_KEY in kwargs:
                kwargs = dict(kwargs)  # shallow copy if shared
-               kwargs["stable_step_window"] = kwargs.pop("pasos_estables_consecutivos")
+               kwargs["stable_step_window"] = kwargs.pop(LEGACY_KEY)
            return kwargs
 
        apply_remesh_if_globally_stable(G, **normalize_remesh_kwargs(user_kwargs))

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -84,10 +84,10 @@
   stored states before upgrading, for example::
 
       SPANISH_STATE_TOKEN_MAP = {
-          "estable": "stable",
-          "transicion": "transition",
-          "transición": "transition",
-          "disonante": "dissonant",
+          "est" "able": "stable",
+          "trans" "icion": "transition",
+          "transici" "\u00f3n": "transition",
+          "diso" "nante": "dissonant",
       }
 
       def upgrade_state_token(value: str) -> str:
@@ -108,7 +108,7 @@
 - Removed the Spanish compatibility aliases from
   :mod:`tnfr.config.operator_names`. Accessing the retired names now raises
   :class:`AttributeError` pointing to the canonical English constant.
-- Dropped the ``OPERADORES`` alias from :mod:`tnfr.operators.registry`; only the
+- Dropped the ``OPERAD<span></span>ORES`` alias from :mod:`tnfr.operators.registry`; only the
   English :data:`OPERATORS` registry is exported.
 - Updated tests and helpers to enforce the English-only contract for operator
   collections, reflecting the final step in the migration announced in earlier
@@ -148,7 +148,7 @@
 
 ## 10.0.0 (remesh stability window keyword removal)
 
-- Removed the Spanish ``pasos_estables_consecutivos`` keyword from
+- Removed the Spanish ``"pasos_" "est" "ables_consecutivos"`` keyword from
   :func:`tnfr.operators.apply_remesh_if_globally_stable`. Passing the legacy
   identifier now raises :class:`TypeError` with guidance to use the English
   ``stable_step_window`` parameter.
@@ -342,7 +342,7 @@
   * Import sites that referenced ``tnfr.operators.compat`` or the Spanish class
     names exported from :mod:`tnfr.structural` must update their imports to the
     English equivalents.
-  * Diagnostics relying on ``TRANSICION`` should switch to the English
+  * Diagnostics relying on ``TRANS<span></span>ICION`` should switch to the English
     ``TRANSITION`` constant from :mod:`tnfr.config.operator_names`.
 - Versioning and communication plan:
   * Publish this change as **TNFR 2.0.0** and note the breaking removal in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,38 @@ max-line-length = 88
 ignore = ["E501", "W503"]
 exclude = ["benchmarks/"]
 
+[tool.tnfr.language_check]
+disallowed_keywords = [
+  "est\u0061ble",
+  "transici\u006f\u006e",
+  "transici\u00f3n",
+  "diso\u006enante",
+  "operad\u006fres",
+  "operad\u006fr",
+]
+accented_characters = [
+  "\u00e1",
+  "\u00e9",
+  "\u00ed",
+  "\u00f3",
+  "\u00fa",
+  "\u00fc",
+  "\u00f1",
+  "\u00c1",
+  "\u00c9",
+  "\u00cd",
+  "\u00d3",
+  "\u00da",
+  "\u00dc",
+  "\u00d1",
+  "\u00bf",
+  "\u00a1",
+]
+exclude = [
+  "TNFR.pdf",
+  "benchmarks/**/*.pdf",
+]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 addopts = "-m 'not slow' --benchmark-skip"

--- a/scripts/check_language.py
+++ b/scripts/check_language.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Enforce the English-only policy by scanning for Spanish tokens.
+
+This lightweight check runs as part of the repository's quality gate to ensure
+new contributions do not resurrect the legacy Spanish literals that used to
+coexist with the canonical English identifiers. It reads the repository's
+tracked files (excluding binary blobs and opt-in paths) and flags
+case-insensitive matches for the configured Spanish keywords or any accented
+characters that commonly appear in Spanish prose.
+
+The defaults mirror the compatibility tokens retired in TNFR 12.0.0. The
+settings can be customised from ``pyproject.toml`` under
+``[tool.tnfr.language_check]`` if the policy ever evolves. Keeping the logic in
+code (instead of a Flake8 plugin) avoids an extra dependency while still
+providing deterministic enforcement in CI and local development.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - fallback for <=3.10
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # pragma: no cover - missing optional dependency
+        tomllib = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class LanguagePolicy:
+    """Configuration for the English-only enforcement."""
+
+    disallowed_keywords: Sequence[str]
+    accented_characters: Sequence[str]
+    excluded_globs: Sequence[str]
+
+
+DEFAULT_POLICY = LanguagePolicy(
+    disallowed_keywords=(
+        "est\u0061ble",
+        "transici\u006f\u006e",
+        "transici\u00f3n",
+        "diso\u006enante",
+        "operad\u006fres",
+        "operad\u006fr",
+    ),
+    accented_characters=(
+        "\u00e1",
+        "\u00e9",
+        "\u00ed",
+        "\u00f3",
+        "\u00fa",
+        "\u00fc",
+        "\u00f1",
+        "\u00c1",
+        "\u00c9",
+        "\u00cd",
+        "\u00d3",
+        "\u00da",
+        "\u00dc",
+        "\u00d1",
+        "\u00bf",
+        "\u00a1",
+    ),
+    excluded_globs=(
+        "TNFR.pdf",
+        "benchmarks/**/*.pdf",
+    ),
+)
+
+
+def _load_policy(repo_root: Path) -> LanguagePolicy:
+    """Read overrides from ``pyproject.toml`` if available."""
+
+    if tomllib is None:
+        return DEFAULT_POLICY
+
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return DEFAULT_POLICY
+
+    with pyproject.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    tool_section = data.get("tool", {})  # type: ignore[assignment]
+    tnfr_section = tool_section.get("tnfr", {})  # type: ignore[assignment]
+    policy_section = tnfr_section.get("language_check")  # type: ignore[assignment]
+    if not isinstance(policy_section, dict):
+        return DEFAULT_POLICY
+
+    keywords = policy_section.get("disallowed_keywords")
+    accented = policy_section.get("accented_characters")
+    excludes = policy_section.get("exclude")
+
+    return LanguagePolicy(
+        disallowed_keywords=tuple(
+            sorted(
+                {*(DEFAULT_POLICY.disallowed_keywords), *(keywords or [])},
+                key=str.lower,
+            )
+        ),
+        accented_characters=tuple(
+            sorted({*(DEFAULT_POLICY.accented_characters), *(accented or [])})
+        ),
+        excluded_globs=tuple(
+            sorted({*(DEFAULT_POLICY.excluded_globs), *(excludes or [])})
+        ),
+    )
+
+
+def _collect_tracked_files(repo_root: Path) -> Sequence[Path]:
+    """Return the list of tracked files using ``git ls-files``."""
+
+    result = subprocess.run(
+        ["git", "ls-files"],
+        check=True,
+        capture_output=True,
+        cwd=repo_root,
+        text=True,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def _is_binary(path: Path) -> bool:
+    """Heuristically detect binary files via null bytes in the first chunk."""
+
+    try:
+        with path.open("rb") as handle:
+            chunk = handle.read(1024)
+    except OSError:
+        return True
+    return b"\x00" in chunk
+
+
+def _should_exclude(path: Path, patterns: Iterable[str], repo_root: Path) -> bool:
+    """Return ``True`` when ``path`` matches one of the configured globs."""
+
+    relative = path.relative_to(repo_root).as_posix()
+    return any(
+        relative == pattern
+        or relative.startswith(f"{pattern.rstrip('/')}/")
+        or fnmatch.fnmatch(relative, pattern)
+        for pattern in patterns
+    )
+
+
+def _scan_file(
+    path: Path,
+    policy: LanguagePolicy,
+    repo_root: Path,
+) -> list[str]:
+    """Return violation messages for ``path`` under ``policy``."""
+
+    if _should_exclude(path, policy.excluded_globs, repo_root):
+        return []
+    if _is_binary(path):
+        return []
+
+    violations: list[str] = []
+    accent_set = set(policy.accented_characters)
+    keywords_lower = {word.lower() for word in policy.disallowed_keywords}
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        accents_found = sorted({char for char in raw_line if char in accent_set})
+        lowered = raw_line.lower()
+        keywords_found = sorted({word for word in keywords_lower if word in lowered})
+
+        if not accents_found and not keywords_found:
+            continue
+
+        reasons: list[str] = []
+        if keywords_found:
+            reasons.append("Spanish keyword(s): " + ", ".join(keywords_found))
+        if accents_found:
+            reasons.append("accented character(s): " + ", ".join(accents_found))
+        snippet = line if len(line) <= 120 else f"{line[:117]}..."
+        violations.append(
+            f"{path.relative_to(repo_root)}:{line_number}: {'; '.join(reasons)} -> {snippet}"
+        )
+
+    return violations
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point used by ``python scripts/check_language.py``."""
+
+    parser = argparse.ArgumentParser(
+        description="Fail when tracked files include Spanish tokens or accents.",
+    )
+    parser.parse_args(argv)  # Reserved for future switches
+
+    repo_root = Path(__file__).resolve().parents[1]
+    policy = _load_policy(repo_root)
+    tracked_files = _collect_tracked_files(repo_root)
+
+    all_violations: list[str] = []
+    for path in tracked_files:
+        all_violations.extend(_scan_file(path, policy, repo_root))
+
+    if all_violations:
+        print("Spanish language guard detected violations:", file=sys.stderr)
+        for violation in all_violations:
+            print(violation, file=sys.stderr)
+        print(
+            "\nRemove or rewrite the offending tokens before committing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Spanish language guard: no violations detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,7 @@ export PYTHONPATH="$PWD/src"
 # Keep dependency extras aligned with .github/workflows/type-check.yml.
 python -m pip install --quiet ".[test,typecheck]"
 python -m flake8 src
+python scripts/check_language.py
 python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py
 # Mirrors the mypy invocation in .github/workflows/type-check.yml.
 python -m mypy src/tnfr

--- a/src/tnfr/operators/registry.py
+++ b/src/tnfr/operators/registry.py
@@ -67,13 +67,21 @@ def discover_operators() -> None:
     setattr(package, "_operators_discovered", True)
 
 
-__all__ = ("OPERATORS", "register_operator", "discover_operators", "get_operator_class")
+LEGACY_OPERATORS_ALIAS = "OPERAD" "ORES"
+
+
+__all__ = (
+    "OPERATORS",
+    "register_operator",
+    "discover_operators",
+    "get_operator_class",
+)
 
 
 def __getattr__(name: str) -> Any:
     """Provide guidance for legacy registry aliases."""
 
-    if name == "OPERADORES":
+    if name == LEGACY_OPERATORS_ALIAS:
         raise AttributeError(
             f"module '{__name__}' has no attribute '{name}'; use 'OPERATORS' instead."
         )

--- a/tests/unit/dynamics/test_operator_names.py
+++ b/tests/unit/dynamics/test_operator_names.py
@@ -54,8 +54,9 @@ def test_get_operator_class_rejects_spanish_tokens() -> None:
 
 
 def test_registry_exposes_only_english_collection_name() -> None:
+    legacy_alias = "OPERAD" "ORES"
     with pytest.raises(AttributeError) as exc_info:
-        getattr(registry_module, "OPERADORES")
+        getattr(registry_module, legacy_alias)
     message = str(exc_info.value)
-    assert "OPERADORES" in message
+    assert legacy_alias in message
     assert "OPERATORS" in message

--- a/tests/unit/metrics/test_diagnosis_state.py
+++ b/tests/unit/metrics/test_diagnosis_state.py
@@ -28,7 +28,7 @@ def test_normalise_state_token_accepts_canonical_tokens_without_warning():
 
 @pytest.mark.parametrize(
     "legacy_token",
-    ["estable", "disonante", "transicion", "transición"],
+    ["est" "able", "diso" "nante", "trans" "icion", "transici" "\u00f3n"],
 )
 def test_normalise_state_token_rejects_spanish_tokens(legacy_token: str):
     with pytest.raises(ValueError, match="state token must be one of"):

--- a/tests/unit/structural/test_remesh.py
+++ b/tests/unit/structural/test_remesh.py
@@ -1,7 +1,5 @@
 """Remeshing tests."""
 
-
-
 from collections import deque
 
 import pytest
@@ -25,9 +23,7 @@ def _prepare_graph_for_remesh(graph_canon, stable_steps: int = 3):
 
     tau = G.graph["REMESH_TAU_GLOBAL"]
     maxlen = max(2 * tau + 5, 64)
-    G.graph["_epi_hist"] = deque(
-        [{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen
-    )
+    G.graph["_epi_hist"] = deque([{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen)
 
     return G, hist
 
@@ -48,7 +44,10 @@ def test_apply_remesh_legacy_keyword_raises_typeerror(graph_canon):
     G, _ = _prepare_graph_for_remesh(graph_canon)
 
     with pytest.raises(TypeError, match="unexpected keyword argument"):
-        apply_remesh_if_globally_stable(G, pasos_estables_consecutivos=3)
+        apply_remesh_if_globally_stable(
+            G,
+            **{"pasos_" "est" "ables_consecutivos": 3},
+        )
 
     assert "_last_remesh_step" not in G.graph
 
@@ -85,9 +84,7 @@ def test_apply_network_remesh_triggers_callback(graph_canon):
 
     snapshots = []
     for offset in range(tau_req + 1):
-        snapshots.append(
-            {node: float(idx + offset) for idx, node in enumerate(nodes)}
-        )
+        snapshots.append({node: float(idx + offset) for idx, node in enumerate(nodes)})
 
     maxlen = max(tau_req + 5, tau_req + 1)
     G.graph["_epi_hist"] = deque(snapshots, maxlen=maxlen)
@@ -98,9 +95,7 @@ def test_apply_network_remesh_triggers_callback(graph_canon):
         triggered.append(ctx)
         assert graph is G
 
-    callback_manager.register_callback(
-        G, CallbackEvent.ON_REMESH, on_remesh
-    )
+    callback_manager.register_callback(G, CallbackEvent.ON_REMESH, on_remesh)
 
     apply_network_remesh(G)
 


### PR DESCRIPTION
## Summary
- add `scripts/check_language.py` to scan tracked files for disallowed Spanish keywords or accented characters and reuse configuration from `pyproject.toml`
- wire the new guard into `scripts/run_tests.sh` so CI runs it with the existing lint steps
- update contributor docs, release notes, migration guidance, and regression tests to reference legacy Spanish tokens via escaped literals that satisfy the new lint

## Testing
- python scripts/check_language.py
- pytest tests/unit/metrics/test_diagnosis_state.py tests/unit/structural/test_remesh.py tests/unit/dynamics/test_operator_names.py

------
https://chatgpt.com/codex/tasks/task_e_68f961445e1c8321b4c6129540f8e444