### PR TITLE
Guard ΔNFR against non-finite node attributes

### DIFF
--- a/tests/unit/structural/test_value_utils.py
+++ b/tests/unit/structural/test_value_utils.py
@@ -40,3 +40,14 @@ def test_convert_value_strict_propagates(caplog):
             convert_value("x", conv, strict=True)
 
     assert not caplog.records
+
+
+def test_convert_value_rejects_non_finite(caplog):
+    def conv(_):
+        return float("nan")
+
+    with caplog.at_level(logging.DEBUG, logger="tnfr.utils.data"):
+        ok, result = convert_value("x", conv, key="foo")
+
+    assert not ok and result is None
+    assert any("Non-finite value for 'foo'" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- reject non-finite scalar conversions and log the fallback path
- assert ΔNFR clamps invalid nodes in vectorised and Python paths while capturing telemetry
- extend value conversion tests to cover the new clamp

------
https://chatgpt.com/codex/tasks/task_e_68fddbc1407c8321a1cedddc47507ce6