### PR TITLE
Add coverage for validate_sequence argument and token edge cases

### DIFF
--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -130,6 +130,25 @@ def test_validate_sequence_rejects_unknown_tokens() -> None:
     assert not ok and "unknown tokens" in msg
 
 
+def test_validate_sequence_requires_names_argument() -> None:
+    with pytest.raises(TypeError) as excinfo:
+        validate_sequence()
+
+    assert "missing required argument" in str(excinfo.value)
+
+
+def test_validate_sequence_rejects_empty_sequence() -> None:
+    ok, msg = validate_sequence([])
+
+    assert (ok, msg) == (False, "empty sequence")
+
+
+def test_validate_sequence_requires_string_tokens() -> None:
+    ok, msg = validate_sequence([EMISSION, RECEPTION, 101])
+
+    assert (ok, msg) == (False, "tokens must be str")
+
+
 def test_thol_closed_by_silence() -> None:
     ops = [
         Emission(),


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Added targeted tests to ensure `validate_sequence` fails fast when invoked without the required names iterable, when given an empty sequence, and when presented with non-string tokens.

------
https://chatgpt.com/codex/tasks/task_e_68fe6b12a9e883219ffcc1717be229eb