### PR TITLE
Translate test diagnostics from Spanish to English

### DIFF
--- a/tests/unit/dynamics/test_dnfr_cache.py
+++ b/tests/unit/dynamics/test_dnfr_cache.py
@@ -448,7 +448,7 @@ def test_neighbor_sum_buffers_reused_and_results_stable(vectorized, monkeypatch)
         if bar_arr_buffers[3] is not None:
             assert cache.deg_bar_np is bar_arr_buffers[3]
 
-    # Los resultados deben permanecer invariantes tras recomputar.
+    # The results must remain invariant after recomputation.
     for before, after in zip(first, second):
         assert math.isfinite(after)
         assert before == pytest.approx(after)

--- a/tests/unit/metrics/test_invariants.py
+++ b/tests/unit/metrics/test_invariants.py
@@ -74,7 +74,7 @@ def test_remesh_cooldown_if_present(G_small):
         G_small.graph.get("REMESH_COOLDOWN_WINDOW", None),
     )
     if cooldown is None:
-        pytest.skip("No hay REMESH_COOLDOWN definido en el motor")
+        pytest.skip("REMESH_COOLDOWN is not configured in the engine")
 
     w_estab = int(G_small.graph.get("REMESH_STABILITY_WINDOW", 0))
     sf = G_small.graph.setdefault("history", {}).setdefault("stable_frac", [])

--- a/tests/unit/structural/test_set_attr_error.py
+++ b/tests/unit/structural/test_set_attr_error.py
@@ -4,7 +4,7 @@ from tnfr.alias import set_attr_generic
 
 
 def test_set_attr_allows_none_conversion():
-    """``set_attr_generic`` debe permitir valores ``None``."""
+    """``set_attr_generic`` must allow ``None`` values."""
     d = {}
     set_attr_generic(d, ("x",), 123, conv=lambda v: None)
     assert "x" in d and d["x"] is None


### PR DESCRIPTION
## Summary
- translate the remaining Spanish docstring and inline comment in the unit tests to English phrasing
- update the REMESH_COOLDOWN skip message to explain the missing configuration in English so pytest output is clear

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f970defb308321b18e67e862452521