### PR TITLE
Add TOML sequence coverage for CLI

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -197,6 +197,8 @@ def _load_sequence(path: Path) -> ProgramTokens:
             message = str(StructuredFileError(path, exc))
         logger.error("%s", message)
         raise SystemExit(1) from exc
+    if isinstance(data, Mapping) and "sequence" in data:
+        data = data["sequence"]
     return parse_program_tokens(data)
 
 


### PR DESCRIPTION
Adds TOML sequence coverage to the CLI tests and accepts `sequence` keyed mappings when loading custom programs.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68fe82822b6c83218a1bdc5cccdd32cf