### PR TITLE
Relax performance test tolerance for numpy increments

### DIFF
--- a/tests/performance/test_integrators_performance.py
+++ b/tests/performance/test_integrators_performance.py
@@ -141,7 +141,7 @@ def test_apply_increments_numpy_branch_is_faster(monkeypatch, method):
     assert chunk_calls > 0
     # Allow modest timing variance so minor CI noise does not trip the check, while
     # still bounding the optimized path from regressing significantly.
-    assert numpy_time <= fallback_time * 1.1
+    assert numpy_time <= fallback_time * 1.2
 
     for node in graph.nodes:
         assert numpy_results[node] == pytest.approx(fallback_results[node])


### PR DESCRIPTION
## Summary
- relax the numpy performance regression tolerance to mitigate CI timing noise while keeping a bound on regressions

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f975ffda68832191d0f58f4e08cd53