### PR TITLE
Refine NumPy angle vectorization across Si and ΔNFR

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -23,7 +23,7 @@ from time import perf_counter
 from ..alias import get_attr, get_theta_attr, set_dnfr
 from ..cache import CacheManager
 from ..constants import DEFAULTS, get_aliases, get_param
-from ..helpers.numeric import angle_diff
+from ..helpers.numeric import angle_diff, angle_diff_array
 from ..metrics.common import merge_and_normalize_weights
 from ..metrics.trig import neighbor_phase_mean_list
 from ..metrics.trig_cache import compute_theta_trig
@@ -1133,12 +1133,8 @@ def _apply_dnfr_gradients(
         if w_topo != 0.0:
             grad_topo = _ensure_cached_array(cache, "grad_topo_np", deg_array.shape, np)
 
-        np.copyto(grad_phase, theta_np, casting="unsafe")
-        grad_phase -= th_bar
-        grad_phase += math.pi
-        np.mod(grad_phase, math.tau, out=grad_phase)
-        grad_phase -= math.pi
-        grad_phase *= -1.0 / math.pi
+        angle_diff_array(theta_np, th_bar, np=np, out=grad_phase)
+        np.multiply(grad_phase, -1.0 / math.pi, out=grad_phase)
 
         np.copyto(grad_epi, epi_bar, casting="unsafe")
         grad_epi -= epi_np

--- a/src/tnfr/helpers/__init__.py
+++ b/src/tnfr/helpers/__init__.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:  # pragma: no cover - import-time only for typing
     from ..glyph_history import HistoryDict
 from .numeric import (
     angle_diff,
+    angle_diff_array,
     clamp,
     clamp01,
     kahan_sum_nd,
@@ -41,6 +42,7 @@ __all__ = (
     "CacheManager",
     "EdgeCacheManager",
     "angle_diff",
+    "angle_diff_array",
     "cached_node_list",
     "cached_nodes_and_A",
     "clamp",

--- a/src/tnfr/helpers/__init__.pyi
+++ b/src/tnfr/helpers/__init__.pyi
@@ -25,6 +25,7 @@ from ..utils.graph import get_graph_mapping as get_graph_mapping
 from ..utils.graph import increment_edge_version as increment_edge_version
 from ..utils.graph import mark_dnfr_prep_dirty as mark_dnfr_prep_dirty
 from .numeric import angle_diff as angle_diff
+from .numeric import angle_diff_array as angle_diff_array
 from .numeric import clamp as clamp
 from .numeric import clamp01 as clamp01
 from .numeric import kahan_sum_nd as kahan_sum_nd
@@ -33,6 +34,7 @@ __all__ = (
     "CacheManager",
     "EdgeCacheManager",
     "angle_diff",
+    "angle_diff_array",
     "cached_node_list",
     "cached_nodes_and_A",
     "clamp",

--- a/src/tnfr/helpers/numeric.pyi
+++ b/src/tnfr/helpers/numeric.pyi
@@ -5,6 +5,7 @@ __all__: Any
 def __getattr__(name: str) -> Any: ...
 
 angle_diff: Any
+angle_diff_array: Any
 clamp: Any
 clamp01: Any
 kahan_sum_nd: Any

--- a/tests/unit/structural/test_numeric_helpers.py
+++ b/tests/unit/structural/test_numeric_helpers.py
@@ -3,7 +3,7 @@ import math
 import networkx as nx  # type: ignore[import-untyped]
 import pytest
 
-from tnfr.helpers.numeric import angle_diff, similarity_abs
+from tnfr.helpers.numeric import angle_diff, angle_diff_array, similarity_abs
 from tnfr.observers import phase_sync
 
 
@@ -54,3 +54,26 @@ def test_similarity_abs_degenerate_range_returns_full_similarity():
 )
 def test_angle_diff_wraps_boundary_extremes(a, b, expected):
     assert angle_diff(a, b) == pytest.approx(expected)
+
+
+def test_angle_diff_array_matches_scalar():
+    np = pytest.importorskip("numpy")
+
+    angles_a = np.array([0.0, math.pi - 1e-9, -math.pi + 1e-6, math.tau + 0.5])
+    angles_b = np.array([math.pi, -math.pi, 0.0, 0.25])
+    out = angle_diff_array(angles_a, angles_b, np=np)
+    expected = np.array([angle_diff(a, b) for a, b in zip(angles_a, angles_b)], dtype=float)
+    assert np.allclose(out, expected)
+
+
+def test_angle_diff_array_preserves_masked_entries():
+    np = pytest.importorskip("numpy")
+
+    angles_a = np.array([0.0, math.pi / 2, -math.pi / 2])
+    angles_b = np.array([math.pi, 0.0, 0.0])
+    mask = np.array([True, False, True])
+    out = np.full_like(angles_a, fill_value=42.0)
+    angle_diff_array(angles_a, angles_b, np=np, out=out, where=mask)
+
+    expected = np.array([angle_diff(angles_a[0], angles_b[0]), 42.0, angle_diff(angles_a[2], angles_b[2])])
+    assert np.allclose(out, expected)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

#### Summary
- Added a shared `angle_diff_array` helper so NumPy-powered routines reuse the canonical angular wrapping semantics.
- Applied the helper inside `compute_Si` and ΔNFR gradient assembly to remove manual wrapping loops while keeping chunk-aware execution.
- Extended structural numeric tests to validate vector behaviour and mask preservation for the new helper.


------
https://chatgpt.com/codex/tasks/task_e_6901f3a18c508321891b30e47f4fb637