### PR TITLE
Add CLI integration test for Erdos probability validation

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -222,6 +222,12 @@ def test_build_basic_graph_rejects_negative_probability():
         _cli_execution().build_basic_graph(args)
 
 
+def test_build_basic_graph_rejects_probability_above_one():
+    args = argparse.Namespace(nodes=3, topology="erdos", p=1.5, seed=None)
+    with pytest.raises(ValueError, match="p must be between 0 and 1; received 1.5"):
+        _cli_execution().build_basic_graph(args)
+
+
 def test_build_basic_graph_rejects_unknown_topology():
     args = argparse.Namespace(nodes=3, topology="invalid", p=None, seed=None)
     message = (


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Adds an integration test ensuring the CLI rejects Erdős–Rényi probability values above one with the expected error message.


------
https://chatgpt.com/codex/tasks/task_e_68fbbb3ceaa4832196823291679ae7ab