### PR TITLE
Add integration test for zero materialize generator handling

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -393,6 +393,19 @@ def test_flatten_enforces_limit_for_iterables():
         compile_sequence(token_stream(), max_materialize=3)
 
 
+def test_compile_sequence_zero_materialize_stops_iteration():
+    events: list[str] = []
+
+    def token_stream():
+        events.append("iterated")
+        yield Glyph.AL
+
+    ops = compile_sequence(token_stream(), max_materialize=0)
+
+    assert ops == []
+    assert events == []
+
+
 def test_thol_repeat_lt_one_raises():
     with pytest.raises(ValueError, match="repeat must be ≥1"):
         compile_sequence([THOL(body=[], repeat=0)])


### PR DESCRIPTION
- add an integration test covering `compile_sequence` with a generator and `max_materialize=0`
- verify no operations are emitted and the generator remains unconsumed

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fdd696ca4883219da04e44e7eadcd9