### PR TITLE
Add structural test ensuring ΔNFR hook fires per operator

### DIFF
--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -52,6 +52,25 @@ def test_sequence_validation_and_run() -> None:
     assert EPI_PRIMARY in G.nodes[n]
 
 
+def test_run_sequence_triggers_dnfr_hook_every_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    G, node = create_nfr("dnfr")
+    ops = [Emission(), Reception(), Coherence()]
+    call_counter = {"count": 0}
+
+    def stub(graph: nx.Graph, *, n_jobs: int | None = None) -> None:  # pragma: no cover - signature only
+        del n_jobs
+        call_counter["count"] += 1
+
+    monkeypatch.setattr("tnfr.structural.validate_sequence", lambda names: (True, "ok"))
+    G.graph["compute_delta_nfr"] = stub
+
+    run_sequence(G, node, ops)
+
+    assert call_counter["count"] == len(ops)
+
+
 def test_invalid_sequence() -> None:
     ops = [Reception(), Coherence(), Silence()]
     names = [op.name for op in ops]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add a structural unit test that validates `run_sequence` invokes the configured `compute_delta_nfr` hook for each operator by replacing it with a counting stub

## Testing
- `pytest tests/unit/structural/test_structural.py -k dnfr`


------
https://chatgpt.com/codex/tasks/task_e_68fd36c84d8c83219a8cd2182873f825