### PR TITLE
Deprecate tnfr.cache and tnfr.io shims in favor of tnfr.utils

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -17,6 +17,11 @@ tnfr.locking       — process-wide named locks (shared by RNG/caches)
 tnfr.utils.cache   — cache managers exposing shared metrics/evictions
 ```
 
+- ``tnfr.cache`` and ``tnfr.io`` remain as thin compatibility shims that now emit
+  :class:`DeprecationWarning` at import time. Update any downstream references to
+  import from :mod:`tnfr.utils` (or :mod:`tnfr.utils.io`) to stay on the supported
+  API surface.
+
 - `tnfr.structural` exposes `create_nfr` and `run_sequence`, wiring node creation to ΔNFR
   hooks so every operator pass recomputes the gradient canonically.
 - Operator implementations self-register through `tnfr.operators.registry` to guard name

--- a/src/tnfr/cache.py
+++ b/src/tnfr/cache.py
@@ -7,6 +7,14 @@ is kept as a thin facade to preserve the historical import path
 
 from __future__ import annotations
 
+import warnings
+
+warnings.warn(
+    "Importing 'tnfr.cache' is deprecated; use 'tnfr.utils' for the supported API.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from .utils.cache import (
     CacheCapacityConfig,
     CacheLayer,

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import warnings
 from types import ModuleType
 from typing import Any
+
+warnings.warn(
+    "Importing 'tnfr.io' is deprecated; use 'tnfr.utils' for the supported API.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 from .utils import io as _io
 


### PR DESCRIPTION
## Summary
- add DeprecationWarning for `tnfr.cache` and `tnfr.io` imports to point users at `tnfr.utils`
- document the supported cache/IO import surface in the API overview

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_690344aa1274832182579c90ca077fea