### PR TITLE
Add mathematics test coverage and integrate QA checks

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,11 +4,11 @@ export PYTHONPATH="$PWD/src"
 
 # Keep dependency extras aligned with .github/workflows/type-check.yml.
 python -m pip install --quiet ".[test,typecheck]"
-python -m flake8 src
+python -m flake8 src tests/mathematics
 python scripts/check_language.py
 python -m pydocstyle src/tnfr
 # Mirrors the mypy invocation in .github/workflows/type-check.yml.
-python -m mypy src/tnfr
+python -m mypy src/tnfr tests/mathematics
 python -m coverage run --source=src -m pytest "$@"
 python -m coverage report -m
 python -m vulture --min-confidence 80 src tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,31 @@
 """Test utilities."""
 
+from __future__ import annotations
+
 import networkx as nx
 import pytest
 
+np = pytest.importorskip("numpy")
+
 from tnfr.constants import inject_defaults
 from tnfr.utils import cached_import, prune_failed_imports
+
+STRUCTURAL_ATOL = 1e-9
+STRUCTURAL_RTOL = 1e-7
+
+
+@pytest.fixture(scope="session")
+def structural_tolerances() -> dict[str, float]:
+    """Return the canonical absolute/relative tolerances used in tests."""
+
+    return {"atol": STRUCTURAL_ATOL, "rtol": STRUCTURAL_RTOL}
+
+
+@pytest.fixture
+def structural_rng() -> np.random.Generator:
+    """Provide a reproducible RNG aligned with TNFR structural conventions."""
+
+    return np.random.default_rng(seed=12345)
 
 
 @pytest.fixture

--- a/tests/mathematics/__init__.py
+++ b/tests/mathematics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests covering the TNFR mathematics interfaces."""

--- a/tests/mathematics/test_spaces.py
+++ b/tests/mathematics/test_spaces.py
@@ -1,0 +1,92 @@
+"""Tests for TNFR mathematics space abstractions."""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from tnfr.mathematics.spaces import BanachSpaceEPI, HilbertSpace
+
+
+def test_hilbert_space_basis_is_orthonormal(structural_tolerances: dict[str, float]) -> None:
+    space = HilbertSpace(dimension=3)
+
+    basis = space.basis
+
+    np.testing.assert_allclose(
+        basis @ basis.conj().T,
+        np.eye(3, dtype=space.dtype),
+        atol=structural_tolerances["atol"],
+    )
+
+
+def test_hilbert_space_inner_product_and_norm(structural_rng: np.random.Generator) -> None:
+    space = HilbertSpace(dimension=4)
+
+    vector_a = structural_rng.normal(size=4) + 1j * structural_rng.normal(size=4)
+    vector_b = structural_rng.normal(size=4) + 1j * structural_rng.normal(size=4)
+
+    inner = space.inner_product(vector_a, vector_b)
+    manual = np.vdot(np.asarray(vector_a, dtype=space.dtype), np.asarray(vector_b, dtype=space.dtype))
+    assert inner == pytest.approx(manual)
+
+    norm = space.norm(vector_a)
+    assert norm == pytest.approx(np.linalg.norm(vector_a))
+
+
+def test_hilbert_space_projection(structural_rng: np.random.Generator, structural_tolerances: dict[str, float]) -> None:
+    space = HilbertSpace(dimension=3)
+    vector = structural_rng.normal(size=3) + 1j * structural_rng.normal(size=3)
+
+    projected_basis = space.project(vector, onto=1)
+    expected_basis = np.zeros(3, dtype=space.dtype)
+    basis_vector = space.basis[1]
+    coefficient = space.inner_product(vector, basis_vector) / space.inner_product(basis_vector, basis_vector)
+    expected_basis[1] = coefficient
+    np.testing.assert_allclose(projected_basis, expected_basis, atol=structural_tolerances["atol"])
+
+    onto_vector = np.array([1.0 + 0j, 1.0 + 0j, 0.0 + 0j], dtype=space.dtype)
+    projected_vector = space.project(vector, onto=onto_vector)
+    coefficient = np.vdot(vector, onto_vector) / np.vdot(onto_vector, onto_vector)
+    np.testing.assert_allclose(
+        projected_vector,
+        coefficient * onto_vector,
+        atol=structural_tolerances["atol"],
+    )
+
+
+def test_hilbert_space_validation_errors() -> None:
+    with pytest.raises(ValueError):
+        HilbertSpace(dimension=0)
+
+    space = HilbertSpace(dimension=2)
+    with pytest.raises(ValueError):
+        space.inner_product([1.0, 2.0, 3.0], [1.0, 2.0])
+
+    with pytest.raises(IndexError):
+        space.project([1.0, 0.0], onto=2)
+
+
+def test_banach_space_domain_validation() -> None:
+    with pytest.raises(ValueError):
+        BanachSpaceEPI([0.0])
+
+    with pytest.raises(ValueError):
+        BanachSpaceEPI([0.0, 0.0, 1.0])
+
+
+def test_banach_space_coherence_functional(structural_tolerances: dict[str, float]) -> None:
+    domain = (0.0, 0.5, 1.5)
+    epi = np.array([1.0 + 1.0j, 2.0 + 0.0j, -1.0 + 0.5j], dtype=np.complex128)
+    space = BanachSpaceEPI(domain, amplitude_weight=1.5, derivative_weight=0.75)
+
+    functional = space.compute_coherence_functional(epi)
+    amplitude_term = space.amplitude_weight * np.abs(epi) ** 2
+    derivative = np.gradient(epi, space.domain, edge_order=2)
+    derivative_term = space.derivative_weight * np.abs(derivative) ** 2
+
+    np.testing.assert_allclose(functional, amplitude_term + derivative_term, atol=structural_tolerances["atol"])
+
+    expected_norm = np.sqrt(np.trapz(amplitude_term + derivative_term, space.domain))
+    assert space.coherence_norm(epi) == pytest.approx(expected_norm)

--- a/tests/mathematics/test_transforms.py
+++ b/tests/mathematics/test_transforms.py
@@ -1,0 +1,42 @@
+"""Tests documenting the transforms contract behaviour."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from tnfr.mathematics import transforms
+
+
+@pytest.mark.parametrize(
+    "callable_obj",
+    [
+        transforms.build_isometry_factory,
+        transforms.validate_norm_preservation,
+        transforms.ensure_coherence_monotonicity,
+    ],
+)
+def test_transform_contracts_raise_not_implemented(callable_obj: Callable[..., object]) -> None:
+    call_args = {
+        transforms.build_isometry_factory: dict(source_dimension=2, target_dimension=2),
+        transforms.validate_norm_preservation: dict(
+            transform=lambda data: data,
+            probes=[[1.0, 0.0]],
+            metric=lambda data: 1.0,
+        ),
+        transforms.ensure_coherence_monotonicity: dict(coherence_series=[1.0, 1.0]),
+    }[callable_obj]
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        callable_obj(**call_args)
+
+    message = str(excinfo.value)
+    expected_fragments = {
+        transforms.build_isometry_factory: ["Phase 2", "isometry"],
+        transforms.validate_norm_preservation: ["Phase 2", "norm"],
+        transforms.ensure_coherence_monotonicity: ["Phase 2", "coherence"],
+    }[callable_obj]
+    lowered = message.lower()
+    for fragment in expected_fragments:
+        assert fragment.lower() in lowered

--- a/tests/mathematics/test_validator.py
+++ b/tests/mathematics/test_validator.py
@@ -1,0 +1,95 @@
+"""Tests for the NFR spectral validator."""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from tnfr.mathematics.operators import CoherenceOperator, FrequencyOperator
+from tnfr.mathematics.spaces import HilbertSpace
+from tnfr.mathematics.validators import NFRValidator
+
+
+@pytest.fixture
+def validator() -> NFRValidator:
+    hilbert = HilbertSpace(dimension=2)
+    coherence = CoherenceOperator([[1.0, 0.0], [0.0, 2.0]])
+    frequency = FrequencyOperator([0.5, 1.0])
+    return NFRValidator(
+        hilbert_space=hilbert,
+        coherence_operator=coherence,
+        coherence_threshold=0.4,
+        frequency_operator=frequency,
+    )
+
+
+def test_validator_accepts_structurally_sound_state(validator: NFRValidator) -> None:
+    state = np.array([1.0 + 0.0j, 1.0 + 0.0j]) / np.sqrt(2.0)
+
+    overall, summary = validator.validate_state(state)
+
+    assert overall is True
+    assert summary["normalized"] is True
+    assert summary["coherence"]["passed"] is True
+    assert summary["frequency"]["passed"] is True
+    assert summary["unitary_stability"]["passed"] is True
+    assert validator.report(summary) == "All validation checks passed."
+
+
+def test_validator_flags_non_normalised_state(validator: NFRValidator) -> None:
+    state = np.array([2.0 + 0.0j, 0.0 + 0.0j])
+
+    overall, summary = validator.validate_state(state)
+
+    assert overall is False
+    assert summary["normalized"] is False
+    assert summary["coherence"]["passed"] is True
+
+
+def test_validator_frequency_failure() -> None:
+    hilbert = HilbertSpace(dimension=2)
+    coherence = CoherenceOperator([[1.0, 0.0], [0.0, 1.0]])
+    frequency = FrequencyOperator([-0.1, 0.2])
+    validator = NFRValidator(
+        hilbert_space=hilbert,
+        coherence_operator=coherence,
+        coherence_threshold=-0.5,
+        frequency_operator=frequency,
+    )
+
+    state = np.array([1.0 + 0.0j, 0.0 + 0.0j])
+
+    overall, summary = validator.validate_state(state)
+
+    assert overall is False
+    assert summary["frequency"]["passed"] is False
+    assert "frequency positivity" in validator.report(summary)
+
+
+def test_validator_requires_frequency_operator_for_enforcement(validator: NFRValidator) -> None:
+    bare_validator = NFRValidator(
+        hilbert_space=validator.hilbert_space,
+        coherence_operator=validator.coherence_operator,
+        coherence_threshold=validator.coherence_threshold,
+    )
+
+    state = np.array([1.0 + 0.0j, 0.0 + 0.0j])
+
+    with pytest.raises(ValueError):
+        bare_validator.validate_state(state, enforce_frequency_positivity=True)
+
+
+def test_validator_summary_structure(validator: NFRValidator) -> None:
+    state = np.array([1.0 + 0.0j, 1.0 + 0.0j]) / np.sqrt(2.0)
+
+    _, summary = validator.validate_state(state)
+    assert set(summary.keys()) == {"normalized", "coherence", "frequency", "unitary_stability"}
+    coherence = summary["coherence"]
+    assert set(coherence.keys()) == {"passed", "value", "threshold"}
+
+    frequency = summary["frequency"]
+    assert set(frequency.keys()) == {"passed", "value", "enforced"}
+
+    unitary = summary["unitary_stability"]
+    assert set(unitary.keys()) == {"passed", "norm_after"}


### PR DESCRIPTION
### Summary
- add a mathematics-focused test package covering spaces, operators, validator, and transform contracts
- share deterministic tolerance/RNG fixtures and guard numpy usage with importorskip
- extend the test runner script to lint and type-check the new suite

### Testing
- `python -m pytest tests/mathematics`


------
https://chatgpt.com/codex/tasks/task_e_6902207e603c832189c6b44d1ba4a711