### PR TITLE
Add test for trace verbosity fallback to debug

### DIFF
--- a/tests/unit/structural/test_trace.py
+++ b/tests/unit/structural/test_trace.py
@@ -151,6 +151,22 @@ def test_trace_debug_verbosity_includes_all_fields(graph_canon):
     assert "glyphs" in after
 
 
+def test_trace_unknown_verbosity_warns_and_defaults(graph_canon):
+    G = graph_canon()
+    G.graph["TRACE"]["verbosity"] = "mystery"
+
+    with pytest.warns(UserWarning):
+        register_trace(G)
+        callback_manager.invoke_callbacks(G, CallbackEvent.BEFORE_STEP.value)
+        callback_manager.invoke_callbacks(G, CallbackEvent.AFTER_STEP.value)
+
+    hist = G.graph["history"]["trace_meta"]
+    after = hist[1]
+
+    assert after["phase"] == "after"
+    assert "glyphs" in after
+
+
 def test_callback_names_spec():
     """CallbackSpec entries are handled correctly."""
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

- Add a regression test ensuring an unknown TRACE verbosity emits a warning and falls back to the debug preset.
- Confirm the debug preset still records glyph metadata after invoking both before/after callbacks.


------
https://chatgpt.com/codex/tasks/task_e_68fd279302a88321addeaa698842d7a8