### PR TITLE
Add regression test for cached DNFR vector buffers without get_numpy

### DIFF
--- a/tests/unit/dynamics/test_dnfr_vectorization_flags.py
+++ b/tests/unit/dynamics/test_dnfr_vectorization_flags.py
@@ -6,7 +6,12 @@ import pytest
 import tnfr.dynamics.dnfr as dnfr_module
 from tnfr.alias import collect_attr, set_attr
 from tnfr.constants import get_aliases
-from tnfr.dynamics.dnfr import _compute_dnfr, _prepare_dnfr_data
+from tnfr.dynamics.dnfr import (
+    _build_neighbor_sums_common,
+    _compute_dnfr,
+    _compute_dnfr_common,
+    _prepare_dnfr_data,
+)
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
@@ -138,3 +143,81 @@ def test_compute_dnfr_loop_path_without_numpy_module(monkeypatch):
     _assert_loop_state(data)
     dnfr_values = collect_attr(G, G.nodes, ALIAS_DNFR, 0.0)
     assert all(isinstance(val, float) for val in dnfr_values)
+
+
+def test_build_neighbor_sums_uses_cached_numpy_when_get_numpy_none(monkeypatch):
+    np = pytest.importorskip("numpy")
+
+    G = _graph_fixture()
+    data = _prepare_dnfr_data(G)
+
+    data["prefer_sparse"] = True
+    data["A"] = None
+
+    _compute_dnfr(G, data)
+
+    baseline_dnfr = list(collect_attr(G, G.nodes, ALIAS_DNFR, 0.0))
+
+    baseline_stats = _build_neighbor_sums_common(G, data, use_numpy=True)
+    assert baseline_stats is not None
+    baseline_arrays = []
+    for arr in baseline_stats[:-1]:
+        if arr is None:
+            baseline_arrays.append(None)
+        else:
+            baseline_arrays.append(np.array(arr, copy=True))
+
+    baseline_degs = baseline_stats[-1]
+    if baseline_degs is not None:
+        baseline_degs_copy = np.array(baseline_degs, copy=True)
+    else:
+        baseline_degs_copy = None
+
+    accum = data.get("neighbor_accum_np")
+    assert isinstance(accum, np.ndarray)
+    cache = data.get("cache")
+    assert cache is not None
+    assert cache.neighbor_accum_np is accum
+
+    numpy_module = sys.modules.get("numpy")
+    assert numpy_module is np
+
+    monkeypatch.setattr(dnfr_module, "get_numpy", lambda: None)
+
+    fallback_stats = _build_neighbor_sums_common(G, data, use_numpy=True)
+    assert fallback_stats is not None
+
+    fallback_arrays = fallback_stats[:-1]
+    for baseline_arr, fallback_arr in zip(baseline_arrays, fallback_arrays):
+        if baseline_arr is None:
+            assert fallback_arr is None
+        else:
+            assert isinstance(fallback_arr, np.ndarray)
+            np.testing.assert_allclose(fallback_arr, baseline_arr)
+
+    fallback_degs = fallback_stats[-1]
+    if baseline_degs_copy is None:
+        assert fallback_degs is None
+    else:
+        assert isinstance(fallback_degs, np.ndarray)
+        np.testing.assert_allclose(fallback_degs, baseline_degs_copy)
+
+    accum_after = data.get("neighbor_accum_np")
+    assert isinstance(accum_after, np.ndarray)
+    assert cache.neighbor_accum_np is accum_after
+    assert isinstance(data.get("neighbor_edge_values_np"), np.ndarray)
+
+    _compute_dnfr_common(
+        G,
+        data,
+        x=fallback_stats[0],
+        y=fallback_stats[1],
+        epi_sum=fallback_stats[2],
+        vf_sum=fallback_stats[3],
+        count=fallback_stats[4],
+        deg_sum=fallback_stats[5],
+        degs=fallback_stats[6],
+    )
+
+    fallback_dnfr = list(collect_attr(G, G.nodes, ALIAS_DNFR, 0.0))
+    np.testing.assert_allclose(fallback_dnfr, baseline_dnfr)


### PR DESCRIPTION
## Summary
- add regression coverage to ensure cached NumPy buffers remain usable when `get_numpy()` temporarily returns `None`
- import the helper utilities required by the new unit test

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68fdf1664aa8832182f05cae8dc55b14