### PR TITLE
docs: clarify english-only API guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,8 +66,6 @@ The following table highlights how ΔNFR values propagate through the engine and
 
 Operator classes apply the `@register_operator` decorator, which verifies unique ASCII names, binds glyphs, and inserts implementations into the shared `OPERATORS` map used by syntax validators and dynamic dispatch.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L58】 The discovery routine scans the `tnfr.operators` package exactly once per interpreter session, importing every submodule except the registry itself so that registration side effects run reliably before the structural loop accesses them.【F:src/tnfr/operators/registry.py†L33-L58】
 
-> **Compatibility note**: The previous `OPERAD<span></span>ORES` export now resolves through a deprecated module attribute. Existing consumers that import `tnfr.operators.registry.OPERAD<span></span>ORES` continue to receive the same mapping but will emit a `DeprecationWarning`; new code should use `OPERATORS` instead.【F:src/tnfr/operators/registry.py†L44-L58】
-
 When introducing new operators:
 
 - Provide ASCII `name` and canonical `Glyph` binding on the class definition.【F:src/tnfr/operators/definitions.py†L45-L180】
@@ -95,10 +93,10 @@ validation helpers, CLI, and documentation all use the same canonical ASCII toke
 | `transition`  | Crosses thresholds      |
 | `recursivity` | Maintains memory        |
 
-Legacy Spanish spellings (``emision``, ``recepcion``, …) have been removed from the public
-API, the exported ``__all__`` bindings, and the validation layer. Downstream callers must use
-the canonical names shown above; the registry no longer performs alias canonicalisation and
-``get_operator_class()`` raises :class:`KeyError` for Spanish identifiers.【F:src/tnfr/config/operator_names.py†L1-L77】【F:src/tnfr/operators/registry.py†L13-L45】
+Only the canonical English spellings remain in the public API, the exported ``__all__`` bindings,
+and the validation layer. Downstream callers must use the names shown above; the registry no
+longer performs alias canonicalisation and ``get_operator_class()`` raises :class:`KeyError` for
+non-English identifiers.【F:src/tnfr/config/operator_names.py†L1-L77】【F:src/tnfr/operators/registry.py†L13-L45】
 
 ## Enforcing TNFR invariants in runtime orchestration
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ integration.
 
 ## Migration notes
 
-- **Si dispersion keys:** Replace any remaining legacy Si dispersion entries (encoded in
-  ``tests/legacy_tokens.py`` as ``LEGACY_SI_SENSITIVITY_KEY``) in graph payloads or
-  configuration files with the English ``dSi_dphase_disp`` key before upgrading. The runtime
-  now raises :class:`ValueError` listing any unexpected sensitivity keys, and
+- **Si dispersion keys:** Ensure graph payloads and configuration files use the canonical
+  ``dSi_dphase_disp`` attribute for Si dispersion sensitivity before upgrading. The runtime now
+  raises :class:`ValueError` listing any unexpected sensitivity keys, and
   :func:`tnfr.metrics.sense_index.compute_Si_node` rejects unknown keyword arguments.
 - Refer to the [release notes](docs/releases.md#1100-si-dispersion-legacy-keys-removed) for
   a migration snippet that rewrites stored graphs in place prior to running the new version.

--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -14,11 +14,10 @@ facades.
 - **Si** — `tnfr.metrics.sense_index.compute_Si`: ability to produce meaningful reorganisation
   combining νf, phase, and topology.
 - **Phase θ** — `tnfr.dynamics.coordinate_global_local_phase` and related helpers.
-- **Compatibility** — graphs that still expose the legacy phase alias (see
-  ``LEGACY_PHASE_ALIAS`` in ``tests/legacy_tokens.py``) or the ``"θ"`` symbol must
-  be rewritten manually before importing TNFR 15.0.0+. Alias helpers operate
-  purely on the English ``"theta"``/``"phase"`` keys and reject untranslated
-  payloads.
+- **Compatibility** — graphs must expose only the English ``"theta"``/``"phase"``
+  keys before importing TNFR 15.0.0+. Remove any deprecated aliases (including
+  the historical standalone ``"θ"`` symbol) because alias helpers now operate
+  purely on the canonical names and reject untranslated payloads.
 - **Topology** — coupling maps available through operator utilities like
   `tnfr.operators.apply_topological_remesh`.
 

--- a/docs/getting-started/migrating-remesh-window.md
+++ b/docs/getting-started/migrating-remesh-window.md
@@ -1,23 +1,23 @@
 # Migrating remesh stability window usage
 
-TNFR 10.0.0 removes the transitional legacy keyword (encoded in
-``tests/legacy_tokens.py`` as ``LEGACY_REMESH_KEYWORD``) from
-:func:`tnfr.operators.apply_remesh_if_globally_stable`. The operator now
-accepts only the English ``stable_step_window`` parameter. Calls that still use
-or forward the legacy keyword raise :class:`TypeError` immediately so the
-deprecated configuration cannot silently slip through pipelines.
+TNFR 10.0.0 removes the transitional alias for the remesh stability window
+parameter from :func:`tnfr.operators.apply_remesh_if_globally_stable`. The
+operator now accepts only the canonical ``stable_step_window`` argument. Calls
+that forward any other keyword raise :class:`TypeError` immediately so deprecated
+configuration cannot slip through pipelines.
 
-Legacy graphs that still expose the legacy cooldown metadata **had to be
+Legacy graphs that still expose non-canonical cooldown metadata **had to be
 migrated before 2025-03-31**. That date marked the end of the archival
-compatibility window communicated in TNFR 14.x. Starting with ``tnfr`` 15.0.0
-the runtime no longer ships :func:`tnfr.utils.migrations.migrate_legacy_remesh_cooldown`
-or the phase attribute shim, so persisted payloads must already use the English
+compatibility window communicated in TNFR 14.x. Starting with ``tnfr`` 15.0.0 the
+runtime no longer ships :func:`tnfr.utils.migrations.migrate_legacy_remesh_cooldown`
+or the phase attribute shim, so persisted payloads must already use the canonical
 keys.
 
 ## Who is affected?
 
-- Applications that invoked the operator with a ``LEGACY_REMESH_KEYWORD`` payload, e.g.
-  ``apply_remesh_if_globally_stable(G, **{LEGACY_REMESH_KEYWORD: ...})``.
+- Applications that invoked the operator with a deprecated alias, e.g.
+  ``apply_remesh_if_globally_stable(G, **legacy_kwargs)`` where ``legacy_kwargs``
+  forwards a non-English key.
 - Configuration loaders that surfaced the legacy name as part of dynamic
   keyword expansion.
 - Stored automation artifacts (YAML/JSON, notebooks) that preserved the legacy
@@ -25,43 +25,31 @@ keys.
 
 ## Migration steps
 
-1. Replace every occurrence of the legacy keyword with the canonical English
-   parameter. The semantic contract is unchanged::
+1. Replace every occurrence of the deprecated parameter name with the canonical
+   ``stable_step_window`` argument. The semantic contract is unchanged::
 
-       from tests.legacy_tokens import LEGACY_REMESH_KEYWORD
-
-       # Before (TNFR <= 9.x)
-       apply_remesh_if_globally_stable(
-           G,
-           **{LEGACY_REMESH_KEYWORD: 5},
-       )
-
-       # After (TNFR >= 10.0)
        apply_remesh_if_globally_stable(G, stable_step_window=5)
 
-2. If you rely on user-provided dictionaries that may contain the legacy
-   identifier, normalise the payload before calling the operator::
-
-       from tests.legacy_tokens import LEGACY_REMESH_KEYWORD
+2. If you rely on user-provided dictionaries that may contain non-canonical
+   names, normalise the payload before calling the operator::
 
        def normalize_remesh_kwargs(kwargs: dict) -> dict:
-           if LEGACY_REMESH_KEYWORD in kwargs:
-               kwargs = dict(kwargs)  # shallow copy if shared
-               kwargs["stable_step_window"] = kwargs.pop(LEGACY_REMESH_KEYWORD)
-           return kwargs
+           normalized = dict(kwargs)
+           for key in tuple(normalized):
+               if key != "stable_step_window" and key.lower().replace("-", "_") == "stable_step_window":
+                   normalized["stable_step_window"] = normalized.pop(key)
+           return normalized
 
        apply_remesh_if_globally_stable(G, **normalize_remesh_kwargs(user_kwargs))
 
-3. Audit persisted graphs or configs that reference the legacy names **before
+3. Audit persisted graphs or configs that reference non-English names **before
    upgrading to ``tnfr`` 15.0.0**. Without the helper, the update must happen in
    the stored artifact (for example by running a one-off script on the graph
    metadata) prior to importing the new release.
 
 4. Verify that serialized graphs expose only ``"theta"``, ``"phase"`` and
-   ``"REMESH_COOLDOWN_WINDOW"``. Any remaining legacy phase alias, standalone
-   theta symbol, or remesh cooldown identifier (see ``LEGACY_PHASE_ALIAS`` and
-   ``LEGACY_REMESH_CONFIG`` in ``tests/legacy_tokens.py``) indicates the
-   artifact still targets an unsupported contract.
+   ``"REMESH_COOLDOWN_WINDOW"``. Any other synonym indicates the artifact still
+   targets an unsupported contract.
 
 ## Verification checklist
 


### PR DESCRIPTION
## Summary
- remove references to the retired legacy token module across the README and telemetry docs in favor of the canonical English API
- update release notes and the remesh migration guide to describe English-only payload keys without enumerating Spanish identifiers
- highlight the English operator contract in ARCHITECTURE.md without referencing deprecated spellings

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68f9c30a0ecc8321ab6afa36e88595a4