### PR TITLE
Rename prepare_network tests to English identifiers

### DIFF
--- a/tests/unit/dynamics/test_export_dependencies.py
+++ b/tests/unit/dynamics/test_export_dependencies.py
@@ -18,9 +18,9 @@ def test_prepare_network_dependencies():
         "tnfr.utils",
     }
 
-    preparar = EXPORT_DEPENDENCIES["prepare_network"]
-    assert set(preparar["submodules"]) == expected
-    assert preparar["third_party"] == ("networkx",)
+    prepare_manifest = EXPORT_DEPENDENCIES["prepare_network"]
+    assert set(prepare_manifest["submodules"]) == expected
+    assert prepare_manifest["third_party"] == ("networkx",)
 
 
 def test_dynamics_helpers_dependencies():

--- a/tests/unit/structural/test_prepare_network.py
+++ b/tests/unit/structural/test_prepare_network.py
@@ -3,13 +3,13 @@ import networkx as nx
 from tnfr.ontosim import prepare_network
 
 
-def test_prepare_network_init_attrs_por_defecto():
+def test_prepare_network_initializes_attrs_by_default():
     G = nx.path_graph(3)
     prepare_network(G)
     assert all("theta" in d for _, d in G.nodes(data=True))
 
 
-def test_prepare_network_sin_init_attrs():
+def test_prepare_network_allows_disabling_init_attrs():
     G = nx.path_graph(3)
     prepare_network(G, init_attrs=False)
     assert all("theta" not in d for _, d in G.nodes(data=True))


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f97286baec8321a40dd2b741655b9c