### PR TITLE
Reuse cached edge indices for Si vector computation

### DIFF
--- a/src/tnfr/metrics/trig_cache.py
+++ b/src/tnfr/metrics/trig_cache.py
@@ -29,6 +29,8 @@ class TrigCache:
     sin_values: Any
     theta_values: Any
     index: dict[Any, int]
+    edge_src: Any | None = None
+    edge_dst: Any | None = None
 
 
 def _iter_theta_pairs(
@@ -76,6 +78,8 @@ def _compute_trig_python(
         sin_values=sin_values,
         theta_values=theta_values,
         index=index,
+        edge_src=None,
+        edge_dst=None,
     )
 
 
@@ -101,6 +105,8 @@ def compute_theta_trig(
             sin_values=(),
             theta_values=(),
             index={},
+            edge_src=None,
+            edge_dst=None,
         )
 
     node_list, theta_vals = zip(*pairs)
@@ -122,6 +128,8 @@ def compute_theta_trig(
         sin_values=sin_arr,
         theta_values=theta_arr,
         index=index,
+        edge_src=None,
+        edge_dst=None,
     )
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [x] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add optional `edge_src`/`edge_dst` slots to `TrigCache` so edge indices can be reused alongside cached trigonometric state
- refactor the NumPy path of `compute_Si` to pull edge indices from an `edge_version_cache`, fill results via vector assignments, and document the ndarray return when updating in place
- extend the Si test suite to cover cache invalidation on edge mutation and equality with the Python fallback

## Testing
- `pytest tests/unit/metrics/test_compute_Si_numpy_usage.py`
- `pytest tests/unit/metrics/test_trig_cache_reuse.py`


------
https://chatgpt.com/codex/tasks/task_e_68ffc7e1e0f48321a70eacb19f42184e