### PR TITLE
Add coverage for remesh history maxlen scaling

### DIFF
--- a/tests/unit/structural/test_prepare_network.py
+++ b/tests/unit/structural/test_prepare_network.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 from tnfr.constants import METRIC_DEFAULTS
 from tnfr.ontosim import prepare_network
@@ -82,3 +83,20 @@ def test_prepare_network_reuses_existing_history_state():
     assert "phase_state" in history
     assert id(history["phase_state"]) == history_state_id_before
     assert list(history["phase_state"])[-2:] == [1.0, 2.0]
+
+
+@pytest.mark.parametrize(
+    "tau, expected",
+    (
+        (5, 64),
+        (130, 2 * 130 + 5),
+    ),
+)
+def test_prepare_network_scales_epi_hist_maxlen_with_tau(tau, expected):
+    G = nx.path_graph(2)
+    G.graph["REMESH_TAU_GLOBAL"] = tau
+
+    prepare_network(G)
+
+    epi_hist = G.graph["_epi_hist"]
+    assert epi_hist.maxlen == expected


### PR DESCRIPTION
### What it reorganizes
- [x] Preserves operator closure and operational fractality
- [ ] Increases C(t) or reduces ΔNFR where appropriate

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add a parametrized structural test confirming `_epi_hist` sizing respects `max(2 * tau + 5, 64)`
- ensure pytest is available for parametrizing the remesh history test

## Testing
- `pytest --override-ini "addopts=" tests/unit/structural/test_prepare_network.py`


------
https://chatgpt.com/codex/tasks/task_e_68fe81f524d0832190ec4779210879a7