### PR TITLE
Add integration test for THOL handler fallback

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -311,6 +311,21 @@ def test_handle_target_materializes_non_sequence(graph_canon):
     assert isinstance(curr, tuple)
 
 
+def test_handle_thol_none_payload_records_fallback(graph_canon):
+    G = graph_canon()
+    G.add_node(1)
+    trace = deque()
+    handler = HANDLERS[OpTag.THOL]
+
+    result = handler(G, None, None, trace, _step_noop)
+
+    assert result is None
+    assert len(trace) == 1
+    entry = trace[0]
+    assert entry["op"] == OpTag.THOL.name
+    assert entry["g"] == Glyph.THOL.value
+
+
 def test_load_sequence_json_yaml(tmp_path):
     data = [
         "AL",


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Adds an integration-level regression test exercising the THOL handler with a ``None`` payload to ensure the fallback glyph value is recorded in the program trace without raising.


------
https://chatgpt.com/codex/tasks/task_e_68fe639af7408321bd81e50de9a6994f