### PR TITLE
Optimize vectorised phase aggregation for Si metric

### DIFF
--- a/src/tnfr/metrics/trig.pyi
+++ b/src/tnfr/metrics/trig.pyi
@@ -9,4 +9,5 @@ _neighbor_phase_mean_generic: Any
 _phase_mean_from_iter: Any
 accumulate_cos_sin: Any
 neighbor_phase_mean: Any
+neighbor_phase_mean_bulk: Any
 neighbor_phase_mean_list: Any


### PR DESCRIPTION
## Summary
- add ordered trig cache arrays and a bulk neighbour phase helper to support vectorised Si computations
- update `compute_Si` to reuse the cache-backed arrays and bulk helper whenever NumPy is available
- extend the NumPy usage tests to cover the new helper path while keeping the Python fallback numerically aligned

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_68ffbd0a41f4832180b19172f4a8fd18