### PR TITLE
Add regression ensuring runtime.run negative steps stay side-effect free

### DIFF
--- a/tests/unit/dynamics/test_dynamics_run.py
+++ b/tests/unit/dynamics/test_dynamics_run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from collections import deque
 from typing import Any
 
@@ -314,3 +315,19 @@ def test_run_rejects_negative_steps(graph_canon):
 
     with pytest.raises(ValueError, match="must be non-negative"):
         runtime.run(G, steps=-1)
+
+
+def test_run_negative_steps_preserve_stop_state_and_history(graph_canon):
+    """Rejecting negative steps must leave STOP_EARLY state and history untouched."""
+
+    G = graph_canon()
+    stop_cfg_before = copy.deepcopy(G.graph.get("STOP_EARLY"))
+    assert stop_cfg_before is not None
+    # ``history`` should not be created or mutated when ``run`` aborts early.
+    G.graph.pop("history", None)
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        runtime.run(G, steps=-1)
+
+    assert G.graph.get("STOP_EARLY") == stop_cfg_before
+    assert "history" not in G.graph


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68fcf0d7b09483219c6e14a7281fea44