### PR TITLE
Optimize chunked neighbor accumulation scatter addition

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -1751,22 +1751,21 @@ def _accumulate_neighbors_broadcasted(
                 ) -> None:
                     if target_row is None:
                         return
+                    row_view = accum[target_row]
                     if unit_weight:
-                        totals = np.bincount(src_slice, minlength=n)
-                    else:
-                        if values is None:
-                            return
-                        totals = np.bincount(
+                        np.add.at(
+                            row_view,
                             src_slice,
-                            weights=values,
-                            minlength=n,
+                            row_view.dtype.type(1.0),
                         )
-                    if totals.size:
-                        totals = totals.astype(accum.dtype, copy=False)
-                        limit = accum.shape[1]
-                        if totals.size > limit:
-                            totals = totals[:limit]
-                        accum[target_row, : totals.size] += totals
+                        return
+                    if values is None:
+                        return
+                    np.add.at(
+                        row_view,
+                        src_slice,
+                        values.astype(row_view.dtype, copy=False),
+                    )
 
                 _accumulate_chunk_row(
                     cos_row, chunk_matrix[cos_row, :slice_len]


### PR DESCRIPTION
## Summary
- accumulate chunked neighbor values directly into cached buffers with `np.add.at` to avoid per-iteration `bincount` allocations
- keep cached edge workspaces reusable across calls while ensuring dtype-compatible updates

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6901d8732d8c832190b3934918a39908