### PR TITLE
Fix Mathematical Foundations nav to match notebook filenames

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,10 +16,10 @@ nav:
       - Telemetry & utilities: api/telemetry.md
   - Mathematical Foundations:
       - Overview: theory/00_overview.ipynb
-      - Structural operators: theory/01_structural_operators.ipynb
-      - Phase and coupling: theory/02_phase_and_coupling.ipynb
-      - Coherence metrics: theory/03_coherence_metrics.ipynb
-      - Dissonance and bifurcation: theory/04_dissonance_and_bifurcation.ipynb
+      - Hilbert space foundations: theory/01_hilbert_space.ipynb
+      - Coherence operator Ĉ: theory/02_coherence_operator_C_hat.ipynb
+      - Frequency operator Ĵ: theory/03_frequency_operator_J_hat.ipynb
+      - Validator and metrics: theory/04_validator_and_metrics.ipynb
       - Unitary dynamics and ΔNFR: theory/05_unitary_dynamics_and_delta_nfr.ipynb
   - Examples: examples/README.md
   - Security:


### PR DESCRIPTION
## Summary
- update the Mathematical Foundations navigation entries in mkdocs.yml so they point to the actual notebook filenames and add clearer titles

## Testing
- mkdocs build --strict -f mkdocs-temp-no-link.yml

------
https://chatgpt.com/codex/tasks/task_e_690262ae26e48321b0d5d51f4adeda41