### PR TITLE
Add tests for parsing errors and THOL forced closure

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -91,6 +91,13 @@ def test_flatten_accepts_wait_subclass():
     assert ops == [(OpTag.WAIT, 3)]
 
 
+def test_compile_sequence_emits_thol_force_close_sha():
+    program = [THOL(body=[Glyph.AL], force_close=Glyph.SHA)]
+    ops = compile_sequence(program)
+    assert ops[0] == (OpTag.THOL, Glyph.THOL.value)
+    assert ops[-1] == (OpTag.GLYPH, Glyph.SHA.value)
+
+
 def test_play_handles_deeply_nested_blocks(graph_canon):
     G = graph_canon()
     G.add_node(1)

--- a/tests/unit/structural/test_parse_program_errors.py
+++ b/tests/unit/structural/test_parse_program_errors.py
@@ -27,3 +27,13 @@ def test_parse_program_tokens_requires_thol_close_glyph_type():
     payload = {"THOL": {"body": [], "close": 123}}
     with pytest.raises(TypeError, match="THOL close glyph must be"):
         parse_program_tokens([payload])
+
+
+def test_parse_program_tokens_rejects_non_iterable_source():
+    with pytest.raises(TypeError, match="123 is not iterable"):
+        parse_program_tokens(123)
+
+
+def test_parse_program_tokens_requires_thol_mapping():
+    with pytest.raises(TypeError, match="THOL specification must be a mapping"):
+        parse_program_tokens([{"THOL": "bad"}])


### PR DESCRIPTION
## Summary
- add regression tests covering non-iterable sources and malformed THOL specifications in the parser
- ensure THOL blocks forced to close with Glyph.SHA emit the closing glyph when compiled

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fca3cee9648321925698109808e113