### PR TITLE
Deprecate tnfr.mathematics.validators alias in favor of tnfr.validation

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -109,7 +109,11 @@ re-exports the grammar helpers (``validate_sequence``,
 ``run_validators`` and ``GRAPH_VALIDATORS``. Projects should import from
 ``tnfr.validation`` directly—the transitional ``tnfr.utils.validators`` module
 has been removed—so grammar checks and structural graph invariants run together
-before executing TNFR operators.
+before executing TNFR operators. The legacy
+``tnfr.mathematics.validators`` shim now emits a :class:`DeprecationWarning` and
+will be removed once downstream packages finish migrating; update any imports
+to ``tnfr.validation`` (preferred) or ``tnfr.validation.spectral`` to stay on
+the supported path.
 
 When extending the validation pipeline, reuse :data:`tnfr.types.ValidatorFunc`
 to type graph validators. The alias captures the canonical signature accepted

--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -4,6 +4,11 @@ TNFR simulations require auditable telemetry, deterministic caches, and reproduc
 This guide consolidates the APIs that expose coherence data, structural histories, and helper
 facades.
 
+> **Migration note**: Historical imports such as ``tnfr.mathematics.validators`` now
+> raise :class:`DeprecationWarning`. Use ``tnfr.validation`` (preferred) or
+> ``tnfr.validation.spectral`` when wiring validators alongside the telemetry hooks
+> described in this guide so the engine stays aligned with the supported API surface.
+
 ## Official metrics and telemetry
 
 - **C(t)** — `tnfr.metrics.common.compute_coherence`: global stability with optional means for

--- a/docs/foundations.md
+++ b/docs/foundations.md
@@ -7,6 +7,11 @@ scaffolding required to stand up a reproducible spectral experiment, turn on
 validation guards, and observe unitary stability before coupling into higher
 level operators.
 
+> **Migration note**: Legacy imports via ``tnfr.mathematics.validators`` now emit
+> :class:`DeprecationWarning`. Import :mod:`tnfr.validation` directly to access
+> :class:`tnfr.validation.spectral.NFRValidator` when enabling the guards
+> described in this primer.
+
 ## 1. Canonical quick-start
 
 1. **Select a space** – use :class:`tnfr.mathematics.HilbertSpace` for discrete

--- a/src/tnfr/mathematics/validators.py
+++ b/src/tnfr/mathematics/validators.py
@@ -1,14 +1,32 @@
-"""Backward-compatible re-export of spectral validators."""
+"""Deprecated compatibility shim for the historical mathematics validators.
+
+Import :mod:`tnfr.validation` (or :mod:`tnfr.validation.spectral`) directly
+instead of relying on this module.  It will be removed in a future release
+after the ecosystem migrates to the unified validation namespace.
+"""
 
 from __future__ import annotations
+
+import warnings
+from typing import Any
 
 __all__ = ("NFRValidator",)
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name: str) -> Any:
     if name == "NFRValidator":
+        warnings.warn(
+            "tnfr.mathematics.validators is deprecated; import from "
+            "'tnfr.validation' (preferred) or 'tnfr.validation.spectral' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from ..validation.spectral import NFRValidator as _NFRValidator
 
         return _NFRValidator
     raise AttributeError(name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__))
 


### PR DESCRIPTION
## Summary
- emit a DeprecationWarning from `tnfr.mathematics.validators` and document the official validation namespace
- add migration notes to the telemetry and foundations guides outlining the supported imports
- update the API overview to steer consumers toward `tnfr.validation` and `tnfr.validation.spectral`

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_690345f50ce4832199aa3987f7edbb90