### PR TITLE
Add regression tests for graph metadata utilities

### DIFF
--- a/tests/unit/structural/test_utils_graph.py
+++ b/tests/unit/structural/test_utils_graph.py
@@ -1,0 +1,22 @@
+import pytest
+
+from tnfr.utils.graph import get_graph, get_graph_mapping
+
+
+class Sentinel:
+    """Simple sentinel lacking a ``graph`` attribute."""
+
+
+def test_get_graph_raises_type_error_for_unsupported_object():
+    with pytest.raises(TypeError, match="Unsupported graph object: metadata mapping not accessible"):
+        get_graph(Sentinel())
+
+
+def test_get_graph_mapping_warns_and_returns_none_for_non_mapping_value():
+    graph = {"tnfr": ["not", "a", "mapping"]}
+    warn_msg = "tnfr metadata must be a mapping"
+
+    with pytest.warns(UserWarning, match=warn_msg):
+        result = get_graph_mapping(graph, "tnfr", warn_msg)
+
+    assert result is None


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Adds structural tests covering error handling paths in `tnfr.utils.graph`, ensuring unsupported objects raise the documented `TypeError` and non-mapping metadata emits the expected warning while returning `None`.

------
https://chatgpt.com/codex/tasks/task_e_68fd06922be083218d338947b174ccd6