### PR TITLE
Refactor ΔNFR generator to pure NumPy topologies

### DIFF
--- a/docs/fase2_integration.md
+++ b/docs/fase2_integration.md
@@ -35,9 +35,12 @@ pre/post states for validation.
 ## ΔNFR builder
 
 `build_delta_nfr` mirrors the classical ΔNFR constructors through Hermitian
-matrix generators. It supports Laplacian and adjacency variants; the integration
-suite ensures both remain Hermitian and reproducible when seeded. The resulting
-matrices are suitable inputs for spectral dynamics engines or bespoke analyses.
+matrix generators. It accepts a Hilbert space dimension together with the
+desired topology (Laplacian or adjacency), structural frequency scaling ``νf``
+and an additional amplitude ``scale``. The integration suite ensures both
+recipes remain Hermitian and reproducible when seeded with a NumPy RNG. The
+resulting matrices are suitable inputs for spectral dynamics engines or bespoke
+analyses.
 
 ## Dynamics engine
 
@@ -81,7 +84,7 @@ True
 >>> coherence = build_coherence_operator(np.eye(hilbert.dimension) * 0.75)
 >>> round(coherence_expectation(state, coherence), 6)
 0.75
->>> delta = build_delta_nfr(G, variant="adjacency")
+>>> delta = build_delta_nfr(hilbert.dimension, topology="adjacency")
 >>> delta.shape
 (2, 2)
 >>> from tnfr.mathematics import MathematicalDynamicsEngine

--- a/src/tnfr/mathematics/generators.py
+++ b/src/tnfr/mathematics/generators.py
@@ -1,50 +1,91 @@
 """ΔNFR generator construction utilities."""
 from __future__ import annotations
 
-from typing import Literal
+from typing import Final
 
-import networkx as nx
 import numpy as np
-
-from ..types import TNFRGraph
+from numpy.random import Generator
 
 __all__ = ["build_delta_nfr"]
 
+_TOPOLOGIES: Final[set[str]] = {"laplacian", "adjacency"}
 
-_VARIANTS = {"laplacian", "adjacency"}
+
+def _ring_adjacency(dim: int) -> np.ndarray:
+    """Return the adjacency matrix for a coherent ring topology."""
+
+    adjacency = np.zeros((dim, dim), dtype=float)
+    if dim == 1:
+        return adjacency
+
+    indices = np.arange(dim)
+    adjacency[indices, (indices + 1) % dim] = 1.0
+    adjacency[(indices + 1) % dim, indices] = 1.0
+    return adjacency
 
 
-def _ensure_graph(graph: TNFRGraph) -> nx.Graph:
-    if not isinstance(graph, nx.Graph):  # pragma: no cover - defensive
-        raise TypeError("ΔNFR generators require a networkx graph instance.")
-    return graph
+def _laplacian_from_adjacency(adjacency: np.ndarray) -> np.ndarray:
+    """Construct a Laplacian operator from an adjacency matrix."""
+
+    degrees = adjacency.sum(axis=1)
+    laplacian = np.diag(degrees) - adjacency
+    return laplacian
+
+
+def _hermitian_noise(dim: int, rng: Generator) -> np.ndarray:
+    """Generate a Hermitian noise matrix with reproducible statistics."""
+
+    real = rng.standard_normal((dim, dim))
+    imag = rng.standard_normal((dim, dim))
+    noise = real + 1j * imag
+    return 0.5 * (noise + noise.conj().T)
 
 
 def build_delta_nfr(
-    graph: TNFRGraph,
+    dim: int,
     *,
-    variant: Literal["laplacian", "adjacency"] = "laplacian",
-    weight: str = "weight",
-    rng: np.random.Generator | None = None,
-    noise_scale: float = 0.0,
-    dtype: np.dtype = np.dtype(np.complex128),
+    topology: str = "laplacian",
+    nu_f: float = 1.0,
+    scale: float = 1.0,
+    rng: Generator | None = None,
 ) -> np.ndarray:
-    """Return Hermitian ΔNFR generator built from ``graph`` topology."""
+    """Construct a Hermitian ΔNFR generator using canonical TNFR topologies.
 
-    graph = _ensure_graph(graph)
-    if variant not in _VARIANTS:
-        allowed = ", ".join(sorted(_VARIANTS))
-        raise ValueError(f"Unknown ΔNFR variant: {variant}. Expected one of: {allowed}.")
+    Parameters
+    ----------
+    dim:
+        Dimensionality of the Hilbert space supporting the ΔNFR operator.
+    topology:
+        Requested canonical topology. Supported values are ``"laplacian"``
+        and ``"adjacency"``.
+    nu_f:
+        Structural frequency scaling applied to the resulting operator.
+    scale:
+        Additional scaling applied uniformly to the operator amplitude.
+    rng:
+        Optional NumPy :class:`~numpy.random.Generator` used to inject
+        reproducible Hermitian noise.
+    """
 
-    if variant == "laplacian":
-        base = nx.laplacian_matrix(graph, weight=weight).astype(float).toarray()
+    if dim <= 0:
+        raise ValueError("ΔNFR generators require a positive dimensionality.")
+
+    if topology not in _TOPOLOGIES:
+        allowed = ", ".join(sorted(_TOPOLOGIES))
+        raise ValueError(f"Unknown ΔNFR topology: {topology}. Expected one of: {allowed}.")
+
+    adjacency = _ring_adjacency(dim)
+    if topology == "laplacian":
+        base = _laplacian_from_adjacency(adjacency)
     else:
-        base = nx.to_numpy_array(graph, weight=weight, dtype=float)
+        base = adjacency
 
-    hermitian = 0.5 * (base + base.T)
-    if rng is not None and noise_scale > 0.0:
-        noise = rng.standard_normal(hermitian.shape)
-        hermitian = hermitian + noise_scale * 0.5 * (noise + noise.T)
+    matrix = base.astype(np.complex128, copy=False)
 
-    result = np.asarray(hermitian, dtype=np.complex128)
-    return np.asarray(0.5 * (result + result.conj().T), dtype=dtype)
+    if rng is not None:
+        noise = _hermitian_noise(dim, rng)
+        matrix = matrix + (1.0 / np.sqrt(dim)) * noise
+
+    matrix *= (nu_f * scale)
+    hermitian = 0.5 * (matrix + matrix.conj().T)
+    return np.asarray(hermitian, dtype=np.complex128)

--- a/tests/math_integration/test_generators.py
+++ b/tests/math_integration/test_generators.py
@@ -1,0 +1,62 @@
+"""Integration tests for ΔNFR generator construction."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tnfr.mathematics import build_delta_nfr
+
+
+def _expected_ring_adjacency(dim: int) -> np.ndarray:
+    adjacency = np.zeros((dim, dim), dtype=float)
+    if dim == 1:
+        return adjacency
+
+    indices = np.arange(dim)
+    adjacency[indices, (indices + 1) % dim] = 1.0
+    adjacency[(indices + 1) % dim, indices] = 1.0
+    return adjacency
+
+
+def test_build_delta_nfr_returns_hermitian_operators():
+    for topology in ("laplacian", "adjacency"):
+        operator = build_delta_nfr(5, topology=topology)
+        assert operator.shape == (5, 5)
+        assert np.allclose(operator, operator.conj().T)
+
+
+def test_build_delta_nfr_scaling_matches_ring_baselines():
+    dim = 4
+    nu_f = 1.5
+    scale = 0.25
+
+    expected_adjacency = _expected_ring_adjacency(dim) * (nu_f * scale)
+    adjacency = build_delta_nfr(dim, topology="adjacency", nu_f=nu_f, scale=scale)
+    assert np.allclose(adjacency, expected_adjacency)
+
+    ring_laplacian = np.diag([2.0] * dim) - _expected_ring_adjacency(dim)
+    expected_laplacian = ring_laplacian * (nu_f * scale)
+    laplacian = build_delta_nfr(dim, topology="laplacian", nu_f=nu_f, scale=scale)
+    assert np.allclose(laplacian, expected_laplacian)
+
+
+def test_build_delta_nfr_reproducibility_with_seeded_noise():
+    dim = 6
+    seeded_first = build_delta_nfr(dim, rng=np.random.default_rng(2024))
+    seeded_second = build_delta_nfr(dim, rng=np.random.default_rng(2024))
+    unseeded = build_delta_nfr(dim)
+    divergent = build_delta_nfr(dim, rng=np.random.default_rng(2025))
+
+    assert np.allclose(seeded_first, seeded_second)
+    assert np.allclose(seeded_first, seeded_first.conj().T)
+    assert np.allclose(divergent, divergent.conj().T)
+    assert not np.allclose(seeded_first, divergent)
+    assert np.allclose(unseeded, unseeded.conj().T)
+
+
+def test_build_delta_nfr_input_validation():
+    with pytest.raises(ValueError):
+        build_delta_nfr(0)
+
+    with pytest.raises(ValueError):
+        build_delta_nfr(2, topology="unknown")

--- a/tests/math_integration/test_runtime_dynamics.py
+++ b/tests/math_integration/test_runtime_dynamics.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 
-import networkx as nx
 import numpy as np
 import pytest
 
@@ -12,7 +11,6 @@ from tnfr.mathematics import (
     MathematicalDynamicsEngine,
     NFRValidator,
     build_coherence_operator,
-    build_delta_nfr,
     build_frequency_operator,
 )
 from tnfr.node import NodeNX
@@ -150,31 +148,6 @@ def test_mathematical_dynamics_engine_matches_scipy_when_available():
     numpy_step = numpy_engine.step(state, dt=0.5)
     scipy_step = scipy_engine.step(state, dt=0.5)
     assert np.allclose(numpy_step, scipy_step)
-
-
-def test_build_delta_nfr_variants_are_hermitian_and_reproducible():
-    graph = nx.cycle_graph(4)
-    rng1 = np.random.default_rng(42)
-    rng2 = np.random.default_rng(42)
-
-    laplacian_matrix = None
-    repeat_matrix = None
-    try:
-        laplacian_matrix = build_delta_nfr(graph, rng=rng1, noise_scale=0.1)
-        repeat_matrix = build_delta_nfr(graph, rng=rng2, noise_scale=0.1)
-    except ModuleNotFoundError:
-        laplacian_matrix = None
-        repeat_matrix = None
-
-    adjacency_matrix = build_delta_nfr(graph, variant="adjacency")
-    assert np.allclose(adjacency_matrix, adjacency_matrix.conj().T)
-
-    if laplacian_matrix is not None and repeat_matrix is not None:
-        assert np.allclose(laplacian_matrix, laplacian_matrix.conj().T)
-        assert np.allclose(laplacian_matrix, repeat_matrix)
-    else:
-        repeat_adjacency = build_delta_nfr(graph, variant="adjacency")
-        assert np.allclose(adjacency_matrix, repeat_adjacency)
 
 
 def test_operator_factory_wiring_creates_valid_node():


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- Reworked `build_delta_nfr` to construct Hermitian Laplacian and adjacency operators directly from Hilbert space dimensionality using NumPy-based ring topologies, νf/scale controls, and optional seeded noise.
- Added dedicated integration tests that verify topology recipes, scaling behaviour, Hermitian symmetry, and reproducibility of seeded noise while updating legacy runtime checks.
- Updated documentation to outline the new generator interface and usage within the canonical dynamics pipeline.


------
https://chatgpt.com/codex/tasks/task_e_690249899d5c83219ff60718dc048d9e