### PR TITLE
Remove legacy operator registry alias

### DIFF
--- a/src/tnfr/operators/registry.py
+++ b/src/tnfr/operators/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..config.operator_names import canonical_operator_name
 
@@ -67,22 +67,9 @@ def discover_operators() -> None:
     setattr(package, "_operators_discovered", True)
 
 
-LEGACY_OPERATORS_ALIAS = "OPERAD" "ORES"
-
-
 __all__ = (
     "OPERATORS",
     "register_operator",
     "discover_operators",
     "get_operator_class",
 )
-
-
-def __getattr__(name: str) -> Any:
-    """Provide guidance for legacy registry aliases."""
-
-    if name == LEGACY_OPERATORS_ALIAS:
-        raise AttributeError(
-            f"module '{__name__}' has no attribute '{name}'; use 'OPERATORS' instead."
-        )
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/tests/unit/dynamics/test_operator_names.py
+++ b/tests/unit/dynamics/test_operator_names.py
@@ -54,9 +54,9 @@ def test_get_operator_class_rejects_spanish_tokens() -> None:
 
 
 def test_registry_exposes_only_english_collection_name() -> None:
-    legacy_alias = "OPERAD" "ORES"
+    legacy_alias = "OPERADORES"
     with pytest.raises(AttributeError) as exc_info:
         getattr(registry_module, legacy_alias)
-    message = str(exc_info.value)
-    assert legacy_alias in message
-    assert "OPERATORS" in message
+    assert str(exc_info.value) == (
+        f"module '{registry_module.__name__}' has no attribute '{legacy_alias}'"
+    )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases
- ✅ `pytest -o addopts= tests/unit/dynamics/test_operator_names.py`

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f967838eb8832194c21d89559dafd2