### PR TITLE
Restore Semgrep permissions in SAST workflow

### DIFF
--- a/.github/workflows/sast-lint.yml
+++ b/.github/workflows/sast-lint.yml
@@ -111,6 +111,9 @@ jobs:
           name: ${{ env.TOOLS_ARTIFACT }}
           path: ${{ env.VENV_PATH }}
 
+      - name: Fix Semgrep permissions
+        run: chmod +x ${{ env.VENV_PATH }}/bin/semgrep
+
       - name: Install PyYAML
         run: pip install pyyaml
 


### PR DESCRIPTION
## Summary
- ensure the downloaded Semgrep binary regains its executable bit before running scans so the job can execute reliably

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f96f3f88f88321be6025e204d58bca