### PR TITLE
Add structural coverage for glyphless operator invocation

### DIFF
--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -151,3 +151,18 @@ def test_operator_base_types_exposed() -> None:
         Recursivity,
     ):
         assert issubclass(cls, Operator)
+
+
+def test_operator_requires_glyph_assignment(graph_canon) -> None:
+    class GlyphlessOperator(Operator):
+        glyph = None
+
+    op = GlyphlessOperator()
+    graph = graph_canon()
+    target = "node"
+    graph.add_node(target)
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        op(graph, target)
+
+    assert str(excinfo.value) == "Operator without assigned glyph"


### PR DESCRIPTION
Adds a regression test ensuring glyphless operators raise the canonical error when invoked.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fbb5f586288321ac6f4fbe8b63d290