### PR TITLE
Introduce phase-2 operator factories and refresh Node wiring

### DIFF
--- a/docs/fase2_integration.md
+++ b/docs/fase2_integration.md
@@ -68,7 +68,7 @@ provide a lightweight smoke validation for the documentation itself.
 >>> from tnfr.constants import EPI_PRIMARY, VF_PRIMARY, THETA_PRIMARY
 >>> round(G.nodes[node][EPI_PRIMARY], 6)
 0.723125
->>> from tnfr.mathematics import BasicStateProjector, HilbertSpace, build_coherence_operator, build_delta_nfr
+>>> from tnfr.mathematics import BasicStateProjector, HilbertSpace, build_delta_nfr, make_coherence_operator
 >>> from tnfr.mathematics.runtime import normalized, coherence_expectation
 >>> import numpy as np
 >>> hilbert = HilbertSpace(2)
@@ -81,7 +81,7 @@ provide a lightweight smoke validation for the documentation itself.
 ... )
 >>> normalized(state, hilbert)[0]
 True
->>> coherence = build_coherence_operator(np.eye(hilbert.dimension) * 0.75)
+>>> coherence = make_coherence_operator(hilbert.dimension, spectrum=np.full(hilbert.dimension, 0.75))
 >>> round(coherence_expectation(state, coherence), 6)
 0.75
 >>> delta = build_delta_nfr(hilbert.dimension, topology="adjacency")

--- a/src/tnfr/mathematics/__init__.py
+++ b/src/tnfr/mathematics/__init__.py
@@ -3,12 +3,7 @@
 from .dynamics import MathematicalDynamicsEngine
 from .generators import build_delta_nfr
 from .operators import CoherenceOperator, FrequencyOperator
-from .operators_factory import (
-    as_coherence_operator,
-    as_frequency_operator,
-    build_coherence_operator,
-    build_frequency_operator,
-)
+from .operators_factory import make_coherence_operator, make_frequency_operator
 from .projection import BasicStateProjector, StateProjector
 from .runtime import (
     coherence,
@@ -34,10 +29,8 @@ __all__ = [
     "FrequencyOperator",
     "MathematicalDynamicsEngine",
     "build_delta_nfr",
-    "build_coherence_operator",
-    "build_frequency_operator",
-    "as_coherence_operator",
-    "as_frequency_operator",
+    "make_coherence_operator",
+    "make_frequency_operator",
     "NFRValidator",
     "IsometryFactory",
     "build_isometry_factory",

--- a/src/tnfr/node.pyi
+++ b/src/tnfr/node.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Hashable, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Hashable, Iterable, MutableMapping, Sequence
 from typing import Any, Callable, Optional, Protocol, SupportsFloat, TypeVar
 
 import numpy as np
@@ -105,10 +105,12 @@ class NodeNX(NodeProtocol):
         state_projector: StateProjector | None = ...,
         enable_math_validation: Optional[bool] = ...,
         hilbert_space: HilbertSpace | None = ...,
-        coherence_operator: CoherenceOperator | Iterable[Sequence[complex]] | Sequence[complex] | np.ndarray | None = ...,
-        coherence_operator_params: Mapping[str, Any] | None = ...,
-        frequency_operator: FrequencyOperator | Iterable[Sequence[complex]] | Sequence[complex] | np.ndarray | None = ...,
-        frequency_operator_params: Mapping[str, Any] | None = ...,
+        coherence_operator: CoherenceOperator | None = ...,
+        coherence_dim: int | None = ...,
+        coherence_spectrum: Sequence[float] | np.ndarray | None = ...,
+        coherence_c_min: float | None = ...,
+        frequency_operator: FrequencyOperator | None = ...,
+        frequency_matrix: Sequence[Sequence[complex]] | np.ndarray | None = ...,
         coherence_threshold: float | None = ...,
         validator: NFRValidator | None = ...,
         rng: np.random.Generator | None = ...,
@@ -161,11 +163,13 @@ class NodeNX(NodeProtocol):
         *,
         projector: StateProjector | None = ...,
         hilbert_space: HilbertSpace | None = ...,
-        coherence_operator: CoherenceOperator | Iterable[Sequence[complex]] | Sequence[complex] | np.ndarray | None = ...,
-        coherence_operator_params: Mapping[str, Any] | None = ...,
+        coherence_operator: CoherenceOperator | None = ...,
+        coherence_dim: int | None = ...,
+        coherence_spectrum: Sequence[float] | np.ndarray | None = ...,
+        coherence_c_min: float | None = ...,
         coherence_threshold: float | None = ...,
-        freq_op: FrequencyOperator | Iterable[Sequence[complex]] | Sequence[complex] | np.ndarray | None = ...,
-        frequency_operator_params: Mapping[str, Any] | None = ...,
+        frequency_operator: FrequencyOperator | None = ...,
+        frequency_matrix: Sequence[Sequence[complex]] | np.ndarray | None = ...,
         validator: NFRValidator | None = ...,
         enforce_frequency_positivity: bool | None = ...,
         enable_validation: bool | None = ...,

--- a/tests/helpers/mathematics.py
+++ b/tests/helpers/mathematics.py
@@ -10,8 +10,8 @@ from tnfr.mathematics import (
     HilbertSpace,
     MathematicalDynamicsEngine,
     NFRValidator,
-    build_coherence_operator,
-    build_frequency_operator,
+    make_coherence_operator,
+    make_frequency_operator,
 )
 from tnfr.node import NodeNX
 from tnfr.structural import create_nfr
@@ -35,9 +35,9 @@ def build_node_with_operators(
 
     G, node_id = create_nfr("math-node", epi=epi, vf=nu_f, theta=theta)
     hilbert = HilbertSpace(dim)
-    coherence = build_coherence_operator(np.eye(dim) * coherence_value)
+    coherence = make_coherence_operator(dim, spectrum=np.full(dim, coherence_value))
     frequency = (
-        build_frequency_operator(np.eye(dim) * frequency_value)
+        make_frequency_operator(np.eye(dim) * frequency_value)
         if frequency_value is not None
         else None
     )

--- a/tests/math_integration/test_operators_wiring.py
+++ b/tests/math_integration/test_operators_wiring.py
@@ -1,0 +1,95 @@
+"""Integration tests for operator wiring on NodeNX."""
+from __future__ import annotations
+
+import numpy as np
+
+from tnfr.mathematics import (
+    CoherenceOperator,
+    FrequencyOperator,
+    HilbertSpace,
+    make_frequency_operator,
+)
+from tnfr.node import NodeNX
+from tnfr.operators.definitions import Coherence, Emission
+from tnfr.structural import create_nfr
+
+from tests.helpers.compare_classical import DEFAULT_ACCEPTANCE_OPS
+from tests.helpers.mathematics import build_node_with_operators
+
+
+def test_node_accepts_direct_operator_instances() -> None:
+    G, node_id = create_nfr("direct-operators")
+    hilbert = HilbertSpace(2)
+    coherence_matrix = np.array([[0.8, 0.05], [0.05, 0.7]], dtype=np.complex128)
+    frequency_matrix = np.array([[0.4, 0.0], [0.0, 0.6]], dtype=np.complex128)
+
+    coherence_operator = CoherenceOperator(coherence_matrix)
+    frequency_operator = make_frequency_operator(frequency_matrix)
+
+    node = NodeNX(
+        G,
+        node_id,
+        hilbert_space=hilbert,
+        coherence_operator=coherence_operator,
+        frequency_operator=frequency_operator,
+        enable_math_validation=True,
+    )
+
+    assert node.coherence_operator is coherence_operator
+    assert node.frequency_operator is frequency_operator
+
+    summary = node.run_sequence_with_validation(
+        [Emission(), Coherence()], enable_validation=True
+    )
+    assert summary["validation"] is not None
+    assert summary["validation"]["passed"] is True
+
+
+def test_node_constructs_operators_from_factory_parameters() -> None:
+    G, node_id = create_nfr("factory-operators")
+    hilbert = HilbertSpace(3)
+    spectrum = np.array([0.3, 0.4, 0.5])
+    frequency_matrix = np.diag([0.2, 0.25, 0.3]).astype(np.complex128)
+
+    node = NodeNX(
+        G,
+        node_id,
+        hilbert_space=hilbert,
+        coherence_dim=3,
+        coherence_spectrum=spectrum,
+        coherence_c_min=0.25,
+        frequency_matrix=frequency_matrix,
+        enable_math_validation=False,
+    )
+
+    assert isinstance(node.coherence_operator, CoherenceOperator)
+    assert isinstance(node.frequency_operator, FrequencyOperator)
+    np.testing.assert_allclose(node.coherence_operator.spectrum().real, spectrum)
+    np.testing.assert_allclose(node.frequency_operator.matrix, frequency_matrix)
+
+    result = node.run_sequence_with_validation(
+        list(DEFAULT_ACCEPTANCE_OPS), enable_validation=False
+    )
+    assert "coherence_expectation" in result["post_metrics"]
+    assert "frequency_expectation" in result["post_metrics"]
+
+
+def test_run_sequence_uses_factory_overrides() -> None:
+    node, _, _ = build_node_with_operators(frequency_value=None, enable_validation=False)
+    dim = node.hilbert_space.dimension
+    new_spectrum = np.full(dim, 0.85)
+    frequency_matrix = np.eye(dim) * 0.15
+
+    outcome = node.run_sequence_with_validation(
+        list(DEFAULT_ACCEPTANCE_OPS),
+        coherence_dim=dim,
+        coherence_spectrum=new_spectrum,
+        coherence_c_min=0.8,
+        frequency_matrix=frequency_matrix,
+        enable_validation=False,
+    )
+
+    post_metrics = outcome["post_metrics"]
+    assert "coherence_expectation" in post_metrics
+    assert "frequency_positive" in post_metrics
+    assert post_metrics["frequency_positive"] is True

--- a/tests/math_integration/test_runtime_dynamics.py
+++ b/tests/math_integration/test_runtime_dynamics.py
@@ -7,11 +7,11 @@ import pytest
 
 from tnfr.config import context_flags
 from tnfr.mathematics import (
+    CoherenceOperator,
     HilbertSpace,
     MathematicalDynamicsEngine,
     NFRValidator,
-    build_coherence_operator,
-    build_frequency_operator,
+    make_frequency_operator,
 )
 from tnfr.node import NodeNX
 from tnfr.operators.definitions import Coherence, Emission, Reception, Resonance, Transition
@@ -52,7 +52,7 @@ def test_run_sequence_with_validation_reports_metrics(ops):
 def test_run_sequence_with_validation_respects_frequency_override():
     node, _, _ = build_node_with_operators(frequency_value=None)
     outcome = node.run_sequence_with_validation(
-        list(DEFAULT_ACCEPTANCE_OPS), freq_op=None, enable_validation=False
+        list(DEFAULT_ACCEPTANCE_OPS), frequency_operator=None, enable_validation=False
     )
     assert "frequency_positive" not in outcome["post_metrics"]
     assert outcome["validation"] is None
@@ -155,18 +155,20 @@ def test_operator_factory_wiring_creates_valid_node():
     coherence = np.array([[0.9, 0.1], [0.1, 0.8]])
     frequency = np.array([[0.5, 0.2], [0.2, 0.5]])
     hilbert = HilbertSpace(2)
+    coherence_operator = CoherenceOperator(coherence)
+    frequency_operator = make_frequency_operator(frequency)
     validator = NFRValidator(
         hilbert,
-        build_coherence_operator(coherence),
+        coherence_operator,
         coherence_threshold=0.0,
-        frequency_operator=build_frequency_operator(frequency),
+        frequency_operator=frequency_operator,
     )
     node = NodeNX(
         G,
         node_id,
         hilbert_space=hilbert,
-        coherence_operator=coherence,
-        frequency_operator=frequency,
+        coherence_operator=coherence_operator,
+        frequency_operator=frequency_operator,
         coherence_threshold=0.0,
         validator=validator,
         enable_math_validation=True,


### PR DESCRIPTION
## Summary
- add `make_coherence_operator` and `make_frequency_operator` helpers that enforce hermitian/PSD validation
- extend `NodeNX` to resolve operators from direct instances or simplified specifications using the new factories
- refresh mathematical helpers and integration tests to cover both direct injection and factory-driven wiring paths

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_69024abbe0548321bc9a0783c293be01