### PR TITLE
Ensure νf adaptation validates required parameters

### DIFF
--- a/src/tnfr/dynamics/adaptation.py
+++ b/src/tnfr/dynamics/adaptation.py
@@ -91,6 +91,16 @@ def adapt_vf_by_coherence(G: TNFRGraph, n_jobs: int | None = None) -> None:
     (2, True)
     """
 
+    required_keys = ("VF_ADAPT_TAU", "VF_ADAPT_MU")
+    missing_keys = [key for key in required_keys if key not in G.graph]
+    if missing_keys:
+        missing_list = ", ".join(sorted(missing_keys))
+        raise KeyError(
+            "adapt_vf_by_coherence requires graph parameters "
+            f"{missing_list}; call tnfr.constants.inject_defaults(G) "
+            "before adaptation."
+        )
+
     tau = get_graph_param(G, "VF_ADAPT_TAU", int)
     mu = float(get_graph_param(G, "VF_ADAPT_MU"))
     eps_dnfr = cast(DeltaNFR, get_graph_param(G, "EPS_DNFR_STABLE"))

--- a/tests/unit/dynamics/test_vf_coherence.py
+++ b/tests/unit/dynamics/test_vf_coherence.py
@@ -58,6 +58,27 @@ def _vf_clamp_test_graph(graph_canon):
     return G
 
 
+def test_adapt_vf_requires_injected_defaults():
+    bare = nx.Graph()
+    bare.add_edge("seed", "anchor")
+
+    with pytest.raises(KeyError, match="inject_defaults"):
+        adapt_vf_by_coherence(bare)
+
+    inject_defaults(bare)
+
+
+def test_adapt_vf_rejects_non_numeric_tau(graph_canon):
+    G = graph_canon()
+    G.add_edge(0, 1)
+    G.graph["VF_ADAPT_TAU"] = "not-an-int"
+
+    with pytest.raises((TypeError, ValueError)):
+        adapt_vf_by_coherence(G)
+
+    inject_defaults(G, override=True)
+
+
 def test_vf_converge_to_neighbor_average_when_stable(graph_canon):
     G = graph_canon()
     G.add_edge(0, 1)


### PR DESCRIPTION
### Summary
- enforce that νf adaptation raises a helpful error when VF_ADAPT_TAU or VF_ADAPT_MU are missing from the graph configuration
- extend coherence tests to cover missing defaults and non-numeric τ inputs

### Testing
- pytest tests/unit/dynamics/test_vf_coherence.py

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fe74446af48321a34510440fbc2b75