### PR TITLE
Document integration parameter validation and enforce DT_MIN floor

### DIFF
--- a/tests/unit/dynamics/test_integrators.py
+++ b/tests/unit/dynamics/test_integrators.py
@@ -12,6 +12,25 @@ from tnfr.dynamics import update_epi_via_nodal_equation, validate_canon
 from tnfr.initialization import init_node_attrs
 
 
+def test_prepare_integration_params_validations_and_dt_min():
+    G = nx.path_graph(3)
+    inject_defaults(G)
+
+    with pytest.raises(TypeError):
+        integrators_mod.prepare_integration_params(G, dt="bad")
+
+    with pytest.raises(ValueError):
+        integrators_mod.prepare_integration_params(G, dt=-0.1)
+
+    G.graph["DT_MIN"] = 0.2
+    dt_step, steps, _, _ = integrators_mod.prepare_integration_params(G, dt=0.5)
+    assert steps > 1
+    assert dt_step == pytest.approx(0.25)
+
+    with pytest.raises(ValueError):
+        integrators_mod.prepare_integration_params(G, method="heun")
+
+
 @pytest.mark.parametrize("method", ["euler", "rk4"])
 def test_epi_limits_preserved(method):
     G = nx.cycle_graph(6)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Documented explicit error handling and DT_MIN subdivision semantics in `prepare_integration_params`.
- Adjusted DT_MIN splitting to honour minimum step thresholds without reducing below them.
- Added deterministic unit coverage for invalid inputs and DT_MIN handling.

## Testing
- `pytest tests/unit/dynamics/test_integrators.py`


------
https://chatgpt.com/codex/tasks/task_e_68fcceb65a688321994032b489b78f16