### PR TITLE
Add integration test for compile_sequence non-iterable input

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -161,6 +161,11 @@ def test_flatten_accepts_wait_subclass():
     assert ops == [(OpTag.WAIT, 3)]
 
 
+def test_compile_sequence_rejects_non_iterable():
+    with pytest.raises(TypeError, match="is not iterable"):
+        compile_sequence(object())
+
+
 def test_compile_sequence_emits_thol_force_close_sha():
     program = [THOL(body=[Glyph.AL], force_close=Glyph.SHA)]
     ops = compile_sequence(program)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Adds an integration test asserting that `compile_sequence(object())` raises a `TypeError` containing "is not iterable", ensuring deterministic handling of invalid inputs.


------
https://chatgpt.com/codex/tasks/task_e_68fdd744a908832193ddee2d2f178742