### PR TITLE
Use bincount for vector trig aggregation and cover isolated nodes

### DIFF
--- a/src/tnfr/metrics/trig.py
+++ b/src/tnfr/metrics/trig.py
@@ -230,15 +230,22 @@ def neighbor_phase_mean_bulk(
     if sin_arr.ndim != 1 or sin_arr.size != node_count:
         raise ValueError("sin_values must be a 1-D array matching node_count")
 
-    neighbor_cos_sum = np.zeros(node_count, dtype=float)
-    neighbor_sin_sum = np.zeros(node_count, dtype=float)
-
     edge_count = edge_dst_arr.size
     if edge_count:
-        np.add.at(neighbor_cos_sum, edge_dst_arr, cos_arr[edge_src_arr])
-        np.add.at(neighbor_sin_sum, edge_dst_arr, sin_arr[edge_src_arr])
+        neighbor_cos_sum = np.bincount(
+            edge_dst_arr,
+            weights=cos_arr[edge_src_arr],
+            minlength=node_count,
+        )
+        neighbor_sin_sum = np.bincount(
+            edge_dst_arr,
+            weights=sin_arr[edge_src_arr],
+            minlength=node_count,
+        )
         neighbor_counts = np.bincount(edge_dst_arr, minlength=node_count).astype(float)
     else:
+        neighbor_cos_sum = np.zeros(node_count, dtype=float)
+        neighbor_sin_sum = np.zeros(node_count, dtype=float)
         neighbor_counts = np.zeros(node_count, dtype=float)
 
     has_neighbors = neighbor_counts > 0.0


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases
- Tests: `pytest tests/unit/metrics/test_trig_cache_reuse.py tests/unit/metrics/test_si_helpers.py`

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_68ffd823a59083219f4f3aaed4caae1f