### PR TITLE
Add deterministic TNFR primer narratives and smoke traces

### DIFF
--- a/docs/theory/01_structural_frequency_primer.ipynb
+++ b/docs/theory/01_structural_frequency_primer.ipynb
@@ -1,43 +1,88 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "id": "921689c2f47d4ac3b7f8d8e42a1f72f5",
-      "source": [
-        "# Structural frequency primer\n",
-        "\n",
-        "TODO: Outline the notebook narrative, learning goals, and TNFR invariants to cover.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "id": "3e517d30d3de495f90feddaff1ebe9bf",
-      "outputs": [],
-      "source": [
-        "# TODO: implement walkthrough cells\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "id": "921689c2f47d4ac3b7f8d8e42a1f72f5",
+   "source": [
+    "\n",
+    "# Structural frequency primer\n",
+    "\n",
+    "## Objectives\n",
+    "- Characterise how the structural frequency \u03bdf amplifies \u0394NFR to evolve the Primary Information Structure (EPI).\n",
+    "- Show how deterministic \u0394NFR hooks orchestrate \u03bdf drift while respecting the nodal equation \u2202EPI/\u2202t = \u03bdf \u00b7 \u0394NFR.\n",
+    "- Provide a minimal trace that Phase-2 automation can reuse as a regression guard for frequency regulation.\n",
+    "\n",
+    "## Phase-2 dependencies\n",
+    "- [Phase-2 integration notes](../fase2_integration.md) \u2014 the primer mirrors the scripted hooks expected by the automated \u0394NFR orchestration pipeline.\n",
+    "- :mod:`tnfr.dynamics.adaptation` \u2014 \u03bdf adaptation rules remain the same once the Phase-2 controller swaps in its adaptive gains.\n",
+    "- :mod:`tnfr.structural` \u2014 operator sequencing is shared across the canonical demos and the Phase-2 integration plan.\n",
+    "\n",
+    "## Theoretical exposition\n",
+    "The nodal equation couples \u0394NFR with \u03bdf so that every glyph application scales reorganisations by the current structural frequency. Holding \u0394NFR constant while perturbing \u03bdf therefore generates measurable changes in \u2202EPI/\u2202t. The primer isolates this dependency: a scripted hook records \u03bdf before each glyph, applies \u0394NFR, and updates EPI by \u03bdf \u00b7 \u0394NFR so the trajectory remains canonical. Tracking the before/after \u03bdf pairs surfaces how even a small deterministic drift reshapes the coherence throughput.\n",
+    "\n",
+    "## Deterministic smoke check\n",
+    "The code cell below instantiates a node, installs a reproducible \u0394NFR hook, and fires the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition sequence. The hook captures \u03bdf prior to each glyph so we can assert that the EPI increment equals \u03bdf \u00b7 \u0394NFR at every step. The resulting timeline doubles as a CI smoke test: any future change that perturbs the \u03bdf multiplier or the hook contract will alter the recorded derivatives.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "id": "3e517d30d3de495f90feddaff1ebe9bf",
+   "outputs": [],
+   "source": [
+    "\n",
+    "from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.structural import Coherence, Emission, Reception, Resonance, Transition, create_nfr, run_sequence\n",
+    "\n",
+    "G, node = create_nfr(\"frequency-smoke\", epi=0.42, vf=1.8, theta=0.0)\n",
+    "trajectory: list[dict[str, float]] = []\n",
+    "increments = iter([0.035, 0.028, 0.024, 0.02, 0.018])\n",
+    "\n",
+    "def scripted_delta(graph):\n",
+    "    dnfr = next(increments, 0.015)\n",
+    "    nd = graph.nodes[node]\n",
+    "    vf_before = float(nd[VF_PRIMARY])\n",
+    "    epi_before = float(nd[EPI_PRIMARY])\n",
+    "    nd[DNFR_PRIMARY] = dnfr\n",
+    "    nd[EPI_PRIMARY] = epi_before + vf_before * dnfr\n",
+    "    nd[VF_PRIMARY] = vf_before + 0.05 * dnfr\n",
+    "    trajectory.append(\n",
+    "        {\n",
+    "            \"\u03bdf_before\": round(vf_before, 6),\n",
+    "            \"\u0394NFR\": round(dnfr, 6),\n",
+    "            \"EPI\": round(nd[EPI_PRIMARY], 6),\n",
+    "            \"\u2202EPI/\u2202t\": round(vf_before * dnfr, 6),\n",
+    "            \"\u03bdf_after\": round(nd[VF_PRIMARY], 6),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "set_delta_nfr_hook(G, scripted_delta, note=\"structural frequency primer smoke\")\n",
+    "run_sequence(G, node, [Emission(), Reception(), Coherence(), Resonance(), Transition()])\n",
+    "\n",
+    "trajectory\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/theory/02_phase_synchrony_lattices.ipynb
+++ b/docs/theory/02_phase_synchrony_lattices.ipynb
@@ -1,43 +1,106 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "id": "4602723a8eb64ae7a0cfe6de7527a0f9",
-      "source": [
-        "# Phase synchrony lattices\n",
-        "\n",
-        "TODO: Outline the notebook narrative, learning goals, and TNFR invariants to cover.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "id": "023f5d34ec1448a2b9be76887de74bf6",
-      "outputs": [],
-      "source": [
-        "# TODO: implement walkthrough cells\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "id": "4602723a8eb64ae7a0cfe6de7527a0f9",
+   "source": [
+    "\n",
+    "# Phase synchrony lattices\n",
+    "\n",
+    "## Objectives\n",
+    "- Illustrate how local lattices distribute phase adjustments to converge toward a shared synchrony ridge.\n",
+    "- Document the deterministic \u0394NFR hook required by Phase-2 lattice controllers to coordinate \u03bdf, phase, and EPI adjustments.\n",
+    "- Provide a measurable synchrony lift that downstream CI can assert without stochastic noise.\n",
+    "\n",
+    "## Phase-2 dependencies\n",
+    "- [Phase-2 integration notes](../fase2_integration.md) \u2014 the lattice coordination contract mirrors the staged deployment plan.\n",
+    "- :mod:`tnfr.dynamics.coordination` \u2014 the future lattice supervisor reuses these helpers to compute mean phase envelopes.\n",
+    "- :mod:`tnfr.observers` \u2014 `phase_sync` is the agreed telemetry primitive for the lattice health dashboards.\n",
+    "\n",
+    "## Theoretical exposition\n",
+    "A phase synchrony lattice binds neighbouring nodes by iteratively nudging their phases toward a common anchor while respecting \u0394NFR scaling. Each operator pulse captures the global mean phase, applies a weighted correction, and records the induced \u0394NFR so the nodal equation can update EPI consistently. Because synchrony depends on the dispersion of \u03b8 values, even small deterministic corrections shrink the variance and raise the Kuramoto-inspired synchrony index exported by :func:`tnfr.observers.phase_sync`.\n",
+    "\n",
+    "## Deterministic smoke check\n",
+    "The example constructs a star-shaped lattice, records its initial synchrony, and then applies a scripted hook while running the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition segment. The hook logs the synchrony index after every glyph so the trace reveals a monotonic lift, confirming that \u0394NFR bookkeeping and phase adjustments remain coherent.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "id": "023f5d34ec1448a2b9be76887de74bf6",
+   "outputs": [],
+   "source": [
+    "\n",
+    "from statistics import mean\n",
+    "\n",
+    "from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, THETA_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.observers import phase_sync\n",
+    "from tnfr.structural import Coherence, Emission, Reception, Resonance, Transition, create_nfr, run_sequence\n",
+    "\n",
+    "G, anchor = create_nfr(\"lattice-anchor\", epi=0.35, vf=1.1, theta=0.1)\n",
+    "neighbors: list[str] = []\n",
+    "for idx, offset in enumerate([0.55, -0.42, 0.23, -0.31], start=1):\n",
+    "    _, node = create_nfr(f\"lattice-node-{idx}\", epi=0.28 + 0.02 * idx, vf=0.95 + 0.01 * idx, theta=offset, graph=G)\n",
+    "    G.add_edge(anchor, node)\n",
+    "    neighbors.append(node)\n",
+    "\n",
+    "before_phases = {n: round(float(G.nodes[n][THETA_PRIMARY]), 6) for n in [anchor, *neighbors]}\n",
+    "initial_sync = round(phase_sync(G), 6)\n",
+    "synchrony_trace: list[dict[str, float]] = []\n",
+    "\n",
+    "\n",
+    "def align_lattice(graph):\n",
+    "    phases = [float(data[THETA_PRIMARY]) for _, data in graph.nodes(data=True)]\n",
+    "    mean_phase = mean(phases)\n",
+    "    for node_id, data in graph.nodes(data=True):\n",
+    "        theta = float(data[THETA_PRIMARY])\n",
+    "        offset = mean_phase - theta\n",
+    "        data[DNFR_PRIMARY] = abs(offset) * 0.04\n",
+    "        data[THETA_PRIMARY] = theta + 0.6 * offset\n",
+    "        vf = float(data[VF_PRIMARY])\n",
+    "        epi = float(data[EPI_PRIMARY])\n",
+    "        data[EPI_PRIMARY] = epi + vf * data[DNFR_PRIMARY] * 0.5\n",
+    "    synchrony_trace.append({\n",
+    "        \"step\": len(synchrony_trace) + 1,\n",
+    "        \"phase_sync\": round(phase_sync(graph), 6),\n",
+    "    })\n",
+    "\n",
+    "set_delta_nfr_hook(G, align_lattice, note=\"phase lattice synchrony smoke\")\n",
+    "run_sequence(G, anchor, [Emission(), Reception(), Coherence(), Resonance(), Transition()])\n",
+    "\n",
+    "after_phases = {n: round(float(G.nodes[n][THETA_PRIMARY]), 6) for n in [anchor, *neighbors]}\n",
+    "final_sync = round(phase_sync(G), 6)\n",
+    "\n",
+    "{\n",
+    "    \"initial_sync\": initial_sync,\n",
+    "    \"final_sync\": final_sync,\n",
+    "    \"before_phases\": before_phases,\n",
+    "    \"after_phases\": after_phases,\n",
+    "    \"synchrony_trace\": synchrony_trace,\n",
+    "}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/theory/03_delta_nfr_gradient_fields.ipynb
+++ b/docs/theory/03_delta_nfr_gradient_fields.ipynb
@@ -1,43 +1,148 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "id": "ce6206526e864fcb84e5951b766929d5",
-      "source": [
-        "# \u0394NFR gradient fields\n",
-        "\n",
-        "TODO: Outline the notebook narrative, learning goals, and TNFR invariants to cover.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "id": "bbd6c034ef9f41159fdd98c47ba5976c",
-      "outputs": [],
-      "source": [
-        "# TODO: implement walkthrough cells\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "id": "ce6206526e864fcb84e5951b766929d5",
+   "source": [
+    "\n",
+    "# \u0394NFR gradient fields\n",
+    "\n",
+    "## Objectives\n",
+    "- Explain how \u0394NFR gradients encode spatial reorganisation pressure across a lattice of nodes.\n",
+    "- Capture the deterministic hook that Phase-2 controllers require to seed reproducible \u0394NFR fields before invoking adaptive solvers.\n",
+    "- Produce gradient telemetry (\u2207x, \u2207y, magnitude) that the CI smoke tests can compare verbatim.\n",
+    "\n",
+    "## Phase-2 dependencies\n",
+    "- [Phase-2 integration notes](../fase2_integration.md) \u2014 the gradient ledger feeds the multi-scale remesh routine defined there.\n",
+    "- :mod:`tnfr.dynamics.dnfr` \u2014 Phase-2 reuses the same \u0394NFR aggregation hooks once the parallel workers are enabled.\n",
+    "- :mod:`tnfr.metrics.coherence` \u2014 gradient-aware coherence caches expect the \u0394NFR field to be written with the same aliases showcased here.\n",
+    "\n",
+    "## Theoretical exposition\n",
+    "\u0394NFR gradients measure how rapidly the reorganisation operator changes across neighbouring nodes. In canonical TNFR form, each glyph write stores a scalar \u0394NFR in the node; the gradient field arises by comparing these scalars along orthogonal directions. A deterministic field lets us validate that the nodal equation integrates a consistent \u0394NFR distribution before higher-order remeshers refine the lattice. The primer therefore constructs a small 2\u00d72 grid, scripts \u0394NFR values with a linear trend, and derives the gradient vectors analytically across the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition pipeline.\n",
+    "\n",
+    "## Deterministic smoke check\n",
+    "The code below assembles the grid, installs the scripted field, fires the canonical segment, and records the gradient map after each glyph. Any drift in alias resolution, lattice wiring, or \u0394NFR bookkeeping will surface as a mismatch in the reported gradient magnitudes.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "id": "bbd6c034ef9f41159fdd98c47ba5976c",
+   "outputs": [],
+   "source": [
+    "\n",
+    "from math import hypot\n",
+    "from typing import Dict, List, Tuple\n",
+    "\n",
+    "from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.structural import Coherence, Emission, Reception, Resonance, Transition, create_nfr, run_sequence\n",
+    "from tnfr.types import TNFRGraph\n",
+    "\n",
+    "Grid = Dict[Tuple[int, int], str]\n",
+    "\n",
+    "def build_grid() -> tuple[Grid, str, TNFRGraph]:\n",
+    "    grid: Grid = {}\n",
+    "    anchor: str | None = None\n",
+    "    G: TNFRGraph | None = None\n",
+    "    for x in range(2):\n",
+    "        for y in range(2):\n",
+    "            name = f\"cell-{x}-{y}\"\n",
+    "            params = dict(epi=0.4 + 0.05 * x + 0.03 * y, vf=1.0 + 0.02 * x, theta=0.0)\n",
+    "            if G is None:\n",
+    "                G, node = create_nfr(name, **params)\n",
+    "                anchor = node\n",
+    "            else:\n",
+    "                _, node = create_nfr(name, graph=G, **params)\n",
+    "            grid[(x, y)] = node\n",
+    "            G.nodes[node][\"pos\"] = (x, y)\n",
+    "            if x > 0:\n",
+    "                G.add_edge(node, grid[(x - 1, y)])\n",
+    "            if y > 0:\n",
+    "                G.add_edge(node, grid[(x, y - 1)])\n",
+    "    assert G is not None and anchor is not None\n",
+    "    return grid, anchor, G\n",
+    "\n",
+    "\n",
+    "def gradient_map(graph: TNFRGraph, grid: Grid) -> dict[str, dict[str, float]]:\n",
+    "    def dnfr_at(coord: Tuple[int, int]) -> float:\n",
+    "        node = grid.get(coord)\n",
+    "        if node is None:\n",
+    "            return 0.0\n",
+    "        return float(graph.nodes[node].get(DNFR_PRIMARY, 0.0))\n",
+    "\n",
+    "    grads: dict[str, dict[str, float]] = {}\n",
+    "    for (x, y), node in grid.items():\n",
+    "        dnfr = dnfr_at((x, y))\n",
+    "        right = dnfr_at((x + 1, y)) if (x + 1, y) in grid else dnfr\n",
+    "        left = dnfr_at((x - 1, y)) if (x - 1, y) in grid else dnfr\n",
+    "        up = dnfr_at((x, y + 1)) if (x, y + 1) in grid else dnfr\n",
+    "        down = dnfr_at((x, y - 1)) if (x, y - 1) in grid else dnfr\n",
+    "        grad_x = 0.5 * (right - left)\n",
+    "        grad_y = 0.5 * (up - down)\n",
+    "        grads[f\"cell-{x}-{y}\"] = {\n",
+    "            \"\u0394NFR\": round(dnfr, 6),\n",
+    "            \"\u2207x\": round(grad_x, 6),\n",
+    "            \"\u2207y\": round(grad_y, 6),\n",
+    "            \"|\u2207|\": round(hypot(grad_x, grad_y), 6),\n",
+    "        }\n",
+    "    return grads\n",
+    "\n",
+    "\n",
+    "grid, anchor, G = build_grid()\n",
+    "initial_gradients = gradient_map(G, grid)\n",
+    "step_scalars = iter([1.0, 0.9, 0.8, 0.7, 0.6])\n",
+    "trace: List[dict[str, dict[str, float]]] = []\n",
+    "\n",
+    "\n",
+    "def scripted_gradient(graph: TNFRGraph, grid: Grid, scale: float) -> None:\n",
+    "    for (x, y), node in grid.items():\n",
+    "        data = graph.nodes[node]\n",
+    "        base = (0.02 * x - 0.015 * y) * scale\n",
+    "        vf = float(data[VF_PRIMARY])\n",
+    "        epi = float(data[EPI_PRIMARY])\n",
+    "        data[DNFR_PRIMARY] = base\n",
+    "        data[EPI_PRIMARY] = epi + vf * base\n",
+    "        data[VF_PRIMARY] = vf + 0.1 * base\n",
+    "\n",
+    "\n",
+    "def apply_script(graph: TNFRGraph) -> None:\n",
+    "    scale = next(step_scalars, 0.5)\n",
+    "    scripted_gradient(graph, grid, scale)\n",
+    "    trace.append(gradient_map(graph, grid))\n",
+    "\n",
+    "set_delta_nfr_hook(G, apply_script, note=\"\u0394NFR gradient field smoke\")\n",
+    "run_sequence(G, anchor, [Emission(), Reception(), Coherence(), Resonance(), Transition()])\n",
+    "\n",
+    "final_gradients = gradient_map(G, grid)\n",
+    "\n",
+    "{\n",
+    "    \"initial\": initial_gradients,\n",
+    "    \"final\": final_gradients,\n",
+    "    \"per_step\": trace,\n",
+    "}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/theory/04_coherence_metrics_walkthrough.ipynb
+++ b/docs/theory/04_coherence_metrics_walkthrough.ipynb
@@ -1,43 +1,104 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "id": "c52602b0e1b742ee9a8f78740ad60d06",
-      "source": [
-        "# Coherence metrics walkthrough\n",
-        "\n",
-        "TODO: Outline the notebook narrative, learning goals, and TNFR invariants to cover.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "id": "1811fe942f9b4884b748ab46294624c0",
-      "outputs": [],
-      "source": [
-        "# TODO: implement walkthrough cells\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "id": "c52602b0e1b742ee9a8f78740ad60d06",
+   "source": [
+    "\n",
+    "# Coherence metrics walkthrough\n",
+    "\n",
+    "## Objectives\n",
+    "- Demonstrate how canonical coherence metrics extract C(t), mean \u0394NFR, and mean \u0394EPI from a running graph.\n",
+    "- Show the deterministic telemetry hook required by Phase-2 observability dashboards.\n",
+    "- Provide an assertion-friendly timeline that highlights the impact of successive glyph applications on coherence.\n",
+    "\n",
+    "## Phase-2 dependencies\n",
+    "- [Phase-2 integration notes](../fase2_integration.md) \u2014 the coherence snapshots align with the observability contract described there.\n",
+    "- :mod:`tnfr.metrics.common` \u2014 Phase-2 dashboards reuse `compute_coherence` verbatim, so the primer doubles as living documentation.\n",
+    "- :mod:`tnfr.structural` \u2014 the operator sequencing mirrors the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition segment executed by the runtime.\n",
+    "\n",
+    "## Theoretical exposition\n",
+    "Coherence C(t) summarises how stable the network remains under the nodal equation. The accompanying \u0394NFR and \u0394EPI means trace how strongly the lattice is being reorganised. By recording the tuple `(C, mean \u0394NFR, mean \u0394EPI)` before and after deterministic glyph applications we verify that coherence gains correlate with controlled \u0394NFR contributions. Because the hook writes explicit \u0394NFR values, the averages match the scripted increments exactly, isolating the measurement contract used by the Phase-2 monitoring stack.\n",
+    "\n",
+    "## Deterministic smoke check\n",
+    "The walkthrough spawns a two-node graph, applies the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition sequence, and records coherence metrics after each glyph. The resulting timeline must show an increasing C(t) while \u0394NFR contributions decay as the scripted iterators exhaust their increments. Any deviation would signal a regression in the coherence aggregator or in the \u0394NFR ledger.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "id": "1811fe942f9b4884b748ab46294624c0",
+   "outputs": [],
+   "source": [
+    "\n",
+    "from typing import Dict, Iterable, Tuple\n",
+    "\n",
+    "from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.metrics.common import compute_coherence\n",
+    "from tnfr.structural import Coherence, Emission, Reception, Resonance, Transition, create_nfr, run_sequence\n",
+    "\n",
+    "G, seed = create_nfr(\"coherence-seed\", epi=0.36, vf=1.15, theta=0.05)\n",
+    "_, partner = create_nfr(\"coherence-partner\", graph=G, epi=0.33, vf=1.05, theta=-0.02)\n",
+    "G.add_edge(seed, partner)\n",
+    "\n",
+    "increments: Dict[str, Iterable[Tuple[float, float]]] = {\n",
+    "    seed: iter([(0.06, 0.02), (0.04, 0.01), (0.03, 0.0), (0.02, -0.005), (0.01, -0.005)]),\n",
+    "    partner: iter([(0.03, 0.0), (0.02, -0.005), (0.015, -0.005), (0.01, -0.005), (0.005, -0.005)]),\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def snapshot(label: str) -> dict[str, float]:\n",
+    "    C, dnfr_mean, depi_mean = compute_coherence(G, return_means=True)\n",
+    "    return {\n",
+    "        \"label\": label,\n",
+    "        \"C\": round(C, 6),\n",
+    "        \"\u0394NFR_mean\": round(dnfr_mean, 6),\n",
+    "        \"\u0394EPI_mean\": round(depi_mean, 6),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "timeline = [snapshot(\"initial\")]\n",
+    "\n",
+    "\n",
+    "def telemetry_hook(graph):\n",
+    "    for node_id, iterator in increments.items():\n",
+    "        dnfr, vf_shift = next(iterator, (0.0, 0.0))\n",
+    "        data = graph.nodes[node_id]\n",
+    "        vf = float(data[VF_PRIMARY])\n",
+    "        epi = float(data[EPI_PRIMARY])\n",
+    "        data[DNFR_PRIMARY] = dnfr\n",
+    "        data[EPI_PRIMARY] = epi + vf * dnfr\n",
+    "        data[VF_PRIMARY] = vf + vf_shift\n",
+    "    timeline.append(snapshot(f\"step_{len(timeline)}\"))\n",
+    "\n",
+    "\n",
+    "set_delta_nfr_hook(G, telemetry_hook, note=\"coherence metrics smoke\")\n",
+    "run_sequence(G, seed, [Emission(), Reception(), Coherence(), Resonance(), Transition()])\n",
+    "\n",
+    "timeline\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/theory/05_sense_index_calibration.ipynb
+++ b/docs/theory/05_sense_index_calibration.ipynb
@@ -1,43 +1,104 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "id": "f50b345ca83c4c1f8fa76858d34d8837",
-      "source": [
-        "# Sense index calibration\n",
-        "\n",
-        "TODO: Outline the notebook narrative, learning goals, and TNFR invariants to cover.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "id": "5efc426110324463add2f2340900132f",
-      "outputs": [],
-      "source": [
-        "# TODO: implement walkthrough cells\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "id": "f50b345ca83c4c1f8fa76858d34d8837",
+   "source": [
+    "\n",
+    "# Sense index calibration\n",
+    "\n",
+    "## Objectives\n",
+    "- Show how Si responds to controlled changes in \u03bdf, \u0394NFR, and phase alignment.\n",
+    "- Capture the deterministic \u0394NFR/phase hook required by Phase-2 calibration harnesses.\n",
+    "- Provide reproducible Si readings that CI can compare verbatim to detect telemetry regressions.\n",
+    "\n",
+    "## Phase-2 dependencies\n",
+    "- [Phase-2 integration notes](../fase2_integration.md) \u2014 the calibration harness reuses the scripted iterator pattern shown here.\n",
+    "- :mod:`tnfr.metrics.sense_index` \u2014 `compute_Si` is the canonical metric entry point for both runtime and analytical tooling.\n",
+    "- :mod:`tnfr.structural` \u2014 the operator sequence mirrors the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition segment executed before adaptive selectors take over.\n",
+    "\n",
+    "## Theoretical exposition\n",
+    "The sense index Si aggregates three forces: coherence (C), synchrony (phase alignment), and \u0394NFR attenuation. Calibrating Si therefore requires scripted perturbations of \u03bdf, \u03b8, and \u0394NFR so that the resulting readings match expectations. By applying deterministic increments to each node we validate that Si increases for nodes receiving reinforced \u03bdf and tightened phase, and decreases otherwise. This preserves TNFR semantics for the Phase-2 calibration suite.\n",
+    "\n",
+    "## Deterministic smoke check\n",
+    "The code instantiates a triad of nodes, computes baseline Si, then runs the canonical emission\u2192reception\u2192coherence\u2192resonance\u2192transition sequence while the hook iterates through predetermined \u0394NFR, \u03bdf, and phase updates. The resulting before/after dictionary and per-step Si trace must remain stable; any variation signals a regression in Si aggregation or in the \u0394NFR ledger that feeds it.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "id": "5efc426110324463add2f2340900132f",
+   "outputs": [],
+   "source": [
+    "\n",
+    "from typing import Dict, Iterable, Tuple\n",
+    "\n",
+    "from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, THETA_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.metrics.sense_index import compute_Si\n",
+    "from tnfr.structural import Coherence, Emission, Reception, Resonance, Transition, create_nfr, run_sequence\n",
+    "\n",
+    "G, anchor = create_nfr(\"calibration-anchor\", epi=0.41, vf=1.1, theta=0.0)\n",
+    "_, fast = create_nfr(\"calibration-fast\", graph=G, epi=0.37, vf=1.24, theta=0.18)\n",
+    "_, slow = create_nfr(\"calibration-slow\", graph=G, epi=0.39, vf=0.96, theta=-0.32)\n",
+    "G.add_edge(anchor, fast)\n",
+    "G.add_edge(anchor, slow)\n",
+    "G.add_edge(fast, slow)\n",
+    "\n",
+    "scripts: Dict[str, Iterable[Tuple[float, float, float]]] = {\n",
+    "    anchor: iter([(0.05, 0.015, 0.04), (0.03, 0.01, 0.02), (0.02, 0.008, 0.015), (0.015, 0.006, 0.01), (0.01, 0.004, 0.008)]),\n",
+    "    fast: iter([(0.07, 0.02, -0.03), (0.04, 0.015, -0.02), (0.03, 0.012, -0.015), (0.02, 0.008, -0.01), (0.015, 0.006, -0.008)]),\n",
+    "    slow: iter([(0.02, 0.0, 0.05), (0.015, 0.005, 0.03), (0.012, 0.004, 0.02), (0.01, 0.003, 0.015), (0.008, 0.002, 0.01)]),\n",
+    "}\n",
+    "\n",
+    "baseline_si = {node: round(value, 6) for node, value in compute_Si(G, inplace=False).items()}\n",
+    "si_trace: list[dict[str, float]] = []\n",
+    "\n",
+    "\n",
+    "def calibration_hook(graph):\n",
+    "    for node_id, iterator in scripts.items():\n",
+    "        dnfr, vf_shift, theta_shift = next(iterator, (0.0, 0.0, 0.0))\n",
+    "        data = graph.nodes[node_id]\n",
+    "        vf = float(data[VF_PRIMARY])\n",
+    "        epi = float(data[EPI_PRIMARY])\n",
+    "        theta = float(data[THETA_PRIMARY])\n",
+    "        data[DNFR_PRIMARY] = dnfr\n",
+    "        data[EPI_PRIMARY] = epi + vf * dnfr\n",
+    "        data[VF_PRIMARY] = vf + vf_shift\n",
+    "        data[THETA_PRIMARY] = theta + theta_shift\n",
+    "    si_trace.append({node: round(val, 6) for node, val in compute_Si(graph, inplace=False).items()})\n",
+    "\n",
+    "set_delta_nfr_hook(G, calibration_hook, note=\"sense index calibration smoke\")\n",
+    "run_sequence(G, anchor, [Emission(), Reception(), Coherence(), Resonance(), Transition()])\n",
+    "calibrated_si = {node: round(value, 6) for node, value in compute_Si(G, inplace=False).items()}\n",
+    "\n",
+    "{\n",
+    "    \"baseline\": baseline_si,\n",
+    "    \"calibrated\": calibrated_si,\n",
+    "    \"per_step\": si_trace,\n",
+    "}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/theory/06_recursivity_cascades.ipynb
+++ b/docs/theory/06_recursivity_cascades.ipynb
@@ -1,43 +1,119 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "id": "3dfbce55759f43a18ae31ed16b89eb7b",
-      "source": [
-        "# Recursivity cascades\n",
-        "\n",
-        "TODO: Outline the notebook narrative, learning goals, and TNFR invariants to cover.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "id": "6ccee369318f4f6eb88a2244849b3f47",
-      "outputs": [],
-      "source": [
-        "# TODO: implement walkthrough cells\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "id": "3dfbce55759f43a18ae31ed16b89eb7b",
+   "source": [
+    "\n",
+    "# Recursivity cascades\n",
+    "\n",
+    "## Objectives\n",
+    "- Describe how recursivity propagates structural echoes across nested EPIs.\n",
+    "- Capture the deterministic \u0394NFR hook required by Phase-2 remesh cascades.\n",
+    "- Provide reproducible traces that verify multi-scale coherence after each recursion step.\n",
+    "\n",
+    "## Phase-2 dependencies\n",
+    "- [Phase-2 integration notes](../fase2_integration.md) \u2014 the recursive remesh orchestration consumes the same trace structure emitted here.\n",
+    "- :mod:`tnfr.structural` \u2014 Phase-2 triggers the same canonical recursivity\u2192reception\u2192coherence\u2192resonance\u2192transition pipeline when stitching sub-EPIs.\n",
+    "- :mod:`tnfr.operators.definitions` \u2014 glyph assignments stay identical, ensuring the deterministic trace matches runtime expectations.\n",
+    "\n",
+    "## Theoretical exposition\n",
+    "Recursivity replays structural motifs across scales. Each application copies the local \u0394NFR ledger into progressively finer sub-EPIs, adjusting \u03bdf so that coherence remains invariant. By scripting the \u0394NFR injections per level (root \u2192 child \u2192 leaf) we can verify that the resulting EPI and \u03bdf trajectories evolve proportionally and that the cascade trace records the nested ratios required for Phase-2 remeshing.\n",
+    "\n",
+    "## Deterministic smoke check\n",
+    "The notebook builds a three-level chain, executes the canonical recursivity\u2192reception\u2192coherence\u2192resonance\u2192transition segment, and records EPI/\u03bdf pairs after each application. The before/after snapshots and the trace grouped by level are deterministic, allowing CI to detect any modification to the cascade grammar or \u0394NFR propagation rules.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "id": "6ccee369318f4f6eb88a2244849b3f47",
+   "outputs": [],
+   "source": [
+    "\n",
+    "from collections import defaultdict\n",
+    "from typing import Dict, Iterable, List, Tuple\n",
+    "\n",
+    "from tnfr.constants import DNFR_PRIMARY, EPI_PRIMARY, VF_PRIMARY\n",
+    "from tnfr.dynamics import set_delta_nfr_hook\n",
+    "from tnfr.structural import Coherence, Reception, Recursivity, Resonance, Transition, create_nfr, run_sequence\n",
+    "\n",
+    "G, root = create_nfr(\"cascade-root\", epi=0.5, vf=1.02, theta=0.0)\n",
+    "_, child = create_nfr(\"cascade-child\", graph=G, epi=0.34, vf=1.08, theta=0.12)\n",
+    "_, leaf = create_nfr(\"cascade-leaf\", graph=G, epi=0.26, vf=1.12, theta=-0.18)\n",
+    "G.add_edge(root, child)\n",
+    "G.add_edge(child, leaf)\n",
+    "\n",
+    "scripts: Dict[str, Iterable[Tuple[float, float]]] = {\n",
+    "    root: iter([(0.04, 0.02), (0.03, 0.015), (0.025, 0.012), (0.02, 0.01), (0.015, 0.008)]),\n",
+    "    child: iter([(0.032, 0.015), (0.024, 0.01), (0.02, 0.008), (0.016, 0.006), (0.012, 0.005)]),\n",
+    "    leaf: iter([(0.025, 0.01), (0.018, 0.008), (0.015, 0.006), (0.012, 0.005), (0.01, 0.004)]),\n",
+    "}\n",
+    "\n",
+    "cascade_trace: List[Tuple[str, float, float]] = []\n",
+    "labels = {root: \"root\", child: \"child\", leaf: \"leaf\"}\n",
+    "\n",
+    "\n",
+    "def snapshot() -> dict[str, dict[str, float]]:\n",
+    "    return {\n",
+    "        labels[node]: {\n",
+    "            \"EPI\": round(float(G.nodes[node][EPI_PRIMARY]), 6),\n",
+    "            \"\u03bdf\": round(float(G.nodes[node][VF_PRIMARY]), 6),\n",
+    "        }\n",
+    "        for node in (root, child, leaf)\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def cascade_hook(graph):\n",
+    "    for node_id, iterator in scripts.items():\n",
+    "        dnfr, vf_shift = next(iterator, (0.0, 0.0))\n",
+    "        data = graph.nodes[node_id]\n",
+    "        vf_before = float(data[VF_PRIMARY])\n",
+    "        epi_before = float(data[EPI_PRIMARY])\n",
+    "        data[DNFR_PRIMARY] = dnfr\n",
+    "        data[EPI_PRIMARY] = epi_before + vf_before * dnfr\n",
+    "        data[VF_PRIMARY] = vf_before + vf_shift\n",
+    "        cascade_trace.append(\n",
+    "            (labels[node_id], round(float(data[EPI_PRIMARY]), 6), round(float(data[VF_PRIMARY]), 6))\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "before = snapshot()\n",
+    "set_delta_nfr_hook(G, cascade_hook, note=\"recursivity cascade smoke\")\n",
+    "run_sequence(G, root, [Recursivity(), Reception(), Coherence(), Resonance(), Transition()])\n",
+    "after = snapshot()\n",
+    "\n",
+    "trace_by_level: Dict[str, List[Tuple[float, float]]] = defaultdict(list)\n",
+    "for label, epi_val, vf_val in cascade_trace:\n",
+    "    trace_by_level[label].append((epi_val, vf_val))\n",
+    "\n",
+    "{\n",
+    "    \"before\": before,\n",
+    "    \"after\": after,\n",
+    "    \"trace\": {key: trace_by_level[key] for key in (\"root\", \"child\", \"leaf\")},\n",
+    "}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- replace the primer TODO cells with Phase-2 aligned objectives, dependencies, and theoretical exposition
- add canonical emission→reception→coherence→resonance→transition smoke examples that log reproducible telemetry for each primer
- capture per-step outputs (frequency trajectory, synchrony trace, ΔNFR gradient map, coherence metrics timeline, Si calibration trace, recursivity cascade ledger) for future CI comparisons

## Testing
- scripts/test_docs.sh

------
https://chatgpt.com/codex/tasks/task_e_6902726191bc8321b1be8490b9b324d1