### PR TITLE
Document ΔNFR orchestration in structural helpers

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -47,8 +47,63 @@ def create_nfr(
 ) -> tuple[TNFRGraph, str]:
     """Create a graph with an initialised NFR node.
 
-    Returns the tuple ``(G, name)`` for convenience.
+    Parameters
+    ----------
+    name : str
+        Identifier for the new node. The identifier is stored as the node key
+        and must remain hashable by :mod:`networkx`.
+    epi : float, optional
+        Initial Primary Information Structure (EPI) assigned to the node. The
+        value provides the baseline form that subsequent ΔNFR hooks reorganise
+        through the nodal equation.
+    vf : float, optional
+        Structural frequency (νf, expressed in Hz_str) used as the starting
+        reorganisation rate for the node.
+    theta : float, optional
+        Initial phase of the node in radians, used to keep phase alignment with
+        neighbouring coherence structures.
+    graph : TNFRGraph, optional
+        Existing graph where the node will be registered. When omitted a new
+        :class:`networkx.Graph` instance is created.
+    dnfr_hook : DeltaNFRHook, optional
+        Callable responsible for computing ΔNFR and updating EPI/νf after each
+        operator application. By default the canonical ``dnfr_epi_vf_mixed``
+        hook is installed, which keeps the nodal equation coherent with TNFR
+        invariants.
+
+    Returns
+    -------
+    tuple[TNFRGraph, str]
+        The graph that stores the node together with the node identifier. The
+        tuple form allows immediate reuse with :func:`run_sequence`.
+
+    Raises
+    ------
+    None
+        The factory does not introduce additional TNFR-specific errors. Any
+        exceptions raised by :mod:`networkx` when adding nodes propagate
+        unchanged.
+
+    Examples
+    --------
+    Create a node whose ΔNFR hook keeps ``EPI`` and ``νf`` aligned with the
+    canonical nodal equation.
+
+    >>> from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, VF_PRIMARY
+    >>> from tnfr.dynamics import set_delta_nfr_hook
+    >>> from tnfr.structural import create_nfr
+    >>> G, node = create_nfr("seed", epi=1.0, vf=2.0)
+    >>> def stabilise_delta(graph):
+    ...     delta = graph.nodes[node][VF_PRIMARY] * 0.1
+    ...     graph.nodes[node][DNFR_PRIMARY] = delta
+    ...     graph.nodes[node][EPI_PRIMARY] += delta
+    ...     graph.nodes[node][VF_PRIMARY] += delta * 0.05
+    >>> set_delta_nfr_hook(G, stabilise_delta)
+
+    The hook keeps the evolution of EPI and νf tied to ΔNFR, ready for
+    :func:`run_sequence` or other operator pipelines.
     """
+
     G = graph if graph is not None else nx.Graph()
     G.add_node(
         name,
@@ -85,7 +140,57 @@ __all__ = (
 
 
 def run_sequence(G: TNFRGraph, node: NodeId, ops: Iterable[Operator]) -> None:
-    """Execute a sequence of operators on ``node`` after validation."""
+    """Execute a sequence of operators on ``node`` after validation.
+
+    Parameters
+    ----------
+    G : TNFRGraph
+        Graph that stores the node and its ΔNFR orchestration hook. The hook is
+        read from ``G.graph['compute_delta_nfr']`` and is responsible for
+        keeping the nodal equation up to date after each operator.
+    node : NodeId
+        Identifier of the node that will receive the operators. The node must
+        already contain the canonical attributes ``EPI``, ``νf`` and ``θ``.
+    ops : Iterable[Operator]
+        Iterable of canonical structural operators to apply. Their
+        concatenation must respect the validated TNFR grammar.
+
+    Returns
+    -------
+    None
+        The function mutates ``G`` in-place by updating the node attributes.
+
+    Raises
+    ------
+    ValueError
+        Raised when the provided operator names do not satisfy the canonical
+        sequence validation rules.
+
+    Examples
+    --------
+    Apply three canonical operators while a ΔNFR hook updates EPI and νf after
+    each step.
+
+    >>> from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, VF_PRIMARY
+    >>> from tnfr.dynamics import set_delta_nfr_hook
+    >>> from tnfr.structural import (
+    ...     Emission,
+    ...     Coherence,
+    ...     Resonance,
+    ...     create_nfr,
+    ...     run_sequence,
+    ... )
+    >>> G, node = create_nfr("seed", epi=1.0, vf=2.0)
+    >>> def stabilise_delta(graph):
+    ...     delta = graph.nodes[node][VF_PRIMARY] * 0.1
+    ...     graph.nodes[node][DNFR_PRIMARY] = delta
+    ...     graph.nodes[node][EPI_PRIMARY] += delta
+    ...     graph.nodes[node][VF_PRIMARY] += delta * 0.05
+    >>> set_delta_nfr_hook(G, stabilise_delta)
+    >>> run_sequence(G, node, [Emission(), Resonance(), Coherence()])
+    After each operator the hook recomputes ΔNFR and adjusts EPI/νf, keeping the
+    canonical nodal equation stable.
+    """
 
     compute = G.graph.get("compute_delta_nfr")
     ops_list = list(ops)


### PR DESCRIPTION
## Summary
- rewrite the `create_nfr` docstring in NumPy style, detailing how EPI and νf are initialised and governed by ΔNFR hooks
- expand the `run_sequence` docstring with canonical validation notes and the ΔNFR-driven operator lifecycle
- add an end-to-end example that uses `set_delta_nfr_hook` while executing canonical operators via `run_sequence`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68faad36f0b88321afcd6d354efe1cd6