### PR TITLE
Refine validation stubs with concrete TNFR types

### DIFF
--- a/src/tnfr/validation/__init__.pyi
+++ b/src/tnfr/validation/__init__.pyi
@@ -1,4 +1,19 @@
-from typing import Any, Generic, Mapping, Protocol, TypeVar
+from collections.abc import Mapping
+from typing import Any, Generic, Protocol, TypeVar
+
+from ..types import Glyph, TNFRGraph
+from .compatibility import CANON_COMPAT as CANON_COMPAT, CANON_FALLBACK as CANON_FALLBACK
+from .grammar import (
+    GrammarContext,
+    apply_glyph_with_grammar,
+    enforce_canonical_grammar,
+    on_applied_glyph,
+)
+from .graph import GRAPH_VALIDATORS, run_validators, validate_window
+from .rules import coerce_glyph, get_norm, glyph_fallback, normalized_dnfr
+from .runtime import GraphCanonicalValidator, apply_canonical_clamps, validate_canon
+from .spectral import NFRValidator
+from .syntax import validate_sequence
 
 SubjectT = TypeVar("SubjectT")
 
@@ -16,26 +31,25 @@ class Validator(Protocol[SubjectT]):
     def report(self, summary: Mapping[str, Any]) -> str: ...
 
 
-CANON_COMPAT: Any
-CANON_FALLBACK: Any
-GrammarContext: Any
-GraphCanonicalValidator: Any
-NFRValidator: Any
-apply_canonical_clamps: Any
-apply_glyph_with_grammar: Any
-coerce_glyph: Any
-enforce_canonical_grammar: Any
-get_norm: Any
-glyph_fallback: Any
-normalized_dnfr: Any
-on_applied_glyph: Any
-run_validators: Any
-validate_canon: Any
-validate_sequence: Any
-validate_window: Any
-GRAPH_VALIDATORS: Any
-
-__all__: tuple[str, ...]
-
-def __getattr__(name: str) -> Any: ...
-
+__all__ = (
+    "ValidationOutcome",
+    "Validator",
+    "validate_sequence",
+    "GrammarContext",
+    "apply_glyph_with_grammar",
+    "enforce_canonical_grammar",
+    "on_applied_glyph",
+    "validate_window",
+    "run_validators",
+    "GRAPH_VALIDATORS",
+    "coerce_glyph",
+    "glyph_fallback",
+    "normalized_dnfr",
+    "get_norm",
+    "CANON_COMPAT",
+    "CANON_FALLBACK",
+    "GraphCanonicalValidator",
+    "apply_canonical_clamps",
+    "validate_canon",
+    "NFRValidator",
+)

--- a/src/tnfr/validation/compatibility.pyi
+++ b/src/tnfr/validation/compatibility.pyi
@@ -1,8 +1,6 @@
-from typing import Any
+from ..types import Glyph
 
-__all__: Any
+__all__ = ("CANON_COMPAT", "CANON_FALLBACK")
 
-def __getattr__(name: str) -> Any: ...
-
-CANON_COMPAT: Any
-CANON_FALLBACK: Any
+CANON_COMPAT: dict[Glyph, set[Glyph]]
+CANON_FALLBACK: dict[Glyph, Glyph]

--- a/src/tnfr/validation/grammar.pyi
+++ b/src/tnfr/validation/grammar.pyi
@@ -1,11 +1,45 @@
+from collections.abc import Iterable
 from typing import Any
 
-__all__: Any
+from ..node import NodeProtocol
+from ..types import Glyph, NodeId, TNFRGraph
 
-def __getattr__(name: str) -> Any: ...
+__all__ = (
+    "GrammarContext",
+    "_gram_state",
+    "enforce_canonical_grammar",
+    "on_applied_glyph",
+    "apply_glyph_with_grammar",
+)
 
-GrammarContext: Any
-_gram_state: Any
-apply_glyph_with_grammar: Any
-enforce_canonical_grammar: Any
-on_applied_glyph: Any
+
+class GrammarContext:
+    G: TNFRGraph
+    cfg_soft: dict[str, Any]
+    cfg_canon: dict[str, Any]
+    norms: dict[str, Any]
+
+    @classmethod
+    def from_graph(cls, G: TNFRGraph) -> "GrammarContext": ...
+
+
+def _gram_state(nd: dict[str, Any]) -> dict[str, Any]: ...
+
+
+def enforce_canonical_grammar(
+    G: TNFRGraph,
+    n: NodeId,
+    cand: Glyph | str,
+    ctx: GrammarContext | None = ...,
+) -> Glyph | str: ...
+
+
+def on_applied_glyph(G: TNFRGraph, n: NodeId, applied: Glyph | str) -> None: ...
+
+
+def apply_glyph_with_grammar(
+    G: TNFRGraph,
+    nodes: Iterable[NodeId | NodeProtocol] | None,
+    glyph: Glyph | str,
+    window: int | None = ...,
+) -> None: ...

--- a/src/tnfr/validation/rules.pyi
+++ b/src/tnfr/validation/rules.pyi
@@ -1,18 +1,72 @@
-from typing import Any
+from collections.abc import Callable, Mapping
+from typing import Any, TypeVar
 
-__all__: Any
+from ..types import Glyph, NodeId
+from .grammar import GrammarContext
 
-def __getattr__(name: str) -> Any: ...
+__all__ = (
+    "coerce_glyph",
+    "glyph_fallback",
+    "get_norm",
+    "normalized_dnfr",
+    "_norm_attr",
+    "_si",
+    "_accel_norm",
+    "_check_repeats",
+    "_maybe_force",
+    "_check_oz_to_zhir",
+    "_check_thol_closure",
+    "_check_compatibility",
+)
 
-_accel_norm: Any
-_check_compatibility: Any
-_check_oz_to_zhir: Any
-_check_repeats: Any
-_check_thol_closure: Any
-_maybe_force: Any
-_norm_attr: Any
-_si: Any
-coerce_glyph: Any
-get_norm: Any
-glyph_fallback: Any
-normalized_dnfr: Any
+_T = TypeVar("_T")
+
+
+def coerce_glyph(val: _T) -> Glyph | _T: ...
+
+
+def glyph_fallback(cand_key: str, fallbacks: Mapping[str, Any]) -> Glyph | str: ...
+
+
+def get_norm(ctx: GrammarContext, key: str) -> float: ...
+
+
+def _norm_attr(
+    ctx: GrammarContext, nd: Mapping[str, Any], attr_alias: str, norm_key: str
+) -> float: ...
+
+
+def _si(nd: Mapping[str, Any]) -> float: ...
+
+
+def _accel_norm(ctx: GrammarContext, nd: Mapping[str, Any]) -> float: ...
+
+
+def normalized_dnfr(ctx: GrammarContext, nd: Mapping[str, Any]) -> float: ...
+
+
+def _check_repeats(ctx: GrammarContext, n: NodeId, cand: Glyph | str) -> Glyph | str: ...
+
+
+def _maybe_force(
+    ctx: GrammarContext,
+    n: NodeId,
+    cand: Glyph | str,
+    original: Glyph | str,
+    accessor: Callable[[GrammarContext, Mapping[str, Any]], float],
+    key: str,
+) -> Glyph | str: ...
+
+
+def _check_oz_to_zhir(ctx: GrammarContext, n: NodeId, cand: Glyph | str) -> Glyph | str: ...
+
+
+def _check_thol_closure(
+    ctx: GrammarContext,
+    n: NodeId,
+    cand: Glyph | str,
+    st: dict[str, Any],
+) -> Glyph | str: ...
+
+
+def _check_compatibility(ctx: GrammarContext, n: NodeId, cand: Glyph | str) -> Glyph | str: ...

--- a/src/tnfr/validation/spectral.pyi
+++ b/src/tnfr/validation/spectral.pyi
@@ -30,7 +30,7 @@ class NFRValidator(Validator[np.ndarray]):
         /,
         *,
         enforce_frequency_positivity: bool | None = ...,
-    ) -> ValidationOutcome[np.ndarray]: ...
+    ) -> ValidationOutcome[np.ndarray]: ...  # type: ignore[override]
 
     def validate_state(
         self,
@@ -42,5 +42,5 @@ class NFRValidator(Validator[np.ndarray]):
     def report(self, summary: Mapping[str, Any]) -> str: ...
 
 
-__all__: tuple[str, ...]
+__all__ = ("NFRValidator",)
 

--- a/src/tnfr/validation/syntax.pyi
+++ b/src/tnfr/validation/syntax.pyi
@@ -1,10 +1,9 @@
-from typing import Any, Iterable
+from collections.abc import Iterable
 
 from . import ValidationOutcome
 
-__all__: Any
+__all__ = ("validate_sequence",)
 
-def __getattr__(name: str) -> Any: ...
 
 def validate_sequence(
     names: Iterable[str] | object = ..., **kwargs: object


### PR DESCRIPTION
## Summary
- replace Any-based validation stubs with concrete glyph, grammar, and outcome types
- re-export canonical validation helpers from tnfr.validation with accurate signatures
- tighten compatibility and spectral stubs to expose canonical glyph maps and validator metadata

## Testing
- `mypy src/tnfr/validation` *(fails: existing repository typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6904688f06888321a19e183635764d04