### PR TITLE
Streamline CI workflows

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,20 +12,16 @@ on:
 
 jobs:
   pre-commit:
-    name: Python ${{ matrix.python-version }} format check
+    name: Python 3.11 format check
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,4 +35,11 @@ jobs:
           python -m pip install .[test,numpy,yaml,orjson]
 
       - name: Run unit tests
+        if: matrix.python-version != '3.11'
         run: python -m pytest
+
+      - name: Run unit tests with coverage
+        if: matrix.python-version == '3.11'
+        run: |
+          python -m coverage run --source=src -m pytest
+          python -m coverage report -m

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -11,22 +11,19 @@ on:
       - master
 
 jobs:
-  lint-test:
-    name: Python ${{ matrix.python-version }} checks
+  static-analysis:
+    name: Python 3.11 static analysis
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
     env:
       PYTHONPATH: ${{ github.workspace }}/src
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -42,10 +39,6 @@ jobs:
       - name: Run mypy
         run: python -m mypy src/tnfr
 
-      - name: Run tests with coverage
-        run: |
-          python -m coverage run --source=src -m pytest
-          python -m coverage report -m
-
       - name: Run vulture
         run: python -m vulture --min-confidence 80 src tests
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- collapse the format-check workflow onto Python 3.11 to avoid redundant matrix runs
- run flake8, pydocstyle, mypy, and optional vulture on Python 3.11 without invoking pytest
- execute the pytest matrix exclusively via the test-suite workflow and collect coverage on the 3.11 job

## Testing
- not run (CI workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f964d27a68832196f808ed862ddb7f