### PR TITLE
Centralize CLI sentinel parsing for profiling helpers

### DIFF
--- a/benchmarks/full_pipeline_profile.py
+++ b/benchmarks/full_pipeline_profile.py
@@ -59,6 +59,7 @@ from tnfr.metrics.sense_index import (
     compute_Si,
 )
 import tnfr.utils as tnfr_utils
+from tnfr.cli.utils import _coerce_optional_int, _parse_cli_variants
 from tnfr.utils.chunks import resolve_chunk_size
 
 ALIAS_THETA = get_aliases("THETA")
@@ -77,43 +78,6 @@ _TARGET_FUNCTIONS: Mapping[str, tuple[str, str]] = {
         "default_compute_delta_nfr",
     ),
 }
-
-
-def _coerce_optional_int(value: Any) -> int | None:
-    """Normalise CLI integers while honouring ``auto``/``none`` sentinels."""
-
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    text = str(value).strip()
-    if not text:
-        raise ValueError("Empty value is not allowed for configuration options.")
-    lowered = text.lower()
-    if lowered in {"auto", "none", "null"}:
-        return None
-    try:
-        return int(text)
-    except ValueError as exc:
-        raise ValueError(f"Invalid integer value: {value!r}") from exc
-
-
-def _parse_cli_variants(values: Iterable[Any] | None) -> list[int | None]:
-    """Return a stable list of integer/``None`` variants for the CLI options."""
-
-    if values is None:
-        return [None]
-    parsed: list[int | None] = []
-    seen: set[int | None] = set()
-    for raw in values:
-        coerced = _coerce_optional_int(raw)
-        if coerced in seen:
-            continue
-        seen.add(coerced)
-        parsed.append(coerced)
-    return parsed or [None]
-
-
 def _format_config_value(value: int | None) -> str:
     """Human-friendly rendering for configuration values."""
 

--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -6,6 +6,7 @@ import argparse
 from collections import deque
 from collections.abc import Mapping
 from copy import deepcopy
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Optional
 
@@ -45,6 +46,7 @@ from ..utils import (
     safe_write,
 )
 from .arguments import _args_to_dict
+from .utils import _parse_cli_variants
 
 logger = get_logger(__name__)
 
@@ -386,10 +388,12 @@ def cmd_profile_si(args: argparse.Namespace) -> int:
     """Execute ``tnfr profile-si`` returning the exit status."""
 
     try:
-        from benchmarks.compute_si_profile import profile_compute_si
+        profile_module = import_module("benchmarks.compute_si_profile")
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
         logger.error("Sense Index profiling helpers unavailable: %s", exc)
         return 1
+
+    profile_compute_si = getattr(profile_module, "profile_compute_si")
 
     profile_compute_si(
         node_count=int(args.nodes),
@@ -406,13 +410,12 @@ def cmd_profile_pipeline(args: argparse.Namespace) -> int:
     """Execute ``tnfr profile-pipeline`` returning the exit status."""
 
     try:
-        from benchmarks.full_pipeline_profile import (
-            _parse_cli_variants,
-            profile_full_pipeline,
-        )
+        profile_module = import_module("benchmarks.full_pipeline_profile")
     except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
         logger.error("Full pipeline profiling helpers unavailable: %s", exc)
         return 1
+
+    profile_full_pipeline = getattr(profile_module, "profile_full_pipeline")
 
     try:
         si_chunk_sizes = _parse_cli_variants(getattr(args, "si_chunk_sizes", None))

--- a/src/tnfr/cli/utils.py
+++ b/src/tnfr/cli/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -30,3 +31,38 @@ def spec(opt: str, /, **kwargs: Any) -> tuple[str, dict[str, Any]]:
     kwargs.setdefault("dest", opt.lstrip("-").replace("-", "_").replace(".", "_"))
     kwargs.setdefault("default", None)
     return opt, kwargs
+
+
+def _coerce_optional_int(value: Any) -> int | None:
+    """Normalise CLI integers while honouring ``auto``/``none`` sentinels."""
+
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    if not text:
+        raise ValueError("Empty value is not allowed for configuration options.")
+    lowered = text.lower()
+    if lowered in {"auto", "none", "null"}:
+        return None
+    try:
+        return int(text)
+    except ValueError as exc:
+        raise ValueError(f"Invalid integer value: {value!r}") from exc
+
+
+def _parse_cli_variants(values: Iterable[Any] | None) -> list[int | None]:
+    """Return a stable list of integer/``None`` variants for the CLI options."""
+
+    if values is None:
+        return [None]
+    parsed: list[int | None] = []
+    seen: set[int | None] = set()
+    for raw in values:
+        coerced = _coerce_optional_int(raw)
+        if coerced in seen:
+            continue
+        seen.add(coerced)
+        parsed.append(coerced)
+    return parsed or [None]

--- a/src/tnfr/cli/utils.pyi
+++ b/src/tnfr/cli/utils.pyi
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from typing import Any
 
-__all__: Any
+def spec(opt: str, /, **kwargs: Any) -> tuple[str, dict[str, Any]]: ...
 
-def __getattr__(name: str) -> Any: ...
+def _coerce_optional_int(value: Any) -> int | None: ...
 
-annotations: Any
-spec: Any
+def _parse_cli_variants(values: Iterable[Any] | None) -> list[int | None]: ...

--- a/tests/unit/cli/test_cli_utils.py
+++ b/tests/unit/cli/test_cli_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from tnfr.cli import utils
 
 
@@ -23,3 +25,51 @@ def test_spec_respects_explicit_dest_and_default() -> None:
     assert opt == "--grammar-enabled"
     assert params["dest"] == "custom_dest"
     assert params["default"] is False
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        (0, 0),
+        ("0", 0),
+        (" 12 ", 12),
+        ("auto", None),
+        ("NONE", None),
+        ("Null", None),
+    ],
+)
+def test_coerce_optional_int_accepts_known_sentinels(raw: object, expected: int | None) -> None:
+    """The helper should normalise integers and reserved sentinel strings."""
+
+    assert utils._coerce_optional_int(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", " ", "abc", "1.5"])
+def test_coerce_optional_int_rejects_invalid_values(raw: object) -> None:
+    """Non-integer inputs besides the sentinels must raise ``ValueError``."""
+
+    with pytest.raises(ValueError):
+        utils._coerce_optional_int(raw)
+
+
+def test_parse_cli_variants_defaults_to_auto_when_missing() -> None:
+    """Parsing ``None`` or empty iterables should default to the ``auto`` sentinel."""
+
+    assert utils._parse_cli_variants(None) == [None]
+    assert utils._parse_cli_variants([]) == [None]
+
+
+def test_parse_cli_variants_deduplicates_preserving_order() -> None:
+    """Order should be preserved while duplicates collapse to a single entry."""
+
+    variants = utils._parse_cli_variants(["auto", "1", "auto", "2", "1", -3])
+
+    assert variants == [None, 1, 2, -3]
+
+
+def test_parse_cli_variants_propagates_coercion_errors() -> None:
+    """Invalid entries should bubble coercion errors to the caller."""
+
+    with pytest.raises(ValueError):
+        utils._parse_cli_variants(["auto", "bad-value", "2"])


### PR DESCRIPTION
## Summary
- move the optional integer coercion and CLI variant parsing helpers into `tnfr.cli.utils`
- update the profiling commands and benchmarks to reuse the shared helper logic
- expand CLI utility tests to cover valid and invalid sentinel handling

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6903205df5248321bf692faab3d7478b