### PR TITLE
Centralize metrics job coercion helper

### DIFF
--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -25,6 +25,7 @@ __all__ = (
     "merge_graph_weights",
     "merge_and_normalize_weights",
     "min_max_range",
+    "_coerce_jobs",
     "_get_vf_dnfr_max",
 )
 
@@ -148,3 +149,15 @@ def _get_vf_dnfr_max(G: GraphLike) -> tuple[float, float]:
     vfmax = 1.0 if vfmax == 0 else vfmax
     dnfrmax = 1.0 if dnfrmax == 0 else dnfrmax
     return float(vfmax), float(dnfrmax)
+
+
+def _coerce_jobs(raw_jobs: Any | None) -> int | None:
+    """Normalise parallel job hints shared by metrics modules."""
+
+    try:
+        jobs = None if raw_jobs is None else int(raw_jobs)
+    except (TypeError, ValueError):
+        return None
+    if jobs is not None and jobs <= 0:
+        return None
+    return jobs

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -37,7 +37,12 @@ from ..types import (
 )
 from ..utils import get_numpy
 from .coherence import CoherenceMatrixPayload, coherence_matrix, local_phase_sync
-from .common import compute_dnfr_accel_max, min_max_range, normalize_dnfr
+from .common import (
+    _coerce_jobs,
+    compute_dnfr_accel_max,
+    min_max_range,
+    normalize_dnfr,
+)
 from .trig_cache import compute_theta_trig, get_trig_cache
 
 ALIAS_EPI = get_aliases("EPI")
@@ -47,20 +52,6 @@ ALIAS_DNFR = get_aliases("DNFR")
 
 CoherenceSeries = Sequence[CoherenceMatrixPayload | None]
 CoherenceHistory = Mapping[str, CoherenceSeries]
-
-
-def _coerce_jobs(raw_jobs: Any | None) -> int | None:
-    """Normalise ``n_jobs`` values coming from user configuration."""
-
-    try:
-        jobs = None if raw_jobs is None else int(raw_jobs)
-    except (TypeError, ValueError):
-        return None
-    if jobs is not None and jobs <= 0:
-        return None
-    return jobs
-
-
 def _coherence_matrix_to_numpy(
     weight_matrix: Any,
     size: int,

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -51,6 +51,7 @@ from ..utils import (
     stable_json,
 )
 from .common import (
+    _coerce_jobs,
     _get_vf_dnfr_max,
     ensure_neighbors_map,
     merge_graph_weights,
@@ -448,56 +449,6 @@ def compute_Si_node(
     if inplace:
         set_attr(nd, ALIAS_SI, Si)
     return Si
-
-
-def _coerce_jobs(raw_jobs: Any | None) -> int | None:
-    """Normalise ``n_jobs`` while preserving deterministic Si sampling.
-
-    By constraining invalid configurations we avoid parallel plans that could
-    reshuffle ΔNFR readings and blur the structural interpretation of Si.
-
-    Parameters
-    ----------
-    raw_jobs : Any or None
-        Raw configuration value that specifies how many worker processes
-        should participate in the Si computation. Values are accepted even
-        when provided as strings so long as they can be coerced to integers.
-
-    Returns
-    -------
-    int or None
-        A strictly positive integer describing the requested level of
-        parallelism, or ``None`` when the configuration is absent or
-        considered invalid. Returning ``None`` allows the caller to fall back
-        to the single-process implementation that preserves ΔNFR sampling
-        determinism.
-
-    Examples
-    --------
-    >>> _coerce_jobs("4")
-    4
-    >>> _coerce_jobs(-2) is None
-    True
-    >>> _coerce_jobs("not-an-int") is None
-    True
-    >>> _coerce_jobs(None) is None
-    True
-    
-    Notes
-    -----
-    Invalid inputs—such as non-integer values or non-positive integers—are
-    mapped to ``None`` so that Si calculations reuse the deterministic code
-    path. This guarantees reproducible ΔNFR sampling regardless of user
-    configuration quirks.
-    """
-
-    try:
-        jobs = None if raw_jobs is None else int(raw_jobs)
-    except (TypeError, ValueError):
-        return None
-    if jobs is not None and jobs <= 0:
-        return None
-    return jobs
 
 
 def _compute_si_python_chunk(

--- a/tests/unit/metrics/test_jobs_coercion.py
+++ b/tests/unit/metrics/test_jobs_coercion.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tnfr.metrics.common import _coerce_jobs
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (1, 1),
+        ("4", 4),
+        (5.0, 5),
+    ],
+)
+def test_coerce_jobs_accepts_positive_values(raw, expected):
+    assert _coerce_jobs(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [0, -1, "-5"])
+def test_coerce_jobs_rejects_non_positive(raw):
+    assert _coerce_jobs(raw) is None
+
+
+@pytest.mark.parametrize("raw", ["invalid", object()])
+def test_coerce_jobs_rejects_non_numeric(raw):
+    assert _coerce_jobs(raw) is None


### PR DESCRIPTION
Centralized the job coercion helper used by diagnosis and sense index metrics and added focused tests to cover valid, negative, and non-numeric inputs.

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6903222964088321af181626e8172f22