### PR TITLE
Bound documentation notebook execution timeout

### DIFF
--- a/scripts/test_docs.sh
+++ b/scripts/test_docs.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+NOTEBOOK_EXECUTION_TIMEOUT=120
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
@@ -16,7 +18,8 @@ for notebook_dir in docs/theory docs/notebooks; do
   if [ -d "$notebook_dir" ]; then
     while IFS= read -r notebook; do
       PYTHONWARNINGS="ignore:MissingIDFieldWarning" python -m jupyter nbconvert \
-        --to notebook --execute "$notebook" --stdout > /dev/null
+        --to notebook --execute "$notebook" --stdout \
+        --ExecutePreprocessor.timeout="$NOTEBOOK_EXECUTION_TIMEOUT" > /dev/null
     done < <(find "$notebook_dir" -type f -name '*.ipynb' | sort)
   fi
 done


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

- Bounded documentation notebook execution to 120s through a named variable for easier tuning.
- Re-ran `./scripts/test_docs.sh` to verify the notebooks execute successfully with the timeout applied.


------
https://chatgpt.com/codex/tasks/task_e_6902789ac3848321b5bf254128a2364d