### PR TITLE
Add math feature flag controls and expose Node overrides

### DIFF
--- a/src/tnfr/config/__init__.py
+++ b/src/tnfr/config/__init__.py
@@ -7,6 +7,7 @@ previous module level functions so downstream importers remain stable.
 
 from __future__ import annotations
 
+from .feature_flags import context_flags, get_flags
 from .init import apply_config, load_config
 
-__all__ = ("load_config", "apply_config")
+__all__ = ("load_config", "apply_config", "get_flags", "context_flags")

--- a/src/tnfr/config/__init__.pyi
+++ b/src/tnfr/config/__init__.pyi
@@ -6,3 +6,5 @@ def __getattr__(name: str) -> Any: ...
 
 apply_config: Any
 load_config: Any
+get_flags: Any
+context_flags: Any

--- a/src/tnfr/config/feature_flags.py
+++ b/src/tnfr/config/feature_flags.py
@@ -1,0 +1,79 @@
+"""Math feature flag configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
+from typing import Iterator
+
+__all__ = ("MathFeatureFlags", "get_flags", "context_flags")
+
+
+@dataclass(frozen=True)
+class MathFeatureFlags:
+    """Toggle optional mathematical behaviours in the engine."""
+
+    enable_math_validation: bool = False
+    enable_math_dynamics: bool = False
+    log_perf: bool = False
+
+
+_TRUE_VALUES = {"1", "true", "on", "yes", "y", "t"}
+_FALSE_VALUES = {"0", "false", "off", "no", "n", "f"}
+
+_BASE_FLAGS: MathFeatureFlags | None = None
+_FLAGS_STACK: list[MathFeatureFlags] = []
+
+
+def _parse_env_flag(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+    return default
+
+
+def _load_base_flags() -> MathFeatureFlags:
+    global _BASE_FLAGS
+    if _BASE_FLAGS is None:
+        _BASE_FLAGS = MathFeatureFlags(
+            enable_math_validation=_parse_env_flag(
+                "TNFR_ENABLE_MATH_VALIDATION", False
+            ),
+            enable_math_dynamics=_parse_env_flag(
+                "TNFR_ENABLE_MATH_DYNAMICS", False
+            ),
+            log_perf=_parse_env_flag("TNFR_LOG_PERF", False),
+        )
+    return _BASE_FLAGS
+
+
+def get_flags() -> MathFeatureFlags:
+    """Return the currently active feature flags."""
+
+    if _FLAGS_STACK:
+        return _FLAGS_STACK[-1]
+    return _load_base_flags()
+
+
+@contextmanager
+def context_flags(**overrides: bool) -> Iterator[MathFeatureFlags]:
+    """Temporarily override math feature flags."""
+
+    invalid = set(overrides) - set(MathFeatureFlags.__annotations__)
+    if invalid:
+        invalid_names = ", ".join(sorted(invalid))
+        raise TypeError(f"Unknown flag overrides: {invalid_names}")
+
+    previous = get_flags()
+    next_flags = replace(previous, **overrides)
+    _FLAGS_STACK.append(next_flags)
+    try:
+        yield next_flags
+    finally:
+        _FLAGS_STACK.pop()

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -26,6 +26,7 @@ from .alias import (
     set_theta,
     set_vf,
 )
+from .config import get_flags
 from .constants import get_aliases
 from .locking import get_lock
 from .types import (
@@ -229,10 +230,15 @@ class NodeNX(NodeProtocol):
     dnfr: DeltaNFR = ATTR_SPECS["dnfr"].build_property()
     d2EPI: SecondDerivativeEPI = ATTR_SPECS["d2EPI"].build_property()
 
-    def __init__(self, G: TNFRGraph, n: NodeId) -> None:
+    def __init__(
+        self, G: TNFRGraph, n: NodeId, *, enable_math_validation: Optional[bool] = None
+    ) -> None:
         self.G: TNFRGraph = G
         self.n: NodeId = n
         self.graph: MutableMapping[str, Any] = G.graph
+        if enable_math_validation is None:
+            enable_math_validation = get_flags().enable_math_validation
+        self.enable_math_validation: bool = enable_math_validation
         G.graph.setdefault("_node_cache", {})[n] = self
 
     def _glyph_storage(self) -> MutableMapping[str, Any]:

--- a/tests/math_integration/test_flags.py
+++ b/tests/math_integration/test_flags.py
@@ -1,0 +1,39 @@
+"""Integration tests for math feature flags."""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from tnfr.config.feature_flags import context_flags, get_flags
+from tnfr.node import NodeNX
+
+
+def test_enable_math_validation_precedence() -> None:
+    base_flags = get_flags()
+
+    graph = nx.Graph()
+    graph.add_node("default")
+    node_default = NodeNX(graph, "default")
+    assert node_default.enable_math_validation is base_flags.enable_math_validation
+
+    with context_flags(enable_math_validation=True):
+        graph.add_node("global")
+        node_global = NodeNX(graph, "global")
+        assert node_global.enable_math_validation is True
+
+        graph.add_node("explicit")
+        node_explicit = NodeNX(graph, "explicit", enable_math_validation=False)
+        assert node_explicit.enable_math_validation is False
+
+
+def test_context_flags_restore_after_exception() -> None:
+    original = get_flags()
+    toggled_value = not original.enable_math_validation
+
+    with pytest.raises(RuntimeError):
+        with context_flags(enable_math_validation=toggled_value):
+            assert get_flags().enable_math_validation is toggled_value
+            raise RuntimeError("boom")
+
+    assert get_flags() == original


### PR DESCRIPTION
## Summary
- Introduced `MathFeatureFlags` with cached environment parsing and override context management
- Exposed `get_flags` and `context_flags` through `tnfr.config` and plumbed NodeNX initialisation defaults
- Added math integration tests covering flag precedence and context restoration

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_69023685b4c48321bc332a69a762277d