### PR TITLE
Align structural RNG fixture with canonical seed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def structural_tolerances() -> dict[str, float]:
 def structural_rng() -> np.random.Generator:
     """Provide a reproducible RNG aligned with TNFR structural conventions."""
 
-    return np.random.default_rng(seed=12345)
+    return np.random.default_rng(seed=0)
 
 
 @pytest.fixture


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Update the `structural_rng` fixture to use the canonical `np.random.default_rng(seed=0)` generator.

## Testing
- `pytest tests/mathematics`


------
https://chatgpt.com/codex/tasks/task_e_6902303867588321bfd62c416d2a97c6