### PR TITLE
Expose cache statistics via tnfr.utils

### DIFF
--- a/src/tnfr/telemetry/cache_metrics.py
+++ b/src/tnfr/telemetry/cache_metrics.py
@@ -7,8 +7,13 @@ import weakref
 from dataclasses import dataclass
 from typing import Any, MutableMapping, TYPE_CHECKING
 
-from ..cache import CacheManager, CacheStatistics
-from ..utils import _graph_cache_manager, get_logger, json_dumps
+from ..utils import (
+    _graph_cache_manager,
+    CacheManager,
+    CacheStatistics,
+    get_logger,
+    json_dumps,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers
     from networkx import Graph

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -4,7 +4,18 @@ from __future__ import annotations
 
 from typing import Any, Final
 
-from ..cache import CacheManager
+from ..cache import (
+    CacheCapacityConfig,
+    CacheLayer,
+    CacheManager,
+    CacheStatistics,
+    InstrumentedLRUCache,
+    ManagedLRUCache,
+    MappingCacheLayer,
+    RedisCacheLayer,
+    ShelveCacheLayer,
+    prune_lock_mapping,
+)
 from . import init as _init
 
 WarnOnce = _init.WarnOnce
@@ -118,7 +129,16 @@ __all__ = (
     "clamp01",
     "auto_chunk_size",
     "resolve_chunk_size",
+    "CacheCapacityConfig",
+    "CacheLayer",
     "CacheManager",
+    "CacheStatistics",
+    "InstrumentedLRUCache",
+    "ManagedLRUCache",
+    "MappingCacheLayer",
+    "RedisCacheLayer",
+    "ShelveCacheLayer",
+    "prune_lock_mapping",
     "EdgeCacheManager",
     "DNFR_PREP_STATE_KEY",
     "DnfrPrepState",

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 from typing import Any, Final
 
-from ..cache import CacheManager
+from ..cache import (
+    CacheCapacityConfig,
+    CacheLayer,
+    CacheManager,
+    CacheStatistics,
+    InstrumentedLRUCache,
+    ManagedLRUCache,
+    MappingCacheLayer,
+    RedisCacheLayer,
+    ShelveCacheLayer,
+    prune_lock_mapping,
+)
 from .cache import (
     NODE_SET_CHECKSUM_KEY,
     ScopedCounterCache,
@@ -112,7 +123,16 @@ __all__ = (
     "angle_diff_array",
     "clamp",
     "clamp01",
+    "CacheCapacityConfig",
+    "CacheLayer",
     "CacheManager",
+    "CacheStatistics",
+    "InstrumentedLRUCache",
+    "ManagedLRUCache",
+    "MappingCacheLayer",
+    "RedisCacheLayer",
+    "ShelveCacheLayer",
+    "prune_lock_mapping",
     "EdgeCacheManager",
     "NODE_SET_CHECKSUM_KEY",
     "ScopedCounterCache",

--- a/tests/unit/dynamics/test_dnfr_cache_limits.py
+++ b/tests/unit/dynamics/test_dnfr_cache_limits.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tnfr.cache import CacheCapacityConfig
+from tnfr.utils import CacheCapacityConfig
 from tnfr.utils import (
     DNFR_PREP_STATE_KEY,
     _GRAPH_CACHE_MANAGER_KEY,

--- a/tests/unit/structural/test_cache_layers.py
+++ b/tests/unit/structural/test_cache_layers.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import networkx as nx
 
-from tnfr.cache import CacheLayer, CacheManager, RedisCacheLayer, ShelveCacheLayer
+from tnfr.utils import CacheLayer, CacheManager, RedisCacheLayer, ShelveCacheLayer
 from tnfr.utils import (
     _GRAPH_CACHE_LAYERS_KEY,
     build_cache_manager,

--- a/tests/unit/structural/test_cache_manager_config.py
+++ b/tests/unit/structural/test_cache_manager_config.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 
 import pytest
 
-from tnfr.cache import CacheManager
+from tnfr.utils import CacheManager
 
 
 @pytest.fixture()

--- a/tests/unit/structural/test_cache_manager_metrics.py
+++ b/tests/unit/structural/test_cache_manager_metrics.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from tnfr.cache import CacheManager, CacheStatistics, prune_lock_mapping
+from tnfr.utils import CacheManager, CacheStatistics, prune_lock_mapping
 
 
 def test_cache_manager_aggregate_metrics_combines_counters():

--- a/tests/unit/structural/test_instrumented_lru_cache.py
+++ b/tests/unit/structural/test_instrumented_lru_cache.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 import pytest
 
-from tnfr.cache import CacheManager, InstrumentedLRUCache
+from tnfr.utils import CacheManager, InstrumentedLRUCache
 
 
 class _EventRecorder:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Re-export cache statistics, capacity policies, and layer types via `tnfr.utils` so telemetry code can rely on a single hub for cache helpers.
- Update the utility stub to mirror the runtime exports for typing consumers.
- Point cache telemetry and related unit tests at the new re-export to ensure consistency.

## Testing
- `pytest tests/unit/structural/test_cache_manager_metrics.py tests/unit/structural/test_cache_manager_config.py tests/unit/structural/test_cache_layers.py tests/unit/structural/test_instrumented_lru_cache.py tests/unit/dynamics/test_dnfr_cache_limits.py` *(fails: numpy not installed; suite skipped via importorskip)*

------
https://chatgpt.com/codex/tasks/task_e_6902a2bdfe3c8321a6964dfa0caeba4b