### PR TITLE
Handle non-mapping weight overrides when merging graph weights

### DIFF
--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -70,7 +70,10 @@ def ensure_neighbors_map(G: GraphLike) -> Mapping[Any, Sequence[Any]]:
 def merge_graph_weights(G: GraphLike, key: str) -> dict[str, float]:
     """Merge default weights for ``key`` with any graph overrides."""
 
-    return {**DEFAULTS[key], **G.graph.get(key, {})}
+    overrides = G.graph.get(key, {})
+    if overrides is None or not isinstance(overrides, Mapping):
+        overrides = {}
+    return {**DEFAULTS[key], **overrides}
 
 
 def merge_and_normalize_weights(

--- a/tests/unit/metrics/test_merge_graph_weights.py
+++ b/tests/unit/metrics/test_merge_graph_weights.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tnfr.constants import DEFAULTS
+from tnfr.metrics.common import merge_and_normalize_weights, merge_graph_weights
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("SELECTOR_WEIGHTS", ("w_si", "w_dnfr", "w_accel")),
+        ("SI_WEIGHTS", ("alpha", "beta", "gamma")),
+    ],
+)
+def test_merge_graph_weights_fallback_for_none(graph_canon, key):
+    key_name, fields = key
+    G = graph_canon()
+    G.graph[key_name] = None
+
+    merged = merge_graph_weights(G, key_name)
+    normalized = merge_and_normalize_weights(G, key_name, fields)
+
+    assert merged == DEFAULTS[key_name]
+    assert normalized == pytest.approx(DEFAULTS[key_name])
+
+
+@pytest.mark.parametrize(
+    "override,key",
+    [
+        (1.0, ("SELECTOR_WEIGHTS", ("w_si", "w_dnfr", "w_accel"))),
+        (0, ("SI_WEIGHTS", ("alpha", "beta", "gamma"))),
+    ],
+)
+def test_merge_graph_weights_fallback_for_scalars(graph_canon, override, key):
+    key_name, fields = key
+    G = graph_canon()
+    G.graph[key_name] = override
+
+    merged = merge_graph_weights(G, key_name)
+    normalized = merge_and_normalize_weights(G, key_name, fields)
+
+    assert merged == DEFAULTS[key_name]
+    assert normalized == pytest.approx(DEFAULTS[key_name])


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Hardened `merge_graph_weights` so non-mapping overrides fall back to defaults instead of erroring.
- Added regression coverage for `merge_graph_weights` and `merge_and_normalize_weights` when graph overrides are `None` or scalar.

## Testing
- `pytest tests/unit/metrics/test_merge_graph_weights.py`


------
https://chatgpt.com/codex/tasks/task_e_68fe7c17076c83219c5e3a70bf32d2c4