### PR TITLE
Introduce NodeAttrMap alias for shared node attribute typing

### DIFF
--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -8,7 +8,7 @@ from typing import Any, Iterable, Mapping, Sequence
 from ..alias import collect_attr, get_attr, multi_recompute_abs_max
 from ..constants import DEFAULTS, get_aliases
 from ..utils.numeric import clamp01, kahan_sum_nd
-from ..types import GraphLike
+from ..types import GraphLike, NodeAttrMap
 from ..utils import edge_version_cache, get_numpy, normalize_weights
 
 ALIAS_DNFR = get_aliases("DNFR")
@@ -104,7 +104,7 @@ def compute_dnfr_accel_max(G: GraphLike) -> dict[str, float]:
     )
 
 
-def normalize_dnfr(nd: Mapping[str, Any], max_val: float) -> float:
+def normalize_dnfr(nd: NodeAttrMap, max_val: float) -> float:
     """Normalise ``|ΔNFR|`` using ``max_val``."""
 
     if max_val <= 0:

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -42,7 +42,7 @@ from typing import Any, Callable, Iterable, Iterator, Mapping, MutableMapping, c
 from ..alias import get_attr, set_attr
 from ..constants import get_aliases
 from ..utils.numeric import angle_diff, angle_diff_array, clamp01
-from ..types import GraphLike
+from ..types import GraphLike, NodeAttrMap
 from ..utils import (
     edge_version_cache,
     get_numpy,
@@ -85,7 +85,7 @@ class _SiStructuralCache:
     def rebuild(
         self,
         node_ids: Iterable[Any],
-        node_data: Mapping[Any, Mapping[str, Any]],
+        node_data: Mapping[Any, NodeAttrMap],
         *,
         np: Any,
     ) -> tuple[Any, Any]:
@@ -120,7 +120,7 @@ class _SiStructuralCache:
     def ensure_current(
         self,
         node_ids: Iterable[Any],
-        node_data: Mapping[Any, Mapping[str, Any]],
+        node_data: Mapping[Any, NodeAttrMap],
         *,
         np: Any,
     ) -> tuple[Any, Any]:
@@ -142,7 +142,7 @@ class _SiStructuralCache:
 
 def _build_structural_cache(
     node_ids: Iterable[Any],
-    node_data: Mapping[Any, Mapping[str, Any]],
+    node_data: Mapping[Any, NodeAttrMap],
     *,
     np: Any,
 ) -> _SiStructuralCache:
@@ -154,7 +154,7 @@ def _build_structural_cache(
 def _ensure_structural_arrays(
     G: GraphLike,
     node_ids: Iterable[Any],
-    node_data: Mapping[Any, Mapping[str, Any]],
+    node_data: Mapping[Any, NodeAttrMap],
     *,
     np: Any,
 ) -> tuple[Any, Any]:
@@ -573,7 +573,7 @@ def _compute_si_python_chunk(
 
 
 def _iter_python_payload_chunks(
-    nodes_data: Iterable[tuple[Any, Mapping[str, Any]]],
+    nodes_data: Iterable[tuple[Any, NodeAttrMap]],
     *,
     neighbors: Mapping[Any, Iterable[Any]],
     thetas: Mapping[Any, float],
@@ -755,7 +755,7 @@ def compute_Si(
     if not nodes_data:
         return {}
 
-    node_mapping = cast(Mapping[Any, Mapping[str, Any]], nodes_view)
+    node_mapping = cast(Mapping[Any, NodeAttrMap], nodes_view)
     node_count = len(nodes_data)
 
     trig_order = list(getattr(trig, "order", ()))

--- a/src/tnfr/metrics/trig_cache.py
+++ b/src/tnfr/metrics/trig_cache.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
 from ..alias import get_theta_attr
-from ..types import GraphLike
+from ..types import GraphLike, NodeAttrMap
 from ..utils import edge_version_cache, get_numpy
 
 __all__ = ("TrigCache", "compute_theta_trig", "get_trig_cache", "_compute_trig_python")
@@ -37,7 +37,7 @@ class TrigCache:
 
 
 def _iter_theta_pairs(
-    nodes: Iterable[tuple[Any, Mapping[str, Any] | float]],
+    nodes: Iterable[tuple[Any, NodeAttrMap | float]],
 ) -> Iterable[tuple[Any, float]]:
     """Yield ``(node, θ)`` pairs from ``nodes``."""
 
@@ -49,7 +49,7 @@ def _iter_theta_pairs(
 
 
 def _compute_trig_python(
-    nodes: Iterable[tuple[Any, Mapping[str, Any] | float]],
+    nodes: Iterable[tuple[Any, NodeAttrMap | float]],
 ) -> TrigCache:
     """Compute trigonometric mappings using pure Python."""
 
@@ -90,7 +90,7 @@ def _compute_trig_python(
 
 
 def compute_theta_trig(
-    nodes: Iterable[tuple[Any, Mapping[str, Any] | float]],
+    nodes: Iterable[tuple[Any, NodeAttrMap | float]],
     np: Any | None = None,
 ) -> TrigCache:
     """Return trigonometric mappings of ``θ`` per node."""

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -72,6 +72,7 @@ __all__ = (
     "FloatArray",
     "FloatMatrix",
     "NodeInitAttrMap",
+    "NodeAttrMap",
 )
 
 
@@ -107,6 +108,9 @@ Node: TypeAlias = NodeId
 
 NodeInitAttrMap: TypeAlias = MutableMapping[str, float]
 #: Mutable mapping storing scalar node attributes during initialization.
+
+NodeAttrMap: TypeAlias = Mapping[str, Any]
+#: Read-only mapping exposing resolved node attributes during execution.
 
 GammaSpec: TypeAlias = Mapping[str, Any]
 #: Mapping describing Γ evaluation parameters for a node or graph.

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, MutableMapping, Sequence
 from enum import Enum
 from typing import Any, Callable, ContextManager, Iterable, Protocol, TypedDict, cast
 
@@ -36,6 +36,8 @@ TNFRGraph: TypeAlias = nx.Graph
 Graph: TypeAlias = TNFRGraph
 NodeId: TypeAlias = Hashable
 Node: TypeAlias = NodeId
+NodeInitAttrMap: TypeAlias = MutableMapping[str, float]
+NodeAttrMap: TypeAlias = Mapping[str, Any]
 GammaSpec: TypeAlias = Mapping[str, Any]
 EPIValue: TypeAlias = float
 DeltaNFR: TypeAlias = float

--- a/src/tnfr/validation/graph.py
+++ b/src/tnfr/validation/graph.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import numbers
 import sys
-from collections.abc import Mapping
 from typing import Callable, Sequence
 
 from .._compat import TypeAlias
@@ -15,6 +14,7 @@ from ..constants import get_aliases, get_param
 from ..utils.numeric import within_range
 from ..types import (
     EPIValue,
+    NodeAttrMap,
     NodeId,
     StructuralFrequency,
     TNFRGraph,
@@ -25,7 +25,7 @@ ALIAS_VF = get_aliases("VF")
 ValidatorFunc: TypeAlias = Callable[[TNFRGraph], None]
 """Callable signature expected for validation routines."""
 
-NodeData = Mapping[str, object]
+NodeData = NodeAttrMap
 """Read-only node attribute mapping used by validators."""
 
 AliasSequence = Sequence[str]

--- a/src/tnfr/validation/graph.pyi
+++ b/src/tnfr/validation/graph.pyi
@@ -1,10 +1,10 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Callable, Tuple
 
-from ..types import EPIValue, NodeId, StructuralFrequency, TNFRGraph
+from ..types import EPIValue, NodeAttrMap, NodeId, StructuralFrequency, TNFRGraph
 
 ValidatorFunc = Callable[[TNFRGraph], None]
-NodeData = Mapping[str, object]
+NodeData = NodeAttrMap
 AliasSequence = Sequence[str]
 
 GRAPH_VALIDATORS: Tuple[ValidatorFunc, ...]


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add the canonical `NodeAttrMap` alias alongside `NodeInitAttrMap` and export it for reuse across the engine
- replace ad-hoc node attribute mapping annotations in graph validation and Si/θ metrics with the shared alias
- align the `.pyi` stubs with the runtime modules so validators and metrics expose the same typing contract


------
https://chatgpt.com/codex/tasks/task_e_690292ccc0f0832194ac21c87f474ca8