### PR TITLE
Clarify create_nfr docstring exception guidance

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -103,12 +103,10 @@ def create_nfr(
         The graph that stores the node together with the node identifier. The
         tuple form allows immediate reuse with :func:`run_sequence`.
 
-    Raises
-    ------
-    None
-        The factory does not introduce additional TNFR-specific errors. Any
-        exceptions raised by :mod:`networkx` when adding nodes propagate
-        unchanged.
+    Notes
+    -----
+    The factory does not introduce additional TNFR-specific errors. Any
+    exceptions raised by :mod:`networkx` when adding nodes propagate unchanged.
 
     Examples
     --------


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fb93893f80832181d54be60cb0e6e0