### PR TITLE
Configure repository-wide pydocstyle enforcement

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -37,7 +37,7 @@ jobs:
         run: python -m flake8 src
 
       - name: Run pydocstyle
-        run: python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py
+        run: python -m pydocstyle src/tnfr
 
       - name: Run mypy
         run: python -m mypy src/tnfr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,17 @@ max-line-length = 88
 ignore = ["E501", "W503"]
 exclude = ["benchmarks/"]
 
+[tool.pydocstyle]
+convention = "numpy"
+add-ignore = [
+  "D100",  # Legacy modules lack mandatory module docstrings.
+  "D101",  # Public classes inherit legacy docstring coverage.
+  "D102",  # Public methods lack docstrings in existing API surface.
+  "D103",  # Numerous public functions still require canonical docstrings.
+  "D105",  # Magic methods follow structural semantics without docstrings.
+  "D202",  # Allow blank line after docstring where needed for readability.
+]
+
 [tool.tnfr.language_check]
 exclude = [
   "TNFR.pdf",

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -6,7 +6,7 @@ export PYTHONPATH="$PWD/src"
 python -m pip install --quiet ".[test,typecheck]"
 python -m flake8 src
 python scripts/check_language.py
-python -m pydocstyle --add-ignore=D202 src/tnfr/selector.py src/tnfr/utils/data.py src/tnfr/utils/graph.py
+python -m pydocstyle src/tnfr
 # Mirrors the mypy invocation in .github/workflows/type-check.yml.
 python -m mypy src/tnfr
 python -m coverage run --source=src -m pytest "$@"

--- a/src/tnfr/cli/__init__.py
+++ b/src/tnfr/cli/__init__.py
@@ -1,3 +1,5 @@
+"""Command-line interface entry points for TNFR."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -2074,7 +2074,7 @@ def _apply_dnfr_hook(
     note: str | None = None,
     n_jobs: int | None = None,
 ) -> None:
-    """Generic helper to compute and store ΔNFR using ``grads``.
+    """Compute and store ΔNFR using ``grads``.
 
     Parameters
     ----------
@@ -2243,7 +2243,7 @@ class _NeighborAverageGradient:
 
 
 def dnfr_phase_only(G: TNFRGraph, *, n_jobs: int | None = None) -> None:
-    """Example: ΔNFR from phase only (Kuramoto-like).
+    """Compute ΔNFR from phase only (Kuramoto-like).
 
     Parameters
     ----------
@@ -2267,7 +2267,7 @@ def dnfr_phase_only(G: TNFRGraph, *, n_jobs: int | None = None) -> None:
 
 
 def dnfr_epi_vf_mixed(G: TNFRGraph, *, n_jobs: int | None = None) -> None:
-    """Example: ΔNFR without phase, mixing EPI and νf.
+    """Compute ΔNFR without phase, mixing EPI and νf.
 
     Parameters
     ----------

--- a/src/tnfr/execution.py
+++ b/src/tnfr/execution.py
@@ -204,7 +204,7 @@ def wait(steps: int = 1) -> WAIT:
 
 
 def basic_canonical_example() -> list[Token]:
-    """Reference canonical sequence.
+    """Return the canonical preset sequence.
 
     Returns a copy of the canonical preset tokens to keep CLI defaults aligned
     with :func:`tnfr.config.presets.get_preset`.

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -47,8 +47,7 @@ def _default_gamma_spec() -> tuple[bytes, str]:
 
 
 def _ensure_kuramoto_cache(G: TNFRGraph, t: float | int) -> None:
-    """Cache ``(R, ψ)`` for the current step ``t`` using
-    ``edge_version_cache``."""
+    """Cache ``(R, ψ)`` for the current step ``t`` using ``edge_version_cache``."""
     checksum = G.graph.get("_dnfr_nodes_checksum")
     if checksum is None:
         # reuse checksum from cached_nodes_and_A when available
@@ -203,7 +202,7 @@ def _gamma_kuramoto(
     builder: Callable[..., float],
     **defaults: float,
 ) -> float:
-    """Helper for Kuramoto-based Γ functions.
+    """Construct a Kuramoto-based Γ function.
 
     ``builder`` receives ``(θ_i, R, ψ, *params)`` where ``params`` are
     extracted from ``cfg`` according to ``defaults``.
@@ -249,7 +248,7 @@ def gamma_kuramoto_linear(
 def gamma_kuramoto_bandpass(
     G: TNFRGraph, node: NodeId, t: float | int, cfg: GammaSpec
 ) -> float:
-    """Γ = β · R(1-R) · sign(cos(θ_i - ψ))"""
+    """Compute Γ = β · R(1-R) · sign(cos(θ_i - ψ))."""
 
     return _gamma_kuramoto(G, node, cfg, _builder_bandpass, beta=0.0)
 
@@ -306,8 +305,7 @@ def eval_gamma(
     strict: bool = False,
     log_level: int | None = None,
 ) -> float:
-    """Evaluate Γi for ``node`` according to ``G.graph['GAMMA']``
-    specification.
+    """Evaluate Γi for ``node`` using ``G.graph['GAMMA']`` specification.
 
     If ``strict`` is ``True`` exceptions raised during evaluation are
     propagated instead of returning ``0.0``. Likewise, if the specified

--- a/src/tnfr/immutable.py
+++ b/src/tnfr/immutable.py
@@ -64,7 +64,7 @@ def _cycle_guard(value: Any, seen: set[int] | None = None) -> Iterator[set[int]]
 def _check_cycle(
     func: Callable[[Any, set[int] | None], FrozenSnapshot],
 ) -> Callable[[Any, set[int] | None], FrozenSnapshot]:
-    """Decorator applying :func:`_cycle_guard` to ``func``."""
+    """Apply :func:`_cycle_guard` to ``func``."""
 
     @wraps(func)
     def wrapper(value: Any, seen: set[int] | None = None) -> FrozenSnapshot:

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -1001,7 +1001,7 @@ def _record_metrics(
     *pairs: MetricRecord,
     evaluate: bool = False,
 ) -> None:
-    """Generic recorder for metric values."""
+    """Record metric values for the trace history."""
 
     metrics = cast(MutableMapping[str, list[Any]], hist)
     for payload, key in pairs:

--- a/src/tnfr/metrics/trig.py
+++ b/src/tnfr/metrics/trig.py
@@ -123,7 +123,7 @@ def _neighbor_phase_mean_generic(
     np: Any | None = None,
     fallback: float = 0.0,
 ) -> float:
-    """Internal helper delegating to :func:`_neighbor_phase_mean_core`.
+    """Compute the neighbour phase mean via :func:`_neighbor_phase_mean_core`.
 
     ``obj`` may be either a node bound to a graph or a sequence of neighbours.
     When ``cos_map`` and ``sin_map`` are ``None`` the function assumes ``obj`` is

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -180,7 +180,7 @@ def _trace_setup(
     dict[str, Any] | None,
     str | None,
 ]:
-    """Common configuration for trace snapshots.
+    """Prepare common configuration for trace snapshots.
 
     Returns the active configuration, capture set, history and key under
     which metadata will be stored. If tracing is disabled returns
@@ -214,7 +214,7 @@ EMPTY_MAPPING: Mapping[str, Any] = MappingProxyType({})
 
 
 def mapping_field(G: TNFRGraph, graph_key: str, out_key: str) -> TraceMetadata:
-    """Helper to copy mappings from ``G.graph`` into trace output."""
+    """Copy mappings from ``G.graph`` into trace output."""
     mapping = get_graph_mapping(
         G, graph_key, f"G.graph[{graph_key!r}] is not a mapping; ignoring"
     )
@@ -501,8 +501,7 @@ for spec in TRACE_FIELD_SPECS:
 
 
 def register_trace(G: TNFRGraph) -> None:
-    """Enable before/after-step snapshots and dump operational metadata
-    to history.
+    """Enable before/after-step snapshots and dump operational metadata to history.
 
     Trace snapshots are stored as :class:`TraceSnapshot` entries in
     ``G.graph['history'][TRACE.history_key]`` with:


### PR DESCRIPTION
## Summary
- configure pydocstyle via pyproject.toml using the numpy convention and legacy ignores
- update local and CI scripts to invoke python -m pydocstyle src/tnfr with the shared settings
- clean up affected docstrings and add the CLI package docstring so the global check passes

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68faaa8503ac832199419329e2bd3f7e