### PR TITLE
Update GPT URL to use English slug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ tnfr = "tnfr.cli:main"
 [project.urls]
 Homepage = "https://pypi.org/project/tnfr/"
 Repository = "https://github.com/fermga/TNFR-Python-Engine"
-GPT = "https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-teoria-de-la-naturaleza-fractal-resonante"
+GPT = "https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-resonant-fractal-nature-theory"
 
 [tool.setuptools.dynamic]
 version = { attr = "tnfr._version.__version__" }


### PR DESCRIPTION
## Summary
- update the GPT project URL in `pyproject.toml` to use the English slug for the TNFR space

## Testing
- python -m build --sdist --wheel --outdir /tmp/build

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68f97ce44d8c8321a1646cce36f72b87