### PR TITLE
Ensure coherence expectations return real scalars

### DIFF
--- a/src/tnfr/mathematics/validators.py
+++ b/src/tnfr/mathematics/validators.py
@@ -69,8 +69,9 @@ class NFRValidator:
         normalized = bool(self.hilbert_space.is_normalized(vector, atol=self.atol))
         normalised_vector = self._normalise(vector)
 
-        expectation = self.coherence_operator.expectation(normalised_vector, normalise=False)
-        coherence_value = float(expectation.real)
+        coherence_value = self.coherence_operator.expectation(
+            normalised_vector, normalise=False, atol=self.atol
+        )
         coherence_ok = bool(coherence_value + self.atol >= self.coherence_threshold)
 
         frequency_summary: dict[str, Any] | None = None
@@ -86,7 +87,9 @@ class NFRValidator:
             min_frequency = float(np.min(spectrum)) if spectrum.size else float("inf")
 
             frequency_value = float(
-                self.frequency_operator.project_frequency(normalised_vector, normalise=False)
+                self.frequency_operator.project_frequency(
+                    normalised_vector, normalise=False, atol=self.atol
+                )
             )
             projection_non_negative = bool(frequency_value + self.atol >= 0.0)
 

--- a/tests/mathematics/test_operators.py
+++ b/tests/mathematics/test_operators.py
@@ -52,7 +52,8 @@ def test_coherence_operator_expectation(structural_rng: np.random.Generator) -> 
     state = structural_rng.normal(size=2) + 1j * structural_rng.normal(size=2)
     expectation = operator.expectation(state)
     manual = np.vdot(state / np.linalg.norm(state), matrix @ (state / np.linalg.norm(state)))
-    assert expectation == pytest.approx(manual)
+    assert isinstance(expectation, float)
+    assert expectation == pytest.approx(float(manual.real))
 
     with pytest.raises(ValueError):
         operator.expectation([1.0, 0.0, 0.0])
@@ -74,7 +75,7 @@ def test_frequency_operator_properties(structural_rng: np.random.Generator) -> N
     state = structural_rng.normal(size=3) + 1j * structural_rng.normal(size=3)
     projected = operator.project_frequency(state)
     assert isinstance(projected, float)
-    assert projected == pytest.approx(operator.expectation(state).real)
+    assert projected == pytest.approx(operator.expectation(state))
 
 
 def test_frequency_operator_negative_spectrum_detected() -> None:


### PR DESCRIPTION
## Summary
- enforce real-valued coherence expectations with tolerance checks
- propagate scalar expectations into frequency projections and validator summaries
- align operator tests with the real-valued contract

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6902328cf8ac832181a35b370206c83f