### PR TITLE
Add integration test for unsupported compile tokens

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -398,6 +398,18 @@ def test_thol_repeat_lt_one_raises():
         compile_sequence([THOL(body=[], repeat=0)])
 
 
+def test_flatten_rejects_unsupported_token_type():
+    class CustomTarget(TARGET):
+        pass
+
+    token = CustomTarget([1])
+    ops = compile_sequence([token])
+    assert ops == [(OpTag.TARGET, token)]
+
+    with pytest.raises(TypeError, match="Unsupported token"):
+        compile_sequence([object()])
+
+
 def test_thol_evaluator_multiple_repeats():
     ops = compile_sequence([THOL(body=[Glyph.AL, Glyph.RA], repeat=3)])
     assert ops == [


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Adds an integration test that ensures `compile_sequence` surfaces a `TypeError` for unsupported tokens while still permitting subclasses of canonical tokens like `TARGET`.


------
https://chatgpt.com/codex/tasks/task_e_68fd3b04cd1883219c1c2b56de7ab4ec