### PR TITLE
Stabilize cached neighbor phase aggregation throughput

### DIFF
--- a/src/tnfr/metrics/trig.py
+++ b/src/tnfr/metrics/trig.py
@@ -264,30 +264,35 @@ def neighbor_phase_mean_bulk(
     )
 
     if edge_count:
+        cos_bincount = np.bincount(
+            edge_dst_arr,
+            weights=cos_arr[edge_src_arr],
+            minlength=node_count,
+        )
+        sin_bincount = np.bincount(
+            edge_dst_arr,
+            weights=sin_arr[edge_src_arr],
+            minlength=node_count,
+        )
+        count_bincount = np.bincount(
+            edge_dst_arr,
+            minlength=node_count,
+        ).astype(float, copy=False)
+
         if not has_cos_buffer:
-            neighbor_cos_sum = np.bincount(
-                edge_dst_arr,
-                weights=cos_arr[edge_src_arr],
-                minlength=node_count,
-            )
+            neighbor_cos_sum = cos_bincount
         else:
-            np.add.at(neighbor_cos_sum, edge_dst_arr, cos_arr[edge_src_arr])
+            np.copyto(neighbor_cos_sum, cos_bincount)
 
         if not has_sin_buffer:
-            neighbor_sin_sum = np.bincount(
-                edge_dst_arr,
-                weights=sin_arr[edge_src_arr],
-                minlength=node_count,
-            )
+            neighbor_sin_sum = sin_bincount
         else:
-            np.add.at(neighbor_sin_sum, edge_dst_arr, sin_arr[edge_src_arr])
+            np.copyto(neighbor_sin_sum, sin_bincount)
 
         if not has_count_buffer:
-            neighbor_counts = np.bincount(
-                edge_dst_arr, minlength=node_count
-            ).astype(float)
+            neighbor_counts = count_bincount
         else:
-            np.add.at(neighbor_counts, edge_dst_arr, 1.0)
+            np.copyto(neighbor_counts, count_bincount)
     else:
         if neighbor_cos_sum is None:
             neighbor_cos_sum = np.zeros(node_count, dtype=float)

--- a/tests/unit/metrics/test_trig_cache_reuse.py
+++ b/tests/unit/metrics/test_trig_cache_reuse.py
@@ -139,7 +139,18 @@ def test_neighbor_phase_mean_bulk_reuses_buffers():
         mean_sin=mean_sin,
     )
 
+    fresh_theta, fresh_mask = neighbor_phase_mean_bulk(
+        edge_src,
+        edge_dst,
+        cos_values=cos_values,
+        sin_values=sin_values,
+        theta_values=theta,
+        node_count=theta.size,
+        np=np,
+    )
+
     assert mask.tolist() == [False, True, True, False]
+    assert fresh_mask.tolist() == mask.tolist()
     assert cos_sum is not None and sin_sum is not None
     assert counts is not None and mean_cos is not None and mean_sin is not None
     assert np.all(np.isfinite(cos_sum))
@@ -151,6 +162,7 @@ def test_neighbor_phase_mean_bulk_reuses_buffers():
     assert counts[3] == 0.0
     assert mean_cos[0] == 0.0
     assert mean_sin[3] == 0.0
+    np.testing.assert_allclose(mean_theta, fresh_theta, rtol=1e-12, atol=1e-12)
 
     cos_sum.fill(np.nan)
     sin_sum.fill(np.nan)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [x] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6901eb777b0883219311a278930253ca