### PR TITLE
Add unit tests covering CLI SystemExit handling

### DIFF
--- a/tests/unit/cli/test_run_cli_program.py
+++ b/tests/unit/cli/test_run_cli_program.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from tnfr.cli import execution
+
+
+@pytest.fixture()
+def cli_args() -> argparse.Namespace:
+    return argparse.Namespace()
+
+
+def test_run_cli_program_returns_one_when_resolve_program_exits_with_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: argparse.Namespace,
+) -> None:
+    def fake_resolve_program(*_: object, **__: object) -> None:
+        raise SystemExit(0)
+
+    def fail_run_program(*_: object, **__: object) -> None:
+        pytest.fail("run_program should not be called")
+
+    monkeypatch.setattr(execution, "resolve_program", fake_resolve_program)
+    monkeypatch.setattr(execution, "run_program", fail_run_program)
+
+    result = execution._run_cli_program(cli_args)
+
+    assert result == (1, None)
+
+
+def test_run_cli_program_returns_one_when_resolve_program_exits_with_message(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: argparse.Namespace,
+) -> None:
+    def fake_resolve_program(*_: object, **__: object) -> None:
+        raise SystemExit("boom")
+
+    def fail_run_program(*_: object, **__: object) -> None:
+        pytest.fail("run_program should not be called")
+
+    monkeypatch.setattr(execution, "resolve_program", fake_resolve_program)
+    monkeypatch.setattr(execution, "run_program", fail_run_program)
+
+    result = execution._run_cli_program(cli_args)
+
+    assert result == (1, None)
+
+
+def test_run_cli_program_returns_one_when_run_program_exits_with_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: argparse.Namespace,
+) -> None:
+    sentinel_program = object()
+
+    def fake_resolve_program(*_: object, **__: object) -> object:
+        return sentinel_program
+
+    def fake_run_program(*_: object, **__: object) -> None:
+        raise SystemExit(0)
+
+    monkeypatch.setattr(execution, "resolve_program", fake_resolve_program)
+    monkeypatch.setattr(execution, "run_program", fake_run_program)
+
+    result = execution._run_cli_program(cli_args)
+
+    assert result == (1, None)
+
+
+def test_run_cli_program_returns_one_when_run_program_exits_with_message(
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: argparse.Namespace,
+) -> None:
+    sentinel_program = object()
+
+    def fake_resolve_program(*_: object, **__: object) -> object:
+        return sentinel_program
+
+    def fake_run_program(*_: object, **__: object) -> None:
+        raise SystemExit("boom")
+
+    monkeypatch.setattr(execution, "resolve_program", fake_resolve_program)
+    monkeypatch.setattr(execution, "run_program", fake_run_program)
+
+    result = execution._run_cli_program(cli_args)
+
+    assert result == (1, None)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Adds targeted unit tests that patch `resolve_program` and `run_program` to raise `SystemExit`, confirming `_run_cli_program` normalizes the resulting exit codes to `(1, None)`.


------
https://chatgpt.com/codex/tasks/task_e_68fe81281be483218857c0c26b2dddd0