### PR TITLE
Unify CLI IO helper imports through tnfr.utils facade

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -26,7 +26,6 @@ from ..dynamics import (
 from ..execution import CANONICAL_PRESET_NAME, play
 from ..flatten import parse_program_tokens
 from ..glyph_history import ensure_history
-from ..io import StructuredFileError, read_structured_file, safe_write
 from ..metrics import (
     build_metrics_summary,
     export_metrics,
@@ -38,8 +37,13 @@ from ..ontosim import prepare_network
 from ..sense import register_sigma_callback
 from ..trace import register_trace
 from ..types import ProgramTokens
-from ..io import json_dumps
-from ..utils import get_logger
+from ..utils import (
+    StructuredFileError,
+    get_logger,
+    json_dumps,
+    read_structured_file,
+    safe_write,
+)
 from .arguments import _args_to_dict
 
 logger = get_logger(__name__)

--- a/src/tnfr/cli/execution.pyi
+++ b/src/tnfr/cli/execution.pyi
@@ -18,7 +18,6 @@ from ..dynamics import (
 from ..execution import CANONICAL_PRESET_NAME, play, seq
 from ..flatten import parse_program_tokens
 from ..glyph_history import ensure_history
-from ..io import StructuredFileError, read_structured_file, safe_write
 from ..metrics import (
     build_metrics_summary,
     export_metrics,
@@ -30,8 +29,13 @@ from ..ontosim import prepare_network
 from ..sense import register_sigma_callback
 from ..trace import register_trace
 from ..types import Glyph, ProgramTokens
-from ..io import json_dumps
-from ..utils import get_logger
+from ..utils import (
+    StructuredFileError,
+    get_logger,
+    json_dumps,
+    read_structured_file,
+    safe_write,
+)
 from .arguments import _args_to_dict
 
 DEFAULT_SUMMARY_SERIES_LIMIT: int

--- a/src/tnfr/config/init.py
+++ b/src/tnfr/config/init.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..constants import inject_defaults
-from ..io import read_structured_file
+from ..utils import read_structured_file
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checkers
     import networkx as nx

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, NamedTuple
 
 from .alias import get_theta_attr
 from .constants import DEFAULTS
-from .io import json_dumps
+from .utils import json_dumps
 from .metrics.trig_cache import get_trig_cache
 from .types import GammaSpec, NodeId, TNFRGraph
 from .utils import (

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -10,7 +10,7 @@ from typing import Mapping, TextIO
 
 from ..config.constants import GLYPHS_CANONICAL
 from ..glyph_history import ensure_history
-from ..io import json_dumps, safe_write
+from ..utils import json_dumps, safe_write
 from ..types import Graph
 from .core import glyphogram_series
 from .glyph_timing import SigmaTrace

--- a/src/tnfr/telemetry/cache_metrics.py
+++ b/src/tnfr/telemetry/cache_metrics.py
@@ -8,8 +8,7 @@ from dataclasses import dataclass
 from typing import Any, MutableMapping, TYPE_CHECKING
 
 from ..cache import CacheManager, CacheStatistics
-from ..io import json_dumps
-from ..utils import _graph_cache_manager, get_logger
+from ..utils import _graph_cache_manager, get_logger, json_dumps
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers
     from networkx import Graph

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -83,8 +83,11 @@ from .numeric import (
 from ..io import (
     DEFAULT_PARAMS,
     JsonDumpsParams,
+    StructuredFileError,
     clear_orjson_param_warnings,
     json_dumps,
+    read_structured_file,
+    safe_write,
 )
 
 __all__ = (
@@ -149,6 +152,9 @@ __all__ = (
     "DEFAULT_PARAMS",
     "json_dumps",
     "clear_orjson_param_warnings",
+    "read_structured_file",
+    "safe_write",
+    "StructuredFileError",
     "kahan_sum_nd",
     "similarity_abs",
     "within_range",

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -78,8 +78,11 @@ from .init import (
 from ..io import (
     DEFAULT_PARAMS,
     JsonDumpsParams,
+    StructuredFileError,
     clear_orjson_param_warnings,
     json_dumps,
+    read_structured_file,
+    safe_write,
 )
 from ..validation import run_validators, validate_window
 
@@ -139,6 +142,9 @@ __all__ = (
     "DEFAULT_PARAMS",
     "json_dumps",
     "clear_orjson_param_warnings",
+    "read_structured_file",
+    "safe_write",
+    "StructuredFileError",
     "kahan_sum_nd",
     "similarity_abs",
     "within_range",


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

---

- Re-exported structured IO helpers (JSON dumps, safe writes, structured-file errors) from `tnfr.utils` to complete the facade.
- Updated CLI, telemetry, metrics, gamma, and config modules to consume the utils exports instead of `tnfr.io` directly, keeping type stubs in sync.
- Exercised `tnfr run` and `tnfr metrics` flows to confirm serialization and logging behaviour remain stable.

### Testing
- `PYTHONPATH=src python -c "from tnfr.cli import main; import sys; sys.exit(main(['run','--steps','0']))"`
- `PYTHONPATH=src python -c "from tnfr.cli import main; import sys; sys.exit(main(['metrics','--steps','0']))"`


------
https://chatgpt.com/codex/tasks/task_e_69029df712f083218c4f4bfbb4e29efe