### PR TITLE
Add integration test for metrics default step count

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -195,6 +195,25 @@ def test_cli_metrics_accepts_summary_limit(monkeypatch):
     assert recorded["series_limit"] == 7
 
 
+def test_cli_metrics_uses_default_steps(monkeypatch):
+    recorded: dict[str, Any] = {}
+
+    def fake_run_cli_program(args):  # noqa: ANN001 - test helper
+        recorded["args_steps"] = getattr(args, "steps", None)
+        return 0, object()
+
+    def fake_build_summary(graph, *, series_limit=None):  # noqa: ANN001 - test helper
+        return {}, False
+
+    monkeypatch.setattr("tnfr.cli.execution._run_cli_program", fake_run_cli_program)
+    monkeypatch.setattr("tnfr.cli.execution.build_metrics_summary", fake_build_summary)
+
+    rc = main(["metrics"])
+
+    assert rc == 0
+    assert recorded["args_steps"] == 200
+
+
 def test_cli_run_saves_history_when_requested(monkeypatch, tmp_path):
     sentinel_history = {"history": "sentinel"}
     saved_calls: deque[tuple[str, Any]] = deque()


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fce30d6f308321a127fb1431128dd5