### PR TITLE
Improve chunked Si dispersion vectorisation

### DIFF
--- a/tests/unit/metrics/test_compute_Si_numpy_usage.py
+++ b/tests/unit/metrics/test_compute_Si_numpy_usage.py
@@ -297,7 +297,7 @@ def test_compute_Si_vectorized_chunked_results_match(monkeypatch, graph_canon):
 
     original_resolve = sense_index_mod.resolve_chunk_size
     captured: list[tuple[int | None, int, int]] = []
-    workspace_calls: list[tuple[int, int]] = []
+    workspace_calls: list[int] = []
 
     def tracking_resolve(chunk_pref, total, **kwargs):
         result = original_resolve(chunk_pref, total, **kwargs)
@@ -308,9 +308,9 @@ def test_compute_Si_vectorized_chunked_results_match(monkeypatch, graph_canon):
 
     original_workspace = sense_index_mod._ensure_chunk_workspace
 
-    def tracking_workspace(G, *, effective_chunk, count, np):
-        workspace_calls.append((effective_chunk, count))
-        return original_workspace(G, effective_chunk=effective_chunk, count=count, np=np)
+    def tracking_workspace(G, *, mask_count, np):
+        workspace_calls.append(mask_count)
+        return original_workspace(G, mask_count=mask_count, np=np)
 
     monkeypatch.setattr(
         "tnfr.metrics.sense_index._ensure_chunk_workspace",
@@ -318,13 +318,14 @@ def test_compute_Si_vectorized_chunked_results_match(monkeypatch, graph_canon):
     )
 
     chunked = compute_Si(G_chunked, inplace=False, chunk_size=5)
+    neighbor_count = sum(1 for node in G_chunked.nodes if G_chunked.degree(node) > 0)
 
     assert captured and captured[-1][0] == 5
     resolved_chunk = captured[-1][2]
     assert resolved_chunk <= 5
     assert resolved_chunk < node_count
     assert captured[-1][1] == node_count
-    assert workspace_calls == [(resolved_chunk, node_count)]
+    assert workspace_calls == [neighbor_count]
     assert set(chunked) == set(baseline)
     for node in baseline:
         assert chunked[node] == pytest.approx(baseline[node])


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [x] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Replaced the chunked Si phase dispersion loop with a fully vectorised path that operates on the masked neighbour indices in bulk.
- Simplified the cached workspace buffers to track the masked neighbour population and removed redundant padding.
- Extended the chunked Si unit checks and performance benchmark to assert parity with the fallback path while enforcing the improved timing under small chunk hints.

## Testing
- `pytest -o addopts='' tests/unit/metrics/test_compute_Si_numpy_usage.py::test_compute_Si_vectorized_chunked_results_match -q`
- `pytest -o addopts='' tests/performance/test_sense_performance.py::test_compute_Si_vectorized_outperforms_python -q`


------
https://chatgpt.com/codex/tasks/task_e_6901e29484c083219298cbc1d2d8e4a4