### PR TITLE
Ensure SAST tooling artifact includes hidden files

### DIFF
--- a/.github/workflows/sast-lint.yml
+++ b/.github/workflows/sast-lint.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           name: ${{ env.TOOLS_ARTIFACT }}
           path: ${{ env.VENV_PATH }}
+          include-hidden-files: true
           if-no-files-found: error
 
   bandit:


### PR DESCRIPTION
## Summary
- ensure the shared virtual environment artifact includes hidden directories so the `.venv` contents persist across jobs

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f96754304c832193ce95d6bbe6ec6e