### PR TITLE
Add regression test for simultaneous history save and export

### DIFF
--- a/tests/unit/cli/test_history_persistence.py
+++ b/tests/unit/cli/test_history_persistence.py
@@ -137,3 +137,43 @@ def test_persist_history_exports_metrics(
     assert saved_payloads == []
     assert exported_payloads == [(graph, str(base_path), "jsonl")]
     assert graph.graph["history"] is history
+
+
+def test_persist_history_handles_save_and_export_simultaneously(
+    graph_with_history: tuple[nx.Graph, dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    graph, history = graph_with_history
+    destination = tmp_path / "history.json"
+    base_path = tmp_path / "export"
+    args = argparse.Namespace(
+        save_history=str(destination),
+        export_history_base=str(base_path),
+        export_format="jsonl",
+    )
+
+    ensure_args: list[nx.Graph] = []
+    saved_payloads: list[tuple[str, dict[str, Any]]] = []
+    exported_payloads: list[tuple[nx.Graph, str, str]] = []
+
+    def fake_ensure_history(G: nx.Graph) -> dict[str, Any]:
+        ensure_args.append(G)
+        return history
+
+    def fake_save_json(path: str, data: dict[str, Any]) -> None:
+        saved_payloads.append((path, data))
+
+    def fake_export_metrics(G: nx.Graph, base: str, *, fmt: str) -> None:
+        exported_payloads.append((G, base, fmt))
+
+    monkeypatch.setattr(execution, "ensure_history", fake_ensure_history)
+    monkeypatch.setattr(execution, "_save_json", fake_save_json)
+    monkeypatch.setattr(execution, "export_metrics", fake_export_metrics)
+
+    execution._persist_history(graph, args)
+
+    assert ensure_args == [graph]
+    assert saved_payloads == [(str(destination), history)]
+    assert exported_payloads == [(graph, str(base_path), "jsonl")]
+    assert graph.graph["history"] is history


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add coverage ensuring `_persist_history` handles saving JSON history and exporting metrics in the same invocation
- validate the regression using deterministic paths provided by `tmp_path`

## Testing
- pytest -o addopts="" tests/unit/cli/test_history_persistence.py


------
https://chatgpt.com/codex/tasks/task_e_68fdedfc3860832196a6f9b53ebb35bd