### PR TITLE
Add regression test for load_config non-object rejection

### DIFF
--- a/tests/unit/structural/test_config_apply.py
+++ b/tests/unit/structural/test_config_apply.py
@@ -56,6 +56,18 @@ def test_load_config_accepts_mapping(monkeypatch, tmp_path):
     assert loaded == data
 
 
+def test_load_config_requires_object(monkeypatch, tmp_path):
+    def fake_reader(path):
+        return [("bad", "structure")]
+
+    monkeypatch.setattr("tnfr.config.init.read_structured_file", fake_reader)
+    path = tmp_path / "dummy.json"
+    path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain an object"):
+        load_config(path)
+
+
 def test_load_config_accepts_str(tmp_path):
     cfg = {"RANDOM_SEED": 7}
     path = tmp_path / "cfg.json"


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68fcd920a80c83219abfb51159bdfb3c