### PR TITLE
Ensure CoherenceOperator retains explicit DEFAULT_C_MIN thresholds

### DIFF
--- a/src/tnfr/mathematics/operators.py
+++ b/src/tnfr/mathematics/operators.py
@@ -18,6 +18,7 @@ else:  # pragma: no cover - runtime alias
 __all__ = ["CoherenceOperator", "FrequencyOperator"]
 
 DEFAULT_C_MIN: float = 0.1
+_C_MIN_UNSET = object()
 
 
 def _as_complex_vector(vector: Sequence[complex] | np.ndarray) -> ComplexVector:
@@ -57,7 +58,7 @@ class CoherenceOperator:
         self,
         operator: Sequence[Sequence[complex]] | Sequence[complex] | np.ndarray,
         *,
-        c_min: float = DEFAULT_C_MIN,
+        c_min: float | object = _C_MIN_UNSET,
         ensure_hermitian: bool = True,
         atol: float = 1e-9,
     ) -> None:
@@ -77,7 +78,10 @@ class CoherenceOperator:
             else:
                 self.eigenvalues = np.linalg.eigvals(self.matrix)
         derived_c_min = float(np.min(self.eigenvalues.real))
-        self.c_min = float(c_min) if c_min is not DEFAULT_C_MIN else derived_c_min
+        if c_min is _C_MIN_UNSET:
+            self.c_min = derived_c_min
+        else:
+            self.c_min = float(c_min)
 
     @staticmethod
     def _check_hermitian(matrix: ComplexMatrix, *, atol: float = 1e-9) -> bool:

--- a/tests/mathematics/test_operators.py
+++ b/tests/mathematics/test_operators.py
@@ -6,7 +6,7 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
-from tnfr.mathematics.operators import CoherenceOperator, FrequencyOperator
+from tnfr.mathematics.operators import DEFAULT_C_MIN, CoherenceOperator, FrequencyOperator
 
 
 def test_coherence_operator_from_matrix(structural_tolerances: dict[str, float]) -> None:
@@ -35,6 +35,13 @@ def test_coherence_operator_allows_custom_c_min() -> None:
     operator = CoherenceOperator([[1.0, 0.0], [0.0, 2.0]], c_min=0.25)
 
     assert operator.c_min == pytest.approx(0.25)
+    assert min(operator.eigenvalues.real) != pytest.approx(operator.c_min)
+
+
+def test_coherence_operator_respects_default_constant_when_explicit() -> None:
+    operator = CoherenceOperator([[1.0, 0.0], [0.0, 2.0]], c_min=DEFAULT_C_MIN)
+
+    assert operator.c_min == pytest.approx(DEFAULT_C_MIN)
     assert min(operator.eigenvalues.real) != pytest.approx(operator.c_min)
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_69022c927f7083218804fb67860f937c