### PR TITLE
Integrate semantic-release automation for TNFR versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,19 +2,90 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
+  prepare:
+    name: Plan semantic release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      released: ${{ steps.plan.outputs.released }}
+      version: ${{ steps.plan.outputs.version }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install semantic release tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install python-semantic-release build
+
+      - name: Detect next version
+        id: plan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+        run: |
+          set +e
+          VERSION_OUTPUT=$(python -m semantic_release version --print 2>&1)
+          STATUS=$?
+          set -e
+          echo "$VERSION_OUTPUT"
+          if [ "$STATUS" -ne 0 ]; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          VERSION=$(echo "$VERSION_OUTPUT" | tail -n 1 | tr -d ' \n')
+          if [ -z "$VERSION" ]; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Apply release tag
+        if: steps.plan.outputs.released == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+        run: python -m semantic_release version --skip-build --no-vcs-release
+
+      - name: Emit tag output
+        id: tag
+        if: steps.plan.outputs.released == 'true'
+        run: |
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+        env:
+          VERSION: ${{ steps.plan.outputs.version }}
+
   publish:
     name: Build and publish release
+    needs: prepare
+    if: needs.prepare.outputs.released == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     steps:
-      - name: Checkout repository
+      - name: Checkout release tag
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -24,9 +95,11 @@ jobs:
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build
+          python -m pip install build python-semantic-release
 
       - name: Build distributions
+        env:
+          TNFR_VERSION: ${{ needs.prepare.outputs.version }}
         run: python -m build
 
       - name: Publish to PyPI
@@ -38,7 +111,11 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
           files: dist/*
-          generate_release_notes: true
+
+      - name: Inject TNFR release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+        run: python -m semantic_release changelog --post-to-release-tag ${{ needs.prepare.outputs.tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 site/
 *.egg-info/
 *.egg
+.semantic_release/
+src/tnfr/_generated_version.py
 .venv/
 .env
 .pytest_cache/

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,31 @@
 # Release notes
 
-## 16.0.0 (glyph load history cleanup)
+## Semantic release workflow
+
+We manage versions with `python-semantic-release`, deriving release tags directly from the TNFR commit history so the ledger reflects actual structural reorganisations.
+
+### Commit taxonomy
+
+- `feat:` or `structure:` — publish a **minor** bump describing new coherence capabilities or structural monitoring.
+- `fix:`, `perf:`, `refactor:`, `docs:`, `test:`, `build:`, `ci:`, `style:`, or `chore:` — issue a **patch** bump covering stabilisation and instrumentation work.
+- Append `!` to the type or add a `BREAKING CHANGE:` footer to flag a **major** bump that requires downstream synchronisation.
+
+### Workflow orchestration
+
+- Pushing to `main` triggers the `Release` workflow.
+- The `prepare` job runs `python -m semantic_release version --skip-build --no-vcs-release` to compute the next version, apply the TNFR-aware templates under `meta/semantic_release/templates`, and push the resulting `vX.Y.Z` tag.
+- The computed version is exposed as a workflow output and reused by the packaging job for builds, uploads, and GitHub releases.
+
+### TNFR safeguards during bumps
+
+- Release notes generated from the custom templates reiterate the preservation of coherence C(t), phase synchrony, and structural frequency νf.
+- The build job exports the resolved version through the `TNFR_VERSION` environment variable so :mod:`tnfr._version` stays aligned with the freshly tagged metadata.
+- Semantic-release commits do not introduce new operators; they document validated reorganisations and keep ΔNFR semantics intact.
+
+## Historical ledger
+<!-- version history -->
+
+### 16.0.0 (glyph load history cleanup)
 
 - **Breaking change**: Removed the deprecated glyph load history identifier that
   predated the English rename. Metrics initialisation and the coherence
@@ -12,7 +37,7 @@
   graph into this release. Persist the rewritten payloads so downstream tooling
   reads the same identifiers.
 
-## 14.0.0 (Spanish compatibility messaging retired)
+### 14.0.0 (Spanish compatibility messaging retired)
 
 - Finalised the English-only surface by removing Spanish-specific guidance from
   :mod:`tnfr.alias`, :mod:`tnfr.metrics.sense_index`, and the operator registry
@@ -29,7 +54,7 @@
 - Updated guides and release notes to describe the final English-only contract
   and the requirement to normalise archives with the compatibility helpers.
 
-## 13.1.0 (preset legacy tuple removed)
+### 13.1.0 (preset legacy tuple removed)
 
 - **Breaking change**: Removed the exported
   :data:`tnfr.config.presets.REMOVED_PRESET_NAMES` tuple now that only the
@@ -41,7 +66,7 @@
   ``KeyError('Preset not found: …')`` without additional guidance, matching the
   behaviour for unknown presets.
 
-## 13.0.0 (selector norms alias removed)
+### 13.0.0 (selector norms alias removed)
 
 - **Breaking change**: Removed the deprecated
   :func:`tnfr.selector._norms_para_selector` alias. Callers must import and use
@@ -50,7 +75,7 @@
 - Updated selector utilities documentation and tests to reference only the
   English helper so downstream projects surface the rename during upgrades.
 
-## 12.1.0 (selector norms helper renamed)
+### 12.1.0 (selector norms helper renamed)
 
 - Renamed the selector norms helper to the English-only
   :func:`tnfr.selector._selector_norms` identifier to align selector internals
@@ -60,7 +85,7 @@
 - Updated :mod:`tnfr.dynamics` and the selector unit tests to consume the new
   helper, keeping the cached norms behaviour unchanged.
 
-## 12.0.0 (diagnosis state Spanish shim removed)
+### 12.0.0 (diagnosis state Spanish shim removed)
 
 - Removed the :func:`tnfr.constants.enable_spanish_state_tokens` and
   :func:`tnfr.constants.disable_spanish_state_tokens` compatibility helpers along
@@ -87,7 +112,7 @@
   Persist the rewritten payloads before installing **TNFR 12.0.0** to avoid the
   new ``ValueError`` exceptions when loading historical archives.
 
-## 11.2.0 (operator collections English-only)
+### 11.2.0 (operator collections English-only)
 
 - Removed the Spanish compatibility aliases from
   :mod:`tnfr.config.operator_names`. Accessing the retired names now raises
@@ -98,7 +123,7 @@
   collections, reflecting the final step in the migration announced in earlier
   releases.
 
-## 11.1.0 (glyph load Spanish aggregates removed)
+### 11.1.0 (glyph load Spanish aggregates removed)
 
 - :func:`tnfr.observers.glyph_load` now reports only the English aggregate
   keys ``"_stabilizers"`` and ``"_disruptors"``. The runtime no longer mirrors
@@ -109,7 +134,7 @@
 - Updated the structural and metrics unit tests to enforce the English-only
   contract and removed the fixtures that patched Spanish aggregate labels.
 
-## 11.0.0 (Si dispersion legacy keys removed)
+### 11.0.0 (Si dispersion legacy keys removed)
 
 - Removed the legacy Si dispersion attribute from the sense index sensitivity
   cache. Loading graphs or configuration payloads that still define the retired
@@ -125,7 +150,7 @@
   persist the rewritten payload so the runtime no longer encounters retired
   identifiers.
 
-## 10.0.0 (remesh stability window keyword removal)
+### 10.0.0 (remesh stability window keyword removal)
 
 - Removed the transitional remesh stability keyword alias from
   :func:`tnfr.operators.apply_remesh_if_globally_stable`. Passing any
@@ -137,7 +162,7 @@
   audit stored configurations. See :doc:`getting-started/migrating-remesh-window`
   for detailed steps.
 
-## 15.0.0 (legacy migration helpers removed)
+### 15.0.0 (legacy migration helpers removed)
 
 - Finalised the English-only payload contract by removing
   :func:`tnfr.utils.migrations.migrate_legacy_phase_attributes` and
@@ -155,7 +180,7 @@
 - Added documentation in :doc:`getting-started/migrating-remesh-window` that
   summarises the deadline and required checks before adopting this release.
 
-## 9.0.0 (canonical preset rename)
+### 9.0.0 (canonical preset rename)
 
 - Renamed the canonical tutorial preset to the English-only identifier
   ``"canonical_example"``. The previous tutorial alias now raises a
@@ -171,7 +196,7 @@
   only the English preset names. Downstream automation should update any stored
   configuration that still references the encoded legacy token.
 
-## 8.1.0 (remesh cooldown alias removal)
+### 8.1.0 (remesh cooldown alias removal)
 
 - Removed the remesh cooldown alias from :mod:`tnfr.constants.core.RemeshDefaults`
   and from the remesh operator pipeline. Configuration loaders and runtime
@@ -193,7 +218,7 @@
       migrate_legacy_remesh_cooldown(G)
       inject_defaults(G)  # optional, keeps defaults in sync
 
-## 8.0.0 (phase alias enforcement)
+### 8.0.0 (phase alias enforcement)
 
 - Finalised the phase attribute migration by rejecting the legacy phase alias.
   Access helpers in :mod:`tnfr.alias` now operate strictly on the English
@@ -206,7 +231,7 @@
 - Updated documentation and tests to reflect the English-only phase contract
   and removed the automatic rewrites for the legacy alias.
 
-## 7.0.1 (English deprecation messaging)
+### 7.0.1 (English deprecation messaging)
 
 - Reworded the remaining deprecation warnings and validation errors that still
   surfaced Spanish text. Downstream tooling now emits English-only guidance
@@ -216,7 +241,7 @@
   removed; import :mod:`tnfr.config.constants`, :mod:`tnfr.config.presets`, and
   :mod:`tnfr.validation.grammar` instead.
 
-## 7.0.0 (Spanish identifiers removed)
+### 7.0.0 (Spanish identifiers removed)
 
 - Removed the legacy glyph constants that mirrored the English
   :data:`tnfr.config.constants.STABILIZERS` and
@@ -235,7 +260,7 @@
 - Updated tests and documentation to reflect the English-only contract across
   glyph constants, preset helpers, and diagnostic state utilities.
 
-## 6.1.0 (preset alias deprecation window)
+### 6.1.0 (preset alias deprecation window)
 
 - Announced the removal of the non-English preset identifiers scheduled for
   **TNFR 7.0**. The engine now emits :class:`FutureWarning` when deprecated names
@@ -250,7 +275,7 @@
   substitution pass using the provided mapping so that persisted data stores
   only the English preset names.
 
-## 6.0.0 (node aliases removed)
+### 6.0.0 (node aliases removed)
 
 - Removed the module-level aliases that mirrored the node class names from
   :mod:`tnfr.node`. Code importing those symbols must switch to the canonical
@@ -265,7 +290,7 @@
 - Published the backward-incompatible change as **TNFR 6.0.0** to honour the
   semantic versioning contract and flag the immediate API removal.
 
-## 5.0.0 (prepare_network alias retired)
+### 5.0.0 (prepare_network alias retired)
 
 - Removed the helper alias constructed as
   ``"".join(chr(cp) for cp in (112, 114, 101, 112, 97, 114, 97, 114, 95, 114, 101, 100))``.
@@ -277,7 +302,7 @@
 - Bumped the package version to **5.0.0** to flag the
   backward-incompatible API change.
 
-## 2.0.0 (Spanish alias removal)
+### 2.0.0 (Spanish alias removal)
 
 - Removed the Spanish compatibility tables from :mod:`tnfr.config.operator_names`.
   Only the English tokens (``emission``, ``reception``, ``coherence``, etc.) are
@@ -310,7 +335,7 @@
     the removal of ``tnfr.operators.compat``.
   * Update API docs, tutorials, and CLI references to show only English tokens.
 
-## 1.x compatibility window (historical)
+### 1.x compatibility window (historical)
 
 - English operator identifiers became canonical in 1.x. The registry published
   the English tokens and the CLI expected the same literals while the Spanish

--- a/meta/semantic_release/templates/conventional/md/.components/changelog_header.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/changelog_header.md.j2
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+> TNFR release ledger. Each entry logs structural reorganisations while preserving total coherence C(t), synchronised phase couplings, and validated structural frequency νf.
+
+{%    if ctx.changelog_mode == "update" %}{#  # IMPORTANT: add insertion flag for next version update #}{{
+        insertion_flag ~ "\n"
+
+}}{%  endif %}

--- a/meta/semantic_release/templates/conventional/md/.components/changelog_init.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/changelog_init.md.j2
@@ -1,0 +1,29 @@
+{#
+This changelog template initializes a full changelog for the project,
+it follows the following logic:
+  1. Header
+  2. Any Unreleased Details (uncommon)
+  3. all previous releases except the very first release
+  4. the first release
+
+#}{#
+   #    Header
+#}{%    include "changelog_header.md.j2"
+-%}{#
+   #    Any Unreleased Details (uncommon)
+#}{%    include "unreleased_changes.md.j2"
+-%}{#
+    #   Since this is initialization, we are generating all the previous
+    #   release notes per version. The very first release notes is specialized
+#}{%    if releases | length > 0
+%}{%      for release in releases
+%}{{        "\n"
+}}{%        if loop.last and ctx.mask_initial_release
+%}{%-         include "first_release.md.j2"
+-%}{%       else
+%}{%-         include "versioned_changes.md.j2"
+-%}{%       endif
+%}{{       "\n"
+}}{%      endfor
+%}{%    endif
+%}

--- a/meta/semantic_release/templates/conventional/md/.components/changelog_update.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/changelog_update.md.j2
@@ -1,0 +1,71 @@
+{#
+This Update changelog template uses the following logic:
+
+  1. Read previous changelog file (ex. project_root/CHANGELOG.md)
+  2. Split on insertion flag (ex. <!-- version list -->)
+  3. Print top half of previous changelog
+  3. New Changes (unreleased commits & newly released)
+  4. Print bottom half of previous changelog
+
+  Note: if a previous file was not found, it does not write anything at the bottom
+        but render does NOT fail
+
+#}{%  set prev_changelog_contents = prev_changelog_file | read_file | safe
+%}{%  set changelog_parts = prev_changelog_contents.split(insertion_flag, maxsplit=1)
+%}{#
+#}{%  if changelog_parts | length < 2
+%}{#    # insertion flag was not found, check if the file was empty or did not exist
+#}{%    if prev_changelog_contents | length > 0
+%}{#      # File has content but no insertion flag, therefore, file will not be updated
+#}{{      changelog_parts[0]
+}}{%    else
+%}{#      # File was empty or did not exist, therefore, it will be created from scratch
+#}{%      include "changelog_init.md.j2"
+%}{%    endif
+%}{%  else
+%}{#
+   #    Previous Changelog Header
+   #      - Depending if there is header content, then it will separate the insertion flag
+   #        with a newline from header content, otherwise it will just print the insertion flag
+#}{%    set prev_changelog_top = changelog_parts[0] | trim
+%}{%    if prev_changelog_top | length > 0
+%}{{
+          "%s\n\n%s\n" | format(prev_changelog_top, insertion_flag | trim)
+
+}}{%    else
+%}{{
+          "%s\n" | format(insertion_flag | trim)
+
+}}{%    endif
+%}{#
+   #    Any Unreleased Details (uncommon)
+#}{%    include "unreleased_changes.md.j2"
+-%}{#
+#}{%    if releases | length > 0
+%}{#      # Latest Release Details
+#}{%      set release = releases[0]
+%}{#
+#}{%      if releases | length == 1 and ctx.mask_initial_release
+%}{#        # First Release detected
+#}{{        "\n"
+}}{%-       include "first_release.md.j2"
+-%}{{       "\n"
+}}{#
+#}{%      elif "# " ~ release.version.as_semver_tag() ~ " " not in changelog_parts[1]
+%}{#        # The release version is not already in the changelog so we add it
+#}{{        "\n"
+}}{%-       include "versioned_changes.md.j2"
+-%}{{       "\n"
+}}{#
+#}{%      endif
+%}{%    endif
+%}{#
+   #    Previous Changelog Footer
+   #      - skips printing footer if empty, which happens when the insertion_flag
+   #        was at the end of the file (ignoring whitespace)
+#}{%    set previous_changelog_bottom = changelog_parts[1] | trim
+%}{%    if previous_changelog_bottom | length > 0
+%}{{      "\n%s\n" | format(previous_changelog_bottom)
+}}{%    endif
+%}{%  endif
+%}

--- a/meta/semantic_release/templates/conventional/md/.components/changes.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/changes.md.j2
@@ -1,0 +1,129 @@
+{%    from 'macros.md.j2' import apply_alphabetical_ordering_by_brk_descriptions
+%}{%  from 'macros.md.j2' import apply_alphabetical_ordering_by_descriptions
+%}{%  from 'macros.md.j2' import apply_alphabetical_ordering_by_release_notices
+%}{%  from 'macros.md.j2' import format_breaking_changes_description, format_commit_summary_line
+%}{%  from 'macros.md.j2' import format_release_notice
+%}{#
+EXAMPLE:
+
+### Features
+
+- Add new feature ([#10](https://domain.com/namespace/repo/pull/10),
+  [`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+- **scope**: Add new feature ([`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+### Bug Fixes
+
+- Fix bug ([#11](https://domain.com/namespace/repo/pull/11),
+  [`abcdef1`](https://domain.com/namespace/repo/commit/HASH))
+
+### Breaking Changes
+
+- With the change _____, the change causes ___ effect. Ultimately, this section
+  it is a more detailed description of the breaking change. With an optional
+  scope prefix like the commit messages above.
+
+- **scope**: this breaking change has a scope to identify the part of the code that
+  this breaking change applies to for better context.
+
+### Additional Release Information
+
+- This is a release note that provides additional information about the release
+  that is not a breaking change or a feature/bug fix.
+
+- **scope**: this release note has a scope to identify the part of the code that
+  this release note applies to for better context.
+
+#}{%  set max_line_width = max_line_width | default(100)
+%}{%  set hanging_indent = hanging_indent | default(2)
+%}{#
+#}{%  for type_, commits in commit_objects if type_ != "unknown"
+%}{#    PREPROCESS COMMITS (order by description & format description line)
+#}{%    set ns = namespace(commits=commits)
+%}{%    set _ = apply_alphabetical_ordering_by_descriptions(ns)
+%}{#
+#}{%    set commit_descriptions = []
+%}{#
+#}{%    for commit in ns.commits
+%}{#      # Add reference links to the commit summary line
+#}{%      set description = "- %s" | format(format_commit_summary_line(commit))
+%}{%      set description = description | autofit_text_width(max_line_width, hanging_indent)
+%}{%      set _ = commit_descriptions.append(description)
+%}{%    endfor
+%}{#
+   #    # PRINT SECTION (header & commits)
+#}{%    if commit_descriptions | length > 0
+%}{{      "\n"
+}}{{      "### %s\n" | format(type_ | title)
+}}{{      "\n"
+}}{{      "%s\n" | format(commit_descriptions | unique | join("\n\n"))
+}}{%    endif
+%}{%  endfor
+%}{#
+      # Determine if there are any breaking change commits by filtering the list by breaking descriptions
+      # commit_objects is a list of tuples [("Features", [ParsedCommit(), ...]), ("Bug Fixes", [ParsedCommit(), ...])]
+      # HOW: Filter out breaking change commits that have no breaking descriptions
+      #  1. Re-map the list to only the list of commits under the breaking category from the list of tuples
+      #  2. Peel off the outer list to get a list of ParsedCommit objects
+      #  3. Filter the list of ParsedCommits to only those with a breaking description
+#}{%  set breaking_commits = commit_objects | map(attribute="1.0")
+%}{%  set breaking_commits = breaking_commits | rejectattr("error", "defined") | selectattr("breaking_descriptions.0") | list
+%}{#
+#}{%  if breaking_commits | length > 0
+%}{#    PREPROCESS COMMITS
+#}{%    set brk_ns = namespace(commits=breaking_commits)
+%}{%    set _ = apply_alphabetical_ordering_by_brk_descriptions(brk_ns)
+%}{#
+#}{%    set brking_descriptions = []
+%}{#
+#}{%    for commit in brk_ns.commits
+%}{%      set full_description = "- %s" | format(
+            format_breaking_changes_description(commit).split("\n\n") | join("\n\n- ")
+          )
+%}{%      set _ = brking_descriptions.append(
+            full_description | autofit_text_width(max_line_width, hanging_indent)
+          )
+%}{%    endfor
+%}{#
+   #    # PRINT BREAKING CHANGE DESCRIPTIONS (header & descriptions)
+#}{{    "\n"
+}}{{    "### Breaking Changes\n"
+}}{{
+        "\n%s\n" | format(brking_descriptions | unique | join("\n\n"))
+}}{#
+#}{%  endif
+%}{#
+      # Determine if there are any commits with release notice information by filtering the list by release_notices
+      # commit_objects is a list of tuples [("Features", [ParsedCommit(), ...]), ("Bug Fixes", [ParsedCommit(), ...])]
+      # HOW: Filter out commits that have no release notices
+      #  1. Re-map the list to only the list of commits from the list of tuples
+      #  2. Peel off the outer list to get a list of ParsedCommit objects
+      #  3. Filter the list of ParsedCommits to only those with a release notice
+#}{%  set notice_commits = commit_objects | map(attribute="1.0")
+%}{%  set notice_commits = notice_commits | rejectattr("error", "defined") | selectattr("release_notices.0") | list
+%}{#
+#}{%  if notice_commits | length > 0
+%}{#    PREPROCESS COMMITS
+#}{%    set notice_ns = namespace(commits=notice_commits)
+%}{%    set _ = apply_alphabetical_ordering_by_release_notices(notice_ns)
+%}{#
+#}{%    set release_notices = []
+%}{#
+#}{%    for commit in notice_ns.commits
+%}{%      set full_description = "- %s" | format(
+            format_release_notice(commit).split("\n\n") | join("\n\n- ")
+          )
+%}{%      set _ = release_notices.append(
+            full_description | autofit_text_width(max_line_width, hanging_indent)
+          )
+%}{%    endfor
+%}{#
+   #    # PRINT RELEASE NOTICE INFORMATION (header & descriptions)
+#}{{    "\n"
+}}{{    "### Additional Release Information\n"
+}}{{
+        "\n%s\n" | format(release_notices | unique | join("\n\n"))
+}}{#
+#}{%  endif
+%}

--- a/meta/semantic_release/templates/conventional/md/.components/first_release.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/first_release.md.j2
@@ -1,0 +1,18 @@
+{#  EXAMPLE:
+
+## vX.X.X (YYYY-MMM-DD)
+
+_This release is published under the MIT License._       # Release Notes Only
+
+- Initial Release
+
+#}{{
+"## %s (%s)\n" | format(
+    release.version.as_semver_tag(),
+    release.tagged_date.strftime("%Y-%m-%d")
+)
+}}{%  if license_name is defined and license_name
+%}{{    "\n_This release is published under the %s License._\n" | format(license_name)
+}}{%  endif
+%}
+- Initial Release

--- a/meta/semantic_release/templates/conventional/md/.components/macros.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/macros.md.j2
@@ -1,0 +1,199 @@
+{#
+  MACRO: format a inline link reference in Markdown
+#}{%  macro format_link(link, label)
+%}{{    "[%s](%s)" | format(label, link)
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: Capitalize the first letter of a string only
+#}{%  macro capitalize_first_letter_only(sentence)
+%}{{    (sentence[0] | upper) ~ sentence[1:]
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: commit message links or PR/MR links of commit
+#}{%  macro commit_msg_links(commit)
+%}{%    if commit.error is undefined
+%}{#
+   #      # Initialize variables
+#}{%      set link_references = []
+%}{%      set summary_line = capitalize_first_letter_only(
+            commit.descriptions[0] | safe
+          )
+%}{#
+#}{%      if commit.linked_merge_request != ""
+%}{#        # Add PR references with a link to the PR
+#}{%        set _ = link_references.append(
+              format_link(
+                commit.linked_merge_request | pull_request_url,
+                commit.linked_merge_request
+              )
+            )
+%}{%      endif
+%}{#
+   #      # DEFAULT: Always include the commit hash as a link
+#}{%      set _ = link_references.append(
+            format_link(
+              commit.hexsha | commit_hash_url,
+              "`%s`" | format(commit.short_hash)
+            )
+          )
+%}{#
+#}{%      set formatted_links = ""
+%}{%      if link_references | length > 0
+%}{%        set formatted_links = " (%s)" | format(link_references | join(", "))
+%}{%      endif
+%}{#
+          # Return the modified summary_line
+#}{{      summary_line ~ formatted_links
+}}{%    endif
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: format commit summary line
+#}{%  macro format_commit_summary_line(commit)
+%}{#    # Check for Parsing Error
+#}{%    if commit.error is undefined
+%}{#
+   #      # Add any message links to the commit summary line
+#}{%      set summary_line = commit_msg_links(commit)
+%}{#
+#}{%      if commit.scope
+%}{%        set summary_line = "**%s**: %s" | format(commit.scope, summary_line)
+%}{%      endif
+%}{#
+   #      # Return the modified summary_line
+#}{{      summary_line
+}}{#
+#}{%    else
+%}{#      # Return the first line of the commit if there was a Parsing Error
+#}{{      (commit.commit.message | string).split("\n", maxsplit=1)[0]
+}}{%    endif
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: format a commit descriptions list by:
+  - Capitalizing the first line of the description
+  - Adding an optional scope prefix
+  - Joining the rest of the descriptions with a double newline
+#}{%  macro format_attr_paragraphs(commit, attribute)
+%}{#    NOTE: requires namespace because of the way Jinja2 handles variable scoping with loops
+#}{%    set ns = namespace(full_description="")
+%}{#
+#}{%    if commit.error is undefined
+%}{%      for paragraph in commit | attr(attribute)
+%}{%        if paragraph | trim | length > 0
+%}{#
+#}{%          set ns.full_description = [
+                ns.full_description,
+                capitalize_first_letter_only(paragraph) | trim | safe,
+              ] | join("\n\n")
+%}{#
+#}{%        endif
+%}{%      endfor
+%}{#
+#}{%      set ns.full_description = ns.full_description | trim
+%}{#
+#}{%      if commit.scope
+%}{%        set ns.full_description = "**%s**: %s" | format(
+              commit.scope, ns.full_description
+            )
+%}{%      endif
+%}{%    endif
+%}{#
+#}{{    ns.full_description
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: format the breaking changes description by:
+  - Capitalizing the description
+  - Adding an optional scope prefix
+#}{%  macro format_breaking_changes_description(commit)
+%}{{    format_attr_paragraphs(commit, 'breaking_descriptions')
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: format the release notice by:
+  - Capitalizing the description
+  - Adding an optional scope prefix
+#}{%  macro format_release_notice(commit)
+%}{{    format_attr_paragraphs(commit, "release_notices")
+}}{%  endmacro
+%}
+
+
+{#
+   MACRO: order commits alphabetically by scope and attribute
+   - Commits are sorted based on scope and then the attribute alphabetically
+   - Commits without scope are placed first and sorted alphabetically by the attribute
+   - parameter: ns (namespace) object with a commits list
+   - parameter: attr (string) attribute to sort by
+   - returns None but modifies the ns.commits list in place
+#}{%  macro order_commits_alphabetically_by_scope_and_attr(ns, attr)
+%}{%    set ordered_commits = []
+%}{#
+   #    # Eliminate any ParseError commits from input set
+#}{%    set filtered_commits = ns.commits | rejectattr("error", "defined") | list
+%}{#
+   #    # grab all commits with no scope and sort alphabetically by attr
+#}{%    for commit in filtered_commits | rejectattr("scope") | sort(attribute=attr)
+%}{%      set _ = ordered_commits.append(commit)
+%}{%     endfor
+%}{#
+   #    # grab all commits with a scope and sort alphabetically by the scope and then attr
+#}{%    for commit in filtered_commits | selectattr("scope") | sort(attribute=(['scope', attr] | join(",")))
+%}{%      set _ = ordered_commits.append(commit)
+%}{%    endfor
+%}{#
+   #    # Return the ordered commits
+#}{%    set ns.commits = ordered_commits
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized summaries and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_descriptions(ns)
+%}{%    set _ = order_commits_alphabetically_by_scope_and_attr(ns, 'descriptions.0')
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized breaking changes and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_brk_descriptions(ns)
+%}{%    set _ = order_commits_alphabetically_by_scope_and_attr(ns, 'breaking_descriptions.0')
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized release notices and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_release_notices(ns)
+%}{%    set _ = order_commits_alphabetically_by_scope_and_attr(ns, 'release_notices.0')
+%}{%  endmacro
+%}

--- a/meta/semantic_release/templates/conventional/md/.components/unreleased_changes.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/unreleased_changes.md.j2
@@ -1,0 +1,7 @@
+{%    if unreleased_commits | length > 0
+%}{{    "\n## Unreleased\n"
+}}{%    set commit_objects = unreleased_commits
+%}{%    include "changes.md.j2"
+-%}{{   "\n"
+}}{%  endif
+%}

--- a/meta/semantic_release/templates/conventional/md/.components/versioned_changes.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.components/versioned_changes.md.j2
@@ -1,0 +1,19 @@
+{#  EXAMPLE:
+
+## vX.X.X (YYYY-MMM-DD)
+
+_This release is published under the MIT License._            # Release Notes Only
+
+{{ change_sections }}
+
+#}{{
+"## %s (%s)\n" | format(
+  release.version.as_semver_tag(),
+  release.tagged_date.strftime("%Y-%m-%d")
+)
+}}{%  if license_name is defined and license_name %}{{    "\n_This release is published under the %s License._\n" | format(license_name)
+}}{%  endif %}{{
+    "\n**TNFR structural safeguards**\n"}}
+{{ "- Coherence C(t) tracked through the validated operator sequence.\n" }}
+{{ "- Phase synchrony verified before coupling propagation.\n" }}
+{{ "- Structural frequency νf logged for downstream audits.\n" }}{%  set commit_objects = release["elements"] | dictsort %}{%  include "changes.md.j2" -%}

--- a/meta/semantic_release/templates/conventional/md/.release_notes.md.j2
+++ b/meta/semantic_release/templates/conventional/md/.release_notes.md.j2
@@ -1,0 +1,62 @@
+{#  EXAMPLE:
+
+## v1.0.0 (2020-01-01)
+
+_This release is published under the MIT License._
+
+### Features
+
+- Add new feature ([#10](https://domain.com/namespace/repo/pull/10), [`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+- **scope**: Add new feature ([`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+### Bug Fixes
+
+- Fix bug (#11, [`abcdef1`](https://domain.com/namespace/repo/commit/HASH))
+
+### Breaking Changes
+
+- With the change _____, the change causes ___ effect. Ultimately, this section it is a more detailed description of the breaking change. With an optional scope prefix like the commit messages above.
+
+- **scope**: this breaking change has a scope to identify the part of the code that this breaking change applies to for better context.
+
+### Additional Release Information
+
+- This is a release note that provides additional information about the release that is not a breaking change or a feature/bug fix.
+
+- **scope**: this release note has a scope to identify the part of the code that this release note applies to for better context.
+
+---
+
+**Detailed Changes**: [vX.X.X...vX.X.X](https://domain.com/namespace/repo/compare/vX.X.X...vX.X.X)
+
+#}{#  # Set line width to 1000 to avoid wrapping as GitHub will handle it
+#}{%  set max_line_width = max_line_width | default(1000)
+%}{%  set hanging_indent = hanging_indent | default(2)
+%}{%  set license_name = license_name | default("", True)
+%}{%  set releases = context.history.released.values() | list
+%}{%  set curr_release_index = releases.index(release)
+%}{#
+#}{%  if mask_initial_release and curr_release_index == releases | length - 1
+%}{#    # On a first release, generate our special message
+#}{%    include ".components/first_release.md.j2"
+%}{%  else
+%}{#    # Not the first release so generate notes normally
+#}{%    include ".components/versioned_changes.md.j2"
+-%}{#
+#}{%    set prev_release_index = curr_release_index + 1
+%}{#
+#}{%    if 'compare_url' is filter and prev_release_index < releases | length
+%}{%      set prev_version_tag = releases[prev_release_index].version.as_tag()
+%}{%      set new_version_tag = release.version.as_tag()
+%}{%      set version_compare_url = prev_version_tag | compare_url(new_version_tag)
+%}{%      set detailed_changes_link = '[{}...{}]({})'.format(
+            prev_version_tag, new_version_tag, version_compare_url
+          )
+%}{{      "\n"
+}}{{      "---\n"
+}}{{      "\n"
+}}{{      "**Detailed Changes**: %s" | format(detailed_changes_link)
+}}{%    endif
+%}{%  endif
+%}

--- a/meta/semantic_release/templates/conventional/md/CHANGELOG.md.j2
+++ b/meta/semantic_release/templates/conventional/md/CHANGELOG.md.j2
@@ -1,0 +1,21 @@
+{#
+    This changelog template controls which changelog creation occurs
+    based on which mode is provided.
+
+    Modes:
+        - init: Initialize a full changelog from scratch
+        - update: Insert new version details where the placeholder exists in the current changelog
+
+#}{%  set insertion_flag = ctx.changelog_insertion_flag
+%}{%  set unreleased_commits = ctx.history.unreleased | dictsort
+%}{%  set releases = ctx.history.released.values() | list
+%}{#
+#}{%  if ctx.changelog_mode == "init"
+%}{%    include ".components/changelog_init.md.j2"
+%}{#
+#}{%  elif ctx.changelog_mode == "update"
+%}{%    set prev_changelog_file = ctx.prev_changelog_file
+%}{%    include ".components/changelog_update.md.j2"
+%}{#
+#}{%  endif
+%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ typecheck = [
   "types-cachetools>=6.0.0.0",
   "numpy>=1.24",
 ]
+release = [
+  "python-semantic-release>=10.4,<11",
+  "setuptools-scm>=8,<9",
+  "build>=1",
+]
 
 [project.scripts]
 tnfr = "tnfr.cli:main"
@@ -59,11 +64,41 @@ Homepage = "https://pypi.org/project/tnfr/"
 Repository = "https://github.com/fermga/TNFR-Python-Engine"
 GPT = "https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-resonant-fractal-nature-theory"
 
-[tool.setuptools.dynamic]
-version = { attr = "tnfr._version.__version__" }
-
 [tool.setuptools.package-data]
 tnfr = ["py.typed"]
+
+[tool.setuptools_scm]
+tag_regex = '^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
+local_scheme = "no-local-version"
+write_to = "src/tnfr/_generated_version.py"
+
+[tool.semantic_release]
+version_source = "tag"
+commit_parser = "conventional"
+allow_zero_version = false
+major_on_zero = false
+tag_format = "v{version}"
+
+[tool.semantic_release.branches.main]
+match = "^main$"
+prerelease = false
+
+[tool.semantic_release.changelog]
+template_dir = "meta/semantic_release/templates"
+mode = "update"
+changelog_file = ""
+
+[tool.semantic_release.changelog.default_templates]
+mask_initial_release = true
+
+[tool.semantic_release.commit_parser_options]
+minor_tags = ["feat", "structure"]
+patch_tags = ["fix", "perf", "refactor", "docs", "test", "build", "ci", "style", "chore"]
+other_allowed_tags = ["revert", "docs", "test", "build", "ci", "style", "refactor", "perf", "chore"]
+allowed_tags = ["feat", "fix", "perf", "refactor", "docs", "test", "build", "ci", "style", "chore", "structure", "revert"]
+default_bump_level = 0
+parse_squash_commits = true
+ignore_merge_commits = true
 
 [tool.black]
 line-length = 88
@@ -124,5 +159,5 @@ ignore_missing_imports = true
 
 
 [build-system]
-requires = ["setuptools>=78.1.1", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"

--- a/src/tnfr/_version.py
+++ b/src/tnfr/_version.py
@@ -1,7 +1,49 @@
-"""Package version for :mod:`tnfr`."""
+"""Runtime version discovery for :mod:`tnfr`."""
 
 from __future__ import annotations
 
+import os
+from importlib import metadata
+from typing import Final
+
 __all__ = ["__version__"]
 
-__version__ = "6.0.0"
+
+def _read_version() -> str:
+    """Resolve the published package version while preserving TNFR invariants."""
+
+    env_version = os.environ.get("TNFR_VERSION")
+    if env_version:
+        return env_version
+
+    try:
+        return metadata.version("tnfr")
+    except metadata.PackageNotFoundError:
+        pass
+
+    try:  # pragma: no cover - only present in built distributions
+        from . import _generated_version  # type: ignore
+    except ImportError:  # pragma: no cover - optional artifact
+        pass
+    else:
+        generated = getattr(_generated_version, "version", None)
+        if isinstance(generated, str) and generated:
+            return generated
+        legacy = getattr(_generated_version, "__version__", None)
+        if isinstance(legacy, str) and legacy:
+            return legacy
+
+    try:
+        from setuptools_scm import get_version
+    except Exception:  # pragma: no cover - optional dependency
+        pass
+    else:
+        try:
+            return get_version(relative_to=__file__)
+        except LookupError:
+            pass
+
+    return "0.0.0"
+
+
+__version__: Final[str] = _read_version()


### PR DESCRIPTION
## Summary
- configure python-semantic-release with TNFR-specific templates and commit taxonomy
- switch runtime version discovery to semantic metadata with setuptools-scm fallbacks
- update release workflow to compute tags, share version outputs, and document the process for TNFR teams

## Testing
- pytest -m 'not slow' *(fails: tests expect legacy selector helpers and stress package relative import layout)*

------
https://chatgpt.com/codex/tasks/task_e_68ff1a80346883219833aeb433cb434f