### PR TITLE
Add CLI run overrides integration test

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -127,6 +127,26 @@ def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     )
     add_common_args(p_run)
     p_run.add_argument("--steps", type=int, default=100)
+    p_run.add_argument(
+        "--use-Si",
+        dest="use_Si",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Recompute the Sense Index during the run (use --no-use-Si to disable)",
+    )
+    p_run.add_argument(
+        "--apply-glyphs",
+        dest="apply_glyphs",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Apply glyphs at every step (use --no-apply-glyphs to disable)",
+    )
+    p_run.add_argument(
+        "--dnfr-n-jobs",
+        dest="dnfr_n_jobs",
+        type=int,
+        help="Override ΔNFR parallel jobs forwarded to the runtime",
+    )
     add_canon_toggle(p_run)
     add_grammar_selector_args(p_run)
     add_history_export_args(p_run)

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -247,6 +247,13 @@ def run_program(
             if value is not None:
                 run_kwargs[attr] = value
 
+        job_overrides: dict[str, Any] = {}
+        dnfr_jobs = getattr(args, "dnfr_n_jobs", None)
+        if dnfr_jobs is not None:
+            job_overrides["dnfr_n_jobs"] = int(dnfr_jobs)
+        if job_overrides:
+            run_kwargs["n_jobs"] = job_overrides
+
         run(G, steps=steps, **run_kwargs)
     else:
         play(G, program)

--- a/tests/integration/test_cli_run_execution.py
+++ b/tests/integration/test_cli_run_execution.py
@@ -1,0 +1,109 @@
+"""Integration coverage for the CLI ``run`` command calling the runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx  # type: ignore[import-untyped]
+import pytest
+
+from tnfr.cli import main
+
+
+def test_cli_run_invokes_runtime_with_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure ``tnfr run`` forwards overrides to the runtime entry point."""
+
+    build_args: dict[str, Any] = {}
+    runtime_calls: list[dict[str, Any]] = []
+
+    def fake_build_basic_graph(args):  # noqa: ANN001 - test helper
+        build_args["nodes"] = args.nodes
+        build_args["topology"] = args.topology
+        graph = nx.Graph()
+        graph.add_nodes_from(range(args.nodes))
+        graph.graph["history"] = {"C_steps": []}
+        graph.graph["hooks"] = {}
+        return graph
+
+    def fake_prepare_network(graph: nx.Graph) -> None:
+        graph.graph["prepared"] = True
+
+    def fake_register_callbacks(graph: nx.Graph) -> None:
+        graph.graph["hooks"]["registered"] = True
+
+    def fake_ensure_history(graph: nx.Graph) -> dict[str, Any]:
+        return graph.graph.setdefault("history", {"C_steps": []})
+
+    def fake_runtime_run(
+        graph: nx.Graph,
+        *,
+        steps: int,
+        dt: float | None = None,
+        use_Si: bool = True,
+        apply_glyphs: bool = True,
+        n_jobs: dict[str, Any] | None = None,
+    ) -> None:
+        runtime_calls.append(
+            {
+                "graph": graph,
+                "steps": steps,
+                "dt": dt,
+                "use_Si": use_Si,
+                "apply_glyphs": apply_glyphs,
+                "n_jobs": n_jobs,
+            }
+        )
+        history = graph.graph.setdefault("history", {"C_steps": []})
+        history.setdefault("C_steps", []).append({"step": steps, "dt": dt})
+        graph.graph.setdefault("hook_metadata", {})["runtime"] = {
+            "apply_glyphs": apply_glyphs,
+            "n_jobs": n_jobs,
+        }
+
+    monkeypatch.setattr("tnfr.cli.execution.build_basic_graph", fake_build_basic_graph)
+    monkeypatch.setattr("tnfr.cli.execution.prepare_network", fake_prepare_network)
+    monkeypatch.setattr(
+        "tnfr.cli.execution.register_callbacks_and_observer", fake_register_callbacks
+    )
+    monkeypatch.setattr("tnfr.cli.execution.ensure_history", fake_ensure_history)
+    monkeypatch.setattr("tnfr.cli.execution._log_run_summaries", lambda *_, **__: None)
+    monkeypatch.setattr("tnfr.dynamics.runtime.run", fake_runtime_run)
+    monkeypatch.setattr("tnfr.cli.execution.run", fake_runtime_run)
+
+    rc = main(
+        [
+            "run",
+            "--nodes",
+            "4",
+            "--steps",
+            "2",
+            "--topology",
+            "complete",
+            "--dnfr-n-jobs",
+            "3",
+            "--dt",
+            "0.125",
+            "--no-use-Si",
+            "--no-apply-glyphs",
+        ]
+    )
+
+    assert rc == 0
+    assert build_args == {"nodes": 4, "topology": "complete"}
+    assert len(runtime_calls) == 1
+    call = runtime_calls[0]
+    assert call["steps"] == 2
+    assert call["dt"] == pytest.approx(0.125)
+    assert call["use_Si"] is False
+    assert call["apply_glyphs"] is False
+    assert call["n_jobs"] == {"dnfr_n_jobs": 3}
+
+    graph = call["graph"]
+    assert graph.graph["prepared"] is True
+    assert graph.graph["hooks"]["registered"] is True
+    history = graph.graph["history"]
+    assert history["C_steps"]
+    assert graph.graph["hook_metadata"]["runtime"] == {
+        "apply_glyphs": False,
+        "n_jobs": {"dnfr_n_jobs": 3},
+    }


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Extend the ``tnfr run`` parser with optional Sense Index toggles, glyph control, and ΔNFR job override flags.
- Ensure CLI execution forwards the dnfr job override mapping into ``runtime.run`` when provided.
- Add an integration test that monkeypatches the runtime to verify overrides, history updates, and metadata propagation when invoking ``main`` with edge-case flags.

## Testing
- pytest tests/integration/test_cli_run_execution.py

------
https://chatgpt.com/codex/tasks/task_e_68fde6e5b2848321b7a1b675d3bcf2f1