### PR TITLE
Document operator and metric docstring templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,12 @@ When contributing:
   module.
 - Write docstrings and comments in English and reference operators by their
   canonical English identifiers. Follow the
-  [NumPy-style docstring guide](docs/api/docstring_style.md) so automated tools
-  and reviewers can track how each API reorganises EPI, νf, and ΔNFR. Module
-  headers, public classes, public methods/functions, and magic methods must now
-  include a docstring; targeted ``# noqa: Dxxx`` suppressions require a short
+  [NumPy-style docstring guide](docs/api/docstring_style.md), including the
+  dedicated templates for `tnfr.operators.definitions` and
+  `tnfr.metrics.sense_index`, so automated tools and reviewers can trace how
+  each API reorganises EPI, νf, ΔNFR, and phase. Module headers, public
+  classes, public methods/functions, and magic methods must now include a
+  docstring; targeted ``# noqa: Dxxx`` suppressions require a short
   justification beside the directive.
 - Update existing code to migrate any remaining legacy strings to the English
   tokens.

--- a/docs/api/docstring_style.md
+++ b/docs/api/docstring_style.md
@@ -51,6 +51,99 @@ Examples
 - **Examples**: provide runnable fragments that show the expected workflow.
   Annotate EPI, νf, and ΔNFR values when it clarifies semantics.
 
+## Operators in `tnfr.operators.definitions`
+
+Operator classes describe how they reorganise coherence when applied to a
+node. Each docstring must explain the **structural effect** (what the operator
+does to EPI, ΔNFR, νf, and phase) before covering implementation notes. Use the
+following template when adding or updating operators:
+
+```python
+"""State the operator's structural effect in one sentence."""
+
+class Emission(Operator):
+    """Boost ΔNFR towards positive expansion while preserving phase locks."""
+
+    def __call__(self, graph, node, /, *, intensity=1.0):
+        """Apply the emission pulse to increase νf and ΔNFR coherently.
+
+        Parameters
+        ----------
+        graph : TNFRGraph
+            Graph containing the node; carries EPI, νf, ΔNFR, and phase data.
+        node : Hashable
+            Node receiving the emission. Document how the pulse alters its EPI.
+        intensity : float, default 1.0
+            Scales the emission; explain expected ΔNFR growth and phase guardrails.
+
+        Returns
+        -------
+        TNFRGraph
+            The updated graph. Describe telemetry adjustments (ΔNFR hooks, phase).
+
+        Examples
+        --------
+        >>> from tnfr import operators, structural
+        >>> G, node = structural.create_nfr("seed", epi=0.3, vf=1.0)
+        >>> op = operators.definitions.Emission(intensity=0.5)
+        >>> G = op(G, node)
+        >>> round(G.nodes[node]["vf"], 2)
+        1.0
+        >>> G.nodes[node]["phase"]
+        ...  # Illustrate phase guard and ΔNFR change (ΔNFR > 0).
+        """
+```
+
+**Reminders**
+
+- Highlight how ΔNFR shifts (sign, magnitude) and how νf and phase react.
+- Show an example where ΔNFR, νf, and phase are logged or asserted so reviewers
+  can trace the structural impact.
+
+## Metrics in `tnfr.metrics.sense_index`
+
+Metrics expose how coherence and sensing change over time. Docstrings must
+clarify how the metric reads ΔNFR and νf to produce a sense index while
+referencing phase as needed. Start from this template:
+
+```python
+def sense_index(graph, node):
+    """Compute Si by mapping ΔNFR, νf, and phase to a stability score.
+
+    Parameters
+    ----------
+    graph : TNFRGraph
+        Graph with stored ΔNFR traces, νf (Hz_str), and phase for each node.
+    node : Hashable
+        Node whose sensory coherence is measured. Describe expected ΔNFR bounds.
+
+    Returns
+    -------
+    float
+        Sense index (Si). Explain how ΔNFR, νf, and phase contribute to the
+        final value.
+
+    Examples
+    --------
+    >>> from tnfr import metrics, structural
+    >>> G, node = structural.create_nfr("seed", epi=0.8, vf=1.5)
+    >>> G.nodes[node]["phase"] = 0.0
+    >>> G.nodes[node]["delta_nfr"] = 0.12
+    >>> metrics.sense_index.sense_index(G, node)
+    0.92
+    >>> # Detail how ΔNFR and νf shifts change the score.
+    """
+```
+
+**Reminders**
+
+- Include a brief explanation of structural phase handling (e.g., phase drift
+  lowering Si).
+- Document telemetry expectations (ΔNFR traces or νf history) in the parameters
+  or returns section.
+- Ensure examples demonstrate how ΔNFR, νf, and phase values are set before the
+  metric call.
+
 ## Examples from `tnfr.structural`
 
 ### `create_nfr`


### PR DESCRIPTION
## Summary
- expand the docstring style guide with operator and sense index templates that emphasise structural effect descriptions
- remind contributors to document ΔNFR, νf, and phase in operator and metric examples
- reference the new guidance from CONTRIBUTING so docstring authors can find it quickly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb2d8d287483218bdf19e485aa5525