### PR TITLE
Validate frequency operator PSD before instantiation

### DIFF
--- a/src/tnfr/mathematics/operators_factory.py
+++ b/src/tnfr/mathematics/operators_factory.py
@@ -63,9 +63,20 @@ def build_frequency_operator(
     array = _as_array(operator)
     if ensure_hermitian:
         array = _symmetrise(array)
+    if ensure_hermitian and not np.allclose(array, array.conj().T, atol=atol):
+        raise ValueError("Frequency operator must be Hermitian within tolerance.")
+    if ensure_hermitian:
+        eigenvalues = np.linalg.eigvalsh(array)
+    else:
+        eigenvalues = np.linalg.eigvals(array)
     if ensure_positive:
-        array = array @ array.conj().T
-    return FrequencyOperator(array, ensure_hermitian=True, atol=atol)
+        if np.any(np.abs(eigenvalues.imag) > atol):
+            raise ValueError(
+                "Positive semidefinite frequency operators require real eigenvalues."
+            )
+        if np.any(eigenvalues.real < -atol):
+            raise ValueError("Frequency operator must be positive semidefinite.")
+    return FrequencyOperator(array, ensure_hermitian=ensure_hermitian, atol=atol)
 
 
 def as_coherence_operator(

--- a/tests/mathematics/test_operators.py
+++ b/tests/mathematics/test_operators.py
@@ -7,6 +7,7 @@ import pytest
 np = pytest.importorskip("numpy")
 
 from tnfr.mathematics.operators import DEFAULT_C_MIN, CoherenceOperator, FrequencyOperator
+from tnfr.mathematics.operators_factory import build_frequency_operator
 
 
 def test_coherence_operator_from_matrix(structural_tolerances: dict[str, float]) -> None:
@@ -81,3 +82,20 @@ def test_frequency_operator_properties(structural_rng: np.random.Generator) -> N
 def test_frequency_operator_negative_spectrum_detected() -> None:
     operator = FrequencyOperator([-0.5, 0.5])
     assert not operator.is_positive_semidefinite()
+
+
+def test_build_frequency_operator_preserves_valid_matrix(
+    structural_tolerances: dict[str, float]
+) -> None:
+    matrix = np.array([[1.0, 0.2j], [-0.2j, 2.0]], dtype=np.complex128)
+
+    operator = build_frequency_operator(matrix)
+
+    np.testing.assert_allclose(operator.matrix, matrix, atol=structural_tolerances["atol"])
+
+
+def test_build_frequency_operator_rejects_negative_eigenvalues() -> None:
+    matrix = np.array([[1.0, 0.0], [0.0, -0.5]], dtype=np.complex128)
+
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        build_frequency_operator(matrix)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6902462b8bd48321883d4fb4a77a90ae