### PR TITLE
Add flatten_structure cycle and expansion callback tests

### DIFF
--- a/tests/unit/structural/test_flatten_structure.py
+++ b/tests/unit/structural/test_flatten_structure.py
@@ -3,6 +3,19 @@ import pytest
 from tnfr.utils import flatten_structure
 
 
+@pytest.fixture
+def self_referential_list() -> list[object]:
+    cycle: list[object] = [1]
+    cycle.append(cycle)
+    return cycle
+
+
+class _Expandable:
+    def __init__(self, *items: object) -> None:
+        self.items = items
+
+
+
 def _make_set() -> set[int]:
     return {1, 2, 3}
 
@@ -50,3 +63,26 @@ def test_flatten_structure_streaming_iteration():
     assert next(iterator) == 2
     with pytest.raises(StopIteration):
         next(iterator)
+
+
+def test_flatten_structure_handles_self_reference(self_referential_list):
+    flattened = list(flatten_structure(self_referential_list))
+
+    assert flattened == [1]
+    assert len(flattened) == len(set(flattened))
+
+
+def test_flatten_structure_expand_callback_traverses_replacement():
+    outer = _Expandable(_Expandable("a", "b"), _Expandable("c"), "terminal")
+    expanded: list[_Expandable] = []
+
+    def expand(item: object):
+        if isinstance(item, _Expandable):
+            expanded.append(item)
+            return item.items
+        return None
+
+    flattened = list(flatten_structure(outer, expand=expand))
+
+    assert flattened == ["terminal", "a", "b", "c"]
+    assert expanded == [outer, outer.items[0], outer.items[1]]


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Added a fixture that builds a self-referential list to ensure `flatten_structure` halts on cycles without duplicate leaves.
- Added deterministic coverage for the `expand` callback branch so replacement iterables are flattened in a predictable order.

## Testing
- pytest tests/unit/structural/test_flatten_structure.py


------
https://chatgpt.com/codex/tasks/task_e_68feb2d050e08321b6559acaa3844e4e