### PR TITLE
Add DNFR cache test for missing NumPy

### DIFF
--- a/tests/unit/dynamics/test_dnfr_precompute.py
+++ b/tests/unit/dynamics/test_dnfr_precompute.py
@@ -12,6 +12,7 @@ from tnfr.dynamics import (
     _compute_dnfr,
     _prepare_dnfr_data,
 )
+from tnfr.dynamics.dnfr import DnfrCache, _ensure_cached_array
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
@@ -180,3 +181,23 @@ def test_prepare_dnfr_raises_when_cache_state_missing(monkeypatch):
         prepare_dnfr_data(G)
 
     assert fake_manager.rebuild_attempted
+
+
+def test_ensure_cached_array_requires_numpy():
+    cache = DnfrCache(
+        idx={},
+        theta=[],
+        epi=[],
+        vf=[],
+        cos_theta=[],
+        sin_theta=[],
+        neighbor_x=[],
+        neighbor_y=[],
+        neighbor_epi_sum=[],
+        neighbor_vf_sum=[],
+        neighbor_count=[],
+        neighbor_deg_sum=None,
+    )
+
+    with pytest.raises(RuntimeError, match="NumPy is required"):
+        _ensure_cached_array(cache, "dense_components_np", (4, 4), np=None)


### PR DESCRIPTION
## Summary
- add a unit test that ensures `_ensure_cached_array` raises when NumPy is unavailable

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fcdb6b9abc8321b557fc6b668bb89e