### PR TITLE
Add threshold node sampling determinism test

### DIFF
--- a/tests/unit/dynamics/test_node_sample.py
+++ b/tests/unit/dynamics/test_node_sample.py
@@ -41,6 +41,27 @@ def test_node_sample_small_graph(graph_canon):
     assert len(sample) == len(G.nodes())
 
 
+def test_node_sample_threshold_graph_uses_candidate_count(graph_canon):
+    clear_rng_cache()
+    G = _build_graph(50, graph_canon)
+    G.graph["UM_CANDIDATE_COUNT"] = 7
+    G.graph["RANDOM_SEED"] = 999
+    _update_node_sample(G, step=3)
+    sample1 = G.graph.get("_node_sample")
+    assert isinstance(sample1, list)
+    assert len(sample1) == 7
+    assert set(sample1).issubset(set(G.nodes()))
+
+    clear_rng_cache()
+    G_repeat = _build_graph(50, graph_canon)
+    G_repeat.graph["UM_CANDIDATE_COUNT"] = 7
+    G_repeat.graph["RANDOM_SEED"] = 999
+    _update_node_sample(G_repeat, step=3)
+    sample2 = G_repeat.graph.get("_node_sample")
+
+    assert sample1 == sample2
+
+
 def test_node_sample_immutable_after_graph_change(graph_canon):
     G = _build_graph(20, graph_canon)
     _update_node_sample(G, step=0)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add a regression test to confirm the 50-node sampling guard emits a list sized to `UM_CANDIDATE_COUNT`
- verify seeded determinism at the guard boundary by repeating the sampling call after clearing cached RNG state

## Testing
- `pytest tests/unit/dynamics/test_node_sample.py` *(fails: missing plugin providing --benchmark-skip)*

------
https://chatgpt.com/codex/tasks/task_e_68fdf0715d8483218251aad170d5a351