### PR TITLE
Add tests for CLI spec option normalization

### DIFF
--- a/tests/unit/cli/test_cli_utils.py
+++ b/tests/unit/cli/test_cli_utils.py
@@ -1,0 +1,25 @@
+"""Tests for :mod:`tnfr.cli.utils`."""
+
+from __future__ import annotations
+
+from tnfr.cli import utils
+
+
+def test_spec_normalizes_dotted_option_to_dest_and_default_none() -> None:
+    """A dotted or dashed option should normalize dest and default."""
+
+    opt, params = utils.spec("--grammar.enabled")
+
+    assert opt == "--grammar.enabled"
+    assert params["dest"] == "grammar_enabled"
+    assert params["default"] is None
+
+
+def test_spec_respects_explicit_dest_and_default() -> None:
+    """Explicit kwargs should remain unchanged when provided."""
+
+    opt, params = utils.spec("--grammar-enabled", dest="custom_dest", default=False)
+
+    assert opt == "--grammar-enabled"
+    assert params["dest"] == "custom_dest"
+    assert params["default"] is False


### PR DESCRIPTION
## Summary
- add a CLI unit test module covering tnfr.cli.utils.spec
- ensure dotted options normalize to grammar_enabled and default None
- verify explicit dest/default kwargs are preserved

## Testing
- pytest tests/unit/cli/test_cli_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68fc99a08fd483219125458ebf04f070