### PR TITLE
Encode language policy data for configurable Spanish guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,17 +145,24 @@ after installing dependencies, so any violation will fail continuous
 integration before the remaining linters or tests execute. The guard scans the
 tracked files for a configurable set of disallowed Spanish keywords and accented
 characters, exiting with a non-zero status when any matches are found. The
-default list targets the legacy compatibility tokens (`est<span></span>able`, `trans<span></span>icion`,
-`transici&oacute;n`, `diso<span></span>nante`, etc.) that must never re-enter the codebase. You
-can extend or override the defaults by editing the
-`[tool.tnfr.language_check]` table in `pyproject.toml`.
+encoded defaults live in `scripts/language_policy_data.py` as sequences of
+code points that reconstruct the retired compatibility tokens. Extend or
+override them from the `[tool.tnfr.language_check]` table in `pyproject.toml`
+by supplying numeric representations, e.g.
+
+```
+[tool.tnfr.language_check]
+disallowed_keyword_codes = [[101, 106, 101, 109, 112, 108, 111]]
+accent_codepoints = [225]
+```
 
 When the guard reports violations, rewrite the offending strings to their
 English equivalents before committing. For documentation or tests that need to
-mention the historical tokens for migration guidance, import the encoded
-constants from `tests/legacy_tokens.py` or reconstruct them from Unicode code
-points (for example ``"".join(chr(cp) for cp in (...))``) so the underlying
-files stay ASCII-only while avoiding raw Spanish text.
+reference the historical tokens, rely on the helpers in
+`scripts/language_policy_data.py` (for example
+`decode_keyword_codes(((101, 106, 101, 109, 112, 108, 111),))`) or the curated
+constants in `tests/legacy_tokens.py` so files stay ASCII-only while avoiding
+raw Spanish text.
 
 Make sure to honor the patterns in `.gitignore` so that dependency and build
 artifacts (e.g., `node_modules/` or `dist/`) are not committed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,41 +80,6 @@ ignore = ["E501", "W503"]
 exclude = ["benchmarks/"]
 
 [tool.tnfr.language_check]
-disallowed_keywords = [
-  "est\u0061ble",
-  "transici\u006f\u006e",
-  "transici\u00f3n",
-  "diso\u006enante",
-  "operad\u006fres",
-  "operad\u006fr",
-  "e\u006aemplo",
-  "\u006fpcionales",
-  "\u0064ependencia",
-  "\u0063ompatibilidad",
-  "\u0076alores",
-  "\u0064ebe",
-  "\u0072ecomputar",
-  "\u006d\u006ftor",
-  "\u0070or_defecto",
-]
-accented_characters = [
-  "\u00e1",
-  "\u00e9",
-  "\u00ed",
-  "\u00f3",
-  "\u00fa",
-  "\u00fc",
-  "\u00f1",
-  "\u00c1",
-  "\u00c9",
-  "\u00cd",
-  "\u00d3",
-  "\u00da",
-  "\u00dc",
-  "\u00d1",
-  "\u00bf",
-  "\u00a1",
-]
 exclude = [
   "TNFR.pdf",
   "benchmarks/**/*.pdf",

--- a/scripts/language_policy_data.py
+++ b/scripts/language_policy_data.py
@@ -1,0 +1,119 @@
+"""Encoded legacy tokens for the Spanish language guard."""
+
+from __future__ import annotations
+
+from base64 import b64decode
+from typing import Iterable, Sequence, Any
+
+LEGACY_KEYWORD_CODEPOINTS: tuple[tuple[int, ...], ...] = (
+    (101, 115, 116, 97, 98, 108, 101),
+    (116, 114, 97, 110, 115, 105, 99, 105, 111, 110),
+    (116, 114, 97, 110, 115, 105, 99, 105, 243, 110),
+    (100, 105, 115, 111, 110, 97, 110, 116, 101),
+    (111, 112, 101, 114, 97, 100, 111, 114, 101, 115),
+    (111, 112, 101, 114, 97, 100, 111, 114),
+    (101, 106, 101, 109, 112, 108, 111),
+    (111, 112, 99, 105, 111, 110, 97, 108, 101, 115),
+    (100, 101, 112, 101, 110, 100, 101, 110, 99, 105, 97),
+    (99, 111, 109, 112, 97, 116, 105, 98, 105, 108, 105, 100, 97, 100),
+    (118, 97, 108, 111, 114, 101, 115),
+    (100, 101, 98, 101),
+    (114, 101, 99, 111, 109, 112, 117, 116, 97, 114),
+    (109, 111, 116, 111, 114),
+    (112, 111, 114, 95, 100, 101, 102, 101, 99, 116, 111),
+)
+
+ACCENT_CODEPOINTS: tuple[int, ...] = (
+    225,
+    233,
+    237,
+    243,
+    250,
+    252,
+    241,
+    193,
+    201,
+    205,
+    211,
+    218,
+    220,
+    209,
+    191,
+    161,
+)
+
+
+def _coerce_code_sequence(candidate: Any) -> tuple[int, ...] | None:
+    """Return a tuple of integers from ``candidate`` when possible."""
+
+    if isinstance(candidate, (str, bytes, bytearray)):
+        return None
+    if isinstance(candidate, int):
+        return (candidate,)
+    try:
+        return tuple(int(part) for part in candidate)
+    except (TypeError, ValueError):
+        return None
+
+
+def decode_keyword_codes(
+    encoded: Iterable[Iterable[int] | Sequence[int]],
+) -> tuple[str, ...]:
+    """Decode an iterable of integer sequences into keyword strings."""
+
+    tokens: list[str] = []
+    for item in encoded:
+        codepoints = _coerce_code_sequence(item)
+        if codepoints is None:
+            continue
+        tokens.append("".join(chr(codepoint) for codepoint in codepoints))
+    return tuple(tokens)
+
+
+def decode_keyword_base64(encoded: Iterable[str]) -> tuple[str, ...]:
+    """Decode base64-encoded keyword strings."""
+
+    tokens: list[str] = []
+    for item in encoded:
+        if not isinstance(item, str):
+            continue
+        try:
+            tokens.append(b64decode(item).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue
+    return tuple(tokens)
+
+
+def decode_accent_codepoints(encoded: Iterable[int]) -> tuple[str, ...]:
+    """Decode integer code points representing accented characters."""
+
+    characters: list[str] = []
+    for item in encoded:
+        try:
+            characters.append(chr(int(item)))
+        except (TypeError, ValueError):
+            continue
+    return tuple(characters)
+
+
+def default_disallowed_keywords() -> tuple[str, ...]:
+    """Return the decoded default disallowed keywords."""
+
+    return decode_keyword_codes(LEGACY_KEYWORD_CODEPOINTS)
+
+
+def default_accented_characters() -> tuple[str, ...]:
+    """Return the decoded default accented characters."""
+
+    return decode_accent_codepoints(ACCENT_CODEPOINTS)
+
+
+__all__ = [
+    "ACCENT_CODEPOINTS",
+    "LEGACY_KEYWORD_CODEPOINTS",
+    "decode_accent_codepoints",
+    "decode_keyword_base64",
+    "decode_keyword_codes",
+    "default_accented_characters",
+    "default_disallowed_keywords",
+]

--- a/tests/unit/scripts/test_language_check.py
+++ b/tests/unit/scripts/test_language_check.py
@@ -11,18 +11,32 @@ _language_check = importlib.util.module_from_spec(_spec)
 sys.modules.setdefault("tnfr_language_check", _language_check)
 _spec.loader.exec_module(_language_check)
 
+DATA_MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "language_policy_data.py"
+_data_spec = importlib.util.spec_from_file_location(
+    "tnfr_language_policy_data", DATA_MODULE_PATH
+)
+assert _data_spec and _data_spec.loader
+_language_policy_data = importlib.util.module_from_spec(_data_spec)
+sys.modules.setdefault("tnfr_language_policy_data", _language_policy_data)
+_data_spec.loader.exec_module(_language_policy_data)
+
+_RECENT_KEYWORD_CODES = (
+    (101, 106, 101, 109, 112, 108, 111),
+    (111, 112, 99, 105, 111, 110, 97, 108, 101, 115),
+    (100, 101, 112, 101, 110, 100, 101, 110, 99, 105, 97),
+    (99, 111, 109, 112, 97, 116, 105, 98, 105, 108, 105, 100, 97, 100),
+    (118, 97, 108, 111, 114, 101, 115),
+    (100, 101, 98, 101),
+    (114, 101, 99, 111, 109, 112, 117, 116, 97, 114),
+    (109, 111, 116, 111, 114),
+    (112, 111, 114, 95, 100, 101, 102, 101, 99, 116, 111),
+)
+
 
 def test_default_policy_contains_recent_tokens() -> None:
     expected = {
-        ("e" "jemplo"),
-        ("o" "pcionales"),
-        ("d" "ependencia"),
-        ("c" "ompatibilidad"),
-        ("v" "alores"),
-        ("d" "ebe"),
-        ("r" "ecomputar"),
-        ("m" "otor"),
-        ("p" "or_defecto"),
+        token.lower()
+        for token in _language_policy_data.decode_keyword_codes(_RECENT_KEYWORD_CODES)
     }
     policy_tokens = {
         word.lower() for word in _language_check.DEFAULT_POLICY.disallowed_keywords
@@ -33,7 +47,9 @@ def test_default_policy_contains_recent_tokens() -> None:
 def test_scan_file_flags_recent_keyword(tmp_path) -> None:
     repo_root = tmp_path
     sample = repo_root / "snippet.txt"
-    keyword = "e" "jemplo"
+    keyword = _language_policy_data.decode_keyword_codes(
+        (_RECENT_KEYWORD_CODES[0],)
+    )[0]
     sample.write_text(f"Line with {keyword} token", encoding="utf-8")
 
     violations = _language_check._scan_file(  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add `scripts/language_policy_data.py` to store the legacy keywords/accent marks as encoded code-point sequences with decoding helpers
- refactor `scripts/check_language.py` to build defaults from the encoded data and accept numeric overrides for keywords/accents
- remove literal Spanish strings from configuration and documentation, updating the docs and tests to describe/use the numeric representation

## Testing
- pytest tests/unit/scripts/test_language_check.py

------
https://chatgpt.com/codex/tasks/task_e_68f9bb254aac8321a83b8489c22d69bf