### PR TITLE
Add integration test for invalid Erdos probability literal

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -195,6 +195,15 @@ def test_cli_metrics_accepts_summary_limit(monkeypatch):
     assert recorded["series_limit"] == 7
 
 
+def test_build_basic_graph_invalid_probability_literal():
+    args = argparse.Namespace(nodes=3, topology="erdos", p="abc", seed=None)
+
+    with pytest.raises(ValueError) as exc_info:
+        _cli_execution().build_basic_graph(args)
+
+    assert "abc" in str(exc_info.value)
+
+
 def test_cli_metrics_uses_default_steps(monkeypatch):
     recorded: dict[str, Any] = {}
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [ ] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [ ] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add an integration test documenting the ValueError when an Erdos topology receives a non-numeric probability literal

## Testing
- `pytest -o addopts='' tests/integration/test_cli.py -k invalid_probability_literal`


------
https://chatgpt.com/codex/tasks/task_e_68fe6430ad508321844fcc1871251960