### PR TITLE
Restore Semgrep executable permissions in SAST workflow

### DIFF
--- a/.github/workflows/sast-lint.yml
+++ b/.github/workflows/sast-lint.yml
@@ -111,11 +111,14 @@ jobs:
           name: ${{ env.TOOLS_ARTIFACT }}
           path: ${{ env.VENV_PATH }}
 
-      - name: Fix virtual environment python permissions
-        run: chmod +x ${{ env.VENV_PATH }}/bin/python
-
       - name: Fix Semgrep permissions
         run: chmod +x ${{ env.VENV_PATH }}/bin/semgrep
+
+      - name: Fix virtual environment bin permissions
+        run: chmod -R +x ${{ env.VENV_PATH }}/bin
+
+      - name: Fix virtual environment python permissions
+        run: chmod +x ${{ env.VENV_PATH }}/bin/python
 
       - name: Install PyYAML
         run: pip install pyyaml


### PR DESCRIPTION
## Summary
- ensure the Semgrep binary regains execute permission immediately after restoring the shared virtual environment
- add a recursive chmod to the virtual environment bin directory while retaining the explicit python fix so all tooling stays invokable

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f97686a45c8321904c754978187b9b