### PR TITLE
Stabilize dynamics eigensystem slots and add regression coverage

### DIFF
--- a/src/tnfr/mathematics/dynamics.py
+++ b/src/tnfr/mathematics/dynamics.py
@@ -1,7 +1,7 @@
 """Spectral dynamics helpers driven by Hermitian ΔNFR generators."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Sequence
 
 import numpy as np
@@ -35,6 +35,8 @@ class MathematicalDynamicsEngine:
     hilbert_space: HilbertSpace
     atol: float = 1e-9
     _use_scipy: bool = False
+    _eigenvalues: np.ndarray = field(init=False, repr=False)
+    _eigenvectors: np.ndarray = field(init=False, repr=False)
 
     def __init__(
         self,

--- a/tests/helpers/mathematics.py
+++ b/tests/helpers/mathematics.py
@@ -68,12 +68,9 @@ def make_dynamics_engine(
     atol: float = 1e-9,
     use_scipy: bool | None = None,
 ) -> MathematicalDynamicsEngine:
-    """Instantiate ``MathematicalDynamicsEngine`` with slot-safe subclassing."""
+    """Instantiate ``MathematicalDynamicsEngine`` with canonical configuration."""
 
-    class _SlotSafeDynamics(MathematicalDynamicsEngine):
-        __slots__ = MathematicalDynamicsEngine.__slots__ + ("_eigenvalues", "_eigenvectors")
-
-    return _SlotSafeDynamics(
+    return MathematicalDynamicsEngine(
         generator,
         hilbert_space=hilbert_space,
         atol=atol,

--- a/tests/math_integration/test_runtime_dynamics.py
+++ b/tests/math_integration/test_runtime_dynamics.py
@@ -8,6 +8,7 @@ import pytest
 
 from tnfr.mathematics import (
     HilbertSpace,
+    MathematicalDynamicsEngine,
     NFRValidator,
     build_coherence_operator,
     build_delta_nfr,
@@ -87,6 +88,18 @@ def test_mathematical_dynamics_engine_matches_analytic_solution():
     trajectory = engine.evolve(state, steps=2, dt=np.pi / 2)
     assert trajectory.shape == (3, 2)
     assert np.allclose(trajectory[0], state)
+
+
+def test_mathematical_dynamics_engine_direct_instantiation_step():
+    hilbert = HilbertSpace(2)
+    generator = np.diag([1.0, -1.0])
+    engine = MathematicalDynamicsEngine(generator, hilbert, use_scipy=False)
+    state = np.array([1.0 + 0j, 0.0 + 0j])
+
+    evolved = engine.step(state, dt=np.pi / 2)
+
+    expected = np.array([-1.0j, 0.0 + 0j])
+    assert np.allclose(evolved, expected)
 
 
 def test_mathematical_dynamics_engine_reproducibility_without_rng():


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add slot-backed eigen caches to the mathematical dynamics engine
- update test helpers to instantiate the engine directly
- cover direct instantiation with a regression step test

## Testing
- `pytest tests/math_integration/test_runtime_dynamics.py`


------
https://chatgpt.com/codex/tasks/task_e_690241a32e94832183fc58c89a036a1f