### PR TITLE
Refactor DNFR chunk accumulation to use stacked state matrix

### DIFF
--- a/tests/unit/dynamics/test_neighbor_accumulation_vectorized.py
+++ b/tests/unit/dynamics/test_neighbor_accumulation_vectorized.py
@@ -160,7 +160,7 @@ def test_neighbor_chunking_matches_unchunked():
     assert edge_workspace is not None
     accum = chunk_data.get("neighbor_accum_np")
     assert accum is not None
-    assert getattr(edge_workspace, "shape", None) == (chunk_size, accum.shape[0])
+    assert getattr(edge_workspace, "shape", None) == (accum.shape[0], chunk_size)
 
     baseline_graph = _dense_weighted_graph(
         np_module, nodes=nodes, topo_weight=topo_weight
@@ -215,7 +215,7 @@ def test_vectorized_neighbor_counts_use_cached_degrees():
 
     edge_workspace = data.get("neighbor_edge_values_np")
     if edge_workspace is not None:
-        assert getattr(edge_workspace, "shape", None)[1] == accum.shape[0]
+        assert getattr(edge_workspace, "shape", None)[0] == accum.shape[0]
 
 
 def test_vectorized_neighbor_counts_fallback_without_degrees():


### PR DESCRIPTION
### Summary
- restructure neighbor chunk accumulation to stack state rows and gather chunks with a single `np.take` plus `np.add.at`
- update DNFR vectorization tests to assert the new workspace layout and apply explicit chunk hints
- isolate cache reuse in broadcast tests when mixing vectorized and fallback computations

### Testing
- pytest tests/unit/dynamics/test_neighbor_accumulation_vectorized.py tests/unit/dynamics/test_dynamics_vectorized.py


------
https://chatgpt.com/codex/tasks/task_e_690143dda0e88321a2574b3d31b4d35f