### PR TITLE
Add TNFR NumPy docstring style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,38 @@ When contributing:
 - Use descriptive English names for every variable, function, class, and
   module.
 - Write docstrings and comments in English and reference operators by their
-  canonical English identifiers.
+  canonical English identifiers. Follow the
+  [NumPy-style docstring guide](docs/api/docstring_style.md) so automated tools
+  and reviewers can track how each API reorganises EPI, νf, and ΔNFR.
 - Update existing code to migrate any remaining legacy strings to the English
   tokens.
+
+Use the following summary as a quick reminder of the expected docstring
+sections when creating or updating public APIs:
+
+```python
+"""One-line summary of the structural effect.
+
+Parameters
+----------
+name : type
+    Describe how the argument influences EPI, νf, ΔNFR, or phase.
+
+Returns
+-------
+return_type
+    State the structural outcome exposed to callers.
+
+Raises
+------
+ExceptionType
+    Mention validation or dissonance guards when relevant.
+
+Examples
+--------
+>>> # Provide runnable snippets that respect TNFR invariants
+"""
+```
 
 The canonical operator identifiers are:
 

--- a/docs/api/docstring_style.md
+++ b/docs/api/docstring_style.md
@@ -1,0 +1,125 @@
+# Guía de docstrings para TNFR
+
+La documentación de las APIs del motor TNFR usa el formato de docstrings tipo
+NumPy. Este estilo es compatible con las herramientas automáticas que generan
+referencias, ejecutan pydocstyle y validan la semántica de operadores. Cada
+nueva función o clase debe describir explícitamente el efecto estructural sobre
+EPI, la frecuencia estructural (νf) y el reorganizador interno ΔNFR.
+
+## Plantilla base
+
+Utiliza la siguiente estructura en cada docstring. Mantén la narrativa en
+inglés (siguiendo la política del repositorio) y enfócate en describir cómo la
+operación reorganiza coherencia y métricas TNFR.
+
+```python
+"""Resume the structural effect in one sentence.
+
+Parameters
+----------
+name : type
+    Clarify how the parameter influences EPI, νf, or ΔNFR.
+
+Returns
+-------
+return_type
+    Explain the structural outcome or telemetry exposed.
+
+Raises
+------
+ExceptionType
+    Document dissonance paths or validation guards.
+
+Examples
+--------
+>>> # Minimal runnable example that respects TNFR invariants
+"""
+```
+
+### Notas clave
+
+- **Encabezado**: una línea que resuma el efecto estructural.
+- **Parameters**: lista cada argumento en orden, con tipo y contexto TNFR. Usa
+  oraciones en inglés y referencia explícita a EPI, νf, ΔNFR o la fase cuando
+  aplique.
+- **Returns**: describe qué recibe el llamador y cómo puede seguir midiendo
+  coherencia (por ejemplo, tuplas que contienen grafos TNFR o hooks ΔNFR).
+- **Raises**: sólo si hay validaciones o condiciones de disonancia relevantes.
+- **Examples**: incluye fragmentos ejecutables que muestren el flujo de trabajo
+  esperado. Anota los valores de EPI, νf y ΔNFR cuando sirva para resaltar la
+  semántica.
+
+## Ejemplos basados en `tnfr.structural`
+
+### `create_nfr`
+
+```python
+"""Create a graph with an initialised NFR node.
+
+Parameters
+----------
+name : str
+    Identifier for the new node; it anchors the primary EPI container.
+epi : float, default 0.0
+    Primary Information Structure (EPI) value assigned to the node.
+vf : float, default 1.0
+    Structural frequency νf in Hz_str that governs reorganisation pace.
+theta : float, default 0.0
+    Initial phase used for coupling checks against neighbour nodes.
+graph : TNFRGraph | None, optional
+    Existing TNFR graph to reuse; a new graph is created when ``None``.
+dnfr_hook : DeltaNFRHook, default dnfr_epi_vf_mixed
+    Callback that recalculates ΔNFR after each operator invocation.
+
+Returns
+-------
+TNFRGraph, str
+    Tuple containing the TNFR graph and the node name for chaining.
+
+Examples
+--------
+>>> from tnfr import structural
+>>> G, node = structural.create_nfr("seed", epi=0.42, vf=2.0)
+>>> G.nodes[node]["epi"]
+0.42
+>>> G.graph["compute_delta_nfr"].__name__
+'dnfr_epi_vf_mixed'
+"""
+```
+
+### `run_sequence`
+
+```python
+"""Execute a sequence of operators on ``node`` after validation.
+
+Parameters
+----------
+G : TNFRGraph
+    Graph that stores EPI, νf, and ΔNFR metadata for each node.
+node : NodeId
+    Node that will receive the operator sequence.
+ops : Iterable[Operator]
+    Ordered structural operators to apply; validation preserves grammar.
+
+Raises
+------
+ValueError
+    Raised when the operator names violate the canonical TNFR grammar.
+
+Examples
+--------
+>>> from tnfr import operators, structural
+>>> G, node = structural.create_nfr("seed", epi=1.0, vf=1.5)
+>>> structural.run_sequence(G, node, [operators.Emission(), operators.Coherence()])
+>>> round(G.nodes[node]["vf"], 2)
+1.5
+"""
+```
+
+## Herramientas que dependen del estilo
+
+- `pydocstyle` valida la presencia de estas secciones.
+- Generadores automáticos de documentación (MkDocs + plugins de autodoc) esperan
+  la forma NumPy para renderizar correctamente tablas y ejemplos.
+- Revisores humanos y asistentes automáticos usan el vocabulario TNFR descrito
+  aquí para verificar coherencia, ΔNFR y νf sin ambigüedades.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ $\partial EPI/\partial t = \nu_f \cdot \Delta NFR(t)$.
   helper facades for reproducible experiments.
 - [Examples library](examples/README.md): runnable scenarios (controlled dissonance loop and
   optical cavity feedback) with CLI counterparts.
+- [Docstring style guide](api/docstring_style.md): NumPy template aligned with TNFR vocabulary
+  so contributors and automated tools describe EPI, νf, and ΔNFR consistently.
 - [Release notes](releases.md): API transitions, compatibility windows, and deprecation timelines.
 
 ## Canonical references


### PR DESCRIPTION
## Summary
- add a NumPy-style docstring guide under `docs/api` with TNFR vocabulary and examples based on `tnfr.structural`
- update the opening style guidance in `CONTRIBUTING.md` to link the new document and show the expected sections inline
- reference the guide from the documentation index so contributors and automation discover it easily

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68faa9822ff48321bf46c904ea67afcd