### PR TITLE
Add regression tests for callbacks_field corruption handling

### DIFF
--- a/tests/unit/structural/test_trace.py
+++ b/tests/unit/structural/test_trace.py
@@ -15,6 +15,7 @@ from tnfr.trace import (
     CallbackSpec,
     TraceFieldSpec,
     _callback_names,
+    callbacks_field,
     gamma_field,
     grammar_field,
     mapping_field,
@@ -191,6 +192,20 @@ def test_grammar_field_non_mapping_warns(graph_canon):
     with pytest.warns(UserWarning):
         out = grammar_field(G)
     assert out == {}
+
+
+def test_callbacks_field_non_mapping_returns_empty(graph_canon):
+    G = graph_canon()
+    G.graph["callbacks"] = "not-a-mapping"
+
+    assert callbacks_field(G) == {}
+
+
+def test_callbacks_field_scalar_entries_are_sanitised(graph_canon):
+    G = graph_canon()
+    G.graph["callbacks"] = {"before_step": 42}
+
+    assert callbacks_field(G) == {"callbacks": {"before_step": None}}
 
 
 def test_mapping_field_returns_proxy(graph_canon):


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fd2a5b47fc8321a94f63f65816cb9d