### PR TITLE
Expose flattened metrics in NodeNX validation telemetry

### DIFF
--- a/src/tnfr/node.pyi
+++ b/src/tnfr/node.pyi
@@ -170,4 +170,5 @@ class NodeNX(NodeProtocol):
         enforce_frequency_positivity: bool | None = ...,
         enable_validation: bool | None = ...,
         rng: np.random.Generator | None = ...,
+        log_metrics: bool = ...,
     ) -> dict[str, Any]: ...


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Flattened `NodeNX.run_sequence_with_validation` metrics into phase-2 scalar fields while keeping legacy keys for callers.
- Added optional `log_metrics` gating to coordinate debug output with feature flags and log one per state.
- Extended mathematical integration tests for the new schema and logging behaviour.

## Testing
- `pytest tests/math_integration -q`


------
https://chatgpt.com/codex/tasks/task_e_690247cb8b48832199dd60ea518030f7