### PR TITLE
Ensure Netlify invokes mkdocs via Python module

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-command = "python -m pip install -r docs/requirements.txt && mkdocs build"
+command = "python -m pip install -r docs/requirements.txt && python -m mkdocs build"
 publish = "site"


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Updated the Netlify build command to call `mkdocs` via `python -m mkdocs` after installing documentation dependencies to ensure the documentation build runs within Netlify's Python environment.


------
https://chatgpt.com/codex/tasks/task_e_68f9681169f48321832d587c6beef6cb