### PR TITLE
Move public glyph and callback aliases into tnfr.types

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -110,3 +110,9 @@ When extending the validation pipeline, reuse :data:`tnfr.types.ValidatorFunc`
 to type graph validators. The alias captures the canonical signature accepted
 by ``GRAPH_VALIDATORS`` and downstream tooling, letting new validators plug into
 the engine without redefining typing contracts.
+
+Selector helpers and glyph telemetry exporters reuse the shared
+:mod:`tnfr.types` module as well. Import :data:`tnfr.types.GlyphCode` for
+selector-compatible identifiers and :data:`tnfr.types.SigmaTrace` or the
+glyph timing aliases when consuming the metrics payloads, ensuring typed
+extensions stay in sync with the public API.

--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -82,7 +82,9 @@ It records Γ specs, selector state, ΔNFR weights, Kuramoto metrics, and operat
 simulation leaves an auditable trail. Callback errors are stored in a ring buffer attached to
 the graph (default length 100). Adjust or inspect the buffer at runtime with
 `tnfr.callback_utils.callback_manager.set_callback_error_limit` and
-`get_callback_error_limit`.
+`get_callback_error_limit`. The ring buffer exposes entries as
+`tnfr.types.CallbackError` mappings so typed consumers can rely on a stable
+schema when exporting diagnostics.
 
 ### Trace verbosity presets
 

--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -14,7 +14,7 @@ import traceback
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any
 
 import networkx as nx
 
@@ -22,6 +22,7 @@ from .constants import DEFAULTS
 from .locking import get_lock
 from .trace import CallbackSpec
 from .utils import get_logger, is_non_string_sequence
+from .types import CallbackError
 
 __all__ = (
     "CallbackEvent",
@@ -177,17 +178,6 @@ class CallbackManager:
 
 Callback = Callable[["nx.Graph", dict[str, Any]], None]
 CallbackRegistry = dict[str, dict[str, "CallbackSpec"]]
-
-
-class CallbackError(TypedDict):
-    """Metadata for a failed callback invocation."""
-
-    event: str
-    step: int | None
-    error: str
-    traceback: str
-    fn: str
-    name: str | None
 
 
 def _func_id(fn: Callable[..., Any]) -> str:

--- a/src/tnfr/callback_utils.pyi
+++ b/src/tnfr/callback_utils.pyi
@@ -5,13 +5,14 @@ import traceback
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any
 
 import networkx as nx
 
 from .constants import DEFAULTS
 from .locking import get_lock
 from .trace import CallbackSpec
+from .types import CallbackError
 from .utils import get_logger, is_non_string_sequence
 
 __all__ = (
@@ -31,14 +32,6 @@ class CallbackEvent(str, Enum):
 
 Callback = Callable[[nx.Graph, dict[str, Any]], None]
 CallbackRegistry = dict[str, dict[str, CallbackSpec]]
-
-class CallbackError(TypedDict):
-    event: str
-    step: int | None
-    error: str
-    traceback: str
-    fn: str
-    name: str | None
 
 class CallbackManager:
     def __init__(self) -> None: ...

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -63,6 +63,7 @@ from concurrent.futures import ProcessPoolExecutor
 
 from ..metrics.sense_index import compute_Si
 from ..operators import apply_glyph
+from ..types import GlyphCode
 from ..utils import get_numpy
 from ..validation import enforce_canonical_grammar, on_applied_glyph
 from ..validation.runtime import apply_canonical_clamps, validate_canon
@@ -112,7 +113,6 @@ from .sampling import update_node_sample as _update_node_sample
 from .selectors import (
     AbstractSelector,
     DefaultGlyphSelector,
-    GlyphCode,
     ParametricGlyphSelector,
     _apply_glyphs,
     _apply_selector,

--- a/src/tnfr/dynamics/__init__.pyi
+++ b/src/tnfr/dynamics/__init__.pyi
@@ -1,6 +1,6 @@
 from typing import Any, Literal, Sequence
 
-from tnfr.types import TNFRGraph
+from tnfr.types import GlyphCode, TNFRGraph
 from tnfr.validation import ValidationOutcome
 
 __all__: tuple[str, ...]
@@ -17,7 +17,6 @@ ALIAS_VF: Sequence[str]
 
 AbstractSelector: Any
 DefaultGlyphSelector: Any
-GlyphCode: Any
 ParametricGlyphSelector: Any
 _SelectorPreselection: Any
 _apply_glyphs: Any

--- a/src/tnfr/dynamics/selectors.py
+++ b/src/tnfr/dynamics/selectors.py
@@ -10,8 +10,6 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from operator import itemgetter
 from typing import Any, cast
-
-from .._compat import TypeAlias
 from ..alias import collect_attr, get_attr
 from ..constants import get_graph_param, get_param
 from ..glyph_history import ensure_history, recent_glyph
@@ -24,12 +22,10 @@ from ..selector import (
     _selector_norms,
     _selector_thresholds,
 )
-from ..types import Glyph, GlyphSelector, HistoryState, NodeId, TNFRGraph
+from ..types import Glyph, GlyphCode, GlyphSelector, HistoryState, NodeId, TNFRGraph
 from ..utils import get_numpy
 from ..validation import enforce_canonical_grammar, on_applied_glyph
 from .aliases import ALIAS_D2EPI, ALIAS_DNFR, ALIAS_DSI, ALIAS_SI
-
-GlyphCode: TypeAlias = Glyph | str
 
 __all__ = (
     "GlyphCode",

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -11,9 +11,8 @@ from typing import Mapping, TextIO
 from ..config.constants import GLYPHS_CANONICAL
 from ..glyph_history import ensure_history
 from ..utils import json_dumps, safe_write
-from ..types import Graph
+from ..types import Graph, SigmaTrace
 from .core import glyphogram_series
-from .glyph_timing import SigmaTrace
 
 
 def _write_csv(

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -12,9 +12,7 @@ from typing import (
     Callable,
     Mapping,
     MutableMapping,
-    MutableSequence,
     Sequence,
-    TypedDict,
     cast,
 )
 
@@ -23,7 +21,17 @@ from ..config.constants import GLYPH_GROUPS, GLYPHS_CANONICAL
 from ..constants import get_aliases, get_param
 from ..glyph_history import append_metric
 from ..glyph_runtime import last_glyph
-from ..types import GraphLike
+from ..types import (
+    GlyphCounts,
+    GlyphMetricsHistory,
+    GlyphMetricsHistoryValue,
+    GlyphTimingByNode,
+    GlyphTimingTotals,
+    GlyphogramRow,
+    GraphLike,
+    MetricsListHistory,
+    SigmaTrace,
+)
 
 ALIAS_EPI = get_aliases("EPI")
 
@@ -46,26 +54,6 @@ def _has_numpy_support(np_obj: object) -> bool:
         and hasattr(np_obj, "fromiter")
         and hasattr(np_obj, "bincount")
     )
-
-
-class SigmaTrace(TypedDict):
-    """Time-aligned σ(t) trace exported alongside glyphograms."""
-
-    t: list[float]
-    sigma_x: list[float]
-    sigma_y: list[float]
-    mag: list[float]
-    angle: list[float]
-
-
-GlyphogramRow = MutableMapping[str, float]
-GlyphTimingTotals = MutableMapping[str, float]
-GlyphTimingByNode = MutableMapping[Any, MutableMapping[str, MutableSequence[float]]]
-GlyphCounts = Mapping[str, int]
-GlyphMetricsHistoryValue = MutableMapping[Any, Any] | MutableSequence[Any]
-GlyphMetricsHistory = MutableMapping[str, GlyphMetricsHistoryValue]
-MetricsListHistory = MutableMapping[str, list[Any]]
-
 _GLYPH_TO_INDEX = {glyph: idx for idx, glyph in enumerate(GLYPHS_CANONICAL)}
 
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Moved `GlyphCode`, `CallbackError`, and the glyph timing TypedDicts/type aliases into `tnfr.types` with matching stub updates.
- Updated selectors, callback utilities, metrics, and exports to consume the shared aliases while keeping module-level re-exports intact.
- Documented the new typed entry points in the API overview and telemetry guides so downstream users adopt the centralized imports.

## Testing
- `pytest tests/unit -q` *(fails: numpy optional dependency is skipped in test bootstrap).*

------
https://chatgpt.com/codex/tasks/task_e_690336d01058832183edca87792920e4