### PR TITLE
Optimize broadcast DNFR accumulation with bincount reductions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,6 +30,22 @@ PYTHONPATH=src python benchmarks/<script>.py
 | `prepare_dnfr_data.py` | ΔNFR data preparation reuse (`tnfr.dynamics._prepare_dnfr_data`). | Exercises cache reuse when assembling phase/EPI/νf arrays. |
 | `neighbor_accumulation_comparison.py` | Broadcast neighbour accumulation (`tnfr.dynamics.dnfr._accumulate_neighbors_numpy`). | Benchmarks the single `np.add.at` accumulator against the legacy stack kernel; on 320 random nodes (p=0.65) with Python 3.11/NumPy 2.3.4 it delivered ~1.9× lower median runtime (0.097 s vs 0.185 s). |
 
+### Broadcast accumulator regression check
+
+The performance test suite now covers the vectorised accumulator that relies on
+`numpy.bincount` to collapse neighbour contributions. Run the slow-marked test
+to validate both speed and numerical parity against the pure-Python path:
+
+```bash
+PYTHONPATH=src pytest tests/performance/test_dynamics_performance.py \
+  -k broadcast_neighbor_accumulator_stays_faster_and_correct -m slow
+```
+
+The command prints per-test timings; the assertion requires the NumPy path to
+complete at least 10 % faster while matching the fallback values within
+`1e-9` relative/absolute tolerance. Use it to capture before/after measurements
+when iterating on `_accumulate_neighbors_broadcasted` or related kernels.
+
 ## Retired scripts
 
 Older benchmarks covering glyph history trimming, usage counters, or glyph

--- a/tests/unit/dynamics/test_dnfr_precompute.py
+++ b/tests/unit/dynamics/test_dnfr_precompute.py
@@ -130,8 +130,9 @@ def test_prepare_reuses_neighbor_reduction_buffers_vectorized():
     edge_values_first = data["neighbor_edge_values_np"]
     accum_first = data["neighbor_accum_np"]
     assert edge_values_first is not None
-    assert edge_values_first.shape == (data["edge_count"],)
     assert accum_first is not None
+    chunk_size = data.get("neighbor_chunk_size") or data["edge_count"]
+    assert edge_values_first.shape == (chunk_size, accum_first.shape[0])
     assert cache.neighbor_edge_values_np is edge_values_first
     assert cache.neighbor_accum_np is accum_first
 

--- a/tests/unit/dynamics/test_dnfr_vectorization_flags.py
+++ b/tests/unit/dynamics/test_dnfr_vectorization_flags.py
@@ -58,7 +58,8 @@ def _assert_vector_state(data, np):
         edge_count = data.get("edge_count", 0)
         if edge_count:
             assert isinstance(edge_values, np.ndarray)
-            assert edge_values.shape == (edge_count,)
+            chunk_size = data.get("neighbor_chunk_size") or edge_count
+            assert edge_values.shape == (chunk_size, accum.shape[0])
         else:
             assert edge_values is None
 
@@ -212,7 +213,9 @@ def test_build_neighbor_sums_uses_cached_numpy_when_get_numpy_none(monkeypatch):
     edge_count = data.get("edge_count", 0)
     if edge_count:
         assert isinstance(edge_workspace, np.ndarray)
-        assert edge_workspace.shape == (edge_count,)
+        chunk_size = data.get("neighbor_chunk_size") or edge_count
+        expected_rows = accum_after.shape[0]
+        assert edge_workspace.shape == (chunk_size, expected_rows)
     else:
         assert edge_workspace is None
 

--- a/tests/unit/dynamics/test_dynamics_vectorized.py
+++ b/tests/unit/dynamics/test_dynamics_vectorized.py
@@ -619,8 +619,9 @@ def test_edge_accumulation_buffers_cached_and_stable(topo_weight, monkeypatch):
     edge_values = cache.neighbor_edge_values_np
     accumulator = cache.neighbor_accum_np
     assert edge_values is not None
-    assert edge_values.shape == (data_vec["edge_count"],)
     assert accumulator is not None
+    chunk_size = data_vec.get("neighbor_chunk_size") or data_vec["edge_count"]
+    assert edge_values.shape == (chunk_size, accumulator.shape[0])
 
     with numpy_disabled(monkeypatch):
         loop_graph = base.copy()
@@ -842,7 +843,8 @@ def test_broadcast_accumulation_dense_graph_equivalence():
     expected_rows = 4 + 1  # cos, sin, epi, vf, count
     if data_vec["w_topo"] != 0.0:
         expected_rows += 1
-    assert edge_buffer.shape == (data_vec["edge_count"],)
+    chunk_size = data_vec.get("neighbor_chunk_size") or data_vec["edge_count"]
+    assert edge_buffer.shape == (chunk_size, expected_rows)
     assert accumulator.shape == (expected_rows, len(data_vec["nodes"]))
 
     for idx, node in enumerate(dense_graph.nodes):


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Replace the broadcast neighbour accumulator’s per-attribute `np.add.at` calls with a single `numpy.bincount` reduction that reuses chunked workspaces and widens cached edge buffers to include every component.
- Extend unit coverage for cache-less and topology-enabled scenarios, update shape assertions to the new workspace layout, and add a slow performance regression test that compares vectorised vs. pure-Python neighbours.
- Document the pytest invocation that captures the broadcast accumulator speed-up in `benchmarks/README.md`.

## Testing
- `pytest tests/unit/dynamics/test_neighbor_accumulation_vectorized.py`
- `pytest tests/unit/dynamics/test_dynamics_vectorized.py`
- `pytest tests/unit/dynamics/test_dnfr_precompute.py`
- `pytest tests/unit/dynamics/test_dnfr_vectorization_flags.py`
- `pytest tests/performance/test_dynamics_performance.py -k broadcast_neighbor_accumulator_stays_faster_and_correct -m slow`


------
https://chatgpt.com/codex/tasks/task_e_68ffef64faa0832186b9cbe7433eec4c