### PR TITLE
Remove validator re-exports from tnfr.utils

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -107,9 +107,9 @@ Use :mod:`tnfr.validation` as the single entry point for canonical validation. I
 re-exports the grammar helpers (``validate_sequence``,
 ``apply_glyph_with_grammar``) alongside the graph invariants enforced by
 ``run_validators`` and ``GRAPH_VALIDATORS``. Projects should import from
-``tnfr.validation`` directly—the transitional ``tnfr.utils.validators`` module
-has been removed—so grammar checks and structural graph invariants run together
-before executing TNFR operators. The legacy
+``tnfr.validation`` directly—``tnfr.utils`` no longer re-exports
+``validate_window`` or ``run_validators``—so grammar checks and structural graph
+invariants run together before executing TNFR operators. The legacy
 ``tnfr.mathematics.validators`` shim now emits a :class:`DeprecationWarning` and
 will be removed once downstream packages finish migrating; update any imports
 to ``tnfr.validation`` (preferred) or ``tnfr.validation.spectral`` to stay on

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -176,8 +176,6 @@ __all__ = (
     "kahan_sum_nd",
     "similarity_abs",
     "within_range",
-    "validate_window",
-    "run_validators",
     "_configure_root",
     "_LOGGING_CONFIGURED",
     "_reset_logging_state",
@@ -201,22 +199,11 @@ _DYNAMIC_EXPORT_TYPES: Final[dict[str, type[object]]] = {
     "_LOGGING_CONFIGURED": bool,
 }
 _DYNAMIC_EXPORTS: Final[frozenset[str]] = frozenset(_DYNAMIC_EXPORT_TYPES)
-_VALIDATOR_EXPORTS = {"validate_window", "run_validators"}
-
-
 def __getattr__(name: str) -> Any:  # pragma: no cover - trivial delegation
     if name in _DYNAMIC_EXPORTS:
         return getattr(_init, name)
-    if name in _VALIDATOR_EXPORTS:
-        if name == "validate_window":
-            from ..validation import validate_window as _validate_window
-
-            return _validate_window
-        from ..validation import run_validators as _run_validators
-
-        return _run_validators
     raise AttributeError(name)
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial delegation
-    return sorted(set(globals()) | _DYNAMIC_EXPORTS | _VALIDATOR_EXPORTS)
+    return sorted(set(globals()) | set(_DYNAMIC_EXPORTS))

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -93,8 +93,6 @@ from ..io import (
     read_structured_file,
     safe_write,
 )
-from ..validation import run_validators, validate_window
-
 __all__ = (
     "IMPORT_LOG",
     "WarnOnce",
@@ -166,8 +164,6 @@ __all__ = (
     "kahan_sum_nd",
     "similarity_abs",
     "within_range",
-    "validate_window",
-    "run_validators",
     "_configure_root",
     "_LOGGING_CONFIGURED",
     "_reset_logging_state",


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Stop exporting `validate_window` and `run_validators` from `tnfr.utils` to keep validation routed through `tnfr.validation`.
- Align typing stubs and module directory metadata with the runtime exports.
- Clarify the validation docs to note that `tnfr.utils` no longer re-exports the validator helpers.


------
https://chatgpt.com/codex/tasks/task_e_69034960c7fc83218fa8c0e36a5c1a10