### PR TITLE
Clone RNGs for deterministic runtime validation

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import math
 from collections.abc import Hashable, Mapping
 from dataclasses import dataclass
@@ -416,8 +417,11 @@ class NodeNX(NodeProtocol):
         def _project(epi: float, vf: float, theta: float) -> np.ndarray:
             local_rng = None
             if rng is not None:
-                state = rng.bit_generator.state
-                local_rng = np.random.default_rng(state)
+                bit_generator = rng.bit_generator
+                cloned_state = copy.deepcopy(bit_generator.state)
+                local_bit_generator = type(bit_generator)()
+                local_bit_generator.state = cloned_state
+                local_rng = np.random.Generator(local_bit_generator)
             vector = projector(epi, vf, theta, hilbert.dimension, rng=local_rng)
             return np.asarray(vector, dtype=np.complex128)
 

--- a/tests/math_integration/test_runtime_dynamics.py
+++ b/tests/math_integration/test_runtime_dynamics.py
@@ -195,6 +195,18 @@ def test_run_sequence_with_validation_is_reproducible_with_seed():
     assert set(graph_one.nodes) == set(graph_two.nodes)
 
 
+def test_run_sequence_with_validation_accepts_generator_instance():
+    rng = np.random.default_rng(1337)
+    summary_one, node_one = math_sequence_summary(DEFAULT_ACCEPTANCE_OPS, rng=rng)
+    summary_two, node_two = math_sequence_summary(DEFAULT_ACCEPTANCE_OPS, rng=rng)
+
+    np.testing.assert_allclose(summary_one["pre"]["state"], summary_two["pre"]["state"])
+    np.testing.assert_allclose(summary_one["post"]["state"], summary_two["post"]["state"])
+    assert summary_one["post"]["metrics"] == summary_two["post"]["metrics"]
+    assert summary_one["validation"] == summary_two["validation"]
+
+    assert node_one is not node_two
+
 def test_new_modules_import_without_cycles():
     for module in (
         "tnfr.mathematics.runtime",


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Clone numpy generators within `NodeNX.run_sequence_with_validation` projections so validation uses deterministic randomness without mutating external generators.
- Allow `math_sequence_summary` to accept real numpy generators and remove the `_SeedProxy` test helper.
- Extend runtime dynamics coverage to prove repeated runs with the same generator produce identical results.

## Testing
- `pytest tests/math_integration/test_runtime_dynamics.py` *(fails: numpy not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902426047688321a441881c124e5006