### PR TITLE
Add NAV jitter tests for default random behaviour

### DIFF
--- a/tests/unit/dynamics/test_nav.py
+++ b/tests/unit/dynamics/test_nav.py
@@ -31,3 +31,56 @@ def test_nav_strict_sets_dnfr_to_vf(graph_canon):
     G.graph["NAV_STRICT"] = True
     apply_glyph(G, 0, "NAV")
     assert nd["ΔNFR"] == pytest.approx(0.8)
+
+
+def test_nav_random_applies_jitter(monkeypatch, graph_canon):
+    sentinel = 0.123
+
+    recorded = {}
+
+    def fake_random_jitter(node, magnitude):
+        recorded["magnitude"] = magnitude
+        return sentinel
+
+    monkeypatch.setattr("tnfr.operators.random_jitter", fake_random_jitter)
+
+    G = graph_canon()
+    G.add_node(0)
+    inject_defaults(G)
+    nd = G.nodes[0]
+    nd["ΔNFR"] = 0.3
+    nd["νf"] = 0.9
+    gf = G.graph["GLYPH_FACTORS"]
+    gf["NAV_jitter"] = 0.2
+    eta = gf["NAV_eta"]
+
+    apply_glyph(G, 0, "NAV")
+
+    expected_base = (1 - eta) * 0.3 + eta * 0.9
+    assert recorded["magnitude"] == pytest.approx(0.2)
+    assert nd["ΔNFR"] == pytest.approx(expected_base + sentinel)
+
+
+def test_nav_random_negative_dnfr_base(monkeypatch, graph_canon):
+    sentinel = -0.077
+
+    def fake_random_jitter(node, magnitude):
+        return sentinel
+
+    monkeypatch.setattr("tnfr.operators.random_jitter", fake_random_jitter)
+
+    G = graph_canon()
+    G.add_node(0)
+    inject_defaults(G)
+    nd = G.nodes[0]
+    nd["ΔNFR"] = -0.4
+    nd["νf"] = 0.6
+    gf = G.graph["GLYPH_FACTORS"]
+    gf["NAV_jitter"] = 0.15
+    eta = gf["NAV_eta"]
+
+    apply_glyph(G, 0, "NAV")
+
+    expected_target = -0.6
+    expected_base = (1 - eta) * (-0.4) + eta * expected_target
+    assert nd["ΔNFR"] == pytest.approx(expected_base + sentinel)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Added unit coverage confirming NAV applies random jitter from glyph factors when NAV_RANDOM remains enabled by default.
- Added a complementary negative-ΔNFR scenario to validate the base calculation before injected jitter is applied.

## Testing
- pytest --override-ini addopts="" tests/unit/dynamics/test_nav.py


------
https://chatgpt.com/codex/tasks/task_e_68fe884592f48321bef291089e73bc6a