### PR TITLE
Add pydocstyle linting to test workflow

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,6 +34,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[test,numpy,yaml,orjson]
 
+      - name: Run docstring lint
+        if: matrix.python-version == '3.11'
+        run: python -m pydocstyle src/tnfr
+
       - name: Enforce English-only language policy
         run: python scripts/check_language.py
 


### PR DESCRIPTION
## Summary
- add a pydocstyle docstring linting step to the test suite workflow
- gate the lint step to the Python 3.11 matrix entry so failures block merges without duplication

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fb91278828832198ea47bdc5b33880