### PR TITLE
Document H_NFR tensor section smoke validation

### DIFF
--- a/docs/theory/01_hilbert_space_h_nfr.ipynb
+++ b/docs/theory/01_hilbert_space_h_nfr.ipynb
@@ -24,6 +24,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0539ce70",
+   "metadata": {},
+   "source": [
+    "### Finite $\\ell^2 \\otimes L^2$ realisation\n",
+    "The TNFR engine realises $H_{\\text{NFR}}$ as a finite section of the coupled discrete/continuous spectrum.  ``tnfr.mathematics.spaces.HilbertSpace`` provides the truncated $\\ell^2$ factor with a canonical orthonormal basis and sesquilinear inner product implemented via ``numpy.vdot``.  The complementary ``tnfr.mathematics.spaces.BanachSpaceEPI`` packages the sampled $L^2$ continuum and associated coherence functional so that spectral vectors can be paired with continuous envelopes.  Together these classes make the tensor-product section explicit: ``HilbertSpace`` handles discrete projections, while ``BanachSpaceEPI`` validates and weights the continuous samples, ensuring the resulting state stays faithful to the $\\ell^2 \\otimes L^2$ geometry used throughout the operators."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "27ddbaed",
    "metadata": {},
    "source": [
@@ -60,6 +69,54 @@
     "    \"‖φ‖\": round(norm_phi, 6),\n",
     "    \"coherence\": round(coherence_value, 6),\n",
     "    \"c_min\": round(coherence_operator.c_min, 6),\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7da2d01",
+   "metadata": {},
+   "source": [
+    "## Deterministic Hilbert-space validation\n",
+    "The following smoke cell checks the norm homogeneity and triangle inequality on fixed vectors and confirms that projections onto an orthonormal basis reproduce the original state, all within the ``HilbertSpace`` abstraction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "633e0c35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from tnfr.mathematics.spaces import HilbertSpace\n",
+    "\n",
+    "space = HilbertSpace(dimension=3)\n",
+    "psi = np.array([1.0 + 0.0j, 0.5 - 0.25j, -0.5j], dtype=np.complex128)\n",
+    "scalar = 0.75 - 0.5j\n",
+    "homogeneity_lhs = space.norm(scalar * psi)\n",
+    "homogeneity_rhs = abs(scalar) * space.norm(psi)\n",
+    "\n",
+    "u = np.array([0.8 + 0.0j, -0.2 + 0.1j, 0.3 - 0.4j], dtype=np.complex128)\n",
+    "v = np.array([-0.3 + 0.2j, 0.4 + 0.0j, -0.1 + 0.1j], dtype=np.complex128)\n",
+    "triangle_lhs = space.norm(u + v)\n",
+    "triangle_rhs = space.norm(u) + space.norm(v)\n",
+    "\n",
+    "basis = [\n",
+    "    np.array([1.0, 0.0, 0.0], dtype=np.complex128),\n",
+    "    np.array([0.0, 1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=np.complex128),\n",
+    "    np.array([0.0, 1 / np.sqrt(2), -1 / np.sqrt(2)], dtype=np.complex128),\n",
+    "]\n",
+    "coefficients = space.project(psi, basis)\n",
+    "basis_matrix = np.vstack(basis)\n",
+    "reconstruction = basis_matrix.conj().T @ coefficients\n",
+    "projection_error = float(np.max(np.abs(reconstruction - psi)))\n",
+    "\n",
+    "{\n",
+    "    'homogeneity_diff': round(homogeneity_lhs - homogeneity_rhs, 12),\n",
+    "    'triangle_gap': round(triangle_lhs - triangle_rhs, 12),\n",
+    "    'projection_error': round(projection_error, 12),\n",
+    "    'coefficients': [complex(round(c.real, 6), round(c.imag, 6)) for c in coefficients],\n",
     "}\n"
    ]
   }


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Documented how `HilbertSpace` and `BanachSpaceEPI` realise the finite ℓ² ⊗ L² section and added deterministic Hilbert-space smoke checks for homogeneity, triangle inequality, and orthonormal projections.

------
https://chatgpt.com/codex/tasks/task_e_69026bc399948321bf418ae56f060e66