### PR TITLE
Add ProgramTokens alias to typing stub

### DIFF
--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -28,7 +28,58 @@ from .glyph_history import HistoryDict as _HistoryDict
 from .tokens import Token
 from .trace import TraceMetadata
 
-__all__: tuple[str, ...]
+__all__: tuple[str, ...] = (
+    "TNFRGraph",
+    "Graph",
+    "NodeId",
+    "Node",
+    "GammaSpec",
+    "EPIValue",
+    "DeltaNFR",
+    "SecondDerivativeEPI",
+    "Phase",
+    "StructuralFrequency",
+    "SenseIndex",
+    "CouplingWeight",
+    "CoherenceMetric",
+    "DeltaNFRHook",
+    "GraphLike",
+    "IntegratorProtocol",
+    "Glyph",
+    "GlyphLoadDistribution",
+    "GlyphSelector",
+    "SelectorPreselectionMetrics",
+    "SelectorPreselectionChoices",
+    "SelectorPreselectionPayload",
+    "SelectorMetrics",
+    "SelectorNorms",
+    "SelectorThresholds",
+    "SelectorWeights",
+    "TraceCallback",
+    "TraceFieldFn",
+    "TraceFieldMap",
+    "TraceFieldRegistry",
+    "HistoryState",
+    "DiagnosisNodeData",
+    "DiagnosisSharedState",
+    "DiagnosisPayload",
+    "DiagnosisResult",
+    "DiagnosisPayloadChunk",
+    "DiagnosisResultList",
+    "DnfrCacheVectors",
+    "DnfrVectorMap",
+    "NeighborStats",
+    "TimingContext",
+    "PresetTokens",
+    "ProgramTokens",
+    "ArgSpec",
+    "TNFRConfigValue",
+    "SigmaVector",
+    "FloatArray",
+    "FloatMatrix",
+    "NodeInitAttrMap",
+    "NodeAttrMap",
+)
 
 def __getattr__(name: str) -> Any: ...
 
@@ -49,6 +100,34 @@ CouplingWeight: TypeAlias = float
 CoherenceMetric: TypeAlias = float
 TimingContext: TypeAlias = ContextManager[None]
 PresetTokens: TypeAlias = Sequence[Token]
+ProgramTokens: TypeAlias = Sequence[Token]
+ArgSpec: TypeAlias = tuple[str, Mapping[str, Any]]
+
+TNFRConfigScalar: TypeAlias = bool | int | float | str | None
+TNFRConfigSequence: TypeAlias = Sequence[TNFRConfigScalar]
+TNFRConfigValue: TypeAlias = (
+    TNFRConfigScalar | TNFRConfigSequence | Mapping[str, "TNFRConfigValue"]
+)
+
+class _SigmaVectorRequired(TypedDict):
+    x: float
+    y: float
+    mag: float
+    angle: float
+    n: int
+
+
+class _SigmaVectorOptional(TypedDict, total=False):
+    glyph: str
+    w: float
+    t: float
+
+
+class SigmaVector(_SigmaVectorRequired, _SigmaVectorOptional): ...
+
+
+FloatArray: TypeAlias = np.ndarray
+FloatMatrix: TypeAlias = np.ndarray
 
 class SelectorThresholds(TypedDict):
     si_hi: float


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add the missing `ProgramTokens` alias to `types.pyi` and export it alongside `PresetTokens`
- expand the stub exports and auxiliary aliases so the typing surface mirrors the runtime module

## Testing
- `python -m mypy src/tnfr tests/mathematics` *(fails: existing typing issues across mathematics modules and caches)*

------
https://chatgpt.com/codex/tasks/task_e_69031c21fe4c8321b8782385e11cbf99