### PR TITLE
Enable chunked batching for Si telemetry

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -72,3 +72,21 @@ The command writes two files:
 Inspect the top entries sorted by `cumtime` (cumulative time per function) to
 spot the phases consuming most wall-clock time. Compare both outputs to confirm
 that vectorisation shifts time into array primitives rather than Python loops.
+
+### Chunked execution switches
+
+Both benchmarks honour the new batching knobs exposed by the engine:
+
+* Set `graph.graph["SI_CHUNK_SIZE"] = 2048` (or pass
+  `chunk_size=2048` when calling `compute_Si`) inside
+  `compute_si_profile.py` to process nodes in deterministic batches. This is
+  helpful when profiling large (>10k nodes) graphs on memory-constrained
+  machines.
+* Set `graph.graph["DNFR_CHUNK_SIZE"] = 4096` before invoking
+  `default_compute_delta_nfr` to bound the accumulator size in the ΔNFR
+  benchmark. Larger chunks favour throughput, while smaller ones keep the
+  temporary buffers inside stricter memory budgets.
+
+Leave both settings unset for medium-sized runs; the automatic heuristics use
+CPU availability and a conservative memory estimate to choose a balanced chunk
+size.

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -36,6 +36,7 @@ from .data import (
     normalize_materialize_limit,
     normalize_weights,
 )
+from .chunks import auto_chunk_size, resolve_chunk_size
 from .graph import (
     get_graph,
     get_graph_mapping,
@@ -71,6 +72,8 @@ __all__ = (
     "MAX_MATERIALIZE_DEFAULT",
     "negative_weights_warn_once",
     "mix_groups",
+    "auto_chunk_size",
+    "resolve_chunk_size",
     "CacheManager",
     "EdgeCacheManager",
     "NODE_SET_CHECKSUM_KEY",

--- a/src/tnfr/utils/chunks.py
+++ b/src/tnfr/utils/chunks.py
@@ -1,0 +1,104 @@
+"""Chunk sizing heuristics for batching structural computations.
+
+The helpers in this module determine how large each processing block should be
+when splitting work across workers or vectorised loops.  They take into account
+the number of items involved, approximate memory pressure, and available CPU
+parallelism so the caller can balance throughput with deterministic behaviour.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Final
+
+DEFAULT_APPROX_BYTES_PER_ITEM: Final[int] = 64
+DEFAULT_CHUNK_CLAMP: Final[int] | None = 131_072
+
+
+def _estimate_available_memory() -> int | None:
+    """Best-effort estimation of free memory available to the process."""
+
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        avail_pages = os.sysconf("SC_AVPHYS_PAGES")
+    except (AttributeError, ValueError, OSError):  # pragma: no cover - platform specific
+        return None
+    if page_size <= 0 or avail_pages <= 0:
+        return None
+    return int(page_size) * int(avail_pages)
+
+
+def auto_chunk_size(
+    total_items: int,
+    *,
+    minimum: int = 1,
+    approx_bytes_per_item: int = DEFAULT_APPROX_BYTES_PER_ITEM,
+    clamp_to: int | None = DEFAULT_CHUNK_CLAMP,
+) -> int:
+    """Infer a safe chunk length when the caller does not specify one."""
+
+    if total_items <= 0:
+        return 0
+
+    minimum = max(1, minimum)
+    approx_bytes_per_item = max(1, approx_bytes_per_item)
+
+    available_memory = _estimate_available_memory()
+    if available_memory is not None and available_memory > 0:
+        safe_bytes = max(approx_bytes_per_item * minimum, available_memory // 8)
+        mem_bound = max(minimum, min(total_items, safe_bytes // approx_bytes_per_item))
+    else:
+        mem_bound = total_items
+
+    if clamp_to is not None:
+        mem_bound = min(mem_bound, clamp_to)
+
+    cpu_count = os.cpu_count() or 1
+    target_chunks = max(1, cpu_count * 4)
+    cpu_chunk = max(minimum, math.ceil(total_items / target_chunks))
+    baseline = max(minimum, min(total_items, 1024))
+    target = max(cpu_chunk, baseline)
+
+    chunk = min(mem_bound, target)
+    chunk = max(minimum, min(total_items, chunk))
+    return chunk
+
+
+def resolve_chunk_size(
+    chunk_size: int | None,
+    total_items: int,
+    *,
+    minimum: int = 1,
+    approx_bytes_per_item: int = DEFAULT_APPROX_BYTES_PER_ITEM,
+    clamp_to: int | None = DEFAULT_CHUNK_CLAMP,
+) -> int:
+    """Return a sanitised chunk size honouring automatic fallbacks."""
+
+    if total_items <= 0:
+        return 0
+
+    resolved: int | None
+    if chunk_size is None:
+        resolved = None
+    else:
+        try:
+            resolved = int(chunk_size)
+        except (TypeError, ValueError):
+            resolved = None
+        else:
+            if resolved <= 0:
+                resolved = None
+
+    if resolved is None:
+        resolved = auto_chunk_size(
+            total_items,
+            minimum=minimum,
+            approx_bytes_per_item=approx_bytes_per_item,
+            clamp_to=clamp_to,
+        )
+
+    return max(minimum, min(total_items, resolved))
+
+
+__all__ = ["auto_chunk_size", "resolve_chunk_size"]

--- a/src/tnfr/utils/chunks.pyi
+++ b/src/tnfr/utils/chunks.pyi
@@ -1,0 +1,21 @@
+from typing import Final
+
+DEFAULT_APPROX_BYTES_PER_ITEM: Final[int]
+DEFAULT_CHUNK_CLAMP: Final[int | None]
+
+def auto_chunk_size(
+    total_items: int,
+    *,
+    minimum: int = ...,
+    approx_bytes_per_item: int = ...,
+    clamp_to: int | None = ...,
+) -> int: ...
+
+def resolve_chunk_size(
+    chunk_size: int | None,
+    total_items: int,
+    *,
+    minimum: int = ...,
+    approx_bytes_per_item: int = ...,
+    clamp_to: int | None = ...,
+) -> int: ...


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Introduced shared chunk-sizing utilities and applied them to `compute_Si` so vectorised and Python paths batch nodes deterministically.
- Balanced NumPy neighbour reductions in ΔNFR by chunking `_accumulate_neighbors_broadcasted` and exposing the `DNFR_CHUNK_SIZE` graph knob.
- Documented batching guidance for telemetry benchmarks and extended Si tests to exercise manual and graph-configured chunk sizing.

## Testing
- `pytest tests/unit/metrics/test_compute_Si_numpy_usage.py`
- `pytest tests/unit/dynamics/test_dynamics_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ffc16586fc83218d84aa21879e3f44