### PR TITLE
Add regression test for integrator factory positional validation

### DIFF
--- a/tests/unit/dynamics/test_runtime_overrides.py
+++ b/tests/unit/dynamics/test_runtime_overrides.py
@@ -134,6 +134,16 @@ def test_call_integrator_factory_supports_zero_or_one_positional_argument():
     assert received is G
 
 
+def test_call_integrator_factory_rejects_multiple_positionals():
+    G = nx.Graph()
+
+    def bad_factory(graph, extra):
+        raise AssertionError("should not be called")
+
+    with pytest.raises(TypeError, match="at most one positional"):
+        runtime._call_integrator_factory(bad_factory, G)
+
+
 def test_call_integrator_factory_handles_non_introspectable_callable(monkeypatch):
     G = nx.Graph()
     calls = []


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add a unit test ensuring integrator factories that demand more than one positional argument raise a `TypeError`.


------
https://chatgpt.com/codex/tasks/task_e_68fbaf520f488321a4dbdbdb854b80a3