### PR TITLE
Add regression test for non-callable graph integrator

### DIFF
--- a/tests/unit/dynamics/test_runtime_overrides.py
+++ b/tests/unit/dynamics/test_runtime_overrides.py
@@ -205,6 +205,20 @@ def test_resolve_integrator_instance_rejects_non_integrator_returns():
         runtime._resolve_integrator_instance(G)
 
 
+def test_resolve_integrator_instance_rejects_non_callable_integrator():
+    G = nx.Graph()
+    G.graph["integrator"] = "not-a-callable"
+
+    with pytest.raises(
+        TypeError,
+        match="Graph integrator must be an AbstractIntegrator, subclass or callable",
+    ):
+        runtime._resolve_integrator_instance(G)
+
+    assert runtime._INTEGRATOR_CACHE_KEY not in G.graph
+    assert G.graph.pop(runtime._INTEGRATOR_CACHE_KEY, None) is None
+
+
 def test_resolve_integrator_instance_uses_cache(monkeypatch):
     G = nx.Graph()
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Added a unit test that configures a non-callable sentinel as the graph integrator, asserts the expected `TypeError`, and verifies the integrator cache key is not left behind after the failure.

------
https://chatgpt.com/codex/tasks/task_e_68fcc7151c64832186d599b973e0af6a