### PR TITLE
Align FloatArray typing in coordination module

### DIFF
--- a/src/tnfr/dynamics/coordination.py
+++ b/src/tnfr/dynamics/coordination.py
@@ -6,9 +6,7 @@ import math
 from collections import deque
 from collections.abc import Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
-from typing import TYPE_CHECKING, Any, TypeVar, cast
-
-from .._compat import TypeAlias
+from typing import Any, TypeVar, cast
 from ..alias import get_theta_attr, set_theta
 from ..constants import (
     DEFAULTS,
@@ -24,19 +22,8 @@ from ..metrics.common import ensure_neighbors_map
 from ..metrics.trig import neighbor_phase_mean_list
 from ..metrics.trig_cache import get_trig_cache
 from ..observers import DEFAULT_GLYPH_LOAD_SPAN, glyph_load, kuramoto_order
-from ..types import NodeId, Phase, TNFRGraph
+from ..types import FloatArray, NodeId, Phase, TNFRGraph
 from ..utils import get_numpy
-
-if TYPE_CHECKING:  # pragma: no cover - typing imports only
-    try:
-        import numpy as np_typing
-        import numpy.typing as npt
-    except ImportError:  # pragma: no cover - optional typing dependency
-        FloatArray: TypeAlias = Any
-    else:
-        FloatArray: TypeAlias = npt.NDArray[np_typing.float_]
-else:  # pragma: no cover - runtime without numpy typing
-    FloatArray: TypeAlias = Any
 
 _DequeT = TypeVar("_DequeT")
 


### PR DESCRIPTION
## Summary
- import the shared `FloatArray` alias from `tnfr.types` within the coordination helpers
- drop the redundant local `TYPE_CHECKING` alias fallback now handled by the shared types module

## Testing
- pytest tests/unit/dynamics *(skipped: numpy not installed in environment)*
- python -m mypy src/tnfr *(fails: existing missing stubs and numpy dependency issues)*

------
https://chatgpt.com/codex/tasks/task_e_69028712b4b08321b9c809fd4ba4ed45