### PR TITLE
Add CLI callback registration unit test

### DIFF
--- a/tests/unit/cli/test_callbacks.py
+++ b/tests/unit/cli/test_callbacks.py
@@ -1,0 +1,45 @@
+"""Tests for callback registration in :mod:`tnfr.cli.execution`."""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from tnfr.cli import execution
+
+
+@pytest.fixture(name="callback_names")
+def _callback_names() -> tuple[str, ...]:
+    return (
+        "register_sigma_callback",
+        "register_metrics_callbacks",
+        "register_trace",
+        "_metrics_step",
+        "validate_canon",
+    )
+
+
+@pytest.mark.parametrize("graph_factory", [nx.Graph])
+def test_register_callbacks_and_observer_invokes_all(
+    monkeypatch: pytest.MonkeyPatch,
+    callback_names: tuple[str, ...],
+    graph_factory: type[nx.Graph],
+) -> None:
+    """``register_callbacks_and_observer`` should invoke each helper once."""
+
+    calls: dict[str, int] = {name: 0 for name in callback_names}
+    graph = graph_factory()
+
+    def make_stub(func_name: str):
+        def _stub(*args, **kwargs):
+            calls[func_name] += 1
+            return None
+
+        return _stub
+
+    for name in callback_names:
+        monkeypatch.setattr(execution, name, make_stub(name))
+
+    execution.register_callbacks_and_observer(graph)
+
+    assert calls == {name: 1 for name in callback_names}


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add a CLI-focused unit test that monkeypatches callback helpers and verifies `register_callbacks_and_observer` invokes each of them once

## Testing
- pytest tests/unit/cli/test_callbacks.py


------
https://chatgpt.com/codex/tasks/task_e_68fcf67693b48321b50fdc5627f73a06