### PR TITLE
Handle non-iterable STOP_EARLY stable_frac history

### DIFF
--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import inspect
 import math
 import sys
-from collections.abc import Mapping, MutableMapping, MutableSequence
+from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence
+from numbers import Real
 from typing import Any, cast
 
 from ..alias import (
@@ -747,8 +748,15 @@ def run(
         )
         if stop_enabled:
             history = ensure_history(G)
-            series = history.get("stable_frac", [])
-            if not isinstance(series, list):
-                series = list(series)
-            if len(series) >= w and all(v >= frac for v in series[-w:]):
+            raw_series = dict.get(history, "stable_frac", [])
+            if not isinstance(raw_series, Iterable):
+                series = []
+            elif isinstance(raw_series, list):
+                series = raw_series
+            else:
+                series = list(raw_series)
+            numeric_series = [v for v in series if isinstance(v, Real)]
+            if len(numeric_series) >= w and all(
+                v >= frac for v in numeric_series[-w:]
+            ):
                 break


### PR DESCRIPTION
## Summary
- guard STOP_EARLY stability window evaluation against non-iterable history entries and ignore non-real samples
- add a regression test that seeds `stable_frac` with `None` and confirms early stopping still appends new values

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Testing
- pytest tests/unit/dynamics/test_dynamics_run.py


------
https://chatgpt.com/codex/tasks/task_e_68fd3ebe01a48321a6b21b0285a4e5e1