### PR TITLE
Add roadmap and runtime notes to the TNFR overview notebook

### DIFF
--- a/docs/theory/00_tnfr_overview.ipynb
+++ b/docs/theory/00_tnfr_overview.ipynb
@@ -25,6 +25,71 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ff288d79",
+   "metadata": {},
+   "source": [
+    "## Documentation roadmap\n",
+    "\n",
+    "The overview notebook sits at the top of the TNFR documentation tree. The index and quickstart guides map the first hops towards examples and reference notes:\n",
+    "\n",
+    "* The [documentation index](../index.md) will grow into the canonical entry point for theory, operations, and release state.\n",
+    "* [Quickstart onboarding](../getting-started/quickstart.md) connects the theoretical framing here with executable flows.\n",
+    "* [Example playbooks](../examples/README.md) and scenario assets stay aligned with the invariants summarized below.\n",
+    "* Theory notebooks in this folder record the proofs, operator derivations, and validation walkthroughs that expand on each invariant.\n",
+    "\n",
+    "The roadmap prioritises filling those stubs while keeping each addition tied back to the invariants listed above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1e14d32",
+   "metadata": {},
+   "source": [
+    "## Opt-in activation summary\n",
+    "\n",
+    "The engine still treats advanced operator stacks (self-organisation cascades, resonance window amplification, and stochastic ΔNFR perturbations) as opt-in features. Builders should:\n",
+    "\n",
+    "* Start with the deterministic hooks illustrated here and in the [foundations primer](../foundations.md) to anchor ΔNFR semantics.\n",
+    "* Enable stochastic or multi-node activations explicitly—either through configuration payloads or runtime wiring—so automation retains control of when a node leaves the canonical scripted envelope.\n",
+    "* Capture telemetry describing why an activation was granted; this notebook's smoke run mirrors the minimal audit fields (ΔNFR weights, νf, θ) that downstream tooling expects.\n",
+    "\n",
+    "See the primer for the design goals behind the opt-in policy and the invariants that must hold once optional activations are enabled."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca4f1802",
+   "metadata": {},
+   "source": [
+    "## Compatibility guarantees\n",
+    "\n",
+    "TNFR follows a semantic versioning contract anchored in reproducible coherence traces. In practice this means:\n",
+    "\n",
+    "* Patch releases stay API-compatible and are safe to absorb in automation once the release notes are reviewed.\n",
+    "* Minor releases may extend operator surfaces or telemetry, but they advertise migrations in advance through the [release ledger](../releases.md).\n",
+    "* Major releases annotate breaking changes with remediation guides such as the [remesh window migration](../getting-started/migrating-remesh-window.md).\n",
+    "\n",
+    "When building long-lived notebooks, pin the `tnfr` version and record the ΔNFR hook signature you depend on so CI replicates the same behaviour after upgrades."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "461a0fda",
+   "metadata": {},
+   "source": [
+    "## Computational cost notes\n",
+    "\n",
+    "Most theoretical notebooks target fast smoke execution to preserve CI latency budgets. Keep in mind:\n",
+    "\n",
+    "* The scripted example below runs in milliseconds and represents the ceiling for per-notebook smoke budgets.\n",
+    "* Operator explorations that require eigen-decompositions should batch them carefully—the `numpy.linalg.eigh` primitive we rely on is `O(N^3)` in the matrix size.\n",
+    "* Prefer vectorised helpers showcased in the [example playbooks](../examples/README.md) before reaching for heavier solvers, and gate expensive scans behind explicit benchmark notebooks.\n",
+    "\n",
+    "Sticking to these constraints keeps the smoke suite reliable while preserving room for deeper exploration notebooks that opt into heavier kernels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0da25765",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- add documentation roadmap, opt-in activation guidance, compatibility guarantees, and computational cost notes ahead of the smoke example in the TNFR overview notebook
- link to supporting documentation and reiterate the O(N^3) `numpy.linalg.eigh` reminder without altering the execution cell

## Testing
- PYTHONPATH=src python - <<'PY'
import os
import nbformat
from nbclient import NotebookClient
os.environ['PYTHONPATH'] = 'src:' + os.environ.get('PYTHONPATH', '')
path = 'docs/theory/00_tnfr_overview.ipynb'
nb = nbformat.read(path, as_version=4)
client = NotebookClient(nb, timeout=120, kernel_name='python3', resources={'metadata': {'path': '.'}})
client.execute()
print('executed')
PY


------
https://chatgpt.com/codex/tasks/task_e_69026aa1857083219634d8839609ca5b