### PR TITLE
Add regression tests for CacheManager capacity validation

### DIFF
--- a/tests/unit/structural/test_instrumented_lru_cache.py
+++ b/tests/unit/structural/test_instrumented_lru_cache.py
@@ -160,6 +160,19 @@ def test_clear_flushes_cache_and_metrics(
     assert stats.evictions == 2
 
 
+def test_configure_rejects_negative_capacity_and_preserves_state() -> None:
+    manager = CacheManager(default_capacity=8, overrides={"foo": 4})
+    baseline_config = manager.export_config()
+
+    with pytest.raises(ValueError):
+        manager.configure(default_capacity=-1)
+    assert manager.export_config() == baseline_config
+
+    with pytest.raises(ValueError):
+        manager.configure(overrides={"foo": -2})
+    assert manager.export_config() == baseline_config
+
+
 def test_callback_registration_runtime_updates() -> None:
     manager = CacheManager()
     recorder = _EventRecorder()


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add a unit test that instantiates CacheManager and verifies negative capacities raise ValueError
- assert export_config remains unchanged after invalid configuration attempts to guard against partial updates

------
https://chatgpt.com/codex/tasks/task_e_68fcd1cb1540832180f025fd3687b32c