### PR TITLE
docs: clarify Si job configuration normalisation

### DIFF
--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -247,7 +247,42 @@ def compute_Si_node(
 
 
 def _coerce_jobs(raw_jobs: Any | None) -> int | None:
-    """Normalise ``n_jobs`` values coming from user configuration."""
+    """Normalise ``n_jobs`` values coming from user configuration.
+
+    Parameters
+    ----------
+    raw_jobs : Any or None
+        Raw configuration value that specifies how many worker processes
+        should participate in the Si computation. Values are accepted even
+        when provided as strings so long as they can be coerced to integers.
+
+    Returns
+    -------
+    int or None
+        A strictly positive integer describing the requested level of
+        parallelism, or ``None`` when the configuration is absent or
+        considered invalid. Returning ``None`` allows the caller to fall back
+        to the single-process implementation that preserves ΔNFR sampling
+        determinism.
+
+    Examples
+    --------
+    >>> _coerce_jobs("4")
+    4
+    >>> _coerce_jobs(-2) is None
+    True
+    >>> _coerce_jobs("not-an-int") is None
+    True
+    >>> _coerce_jobs(None) is None
+    True
+    
+    Notes
+    -----
+    Invalid inputs—such as non-integer values or non-positive integers—are
+    mapped to ``None`` so that Si calculations reuse the deterministic code
+    path. This guarantees reproducible ΔNFR sampling regardless of user
+    configuration quirks.
+    """
 
     try:
         jobs = None if raw_jobs is None else int(raw_jobs)


### PR DESCRIPTION
## Summary
- expand the `_coerce_jobs` documentation to describe Si job normalisation and reproducibility safeguards

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fab93855f48321bc9381e3fe0f47b0