### PR TITLE
Remove duplicate MkDocs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,5 @@
 mkdocs>=1.5,<2.0
 mkdocs-material>=9.5,<10.0
-mkdocs>=1.5
-mkdocs-material>=9.5
 mkdocs-jupyter==0.24.8
 mkdocs-linkcheck==1.0.6
 nbconvert>=7.16


### PR DESCRIPTION
## Summary
- remove redundant unconstrained mkdocs and mkdocs-material entries from docs/requirements.txt to keep the agreed constraints only

## Testing
- pip install -r docs/requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_690276aea08c8321aa8f5bb05929694c