### PR TITLE
Add unit tests for parse_program_tokens error handling

### DIFF
--- a/tests/unit/structural/test_parse_program_errors.py
+++ b/tests/unit/structural/test_parse_program_errors.py
@@ -1,0 +1,29 @@
+"""Focused tests for error handling in ``parse_program_tokens``."""
+
+import pytest
+
+from tnfr.flatten import parse_program_tokens
+
+
+def test_parse_program_tokens_rejects_multiple_keys_mapping():
+    payload = {"WAIT": 1, "THOL": {"body": []}}
+    with pytest.raises(ValueError, match="Invalid token mapping"):
+        parse_program_tokens([payload])
+
+
+def test_parse_program_tokens_rejects_unrecognized_token_key():
+    payload = {"BAD": 1}
+    with pytest.raises(ValueError, match="Unrecognized token"):
+        parse_program_tokens([payload])
+
+
+def test_parse_program_tokens_rejects_unknown_thol_closing_glyph():
+    payload = {"THOL": {"body": [], "close": "NOPE"}}
+    with pytest.raises(ValueError, match="Unknown closing glyph"):
+        parse_program_tokens([payload])
+
+
+def test_parse_program_tokens_requires_thol_close_glyph_type():
+    payload = {"THOL": {"body": [], "close": 123}}
+    with pytest.raises(TypeError, match="THOL close glyph must be"):
+        parse_program_tokens([payload])


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fca03b45b483218319cd0ecb30397f