### PR TITLE
Add runtime clamp coverage tests

### DIFF
--- a/tests/unit/dynamics/test_runtime_clamps.py
+++ b/tests/unit/dynamics/test_runtime_clamps.py
@@ -1,0 +1,62 @@
+"""Tests for canonical clamp enforcement in runtime helpers."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tnfr.alias import get_attr, get_theta_attr
+from tnfr.dynamics.aliases import ALIAS_EPI, ALIAS_VF
+from tnfr.dynamics.runtime import apply_canonical_clamps
+
+
+def test_apply_canonical_clamps_clamps_and_logs(graph_canon):
+    """Nodal EPI/νf values clamp to bounds and strict graphs log alerts."""
+
+    G = graph_canon()
+    node = 0
+    G.add_node(node, psi=5.0, nu_f=-3.0, theta=math.pi + 0.05)
+    G.graph["VALIDATORS_STRICT"] = True
+    G.graph["THETA_WRAP"] = True
+
+    apply_canonical_clamps(G.nodes[node], G, node)
+
+    nd = G.nodes[node]
+    assert get_attr(nd, ALIAS_EPI, 0.0) == pytest.approx(1.0)
+    assert get_attr(nd, ALIAS_VF, 0.0) == pytest.approx(0.0)
+
+    wrapped_theta = get_theta_attr(nd, 0.0)
+    expected_theta = ((math.pi + 0.05 + math.pi) % (2 * math.pi)) - math.pi
+    assert wrapped_theta == pytest.approx(expected_theta)
+    assert -math.pi <= wrapped_theta < math.pi
+
+    alerts = G.graph["history"]["clamp_alerts"]
+    assert len(alerts) == 2
+
+    first = alerts[0]
+    assert first["node"] == node
+    assert first["attr"] == "EPI"
+    assert first["value"] == pytest.approx(5.0)
+
+    second = alerts[1]
+    assert second["node"] == node
+    assert second["attr"] == "VF"
+    assert second["value"] == pytest.approx(-3.0)
+
+
+def test_apply_canonical_clamps_updates_mapping_without_graph():
+    """When called without a graph the mapping itself is clamped and updated."""
+
+    node_data = {"psi": -5.0, "nu_f": 5.0, "theta": -math.pi - 0.2}
+
+    apply_canonical_clamps(node_data)
+
+    assert get_attr(node_data, ALIAS_EPI, 0.0) == pytest.approx(-1.0)
+    assert get_attr(node_data, ALIAS_VF, 0.0) == pytest.approx(1.0)
+
+    wrapped_theta = get_theta_attr(node_data, 0.0)
+    expected_theta = ((-math.pi - 0.2 + math.pi) % (2 * math.pi)) - math.pi
+    assert wrapped_theta == pytest.approx(expected_theta)
+    assert node_data["theta"] == pytest.approx(expected_theta)
+    assert node_data["phase"] == pytest.approx(expected_theta)


### PR DESCRIPTION
## Summary
- add unit tests covering canonical clamp enforcement, strict logging, and theta wrapping
- verify dictionary fallbacks update nodal mappings when no graph is provided

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fb999fe9708321ade92fceaf17961d