### PR TITLE
Add layered cache orchestration with persistent backends

### DIFF
--- a/src/tnfr/utils/cache.pyi
+++ b/src/tnfr/utils/cache.pyi
@@ -52,6 +52,7 @@ class EdgeCacheState:
     cache: MutableMapping[Hashable, Any]
     locks: MutableMapping[Hashable, threading.RLock]
     max_entries: int | None
+    dirty: bool
 
 class EdgeCacheManager:
     _STATE_KEY: str
@@ -73,10 +74,8 @@ class EdgeCacheManager:
         max_entries: int | None | object,
         *,
         create: bool = ...,
-    ) -> tuple[
-        MutableMapping[Hashable, Any] | None,
-        MutableMapping[Hashable, threading.RLock] | None,
-    ]: ...
+    ) -> EdgeCacheState | None: ...
+    def flush_state(self, state: EdgeCacheState) -> None: ...
     def clear(self) -> None: ...
 
 def get_graph_version(graph: Any, key: str, default: int = ...) -> int: ...

--- a/tests/unit/dynamics/test_gamma.py
+++ b/tests/unit/dynamics/test_gamma.py
@@ -244,8 +244,9 @@ def test_kuramoto_cache_step_limit(graph_canon):
     gamma_mod._ensure_kuramoto_cache(G, t=0)
     gamma_mod._ensure_kuramoto_cache(G, t=1)
     gamma_mod._ensure_kuramoto_cache(G, t=2)
-    cache, _ = EdgeCacheManager(G.graph).get_cache(2)
-    entries = [k for k in cache if isinstance(k, tuple)]
+    state = EdgeCacheManager(G.graph).get_cache(2)
+    assert state is not None
+    entries = [k for k in state.cache if isinstance(k, tuple)]
     assert len(entries) == 2
 
 

--- a/tests/unit/structural/test_cache_layers.py
+++ b/tests/unit/structural/test_cache_layers.py
@@ -1,0 +1,129 @@
+"""Tests covering multi-layer cache orchestration."""
+
+from __future__ import annotations
+
+import fnmatch
+from typing import Any
+
+import networkx as nx
+
+from tnfr.cache import CacheLayer, CacheManager, RedisCacheLayer, ShelveCacheLayer
+from tnfr.utils.cache import edge_version_cache
+
+
+class _FlakyLayer(CacheLayer):
+    """Cache layer that can simulate load/store failures."""
+
+    def __init__(self, *, fail_on_store: bool = False, fail_on_load: bool = False) -> None:
+        self.fail_on_store = fail_on_store
+        self.fail_on_load = fail_on_load
+        self._storage: dict[str, Any] = {}
+
+    def load(self, name: str) -> Any:
+        if self.fail_on_load:
+            raise RuntimeError("layer load failure")
+        if name not in self._storage:
+            raise KeyError(name)
+        return self._storage[name]
+
+    def store(self, name: str, value: Any) -> None:
+        if self.fail_on_store:
+            raise RuntimeError("layer store failure")
+        self._storage[name] = value
+
+    def delete(self, name: str) -> None:
+        self._storage.pop(name, None)
+
+    def clear(self) -> None:
+        self._storage.clear()
+
+
+class _FakeRedis:
+    """Minimal Redis client stub used for testing the distributed layer."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any:
+        return self._data.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    def delete(self, *keys: str) -> None:
+        for key in keys:
+            self._data.pop(key, None)
+
+    def scan_iter(self, match: str | None = None):
+        pattern = "*" if match is None else match
+        for key in list(self._data):
+            if fnmatch.fnmatch(key, pattern):
+                yield key
+
+    def keys(self, pattern: str) -> list[str]:
+        return [key for key in self._data if fnmatch.fnmatch(key, pattern)]
+
+
+def test_cache_manager_layer_failover(tmp_path):
+    shelf_layer = ShelveCacheLayer(str(tmp_path / "cache.db"))
+    failing = _FlakyLayer(fail_on_store=True)
+    manager = CacheManager(layers=(failing, shelf_layer))
+    manager.register("demo", lambda: {"value": 0})
+
+    manager.store("demo", {"value": 1})
+    assert manager.get("demo") == {"value": 1}
+
+    shelf_layer.close()
+
+    failing_loader = _FlakyLayer(fail_on_load=True)
+    restored_shelf = ShelveCacheLayer(str(tmp_path / "cache.db"))
+    manager_restarted = CacheManager(layers=(failing_loader, restored_shelf))
+    manager_restarted.register("demo", lambda: {"value": 0})
+
+    restored = manager_restarted.get("demo")
+    assert restored == {"value": 1}
+
+    restored_shelf.close()
+
+
+def test_edge_cache_persists_across_layers(tmp_path):
+    shelf_path = tmp_path / "edge.db"
+    fake_redis = _FakeRedis()
+
+    redis_layer = RedisCacheLayer(client=fake_redis)
+    shelf_layer = ShelveCacheLayer(str(shelf_path))
+    initial_manager = CacheManager(layers=(redis_layer, shelf_layer))
+
+    G = nx.Graph()
+    G.add_nodes_from([0, 1])
+    G.graph["_tnfr_cache_manager"] = initial_manager
+
+    calls = 0
+
+    def builder() -> str:
+        nonlocal calls
+        calls += 1
+        return "persisted"
+
+    assert edge_version_cache(G, "alpha", builder) == "persisted"
+    assert calls == 1
+
+    shelf_layer.close()
+    G.graph.pop("_edge_cache_manager", None)
+
+    restarted_shelf = ShelveCacheLayer(str(shelf_path))
+    restarted_manager = CacheManager(
+        layers=(RedisCacheLayer(client=fake_redis), restarted_shelf)
+    )
+    G.graph["_tnfr_cache_manager"] = restarted_manager
+
+    builder_called = False
+
+    def second_builder() -> str:
+        nonlocal builder_called
+        builder_called = True
+        return "should-not-run"
+
+    assert edge_version_cache(G, "alpha", second_builder) == "persisted"
+    assert builder_called is False
+    restarted_shelf.close()

--- a/tests/unit/structural/test_edge_version_cache.py
+++ b/tests/unit/structural/test_edge_version_cache.py
@@ -50,7 +50,10 @@ def test_edge_version_cache_limit(graph_and_manager):
     ) as record_eviction:
         edge_version_cache(G, "b", lambda: 2, max_entries=2)
         edge_version_cache(G, "c", lambda: 3, max_entries=2)
-    cache, locks = manager_in_graph.get_cache(2)
+    state = manager_in_graph.get_cache(2)
+    assert state is not None
+    cache = state.cache
+    locks = state.locks
     assert "a" not in cache
     assert "b" in cache and "c" in cache
     assert set(locks) == set(cache)
@@ -69,18 +72,27 @@ def test_edge_version_cache_lock_cleanup(graph_and_manager, max_entries):
         edge_version_cache(G, "b", lambda: 2, max_entries=None)
         manager_in_graph = G.graph.get("_edge_cache_manager")
         assert isinstance(manager_in_graph, EdgeCacheManager)
-        cache, locks = manager_in_graph.get_cache(None)
+        state = manager_in_graph.get_cache(None)
+        assert state is not None
+        cache = state.cache
+        locks = state.locks
         cache.pop("a")
         assert "a" not in locks
         assert set(locks) == set(cache)
         edge_version_cache(G, "c", lambda: 3, max_entries=None)
-        cache, locks = manager_in_graph.get_cache(None)
+        state = manager_in_graph.get_cache(None)
+        assert state is not None
+        cache = state.cache
+        locks = state.locks
         assert "a" not in locks
         assert set(locks) == set(cache)
     else:
         for i in range(5):
             edge_version_cache(G, str(i), lambda i=i: i, max_entries=max_entries)
-        cache, locks = EdgeCacheManager(G.graph).get_cache(max_entries)
+        state = EdgeCacheManager(G.graph).get_cache(max_entries)
+        assert state is not None
+        cache = state.cache
+        locks = state.locks
         assert len(cache) <= max_entries
         assert set(locks) == set(cache)
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6901f81f3ca48321a46174cf1b469907