### PR TITLE
Add integration test for empty TARGET selection

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -230,6 +230,22 @@ def test_target_persists_across_wait(graph_canon):
     assert list(G.nodes[2]["glyph_history"]) == [Glyph.AL.value]
 
 
+def test_target_empty_selection_records_zero_count(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from([1, 2, 3])
+
+    play(G, seq(target([]), Glyph.AL), step_fn=_step_noop)
+
+    trace = list(G.graph["history"]["program_trace"])
+    assert trace[0]["op"] == OpTag.TARGET.name
+    assert trace[0]["n"] == 0
+
+    for node in G.nodes:
+        history = G.nodes[node].get("glyph_history")
+        if history is not None:
+            assert list(history) == []
+
+
 @pytest.mark.parametrize(
     "exc_factory",
     [


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Added an integration test covering `play` execution when `target([])` selects no nodes, ensuring the program trace records a `TARGET` entry with a zero count.
- Verified glyph application leaves node histories untouched when no targets are active.

## Testing
- pytest tests/integration/test_program.py::test_target_empty_selection_records_zero_count


------
https://chatgpt.com/codex/tasks/task_e_68fe65667b5c8321bcb05992a021dcf5