### PR TITLE
Use validation facade for grammar imports

### DIFF
--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -64,7 +64,7 @@ from concurrent.futures import ProcessPoolExecutor
 from ..metrics.sense_index import compute_Si
 from ..operators import apply_glyph
 from ..utils import get_numpy
-from ..validation.grammar import enforce_canonical_grammar, on_applied_glyph
+from ..validation import enforce_canonical_grammar, on_applied_glyph
 from . import coordination, dnfr, integrators
 from .adaptation import adapt_vf_by_coherence
 from .aliases import (

--- a/src/tnfr/dynamics/selectors.py
+++ b/src/tnfr/dynamics/selectors.py
@@ -26,7 +26,7 @@ from ..selector import (
 )
 from ..types import Glyph, GlyphSelector, HistoryState, NodeId, TNFRGraph
 from ..utils import get_numpy
-from ..validation.grammar import enforce_canonical_grammar, on_applied_glyph
+from ..validation import enforce_canonical_grammar, on_applied_glyph
 from .aliases import ALIAS_D2EPI, ALIAS_DNFR, ALIAS_DSI, ALIAS_SI
 
 GlyphCode: TypeAlias = Glyph | str

--- a/src/tnfr/execution.py
+++ b/src/tnfr/execution.py
@@ -14,7 +14,7 @@ from .glyph_history import ensure_history
 from .tokens import TARGET, THOL, WAIT, OpTag, Token
 from .types import Glyph, NodeId, TNFRGraph
 from .utils import MAX_MATERIALIZE_DEFAULT, ensure_collection, is_non_string_sequence
-from .validation.grammar import apply_glyph_with_grammar
+from .validation import apply_glyph_with_grammar
 
 AdvanceFn = Callable[[TNFRGraph], None]
 TraceEntry = dict[str, Any]

--- a/src/tnfr/operators/definitions.py
+++ b/src/tnfr/operators/definitions.py
@@ -85,7 +85,7 @@ class Operator:
         """
         if self.glyph is None:
             raise NotImplementedError("Operator without assigned glyph")
-        from ..validation.grammar import (  # local import to avoid cycles
+        from ..validation import (  # local import to avoid cycles
             apply_glyph_with_grammar,
         )
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- consolidate execution and dynamics grammar hooks behind the tnfr.validation facade
- keep operator glyph application using the facade while retaining local import to avoid cycles

## Testing
- pytest tests/unit/validation tests/unit/dynamics/test_selectors.py *(fails: numpy missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69029f27d4908321805654dd848203e6