### PR TITLE
Respect explicit c_min overrides in CoherenceOperator

### DIFF
--- a/tests/mathematics/test_operators.py
+++ b/tests/mathematics/test_operators.py
@@ -31,6 +31,13 @@ def test_coherence_operator_from_eigenvalues() -> None:
     np.testing.assert_array_equal(operator.spectrum(), np.array([1.0, 2.0, 3.0], dtype=np.complex128))
 
 
+def test_coherence_operator_allows_custom_c_min() -> None:
+    operator = CoherenceOperator([[1.0, 0.0], [0.0, 2.0]], c_min=0.25)
+
+    assert operator.c_min == pytest.approx(0.25)
+    assert min(operator.eigenvalues.real) != pytest.approx(operator.c_min)
+
+
 def test_coherence_operator_expectation(structural_rng: np.random.Generator) -> None:
     matrix = np.array([[1.0, 0.0], [0.0, 2.0]], dtype=np.complex128)
     operator = CoherenceOperator(matrix)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Document and honour precedence for `CoherenceOperator.c_min`, defaulting to the spectral floor unless an explicit threshold is provided.
- Extend the operator tests to validate caller-specified coherence minima while keeping coverage for eigenvalue-derived defaults.


------
https://chatgpt.com/codex/tasks/task_e_690229ad6c58832186548d24669e63fb