### PR TITLE
Add CLI regression test for DNFR job override

### DIFF
--- a/tests/unit/cli/test_run_program_sequence.py
+++ b/tests/unit/cli/test_run_program_sequence.py
@@ -138,3 +138,28 @@ def test_run_program_with_null_program_uses_run_mode(
             {"dt": 0.25, "use_Si": False, "apply_glyphs": False},
         )
     ]
+
+
+def test_run_program_forwards_dnfr_jobs_override(
+    simple_graph: nx.Graph,
+    base_args: argparse.Namespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = argparse.Namespace(**vars(base_args), dnfr_n_jobs=3)
+
+    run_kwargs: dict[str, object] = {}
+
+    def fake_run(graph: nx.Graph, **kwargs: object) -> None:
+        run_kwargs.update(kwargs)
+        assert graph is simple_graph
+
+    monkeypatch.setattr(execution, "run", fake_run)
+    monkeypatch.setattr(execution, "_persist_history", lambda *_: None)
+
+    result = execution.run_program(simple_graph, None, args)
+
+    assert result is simple_graph
+    assert run_kwargs == {
+        "steps": 50,
+        "n_jobs": {"dnfr_n_jobs": 3},
+    }


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Adds a regression test that exercises `run_program` when invoked without a program to ensure `dnfr_n_jobs` CLI overrides are forwarded to `execution.run` via the `n_jobs` keyword argument.


------
https://chatgpt.com/codex/tasks/task_e_68fded8fb48c8321a2254ba01c875239