### PR TITLE
Ensure STOP_EARLY windows have a minimum span

### DIFF
--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -735,7 +735,7 @@ def run(
     stop_cfg = get_graph_param(G, "STOP_EARLY", dict)
     stop_enabled = False
     if stop_cfg and stop_cfg.get("enabled", False):
-        w = int(stop_cfg.get("window", 25))
+        w = max(1, int(stop_cfg.get("window", 25)))
         frac = float(stop_cfg.get("fraction", 0.90))
         stop_enabled = True
     job_overrides = _normalize_job_overrides(n_jobs)


### PR DESCRIPTION
## Summary
- clamp the STOP_EARLY window to at least one iteration before evaluating stability history
- add regression coverage for zero and negative STOP_EARLY window configurations

## Testing
- pytest tests/unit/dynamics/test_dynamics_run.py

------
https://chatgpt.com/codex/tasks/task_e_68fea0bb5b048321b39458d2b8d22317