### PR TITLE
Add regression test for ΔNFR hook note metadata

### DIFF
--- a/tests/unit/dynamics/test_dnfr_hooks.py
+++ b/tests/unit/dynamics/test_dnfr_hooks.py
@@ -97,3 +97,21 @@ def test_set_delta_nfr_hook_ignores_jobs_when_missing(graph_canon):
     compute = G.graph["compute_delta_nfr"]
     compute(G, n_jobs=5)
     assert calls == [True]
+
+
+def test_set_delta_nfr_hook_records_note(graph_canon):
+    G = graph_canon()
+    note = "ΔNFR guided by νf"
+
+    def hook(graph, *, n_jobs=None):
+        for node_id in graph.nodes:
+            graph.nodes[node_id][ALIAS_DNFR[0]] = 0.0
+
+    set_delta_nfr_hook(G, hook, note=note)
+    compute = G.graph["compute_delta_nfr"]
+
+    try:
+        compute(G)
+        assert G.graph["_DNFR_META"]["note"] == note
+    finally:
+        G.graph.get("_DNFR_META", {}).pop("note", None)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fddb3a63708321bfc47406711b5353