### PR TITLE
Expose ValidatorFunc alias for graph validators

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -105,3 +105,8 @@ re-exports the grammar helpers (``validate_sequence``,
 ``tnfr.validation`` directly—the transitional ``tnfr.utils.validators`` module
 has been removed—so grammar checks and structural graph invariants run together
 before executing TNFR operators.
+
+When extending the validation pipeline, reuse :data:`tnfr.types.ValidatorFunc`
+to type graph validators. The alias captures the canonical signature accepted
+by ``GRAPH_VALIDATORS`` and downstream tooling, letting new validators plug into
+the engine without redefining typing contracts.

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -25,6 +25,7 @@ else:  # pragma: no cover - runtime fallback without numpy.typing
 __all__ = (
     "TNFRGraph",
     "Graph",
+    "ValidatorFunc",
     "NodeId",
     "Node",
     "GammaSpec",
@@ -99,6 +100,9 @@ else:  # pragma: no cover - runtime fallback without NumPy
 
 Graph: TypeAlias = TNFRGraph
 #: Backwards-compatible alias for :data:`TNFRGraph`.
+
+ValidatorFunc: TypeAlias = Callable[[TNFRGraph], None]
+"""Callable signature enforced by graph validation hooks."""
 
 NodeId: TypeAlias = Hashable
 #: Hashable identifier for a coherent TNFR node.

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -31,6 +31,7 @@ from .trace import TraceMetadata
 __all__: tuple[str, ...] = (
     "TNFRGraph",
     "Graph",
+    "ValidatorFunc",
     "NodeId",
     "Node",
     "GammaSpec",
@@ -85,6 +86,7 @@ def __getattr__(name: str) -> Any: ...
 
 TNFRGraph: TypeAlias = nx.Graph
 Graph: TypeAlias = TNFRGraph
+ValidatorFunc: TypeAlias = Callable[[TNFRGraph], None]
 NodeId: TypeAlias = Hashable
 Node: TypeAlias = NodeId
 NodeInitAttrMap: TypeAlias = MutableMapping[str, float]

--- a/src/tnfr/validation/graph.py
+++ b/src/tnfr/validation/graph.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import numbers
 import sys
-from typing import Callable, Sequence
-
-from .._compat import TypeAlias
+from collections.abc import Sequence
 from ..alias import get_attr
 from ..glyph_runtime import last_glyph
 from ..config.constants import GLYPHS_CANONICAL_SET
@@ -18,12 +16,10 @@ from ..types import (
     NodeId,
     StructuralFrequency,
     TNFRGraph,
+    ValidatorFunc,
 )
 ALIAS_EPI = get_aliases("EPI")
 ALIAS_VF = get_aliases("VF")
-
-ValidatorFunc: TypeAlias = Callable[[TNFRGraph], None]
-"""Callable signature expected for validation routines."""
 
 NodeData = NodeAttrMap
 """Read-only node attribute mapping used by validators."""

--- a/src/tnfr/validation/graph.pyi
+++ b/src/tnfr/validation/graph.pyi
@@ -1,9 +1,14 @@
 from collections.abc import Sequence
-from typing import Callable, Tuple
+from typing import Tuple
 
-from ..types import EPIValue, NodeAttrMap, NodeId, StructuralFrequency, TNFRGraph
-
-ValidatorFunc = Callable[[TNFRGraph], None]
+from ..types import (
+    EPIValue,
+    NodeAttrMap,
+    NodeId,
+    StructuralFrequency,
+    TNFRGraph,
+    ValidatorFunc,
+)
 NodeData = NodeAttrMap
 AliasSequence = Sequence[str]
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Move the `ValidatorFunc` type alias to `tnfr.types` so it is shared across modules and stubs.
- Update the graph validation module and stub to import the centralized alias and drop the local definition.
- Document the public alias in the validation overview so downstream validators reuse the canonical signature.

## Testing
- `pytest tests/unit/validation` *(fails: NumPy optional dependency is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690329d2d4a88321963541ce359572da