### PR TITLE
Consolidate JSON helpers under tnfr.io

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -38,7 +38,8 @@ from ..ontosim import prepare_network
 from ..sense import register_sigma_callback
 from ..trace import register_trace
 from ..types import ProgramTokens
-from ..utils import get_logger, json_dumps
+from ..io import json_dumps
+from ..utils import get_logger
 from .arguments import _args_to_dict
 
 logger = get_logger(__name__)

--- a/src/tnfr/cli/execution.pyi
+++ b/src/tnfr/cli/execution.pyi
@@ -30,7 +30,8 @@ from ..ontosim import prepare_network
 from ..sense import register_sigma_callback
 from ..trace import register_trace
 from ..types import Glyph, ProgramTokens
-from ..utils import get_logger, json_dumps
+from ..io import json_dumps
+from ..utils import get_logger
 from .arguments import _args_to_dict
 
 DEFAULT_SUMMARY_SERIES_LIMIT: int

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -12,13 +12,13 @@ from typing import Any, Callable, NamedTuple
 
 from .alias import get_theta_attr
 from .constants import DEFAULTS
+from .io import json_dumps
 from .metrics.trig_cache import get_trig_cache
 from .types import GammaSpec, NodeId, TNFRGraph
 from .utils import (
     edge_version_cache,
     get_graph_mapping,
     get_logger,
-    json_dumps,
     node_set_checksum,
 )
 

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -1,10 +1,12 @@
-"""Structured file I/O utilities.
+"""Unified I/O helpers for TNFR.
 
-Optional parsers such as ``tomllib``/``tomli`` and ``pyyaml`` are loaded via
-the :func:`tnfr.utils.cached_import` helper. Their import results and
-failure states are cached and can be cleared with
-``cached_import.cache_clear()`` and :func:`tnfr.utils.prune_failed_imports`
-when needed.
+This module consolidates the structured file readers used by the engine with
+the JSON serialisation helpers that used to live under
+``tnfr.utils.io``. Optional dependencies such as ``orjson``,
+``tomllib``/``tomli`` and ``pyyaml`` continue to be resolved lazily through
+the :func:`tnfr.utils.cached_import` helper. Their import results and failure
+states are cached and can be cleared with ``cached_import.cache_clear()`` and
+``tnfr.utils.prune_failed_imports`` when needed.
 """
 
 from __future__ import annotations
@@ -12,11 +14,151 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable
 
-from .utils import LazyImportProxy, cached_import, get_logger
+from .utils import LazyImportProxy, cached_import, get_logger, warn_once
+
+logger = get_logger(__name__)
+
+_ORJSON_PARAMS_MSG = "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson: %s"
+
+_warn_ignored_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
+
+
+def clear_orjson_param_warnings() -> None:
+    """Reset cached warnings for ignored :mod:`orjson` parameters."""
+
+    _warn_ignored_params_once.clear()
+
+
+def _format_ignored_params(combo: frozenset[str]) -> str:
+    """Return a stable representation for ignored parameter combinations."""
+
+    return "{" + ", ".join(map(repr, sorted(combo))) + "}"
+
+
+@dataclass(frozen=True)
+class JsonDumpsParams:
+    """Container describing the parameters used by :func:`json_dumps`."""
+
+    sort_keys: bool = False
+    default: Callable[[Any], Any] | None = None
+    ensure_ascii: bool = True
+    separators: tuple[str, str] = (",", ":")
+    cls: type[json.JSONEncoder] | None = None
+    to_bytes: bool = False
+
+
+DEFAULT_PARAMS = JsonDumpsParams()
+
+
+def _collect_ignored_params(
+    params: JsonDumpsParams, extra_kwargs: dict[str, Any]
+) -> frozenset[str]:
+    """Return a stable set of parameters ignored by :mod:`orjson`."""
+
+    ignored: set[str] = set()
+    if params.ensure_ascii is not True:
+        ignored.add("ensure_ascii")
+    if params.separators != (",", ":"):
+        ignored.add("separators")
+    if params.cls is not None:
+        ignored.add("cls")
+    if extra_kwargs:
+        ignored.update(extra_kwargs.keys())
+    return frozenset(ignored)
+
+
+def _json_dumps_orjson(
+    orjson: Any,
+    obj: Any,
+    params: JsonDumpsParams,
+    **kwargs: Any,
+) -> bytes | str:
+    """Serialize using :mod:`orjson` and warn about unsupported parameters."""
+
+    ignored = _collect_ignored_params(params, kwargs)
+    if ignored:
+        _warn_ignored_params_once(ignored, _format_ignored_params(ignored))
+
+    option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
+    data = orjson.dumps(obj, option=option, default=params.default)
+    return data if params.to_bytes else data.decode("utf-8")
+
+
+def _json_dumps_std(
+    obj: Any,
+    params: JsonDumpsParams,
+    **kwargs: Any,
+) -> bytes | str:
+    """Serialize using the standard library :func:`json.dumps`."""
+
+    result = json.dumps(
+        obj,
+        sort_keys=params.sort_keys,
+        ensure_ascii=params.ensure_ascii,
+        separators=params.separators,
+        cls=params.cls,
+        default=params.default,
+        **kwargs,
+    )
+    return result if not params.to_bytes else result.encode("utf-8")
+
+
+def json_dumps(
+    obj: Any,
+    *,
+    sort_keys: bool = False,
+    default: Callable[[Any], Any] | None = None,
+    ensure_ascii: bool = True,
+    separators: tuple[str, str] = (",", ":"),
+    cls: type[json.JSONEncoder] | None = None,
+    to_bytes: bool = False,
+    **kwargs: Any,
+) -> bytes | str:
+    """Serialize ``obj`` to JSON using ``orjson`` when available."""
+
+    if not isinstance(sort_keys, bool):
+        raise TypeError("sort_keys must be a boolean")
+    if default is not None and not callable(default):
+        raise TypeError("default must be callable when provided")
+    if not isinstance(ensure_ascii, bool):
+        raise TypeError("ensure_ascii must be a boolean")
+    if not isinstance(separators, tuple) or len(separators) != 2:
+        raise TypeError("separators must be a tuple of two strings")
+    if not all(isinstance(part, str) for part in separators):
+        raise TypeError("separators must be a tuple of two strings")
+    if cls is not None:
+        if not isinstance(cls, type) or not issubclass(cls, json.JSONEncoder):
+            raise TypeError("cls must be a subclass of json.JSONEncoder")
+    if not isinstance(to_bytes, bool):
+        raise TypeError("to_bytes must be a boolean")
+
+    if (
+        sort_keys is False
+        and default is None
+        and ensure_ascii is True
+        and separators == (",", ":")
+        and cls is None
+        and to_bytes is False
+    ):
+        params = DEFAULT_PARAMS
+    else:
+        params = JsonDumpsParams(
+            sort_keys=sort_keys,
+            default=default,
+            ensure_ascii=ensure_ascii,
+            separators=separators,
+            cls=cls,
+            to_bytes=to_bytes,
+        )
+    orjson = cached_import("orjson", emit="log")
+    if orjson is not None:
+        return _json_dumps_orjson(orjson, obj, params, **kwargs)
+    return _json_dumps_std(obj, params, **kwargs)
 
 
 def _raise_import_error(name: str, *_: Any, **__: Any) -> Any:
@@ -231,11 +373,6 @@ def read_structured_file(path: Path) -> Any:
         if _is_structured_error(e):
             raise StructuredFileError(path, e) from e
         raise
-
-
-logger = get_logger(__name__)
-
-
 def safe_write(
     path: str | Path,
     write: Callable[[Any], Any],
@@ -309,6 +446,10 @@ def safe_write(
 
 
 __all__ = (
+    "JsonDumpsParams",
+    "DEFAULT_PARAMS",
+    "clear_orjson_param_warnings",
+    "json_dumps",
     "read_structured_file",
     "safe_write",
     "StructuredFileError",

--- a/src/tnfr/io.pyi
+++ b/src/tnfr/io.pyi
@@ -1,11 +1,74 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
-__all__: Any
+__all__: tuple[str, ...]
 
-def __getattr__(name: str) -> Any: ...
 
-StructuredFileError: Any
-TOMLDecodeError: Any
-YAMLError: Any
-read_structured_file: Any
-safe_write: Any
+class JsonDumpsParams:
+    sort_keys: bool
+    default: Callable[[Any], Any] | None
+    ensure_ascii: bool
+    separators: tuple[str, str]
+    cls: type[json.JSONEncoder] | None
+    to_bytes: bool
+
+
+DEFAULT_PARAMS: JsonDumpsParams
+
+
+def clear_orjson_param_warnings() -> None: ...
+
+
+def _json_dumps_orjson(
+    orjson: Any,
+    obj: Any,
+    params: JsonDumpsParams,
+    **kwargs: Any,
+) -> bytes | str: ...
+
+
+def _json_dumps_std(
+    obj: Any,
+    params: JsonDumpsParams,
+    **kwargs: Any,
+) -> bytes | str: ...
+
+
+def json_dumps(
+    obj: Any,
+    *,
+    sort_keys: bool = ...,
+    default: Callable[[Any], Any] | None = ...,
+    ensure_ascii: bool = ...,
+    separators: tuple[str, str] = ...,
+    cls: type[json.JSONEncoder] | None = ...,
+    to_bytes: bool = ...,
+    **kwargs: Any,
+) -> bytes | str: ...
+
+
+class StructuredFileError(Exception):
+    path: Path
+
+
+TOMLDecodeError: type[BaseException]
+YAMLError: type[BaseException]
+
+
+def read_structured_file(path: Path) -> Any: ...
+
+
+def safe_write(
+    path: str | Path,
+    write: Callable[[Any], Any],
+    *,
+    mode: str = ...,
+    encoding: str | None = ...,
+    atomic: bool = ...,
+    sync: bool | None = ...,
+    **open_kwargs: Any,
+) -> None: ...

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -10,9 +10,8 @@ from typing import Mapping, TextIO
 
 from ..config.constants import GLYPHS_CANONICAL
 from ..glyph_history import ensure_history
-from ..io import safe_write
+from ..io import json_dumps, safe_write
 from ..types import Graph
-from ..utils import json_dumps
 from .core import glyphogram_series
 from .glyph_timing import SigmaTrace
 

--- a/src/tnfr/telemetry/cache_metrics.py
+++ b/src/tnfr/telemetry/cache_metrics.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 from typing import Any, MutableMapping, TYPE_CHECKING
 
 from ..cache import CacheManager, CacheStatistics
-from ..utils import get_logger, json_dumps
+from ..io import json_dumps
+from ..utils import get_logger
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers
     from networkx import Graph

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -56,7 +56,7 @@ from .numeric import (
     similarity_abs,
     within_range,
 )
-from .io import (
+from ..io import (
     DEFAULT_PARAMS,
     JsonDumpsParams,
     clear_orjson_param_warnings,

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -73,7 +73,7 @@ from .init import (
     warm_cached_import,
     warn_once,
 )
-from .io import (
+from ..io import (
     DEFAULT_PARAMS,
     JsonDumpsParams,
     clear_orjson_param_warnings,

--- a/src/tnfr/utils/cache.py
+++ b/src/tnfr/utils/cache.py
@@ -40,7 +40,7 @@ from ..cache import (
 from ..types import GraphLike, NodeId, TimingContext, TNFRGraph
 from .graph import get_graph, mark_dnfr_prep_dirty
 from .init import get_logger, get_numpy
-from .io import json_dumps
+from ..io import json_dumps
 
 T = TypeVar("T")
 

--- a/src/tnfr/utils/io.py
+++ b/src/tnfr/utils/io.py
@@ -1,12 +1,20 @@
-"""Serialisation helpers for TNFR, including JSON convenience wrappers."""
+"""Compatibility shims for JSON helpers.
+
+The canonical entry point for JSON serialisation lives under :mod:`tnfr.io`.
+This module re-exports those helpers for backwards compatibility and emits a
+deprecation warning when imported directly.
+"""
 
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass
-from typing import Any, Callable
+import warnings
 
-from .init import cached_import, get_logger, warn_once
+from ..io import (
+    DEFAULT_PARAMS,
+    JsonDumpsParams,
+    clear_orjson_param_warnings,
+    json_dumps,
+)
 
 __all__ = (
     "JsonDumpsParams",
@@ -15,141 +23,9 @@ __all__ = (
     "clear_orjson_param_warnings",
 )
 
-_ORJSON_PARAMS_MSG = "'ensure_ascii', 'separators', 'cls' and extra kwargs are ignored when using orjson: %s"
-
-logger = get_logger(__name__)
-
-_warn_ignored_params_once = warn_once(logger, _ORJSON_PARAMS_MSG)
-
-
-def clear_orjson_param_warnings() -> None:
-    """Reset cached warnings for ignored :mod:`orjson` parameters."""
-
-    _warn_ignored_params_once.clear()
-
-
-def _format_ignored_params(combo: frozenset[str]) -> str:
-    """Return a stable representation for ignored parameter combinations."""
-
-    return "{" + ", ".join(map(repr, sorted(combo))) + "}"
-
-
-@dataclass(frozen=True)
-class JsonDumpsParams:
-    """Container describing the parameters used by :func:`json_dumps`."""
-
-    sort_keys: bool = False
-    default: Callable[[Any], Any] | None = None
-    ensure_ascii: bool = True
-    separators: tuple[str, str] = (",", ":")
-    cls: type[json.JSONEncoder] | None = None
-    to_bytes: bool = False
-
-
-DEFAULT_PARAMS = JsonDumpsParams()
-
-
-def _collect_ignored_params(
-    params: JsonDumpsParams, extra_kwargs: dict[str, Any]
-) -> frozenset[str]:
-    """Return a stable set of parameters ignored by :mod:`orjson`."""
-
-    ignored: set[str] = set()
-    if params.ensure_ascii is not True:
-        ignored.add("ensure_ascii")
-    if params.separators != (",", ":"):
-        ignored.add("separators")
-    if params.cls is not None:
-        ignored.add("cls")
-    if extra_kwargs:
-        ignored.update(extra_kwargs.keys())
-    return frozenset(ignored)
-
-
-def _json_dumps_orjson(
-    orjson: Any,
-    obj: Any,
-    params: JsonDumpsParams,
-    **kwargs: Any,
-) -> bytes | str:
-    """Serialize using :mod:`orjson` and warn about unsupported parameters."""
-
-    ignored = _collect_ignored_params(params, kwargs)
-    if ignored:
-        _warn_ignored_params_once(ignored, _format_ignored_params(ignored))
-
-    option = orjson.OPT_SORT_KEYS if params.sort_keys else 0
-    data = orjson.dumps(obj, option=option, default=params.default)
-    return data if params.to_bytes else data.decode("utf-8")
-
-
-def _json_dumps_std(
-    obj: Any,
-    params: JsonDumpsParams,
-    **kwargs: Any,
-) -> bytes | str:
-    """Serialize using the standard library :func:`json.dumps`."""
-
-    result = json.dumps(
-        obj,
-        sort_keys=params.sort_keys,
-        ensure_ascii=params.ensure_ascii,
-        separators=params.separators,
-        cls=params.cls,
-        default=params.default,
-        **kwargs,
-    )
-    return result if not params.to_bytes else result.encode("utf-8")
-
-
-def json_dumps(
-    obj: Any,
-    *,
-    sort_keys: bool = False,
-    default: Callable[[Any], Any] | None = None,
-    ensure_ascii: bool = True,
-    separators: tuple[str, str] = (",", ":"),
-    cls: type[json.JSONEncoder] | None = None,
-    to_bytes: bool = False,
-    **kwargs: Any,
-) -> bytes | str:
-    """Serialize ``obj`` to JSON using ``orjson`` when available."""
-
-    if not isinstance(sort_keys, bool):
-        raise TypeError("sort_keys must be a boolean")
-    if default is not None and not callable(default):
-        raise TypeError("default must be callable when provided")
-    if not isinstance(ensure_ascii, bool):
-        raise TypeError("ensure_ascii must be a boolean")
-    if not isinstance(separators, tuple) or len(separators) != 2:
-        raise TypeError("separators must be a tuple of two strings")
-    if not all(isinstance(part, str) for part in separators):
-        raise TypeError("separators must be a tuple of two strings")
-    if cls is not None:
-        if not isinstance(cls, type) or not issubclass(cls, json.JSONEncoder):
-            raise TypeError("cls must be a subclass of json.JSONEncoder")
-    if not isinstance(to_bytes, bool):
-        raise TypeError("to_bytes must be a boolean")
-
-    if (
-        sort_keys is False
-        and default is None
-        and ensure_ascii is True
-        and separators == (",", ":")
-        and cls is None
-        and to_bytes is False
-    ):
-        params = DEFAULT_PARAMS
-    else:
-        params = JsonDumpsParams(
-            sort_keys=sort_keys,
-            default=default,
-            ensure_ascii=ensure_ascii,
-            separators=separators,
-            cls=cls,
-            to_bytes=to_bytes,
-        )
-    orjson = cached_import("orjson", emit="log")
-    if orjson is not None:
-        return _json_dumps_orjson(orjson, obj, params, **kwargs)
-    return _json_dumps_std(obj, params, **kwargs)
+warnings.warn(
+    "'tnfr.utils.io' is deprecated and will be removed in a future release; "
+    "import JSON helpers from 'tnfr.io' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/tnfr/utils/io.pyi
+++ b/src/tnfr/utils/io.pyi
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 from typing import Any
 
-__all__: Any
-
-def __getattr__(name: str) -> Any: ...
+__all__: tuple[str, ...]
 
 DEFAULT_PARAMS: Any
 JsonDumpsParams: Any

--- a/tests/property/test_structured_io_roundtrip.py
+++ b/tests/property/test_structured_io_roundtrip.py
@@ -15,8 +15,12 @@ from tests.property.strategies import (
     PROPERTY_TEST_SETTINGS,
     nested_structured_mappings,
 )
-from tnfr.io import StructuredFileError, read_structured_file, safe_write
-from tnfr.utils import json_dumps
+from tnfr.io import (
+    StructuredFileError,
+    json_dumps,
+    read_structured_file,
+    safe_write,
+)
 
 
 def _sort_key(value: Any) -> tuple[str, str]:

--- a/tests/unit/structural/test_json_utils.py
+++ b/tests/unit/structural/test_json_utils.py
@@ -2,8 +2,8 @@ import logging
 
 import pytest
 
+import tnfr.io as json_utils
 import tnfr.utils.init as import_utils
-import tnfr.utils.io as json_utils
 
 from ...utils import clear_orjson_cache
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-import tnfr.utils.io as json_utils
+import tnfr.io as json_utils
 
 
 def clear_orjson_cache() -> None:


### PR DESCRIPTION
## Summary
- consolidate JSON serialization alongside structured file helpers under `tnfr.io` and refresh the type stubs
- add a thin compatibility layer in `tnfr.utils.io` that re-exports the new entry points with a deprecation warning
- update runtime modules and tests to import `json_dumps` from `tnfr.io`

## Testing
- pytest tests/unit/structural/test_json_utils.py *(fails: missing optional dependency numpy required by tests)*
- pytest tests/property/test_structured_io_roundtrip.py *(fails: missing optional dependency numpy required by tests)*

------
https://chatgpt.com/codex/tasks/task_e_6902836443f88321a90cbe81a769d5ee