### PR TITLE
Add integration test for target generator materialization

### DIFF
--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -246,6 +246,24 @@ def test_target_empty_selection_records_zero_count(graph_canon):
             assert list(history) == []
 
 
+def test_target_generator_materializes_selection(graph_canon):
+    G = graph_canon()
+    G.add_nodes_from(["n1", "n2", "n3"])
+
+    nodes = (node for node in ["n1", "n2"])
+    play(G, seq(target(nodes), Glyph.AL), step_fn=_step_noop)
+
+    trace = list(G.graph["history"]["program_trace"])
+    assert trace[0]["op"] == OpTag.TARGET.name
+    assert trace[0]["n"] == 2
+    assert trace[1]["op"] == OpTag.GLYPH.name
+    assert trace[1]["g"] == Glyph.AL.value
+
+    assert list(G.nodes["n1"]["glyph_history"]) == [Glyph.AL.value]
+    assert list(G.nodes["n2"]["glyph_history"]) == [Glyph.AL.value]
+    assert "glyph_history" not in G.nodes["n3"]
+
+
 @pytest.mark.parametrize(
     "exc_factory",
     [


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

- Added an integration test that plays a sequence with a generator-based target selection and asserts the resulting trace and glyph histories remain deterministic and scoped to the intended nodes.


------
https://chatgpt.com/codex/tasks/task_e_68fe7ce038488321aebd6f8ff52df8f8