### PR TITLE
Add tests for observer attachment and history reuse in prepare_network

### DIFF
--- a/tests/unit/structural/test_prepare_network.py
+++ b/tests/unit/structural/test_prepare_network.py
@@ -28,6 +28,24 @@ def test_prepare_network_records_callback_error_when_observer_missing(monkeypatc
     ]
 
 
+def test_prepare_network_attaches_standard_observer(monkeypatch):
+    G = nx.path_graph(2)
+    G.graph["ATTACH_STD_OBSERVER"] = True
+
+    calls = []
+
+    def _stub_attach_observer(graph):
+        calls.append(graph)
+
+    monkeypatch.setattr("tnfr.ontosim.cached_import", lambda *_, **__: _stub_attach_observer)
+
+    returned = prepare_network(G)
+
+    assert returned is G
+    assert calls == [G]
+    assert G.graph.get("_callback_errors", []) == []
+
+
 def test_prepare_network_respects_override_defaults_flag():
     G = nx.path_graph(2)
     G.graph["PHASE_HISTORY_MAXLEN"] = 123
@@ -46,3 +64,21 @@ def test_prepare_network_respects_override_defaults_flag():
 
     assert G_override.graph["PHASE_HISTORY_MAXLEN"] == METRIC_DEFAULTS["PHASE_HISTORY_MAXLEN"]
     assert G_override.graph["REMESH_TAU_GLOBAL"] == 5
+
+
+def test_prepare_network_reuses_existing_history_state():
+    G = nx.path_graph(3)
+    prepare_network(G)
+    history = G.graph["history"]
+    history["custom_metric"] = ["alpha", "beta"]
+    history["phase_state"].extend([1.0, 2.0])
+    history_state_id_before = id(history["phase_state"])
+
+    returned = prepare_network(G)
+
+    assert returned is G
+    assert G.graph["history"] is history
+    assert history["custom_metric"] == ["alpha", "beta"]
+    assert "phase_state" in history
+    assert id(history["phase_state"]) == history_state_id_before
+    assert list(history["phase_state"])[-2:] == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- add coverage ensuring the standard observer hook attaches without recording spurious errors
- validate that existing history buffers persist when prepare_network runs again
- exercise the structural prepare_network test module to confirm deterministic behavior

## Testing
- pytest tests/unit/structural/test_prepare_network.py

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68fe7b5e883883218d72c6471692bba3