### PR TITLE
Ensure docs test script executes theory notebooks

### DIFF
--- a/scripts/test_docs.sh
+++ b/scripts/test_docs.sh
@@ -12,9 +12,11 @@ export PYTHONPATH="$REPO_ROOT/src:${PYTHONPATH:-}"
 
 python -m doctest -o ELLIPSIS docs/index.md docs/foundations.md
 
-if [ -d "docs/notebooks" ]; then
-  while IFS= read -r notebook; do
-    PYTHONWARNINGS="ignore:MissingIDFieldWarning" python -m jupyter nbconvert \
-      --to notebook --execute "$notebook" --stdout > /dev/null
-  done < <(find docs/notebooks -type f -name '*.ipynb' | sort)
-fi
+for notebook_dir in docs/theory docs/notebooks; do
+  if [ -d "$notebook_dir" ]; then
+    while IFS= read -r notebook; do
+      PYTHONWARNINGS="ignore:MissingIDFieldWarning" python -m jupyter nbconvert \
+        --to notebook --execute "$notebook" --stdout > /dev/null
+    done < <(find "$notebook_dir" -type f -name '*.ipynb' | sort)
+  fi
+done


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Summary
- Run documentation notebook tests for both the new `docs/theory` collection and the legacy `docs/notebooks` scaffolds while keeping the nbconvert execution parameters unchanged.

### Testing
- scripts/test_docs.sh

------
https://chatgpt.com/codex/tasks/task_e_690260bbe4348321a594b21383d3e243