### PR TITLE
Add tests for glyph history state normalisation

### DIFF
--- a/tests/unit/structural/test_glyph_history_windowing.py
+++ b/tests/unit/structural/test_glyph_history_windowing.py
@@ -167,6 +167,35 @@ def test_append_metric_respects_historydict_counters():
     assert hist._counts.get("a", 0) == 0
 
 
+def test_append_metric_normalises_phase_state_tokens():
+    hist = HistoryDict()
+
+    for token in ["Stable", "TrAnSiTiOn", "DISSONANT"]:
+        append_metric(hist, "phase_state", token)
+
+    assert hist["phase_state"] == ["stable", "transition", "dissonant"]
+
+
+def test_append_metric_normalises_nested_nodal_diag_states():
+    hist = HistoryDict()
+    nodal_diag_snapshot = {
+        "node-1": {"state": "Stable", "amplitude": 1.0, "details": {"note": "ok"}},
+        "node-2": {"state": "TRANSITION", "other": 2},
+        "node-3": {"other": 3},
+    }
+
+    append_metric(hist, "nodal_diag", nodal_diag_snapshot)
+
+    stored = hist["nodal_diag"]
+    assert isinstance(stored, list)
+    assert len(stored) == 1
+    snapshot = stored[0]
+    assert snapshot["node-1"]["state"] == "stable"
+    assert snapshot["node-2"]["state"] == "transition"
+    assert snapshot["node-3"] == {"other": 3}
+    assert snapshot["node-1"]["details"] == {"note": "ok"}
+
+
 # ---------------------------------------------------------------------------
 # ensure_history integration (window handling)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add regression coverage ensuring phase_state telemetry normalises mixed-case tokens
- verify nodal_diag snapshots canonicalise state fields without disturbing other payload data

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68feb3a294f08321b11de55af0526ef9