### PR TITLE
Add CLI test for conflicting sequence preset usage

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -121,6 +121,23 @@ def test_cli_sequence_file_invalid_json(tmp_path, capsys):
     assert f"Error parsing JSON file at {seq_path}" in captured.out
 
 
+def test_sequence_conflicting_preset_and_sequence_file(tmp_path, capsys):
+    seq_path = tmp_path / "sequence.json"
+    seq_path.write_text("[]", encoding="utf-8")
+
+    rc = main([
+        "sequence",
+        "--preset",
+        "demo",
+        "--sequence-file",
+        str(seq_path),
+    ])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "Cannot use --preset and --sequence-file at the same time" in captured.out
+
+
 def test_cli_metrics_generates_metrics_payload(monkeypatch, tmp_path):
     out = tmp_path / "metrics.json"
     sentinel_graph = object()


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Added an integration test covering `tnfr sequence` with both `--preset` and `--sequence-file` to ensure the CLI rejects conflicting inputs with the documented error message.

## Testing
- `pytest tests/integration/test_cli.py::test_sequence_conflicting_preset_and_sequence_file`


------
https://chatgpt.com/codex/tasks/task_e_68fbaabf65948321bbbe47a980ac63ca