### PR TITLE
Add unit coverage for supports_add_edge behavior

### DIFF
--- a/tests/unit/structural/test_utils_graph.py
+++ b/tests/unit/structural/test_utils_graph.py
@@ -1,6 +1,7 @@
+import networkx as nx
 import pytest
 
-from tnfr.utils.graph import get_graph, get_graph_mapping
+from tnfr.utils.graph import get_graph, get_graph_mapping, supports_add_edge
 
 
 class Sentinel:
@@ -20,3 +21,15 @@ def test_get_graph_mapping_warns_and_returns_none_for_non_mapping_value():
         result = get_graph_mapping(graph, "tnfr", warn_msg)
 
     assert result is None
+
+
+def test_supports_add_edge_returns_true_for_networkx_graph():
+    graph = nx.Graph()
+
+    assert supports_add_edge(graph) is True
+
+
+def test_supports_add_edge_returns_false_for_sentinel_without_add_edge():
+    sentinel = Sentinel()
+
+    assert supports_add_edge(sentinel) is False


### PR DESCRIPTION
## Summary
- add a regression test confirming `supports_add_edge` recognises `networkx.Graph`
- add a negative test covering non-compliant sentinel objects

## Testing
- pytest tests/unit/structural/test_utils_graph.py

------
https://chatgpt.com/codex/tasks/task_e_68feaef449b88321bcf0ca196cd9d856