### PR TITLE
Add unit test covering get_graph_mapping without metadata getter

### DIFF
--- a/tests/unit/structural/test_utils_graph.py
+++ b/tests/unit/structural/test_utils_graph.py
@@ -13,6 +13,20 @@ def test_get_graph_raises_type_error_for_unsupported_object():
         get_graph(Sentinel())
 
 
+class GraphWithoutGetter:
+    """Minimal graph metadata container lacking a ``get`` accessor."""
+
+    def __iter__(self):
+        return iter(())
+
+
+class FakeGraph:
+    """Graph-like object exposing metadata without a ``get`` method."""
+
+    def __init__(self):
+        self.graph = GraphWithoutGetter()
+
+
 def test_get_graph_mapping_warns_and_returns_none_for_non_mapping_value():
     graph = {"tnfr": ["not", "a", "mapping"]}
     warn_msg = "tnfr metadata must be a mapping"
@@ -21,6 +35,12 @@ def test_get_graph_mapping_warns_and_returns_none_for_non_mapping_value():
         result = get_graph_mapping(graph, "tnfr", warn_msg)
 
     assert result is None
+
+
+def test_get_graph_mapping_returns_none_when_graph_lacks_get_method():
+    fake_graph = FakeGraph()
+
+    assert get_graph_mapping(fake_graph, "tnfr", "unused") is None
 
 
 def test_supports_add_edge_returns_true_for_networkx_graph():


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add deterministic fake graph classes exposing metadata without a `get` accessor
- assert `get_graph_mapping` returns `None` without raising for graphs lacking a metadata getter, covering the early-return branch

## Testing
- `pytest tests/unit/structural/test_utils_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68feaf5d05508321877643934668c700