### PR TITLE
Remove deprecated tnfr.cache and tnfr.io shims

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -17,10 +17,9 @@ tnfr.locking       — process-wide named locks (shared by RNG/caches)
 tnfr.utils.cache   — cache managers exposing shared metrics/evictions
 ```
 
-- ``tnfr.cache`` and ``tnfr.io`` remain as thin compatibility shims that now emit
-  :class:`DeprecationWarning` at import time. Update any downstream references to
-  import from :mod:`tnfr.utils` (or :mod:`tnfr.utils.io`) to stay on the supported
-  API surface.
+- ``tnfr.cache`` and ``tnfr.io`` have been removed. Import cache helpers from
+  :mod:`tnfr.utils.cache` and IO helpers from :mod:`tnfr.utils.io` to stay on the
+  supported API surface.
 
 - `tnfr.structural` exposes `create_nfr` and `run_sequence`, wiring node creation to ΔNFR
   hooks so every operator pass recomputes the gradient canonically.

--- a/src/tnfr/cache.py
+++ b/src/tnfr/cache.py
@@ -1,42 +1,7 @@
-"""Compatibility re-export for cache infrastructure primitives.
-
-The canonical implementations now live in :mod:`tnfr.utils.cache`. This module
-is kept as a thin facade to preserve the historical import path
-``tnfr.cache`` for downstream integrations.
-"""
+"""Compatibility shim removed; direct users to :mod:`tnfr.utils.cache`."""
 
 from __future__ import annotations
 
-import warnings
-
-warnings.warn(
-    "Importing 'tnfr.cache' is deprecated; use 'tnfr.utils' for the supported API.",
-    DeprecationWarning,
-    stacklevel=2,
+raise ImportError(
+    "The 'tnfr.cache' module has been removed. Import cache helpers from 'tnfr.utils.cache'."
 )
-
-from .utils.cache import (
-    CacheCapacityConfig,
-    CacheLayer,
-    CacheManager,
-    CacheStatistics,
-    InstrumentedLRUCache,
-    ManagedLRUCache,
-    MappingCacheLayer,
-    RedisCacheLayer,
-    ShelveCacheLayer,
-    prune_lock_mapping,
-)
-
-__all__ = [
-    "CacheLayer",
-    "CacheManager",
-    "CacheCapacityConfig",
-    "CacheStatistics",
-    "InstrumentedLRUCache",
-    "MappingCacheLayer",
-    "RedisCacheLayer",
-    "ShelveCacheLayer",
-    "ManagedLRUCache",
-    "prune_lock_mapping",
-]

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -1,53 +1,7 @@
-"""Backward compatible wrapper for structured IO helpers."""
+"""Compatibility shim removed; direct users to :mod:`tnfr.utils.io`."""
 
 from __future__ import annotations
 
-import warnings
-from types import ModuleType
-from typing import Any
-
-warnings.warn(
-    "Importing 'tnfr.io' is deprecated; use 'tnfr.utils' for the supported API.",
-    DeprecationWarning,
-    stacklevel=2,
+raise ImportError(
+    "The 'tnfr.io' module has been removed. Import IO helpers from 'tnfr.utils.io'."
 )
-
-from .utils import io as _io
-
-JsonDumpsParams = _io.JsonDumpsParams
-DEFAULT_PARAMS = _io.DEFAULT_PARAMS
-clear_orjson_param_warnings = _io.clear_orjson_param_warnings
-json_dumps = _io.json_dumps
-read_structured_file = _io.read_structured_file
-safe_write = _io.safe_write
-StructuredFileError = _io.StructuredFileError
-TOMLDecodeError = _io.TOMLDecodeError
-YAMLError = _io.YAMLError
-
-
-def __getattr__(name: str) -> Any:  # pragma: no cover - thin delegation
-    return getattr(_io, name)
-
-
-def __dir__() -> list[str]:  # pragma: no cover - thin delegation
-    return sorted(set(globals()) | set(dir(_io)))
-
-
-def _get_underlying_module() -> ModuleType:  # pragma: no cover - convenience
-    """Return the underlying implementation module for advanced uses."""
-
-    return _io
-
-
-__all__ = (
-    "JsonDumpsParams",
-    "DEFAULT_PARAMS",
-    "clear_orjson_param_warnings",
-    "json_dumps",
-    "read_structured_file",
-    "safe_write",
-    "StructuredFileError",
-    "TOMLDecodeError",
-    "YAMLError",
-)
-

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -84,7 +84,7 @@ from .init import (
     warm_cached_import,
     warn_once,
 )
-from ..io import (
+from .io import (
     DEFAULT_PARAMS,
     JsonDumpsParams,
     StructuredFileError,

--- a/tests/unit/structural/test_io_optional_imports.py
+++ b/tests/unit/structural/test_io_optional_imports.py
@@ -3,7 +3,7 @@ import types
 
 import pytest
 
-from tnfr import io as io_mod
+import tnfr.utils.io as io_mod
 from tnfr.utils import LazyImportProxy, cached_import
 
 

--- a/tests/unit/structural/test_validators.py
+++ b/tests/unit/structural/test_validators.py
@@ -3,7 +3,7 @@
 import networkx as nx
 import pytest
 
-from tnfr import io as io_mod
+import tnfr.utils.io as io_mod
 from tnfr.alias import set_attr, set_attr_str
 from tnfr.config import load_config
 from tnfr.constants import (


### PR DESCRIPTION
## Summary
- replace the tnfr.cache and tnfr.io modules with explicit ImportErrors that direct integrators to tnfr.utils.cache/io
- update utilities stubs, tests, and documentation to import cache and IO helpers from tnfr.utils
- verify the dedicated IO and cache test suites still pass against the consolidated entry points

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6903d828879c8321ae4a14b0c7184c1f