### PR TITLE
Return ValidationOutcome from syntax sequence validator

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -244,9 +244,10 @@ def run_sequence(G: TNFRGraph, node: NodeId, ops: Iterable[Operator]) -> None:
     ops_list = list(ops)
     names = [op.name for op in ops_list]
 
-    ok, msg = validate_sequence(names)
-    if not ok:
-        raise ValueError(f"Invalid sequence: {msg}")
+    outcome = validate_sequence(names)
+    if not outcome.passed:
+        summary_message = outcome.summary.get("message", "validation failed")
+        raise ValueError(f"Invalid sequence: {summary_message}")
 
     for op in ops_list:
         op(G, node)

--- a/src/tnfr/structural.pyi
+++ b/src/tnfr/structural.pyi
@@ -16,6 +16,7 @@ from .operators.definitions import (
     Silence,
     Transition,
 )
+from .validation import ValidationOutcome
 
 if TYPE_CHECKING:
     import networkx as nx
@@ -35,5 +36,5 @@ def create_nfr(
 
 OPERATORS: dict[str, Operator]
 
-def validate_sequence(names: Iterable[str]) -> tuple[bool, str]: ...
+def validate_sequence(names: Iterable[str]) -> ValidationOutcome[tuple[str, ...]]: ...
 def run_sequence(G: "nx.Graph", node: Hashable, ops: Iterable[Operator]) -> None: ...

--- a/src/tnfr/validation/syntax.py
+++ b/src/tnfr/validation/syntax.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from . import ValidationOutcome
+
 from ..config.operator_names import (
     COHERENCE,
     INTERMEDIATE_OPERATORS,
@@ -135,7 +137,7 @@ def _validate_token_sequence(names: list[str]) -> tuple[bool, str]:
 
 def validate_sequence(
     names: Iterable[str] | object = _MISSING, **kwargs: object
-) -> tuple[bool, str]:
+) -> ValidationOutcome[tuple[str, ...]]:
     """Validate minimal TNFR syntax rules."""
 
     if kwargs:
@@ -147,5 +149,17 @@ def validate_sequence(
     if names is _MISSING:
         raise TypeError("validate_sequence() missing required argument: 'names'")
 
-    sequence = list(names)
-    return _validate_token_sequence(sequence)
+    sequence_list = list(names)
+    passed, message = _validate_token_sequence(sequence_list)
+    canonical_sequence = tuple(sequence_list)
+    summary = {
+        "message": message,
+        "passed": passed,
+        "tokens": canonical_sequence,
+    }
+    return ValidationOutcome(
+        subject=canonical_sequence,
+        passed=passed,
+        summary=summary,
+        artifacts=None,
+    )

--- a/src/tnfr/validation/syntax.pyi
+++ b/src/tnfr/validation/syntax.pyi
@@ -1,7 +1,11 @@
-from typing import Any
+from typing import Any, Iterable
+
+from . import ValidationOutcome
 
 __all__: Any
 
 def __getattr__(name: str) -> Any: ...
 
-validate_sequence: Any
+def validate_sequence(
+    names: Iterable[str] | object = ..., **kwargs: object
+) -> ValidationOutcome[tuple[str, ...]]: ...

--- a/tests/unit/dynamics/test_operators.py
+++ b/tests/unit/dynamics/test_operators.py
@@ -21,6 +21,7 @@ from tnfr.operators import (
 from tnfr.structural import Dissonance, create_nfr, run_sequence
 from tnfr.types import Glyph
 from tnfr.utils import angle_diff
+from tnfr.validation import ValidationOutcome
 
 
 def test_glyph_operations_complete():
@@ -52,7 +53,13 @@ def test_dissonance_operator_increases_dnfr_and_tracks_phase(
         captured["after"] = (nd_local[DNFR_PRIMARY], nd_local[THETA_PRIMARY])
 
     set_delta_nfr_hook(G, scripted_delta)
-    monkeypatch.setattr("tnfr.structural.validate_sequence", lambda names: (True, "ok"))
+
+    def _ok_outcome(names: list[str] | tuple[str, ...]) -> ValidationOutcome[tuple[str, ...]]:
+        sequence = tuple(names)
+        summary = {"message": "ok", "passed": True, "tokens": sequence}
+        return ValidationOutcome(subject=sequence, passed=True, summary=summary)
+
+    monkeypatch.setattr("tnfr.structural.validate_sequence", _ok_outcome)
 
     run_sequence(G, node, [Dissonance()])
 


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_69046752f1188321bafea7ad33d9de01