### PR TITLE
Use in-place accumulation for chunked DNFR neighbor sums

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1719,16 +1719,7 @@ def _accumulate_neighbors_broadcasted(
             ) -> None:
                 if not src_indices.size:
                     return
-                component_accum = np.bincount(
-                    src_indices,
-                    weights=values,
-                    minlength=n,
-                )
-                size = component_accum.size
-                if size < n:
-                    target[:size] += component_accum
-                else:
-                    target += component_accum[:n]
+                np.add.at(target, src_indices, values)
 
             for start in chunk_indices:
                 end = min(start + chunk_step, edge_count)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6901379ce4548321b5aa8ee5843cf5e9