### PR TITLE
Rename math performance logging flag

### DIFF
--- a/src/tnfr/config/feature_flags.py
+++ b/src/tnfr/config/feature_flags.py
@@ -16,13 +16,7 @@ class MathFeatureFlags:
 
     enable_math_validation: bool = False
     enable_math_dynamics: bool = False
-    log_perf: bool = False
-
-    @property
-    def log_performance(self) -> bool:
-        """Backward compatible alias exposing performance logging flag."""
-
-        return self.log_perf
+    log_performance: bool = False
 
 
 _TRUE_VALUES = {"1", "true", "on", "yes", "y", "t"}
@@ -54,7 +48,7 @@ def _load_base_flags() -> MathFeatureFlags:
             enable_math_dynamics=_parse_env_flag(
                 "TNFR_ENABLE_MATH_DYNAMICS", False
             ),
-            log_perf=_parse_env_flag("TNFR_LOG_PERF", False),
+            log_performance=_parse_env_flag("TNFR_LOG_PERF", False),
         )
     return _BASE_FLAGS
 

--- a/tests/math_integration/test_flags.py
+++ b/tests/math_integration/test_flags.py
@@ -37,3 +37,12 @@ def test_context_flags_restore_after_exception() -> None:
             raise RuntimeError("boom")
 
     assert get_flags() == original
+
+
+def test_context_flags_log_performance_restore() -> None:
+    original = get_flags()
+
+    with context_flags(log_performance=True):
+        assert get_flags().log_performance is True
+
+    assert get_flags() == original


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6902457b4e7c832197c9c1c36bfc2556