### PR TITLE
Add regression test for repeated negative weight warnings

### DIFF
--- a/tests/unit/structural/test_normalize_weights.py
+++ b/tests/unit/structural/test_normalize_weights.py
@@ -74,6 +74,23 @@ def test_normalize_weights_warn_once(caplog):
     assert any("Negative weights" in m for m in caplog.messages)
 
 
+def test_normalize_weights_warns_each_time_when_dedup_disabled(caplog):
+    key = "warn-disabled-key"
+    weights = {key: -1.0}
+
+    with caplog.at_level("WARNING"):
+        normalize_weights(weights, (key,), warn_once=False)
+    first_messages = [m for m in caplog.messages if "Negative weights" in m]
+    assert first_messages, "First invocation should warn about negative weights"
+
+    caplog.clear()
+
+    with caplog.at_level("WARNING"):
+        normalize_weights(weights, (key,), warn_once=False)
+    second_messages = [m for m in caplog.messages if "Negative weights" in m]
+    assert second_messages, "Second invocation should warn when deduplication disabled"
+
+
 def test_normalize_weights_raises_on_non_numeric_value():
     weights = {"a": "not-a-number", "b": 2.0}
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Summary
- Added a regression test that ensures negative weight warnings are emitted on each call when `warn_once` is disabled.

### Testing
- pytest tests/unit/structural/test_normalize_weights.py

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fcf2d2a760832185ecf0729dec9109