### PR TITLE
Add strict convert_value propagation test

### DIFF
--- a/tests/unit/structural/test_value_utils.py
+++ b/tests/unit/structural/test_value_utils.py
@@ -2,6 +2,8 @@
 
 import logging
 
+import pytest
+
 from tnfr.utils import convert_value
 
 
@@ -27,3 +29,14 @@ def test_convert_value_logs_custom_level(caplog):
     assert not ok and result is None
     assert len(caplog.records) == 1
     assert caplog.records[0].levelno == logging.INFO
+
+
+def test_convert_value_strict_propagates(caplog):
+    def conv(_):
+        raise ValueError("bad")
+
+    with caplog.at_level(logging.DEBUG, logger="tnfr.utils.data"):
+        with pytest.raises(ValueError):
+            convert_value("x", conv, strict=True)
+
+    assert not caplog.records


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fcf22cfbe88321bdcb93759e4d5198