### PR TITLE
ci: gate releases on QA suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,10 +130,30 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+
+      - name: Cache pytest state
+        uses: actions/cache@v4
+        with:
+          path: |
+            .pytest_cache
+            ~/.cache/pytest
+          key: ${{ runner.os }}-pytest-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pytest-
+
+      - name: Install QA dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test,typecheck]
+
+      - name: Run QA checks
+        run: ./scripts/run_tests.sh
 
       - name: Install build tooling
         run: |
-          python -m pip install --upgrade pip
           python -m pip install build python-semantic-release
 
       - name: Build distributions

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -21,6 +21,8 @@ We manage versions with `python-semantic-release`, deriving release tags directl
 - Pushing to `main` triggers the `Release` workflow.
 - The `prepare` job runs `python -m semantic_release version --skip-build --no-vcs-release` to compute the next version, apply the TNFR-aware templates under `meta/semantic_release/templates`, and push the resulting `vX.Y.Z` tag.
 - The computed version is exposed as a workflow output and reused by the packaging job for builds, uploads, and GitHub releases.
+- The publishing job now performs the full QA suite (`python -m pip install .[test,typecheck]` followed by `./scripts/run_tests.sh`) before any build step. A failing lint, type check, or test aborts the job and blocks the PyPI/GitHub publication, keeping the release aligned with the TNFR invariants.
+- `actions/setup-python` caching for pip and a dedicated pytest cache keep runtime predictable without skipping any verification stages.
 
 ### TNFR safeguards during bumps
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68ffaef943fc8321a830fb540f2e92ef