### PR TITLE
Add integration test for non-canonical glyph rejection

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -305,6 +305,11 @@ def test_thol_recursive_expansion():
     ]
 
 
+def test_compile_sequence_rejects_noncanonical_glyph():
+    with pytest.raises(ValueError, match="Non-canonical glyph"):
+        compile_sequence(["NOT_CANON"])
+
+
 @pytest.mark.parametrize(
     "bad, message",
     [


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

---

## Summary
- add an integration test ensuring `compile_sequence` rejects non-canonical glyph identifiers

## Testing
- pytest --override-ini addopts="" tests/integration/test_program.py -k noncanonical

------
https://chatgpt.com/codex/tasks/task_e_68fc9fc745e88321aea1d768ff263af5