### PR TITLE
Streamline DNFR neighbor accumulation workspace

### DIFF
--- a/tests/unit/dynamics/test_dnfr_precompute.py
+++ b/tests/unit/dynamics/test_dnfr_precompute.py
@@ -130,6 +130,7 @@ def test_prepare_reuses_neighbor_reduction_buffers_vectorized():
     edge_values_first = data["neighbor_edge_values_np"]
     accum_first = data["neighbor_accum_np"]
     assert edge_values_first is not None
+    assert edge_values_first.shape == (data["edge_count"],)
     assert accum_first is not None
     assert cache.neighbor_edge_values_np is edge_values_first
     assert cache.neighbor_accum_np is accum_first

--- a/tests/unit/dynamics/test_dnfr_vectorization_flags.py
+++ b/tests/unit/dynamics/test_dnfr_vectorization_flags.py
@@ -55,9 +55,12 @@ def _assert_vector_state(data, np):
         assert cache.edge_src is not None
         edge_values = cache.neighbor_edge_values_np
         assert data.get("neighbor_edge_values_np") is edge_values
-        if data.get("edge_count", 0):
+        edge_count = data.get("edge_count", 0)
+        if edge_count:
             assert isinstance(edge_values, np.ndarray)
-            assert edge_values.shape[0] == data["edge_count"]
+            assert edge_values.shape == (edge_count,)
+        else:
+            assert edge_values is None
 
 
 def test_compute_dnfr_uses_numpy_even_when_graph_disables_vectorization():
@@ -205,7 +208,13 @@ def test_build_neighbor_sums_uses_cached_numpy_when_get_numpy_none(monkeypatch):
     accum_after = data.get("neighbor_accum_np")
     assert isinstance(accum_after, np.ndarray)
     assert cache.neighbor_accum_np is accum_after
-    assert isinstance(data.get("neighbor_edge_values_np"), np.ndarray)
+    edge_workspace = data.get("neighbor_edge_values_np")
+    edge_count = data.get("edge_count", 0)
+    if edge_count:
+        assert isinstance(edge_workspace, np.ndarray)
+        assert edge_workspace.shape == (edge_count,)
+    else:
+        assert edge_workspace is None
 
     _compute_dnfr_common(
         G,

--- a/tests/unit/dynamics/test_dynamics_vectorized.py
+++ b/tests/unit/dynamics/test_dynamics_vectorized.py
@@ -619,6 +619,7 @@ def test_edge_accumulation_buffers_cached_and_stable(topo_weight, monkeypatch):
     edge_values = cache.neighbor_edge_values_np
     accumulator = cache.neighbor_accum_np
     assert edge_values is not None
+    assert edge_values.shape == (data_vec["edge_count"],)
     assert accumulator is not None
 
     with numpy_disabled(monkeypatch):
@@ -841,7 +842,7 @@ def test_broadcast_accumulation_dense_graph_equivalence():
     expected_rows = 4 + 1  # cos, sin, epi, vf, count
     if data_vec["w_topo"] != 0.0:
         expected_rows += 1
-    assert edge_buffer.shape == (expected_rows, data_vec["edge_count"])
+    assert edge_buffer.shape == (data_vec["edge_count"],)
     assert accumulator.shape == (expected_rows, len(data_vec["nodes"]))
 
     for idx, node in enumerate(dense_graph.nodes):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Replaced the broadcasted neighbor accumulation matrix with per-component `np.add.at` reductions and a cached 1D edge workspace to lower memory pressure while keeping cached signatures intact.
- Updated DNFR vectorization cache expectations and helper tests for the slimmer workspace representation and added assertions on edge-count-aware reuse.
- Added a regression test ensuring the NumPy and Python ΔNFR computation paths yield matching results when `_compute_dnfr_common` is reused.

## Testing
- `pytest -o addopts= tests/unit/dynamics/test_dnfr_vectorization_flags.py tests/unit/dynamics/test_dnfr_precompute.py tests/unit/dynamics/test_dynamics_vectorized.py tests/unit/dynamics/test_dynamics_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ffd944eee48321a17ab65cae45cba2