### PR TITLE
Add mathematics foundations guide and theory notebooks

### DIFF
--- a/docs/foundations.md
+++ b/docs/foundations.md
@@ -1,0 +1,133 @@
+# Foundations — Quick Start (Mathematics)
+
+This guide introduces the mathematical APIs that keep TNFR simulations canonical. It focuses on
+Hilbert-space primitives, ΔNFR orchestration, and telemetry so you can launch reproducible
+experiments without leaving the mathematical layer.
+
+## 1. Setup checklist
+
+1. Install the package and optional notebook extras.
+   ```bash
+   pip install tnfr[notebook]
+   ```
+2. Verify imports succeed inside your environment.
+   ```pycon
+   >>> import tnfr
+   >>> from tnfr.mathematics import HilbertSpace, make_coherence_operator
+   ```
+3. Keep documentation examples doctest-friendly by running them through `python -m doctest` or
+   `pytest --doctest-glob='*.md'` before publishing updates.
+
+## 2. Create a coherent state
+
+Use the Hilbert space helpers to define canonical basis vectors and validate norm preservation.
+
+```pycon
+>>> from tnfr.mathematics import HilbertSpace
+>>> space = HilbertSpace(dimension=3)
+>>> vector = [1.0, 0.0, 0.0]
+>>> space.is_normalized(vector)
+True
+```
+
+The `HilbertSpace` dataclass enforces positive dimensions and returns complex identity bases that
+match TNFR's discrete spectral component. Norm checks rely on `numpy.vdot`, giving you immediate
+feedback if a vector drifts away from unit coherence.
+
+## 3. Activate protective math flags
+
+Mathematical feature flags gate optional checks and logging. You can activate them via environment
+variables or the scoped context manager.
+
+```bash
+export TNFR_ENABLE_MATH_VALIDATION=1
+export TNFR_ENABLE_MATH_DYNAMICS=1
+export TNFR_LOG_PERF=1
+```
+
+or programmatically:
+
+```pycon
+>>> from tnfr.config.feature_flags import context_flags, get_flags
+>>> get_flags().enable_math_validation
+False
+>>> with context_flags(enable_math_validation=True, log_performance=True) as active:
+...     active.enable_math_validation, active.log_performance
+(True, True)
+>>> get_flags().log_performance
+False
+```
+
+The context manager preserves flag stacks so nested overrides unwind cleanly after each experiment.
+
+## 4. Compose operators and track ΔNFR
+
+Operators created in `tnfr.mathematics` keep structural semantics explicit. The factory validates
+spectral inputs and enforces positive semidefinite behaviour, ensuring coherence remains monotonic.
+
+```pycon
+>>> from tnfr.mathematics import make_coherence_operator
+>>> operator = make_coherence_operator(dim=2, c_min=0.3)
+>>> round(operator.c_min, 2)
+0.3
+```
+
+To run operator sequences on graph nodes, couple the mathematics layer with the structural facade:
+
+```pycon
+>>> from tnfr.constants import DNFR_PRIMARY, THETA_PRIMARY, VF_PRIMARY
+>>> from tnfr.dynamics import set_delta_nfr_hook
+>>> from tnfr.structural import Coupling, create_nfr, run_sequence
+>>> G, node = create_nfr("math", vf=1.0, theta=0.2)
+>>> def sync(graph):
+...     graph.nodes[node][DNFR_PRIMARY] = 0.01
+...     graph.nodes[node][THETA_PRIMARY] += 0.02
+...     graph.nodes[node][VF_PRIMARY] += 0.05
+>>> set_delta_nfr_hook(G, sync)
+>>> run_sequence(G, node, [Coupling()])
+>>> round(G.nodes[node][THETA_PRIMARY], 2)
+0.22
+```
+
+The hook keeps ΔNFR, νf, and phase aligned after each operator application, satisfying the nodal
+equation `∂EPI/∂t = νf · ΔNFR(t)`.
+
+## 5. Simulate unitary evolution
+
+Stable unitary flows prevent coherence loss and make ΔNFR modulation auditable. The helper returns
+both the pass/fail flag and the resulting norm so doctests can assert stability.
+
+```pycon
+>>> from tnfr.mathematics import HilbertSpace, make_coherence_operator, stable_unitary
+>>> space = HilbertSpace(dimension=2)
+>>> operator = make_coherence_operator(dim=2, c_min=0.4)
+>>> state = [1.0, 0.0]
+>>> stable_unitary(state, operator, space)
+(True, 1.0)
+```
+
+Pair the call with active logging flags to capture structural frequency, ΔNFR, and phase telemetry.
+
+## 6. Cost reference
+
+| Operation | Primary cost driver | ΔNFR impact | Notes |
+| --- | --- | --- | --- |
+| `make_coherence_operator` | Eigenvalue validation (`O(n)`) | Keeps thresholds ≥ `c_min` | Supply diagonal spectra for cheaper instantiation. |
+| `run_sequence` | Graph traversal (`O(|E|)`) | Applies ΔNFR hook once per operator | Pre-validate sequences with `validate_sequence` to catch grammar drift. |
+| `stable_unitary` | Eigen decomposition (`O(n^3)`) | Preserves Hilbert norm | Cache operators when iterating multiple steps. |
+| `coherence_expectation` | Matrix-vector multiply (`O(n^2)`) | Reports scalar coherence | Toggle `normalise=False` when the state is already unit norm. |
+
+Treat these costs as guidance for smoke tests and notebook demonstrations; production workflows
+should benchmark with representative data.
+
+## 7. Logging best practices
+
+- Use `context_flags(log_performance=True)` around critical sections so `tnfr.mathematics.runtime`
+  emits structured debug entries for each metric (`coherence`, `frequency_positive`, `stable_unitary`).
+- Capture telemetry via `tnfr.telemetry.ensure_cache_metrics_publisher` when you need persistent
+  C(t), νf, Si, and ΔNFR traces.
+- Store logs alongside experiment metadata (seed, operator list, thresholds) so coherence audits can
+  reconstruct the entire structural trajectory.
+
+With these steps the mathematical quick start remains reproducible, doctest-friendly, and aligned
+with TNFR's canonical invariants.

--- a/docs/theory/00_overview.ipynb
+++ b/docs/theory/00_overview.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3760173d",
+   "metadata": {},
+   "source": [
+    "# TNFR Mathematical Foundations Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4d74121",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Summarize how TNFR encodes coherence in mathematical terms.\n",
+    "- Clarify the relationship between EPI, structural frequency νf, and ΔNFR.\n",
+    "- Provide navigation tips for the remaining notebooks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84be7643",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "- `numpy`\n",
+    "- `tnfr`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfa00e08",
+   "metadata": {},
+   "source": [
+    "## TNFR Context\n",
+    "The TNFR engine models coherence through structured transformations operating on Primary Information Structures (EPIs).\n",
+    "\n",
+    "Structural frequency νf, expressed in Hz_str, quantifies how quickly an EPI reorganizes under the action of operators.\n",
+    "\n",
+    "ΔNFR serves as the intrinsic reorganization driver; its controlled modulation keeps coherence monotonic when desired."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "041c4535",
+   "metadata": {
+    "tags": [
+     "smoke-example"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from tnfr.mathematics import HilbertSpace\n",
+    "space = HilbertSpace(dimension=2)\n",
+    "vector = [1.0, 0.0]\n",
+    "print(space.is_normalized(vector))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/theory/01_structural_operators.ipynb
+++ b/docs/theory/01_structural_operators.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e4aef8ff",
+   "metadata": {},
+   "source": [
+    "# Structural Operators in the Mathematical Layer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5858951",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Introduce canonical operators implemented in tnfr.mathematics.\n",
+    "- Demonstrate how operator factories enforce invariants and closure.\n",
+    "- Highlight how operator composition respects structural semantics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "759cbc98",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "- `numpy`\n",
+    "- `tnfr`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45b81584",
+   "metadata": {},
+   "source": [
+    "## TNFR Context\n",
+    "Operators such as CoherenceOperator and FrequencyOperator embed TNFR semantics directly into their evaluation.\n",
+    "\n",
+    "Factories like make_coherence_operator guarantee parameter validation and consistent units.\n",
+    "\n",
+    "Operator composition is tracked so that ΔNFR updates remain interpretable and auditable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1069cd2c",
+   "metadata": {
+    "tags": [
+     "smoke-example"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from tnfr.mathematics import make_coherence_operator\n",
+    "operator = make_coherence_operator(dim=2, c_min=0.2)\n",
+    "print(round(operator.c_min, 2))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/theory/02_phase_and_coupling.ipynb
+++ b/docs/theory/02_phase_and_coupling.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2c4c6dd3",
+   "metadata": {},
+   "source": [
+    "# Phase Alignment and Coupling Checks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df157e8a",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Explain why phase verification precedes any resonance coupling.\n",
+    "- Show how the mathematics package encodes coupling thresholds.\n",
+    "- Relate coupling logs to global coherence monitoring."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0185a4ad",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "- `numpy`\n",
+    "- `tnfr`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd310e5",
+   "metadata": {},
+   "source": [
+    "## TNFR Context\n",
+    "Phase is stored explicitly so that resonance only occurs when nodes synchronize within tolerance.\n",
+    "\n",
+    "Coupling utilities rely on ΔNFR hooks that adjust structural frequency together with phase drift.\n",
+    "\n",
+    "Phase-aware updates prevent hidden collapse events in multi-node simulations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e62cdc1",
+   "metadata": {
+    "tags": [
+     "smoke-example"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from tnfr.constants import DNFR_PRIMARY, THETA_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.structural import Coupling, create_nfr, run_sequence\n",
+    "\n",
+    "G, node = create_nfr(\"pair\", vf=1.0, theta=0.2)\n",
+    "\n",
+    "def sync(graph):\n",
+    "    graph.nodes[node][DNFR_PRIMARY] = 0.01\n",
+    "    graph.nodes[node][THETA_PRIMARY] += 0.02\n",
+    "    graph.nodes[node][VF_PRIMARY] += 0.05\n",
+    "\n",
+    "set_delta_nfr_hook(G, sync)\n",
+    "run_sequence(G, node, [Coupling()])\n",
+    "print(round(G.nodes[node][THETA_PRIMARY], 2))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/theory/03_coherence_metrics.ipynb
+++ b/docs/theory/03_coherence_metrics.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e28ea056",
+   "metadata": {},
+   "source": [
+    "# Coherence Metrics and Logging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ac6d0da",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Outline telemetry available for coherence monitoring.\n",
+    "- Connect metrics to mathematical projections and norms.\n",
+    "- Demonstrate how to collect minimal smoke-test telemetry."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0ed551f",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "- `numpy`\n",
+    "- `tnfr`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c967fc87",
+   "metadata": {},
+   "source": [
+    "## TNFR Context\n",
+    "coherence_expectation and frequency_expectation provide scalar diagnostics tied to Hilbert projections.\n",
+    "\n",
+    "Telemetry streams capture C(t), νf, Si, and phase for downstream visualization.\n",
+    "\n",
+    "Logging hooks in tnfr.telemetry integrate with the mathematics layer to ensure reproducibility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d7318c4",
+   "metadata": {
+    "tags": [
+     "smoke-example"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from tnfr.mathematics import HilbertSpace, coherence_expectation, make_coherence_operator\n",
+    "\n",
+    "space = HilbertSpace(dimension=2)\n",
+    "operator = make_coherence_operator(dim=2, c_min=0.4)\n",
+    "state = np.array([1.0, 0.0])\n",
+    "print(round(coherence_expectation(state, operator), 2))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/theory/04_dissonance_and_bifurcation.ipynb
+++ b/docs/theory/04_dissonance_and_bifurcation.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0f0428bf",
+   "metadata": {},
+   "source": [
+    "# Dissonance Tests and Bifurcation Safety"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69e96da9",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Describe how controlled dissonance increases |ΔNFR|.\n",
+    "- Show how second derivatives gate bifurcation triggers.\n",
+    "- Provide safety checks for experiments exploring collapse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e055e309",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "- `numpy`\n",
+    "- `tnfr`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13f0cb37",
+   "metadata": {},
+   "source": [
+    "## TNFR Context\n",
+    "Dissonance operators deliberately amplify ΔNFR, but the mathematics layer keeps track of νf bounds.\n",
+    "\n",
+    "Bifurcation thresholds rely on comparing ∂²EPI/∂t² against configured tolerances.\n",
+    "\n",
+    "Smoke simulations should log both the trigger condition and post-event coherence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1298465d",
+   "metadata": {
+    "tags": [
+     "smoke-example"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from tnfr.constants import DNFR_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.structural import Dissonance, create_nfr, run_sequence\n",
+    "\n",
+    "G, node = create_nfr(\"probe\")\n",
+    "\n",
+    "def escalate(graph):\n",
+    "    graph.nodes[node][DNFR_PRIMARY] += 0.2\n",
+    "\n",
+    "set_delta_nfr_hook(G, escalate)\n",
+    "run_sequence(G, node, [Dissonance()])\n",
+    "print(round(G.nodes[node][DNFR_PRIMARY], 2))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/theory/05_unitary_dynamics_and_delta_nfr.ipynb
+++ b/docs/theory/05_unitary_dynamics_and_delta_nfr.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c2ad62fe",
+   "metadata": {},
+   "source": [
+    "# Unitary Dynamics and ΔNFR Stabilization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18f5ed1c",
+   "metadata": {},
+   "source": [
+    "## Objectives\n",
+    "- Connect stable_unitary flows with ΔNFR modulation.\n",
+    "- Explain how isometries preserve coherence in evolution.\n",
+    "- Demonstrate a simple unitary update with telemetry logging."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc916309",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "- `numpy`\n",
+    "- `tnfr`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4423765",
+   "metadata": {},
+   "source": [
+    "## TNFR Context\n",
+    "stable_unitary enforces norm preservation so that coherence remains bounded.\n",
+    "\n",
+    "IsometryFactory provides parameterized families of unitary maps aligned with TNFR invariants.\n",
+    "\n",
+    "ΔNFR updates should be logged together with νf to keep experiments reproducible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22c874d4",
+   "metadata": {
+    "tags": [
+     "smoke-example"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from tnfr.mathematics import HilbertSpace, make_coherence_operator, stable_unitary\n",
+    "\n",
+    "space = HilbertSpace(dimension=2)\n",
+    "operator = make_coherence_operator(dim=2, c_min=0.5)\n",
+    "state = [1.0, 0.0]\n",
+    "passed, norm_after = stable_unitary(state, operator, space)\n",
+    "print(passed, round(norm_after, 3))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Quick Start (Mathematics) foundations guide with doctest-friendly sequences, flag activation steps, unitary evolution, and telemetry guidance
- scaffold six mkdocs-jupyter compatible theory notebooks that outline objectives, dependencies, TNFR context, and smoke examples

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_690257ef8838832196ed24c04226dc9f