### PR TITLE
Ensure NodeNX state projector uses keyword arguments

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -521,7 +521,13 @@ class NodeNX(NodeProtocol):
                 local_bit_generator = type(bit_generator)()
                 local_bit_generator.state = cloned_state
                 local_rng = np.random.Generator(local_bit_generator)
-            vector = projector(epi, vf, theta, hilbert.dimension, rng=local_rng)
+            vector = projector(
+                epi=epi,
+                nu_f=vf,
+                theta=theta,
+                dim=hilbert.dimension,
+                rng=local_rng,
+            )
             return np.asarray(vector, dtype=np.complex128)
 
         active_flags = get_flags()

--- a/tests/math_integration/test_projection.py
+++ b/tests/math_integration/test_projection.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import numpy as np
 
-from tnfr.mathematics import BasicStateProjector
+from tnfr.mathematics import BasicStateProjector, HilbertSpace
+from tnfr.node import NodeNX
+from tnfr.structural import create_nfr
 
 
 def test_basic_state_projector_shapes_and_normalisation() -> None:
@@ -43,3 +45,43 @@ def test_basic_state_projector_rng_reproducibility() -> None:
     vec3 = projector(epi=0.2, nu_f=1.3, theta=0.7, dim=5, rng=rng3)
 
     assert not np.allclose(vec1, vec3)
+
+
+class KeywordOnlyDimProjector:
+    """Projector requiring ``dim`` to be provided as a keyword argument."""
+
+    def __init__(self) -> None:
+        self._base = BasicStateProjector()
+        self.calls: list[tuple[float, float, float, int]] = []
+
+    def __call__(
+        self,
+        epi: float,
+        nu_f: float,
+        theta: float,
+        *,
+        dim: int,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        self.calls.append((epi, nu_f, theta, dim))
+        return self._base(epi=epi, nu_f=nu_f, theta=theta, dim=dim, rng=rng)
+
+
+def test_run_sequence_with_validation_supports_keyword_only_projector() -> None:
+    projector = KeywordOnlyDimProjector()
+    G, node_id = create_nfr("keyword-projector", epi=0.3, vf=0.6, theta=0.2)
+    hilbert = HilbertSpace(4)
+    node = NodeNX(
+        G,
+        node_id,
+        state_projector=projector,
+        hilbert_space=hilbert,
+        enable_math_validation=False,
+    )
+
+    result = node.run_sequence_with_validation([], enable_validation=False)
+
+    assert result["pre_state"].shape == (hilbert.dimension,)
+    assert result["post_state"].shape == (hilbert.dimension,)
+    assert len(projector.calls) == 2
+    assert all(call[3] == hilbert.dimension for call in projector.calls)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- call NodeNX state projector helpers with keyword arguments so keyword-only implementations remain supported
- add a regression test that injects a keyword-only `dim` projector and exercises `run_sequence_with_validation`


------
https://chatgpt.com/codex/tasks/task_e_69025120d20083219ee80cf800a30ba9