### PR TITLE
Fix Bandit workflow Python permission restoration

### DIFF
--- a/.github/workflows/sast-lint.yml
+++ b/.github/workflows/sast-lint.yml
@@ -71,6 +71,9 @@ jobs:
           name: ${{ env.TOOLS_ARTIFACT }}
           path: ${{ env.VENV_PATH }}
 
+      - name: Fix Python interpreter permissions
+        run: chmod +x ${{ env.VENV_PATH }}/bin/python
+
       - name: Fix Bandit permissions
         run: chmod +x ${{ env.VENV_PATH }}/bin/bandit
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Restored the execute permission on the cached virtual environment's Python binary before invoking Bandit so the download/upload cycle no longer produces a permission denied error during the scan.


------
https://chatgpt.com/codex/tasks/task_e_68f9771ed1b08321bd9f2f72ed5851d7