### PR TITLE
Standardize CacheManager imports through utils facade

### DIFF
--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, cast
 from time import perf_counter
 
 from ..alias import get_attr, get_theta_attr, set_dnfr
-from ..cache import CacheManager
 from ..constants import DEFAULTS, get_aliases, get_param
 from ..metrics.common import merge_and_normalize_weights
 from ..metrics.trig import neighbor_phase_mean_list
@@ -37,6 +36,7 @@ from ..types import (
 from ..utils import (
     DNFR_PREP_STATE_KEY,
     DnfrPrepState,
+    CacheManager,
     _graph_cache_manager,
     angle_diff,
     angle_diff_array,

--- a/src/tnfr/operators/jitter.py
+++ b/src/tnfr/operators/jitter.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 from cachetools import LRUCache
 
-from ..cache import CacheManager
 from ..rng import base_seed, cache_enabled
 from ..rng import clear_rng_cache as _clear_rng_cache
 from ..rng import (
@@ -16,6 +15,7 @@ from ..rng import (
 )
 from ..types import NodeId, TNFRGraph
 from ..utils import (
+    CacheManager,
     ScopedCounterCache,
     build_cache_manager,
     ensure_node_offset_map,


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6902a22959448321afb101c761034b5a