### PR TITLE
Clarify stubs for removed cache/io shims

### DIFF
--- a/docs/changelog.d/remove-tnfr-helpers.documentation.md
+++ b/docs/changelog.d/remove-tnfr-helpers.documentation.md
@@ -1,1 +1,3 @@
 - Removed the deprecated helper compatibility layer; import helper utilities from `tnfr.utils`.
+- Importing `tnfr.cache` or `tnfr.io` now raises ``ImportError``. Update imports to
+  :mod:`tnfr.utils.cache` and :mod:`tnfr.utils.io` to keep relying on the supported API.

--- a/src/tnfr/cache.pyi
+++ b/src/tnfr/cache.pyi
@@ -1,25 +1,16 @@
-from .utils.cache import (
-    CacheCapacityConfig,
-    CacheLayer,
-    CacheManager,
-    CacheStatistics,
-    InstrumentedLRUCache,
-    ManagedLRUCache,
-    MappingCacheLayer,
-    RedisCacheLayer,
-    ShelveCacheLayer,
-    prune_lock_mapping,
-)
+"""Compatibility stub removed; import from :mod:`tnfr.utils.cache` instead."""
 
-__all__ = [
-    "CacheLayer",
-    "CacheManager",
-    "CacheCapacityConfig",
-    "CacheStatistics",
-    "InstrumentedLRUCache",
-    "MappingCacheLayer",
-    "RedisCacheLayer",
-    "ShelveCacheLayer",
-    "ManagedLRUCache",
-    "prune_lock_mapping",
-]
+from __future__ import annotations
+
+from typing import NoReturn
+
+__all__ = ()
+
+
+def __getattr__(name: str) -> NoReturn:
+    """Indicate that :mod:`tnfr.cache` no longer exports cache helpers."""
+
+
+def __dir__() -> tuple[str, ...]:
+    """Return an empty set of exports to mirror the removed shim."""
+

--- a/src/tnfr/io.pyi
+++ b/src/tnfr/io.pyi
@@ -1,74 +1,16 @@
+"""Compatibility stub removed; import from :mod:`tnfr.utils.io` instead."""
+
 from __future__ import annotations
 
-import json
-from collections.abc import Callable
-from pathlib import Path
-from typing import Any
+from typing import NoReturn
 
-__all__: tuple[str, ...]
+__all__ = ()
 
 
-class JsonDumpsParams:
-    sort_keys: bool
-    default: Callable[[Any], Any] | None
-    ensure_ascii: bool
-    separators: tuple[str, str]
-    cls: type[json.JSONEncoder] | None
-    to_bytes: bool
+def __getattr__(name: str) -> NoReturn:
+    """Indicate that :mod:`tnfr.io` no longer exports IO helpers."""
 
 
-DEFAULT_PARAMS: JsonDumpsParams
+def __dir__() -> tuple[str, ...]:
+    """Return an empty set of exports to mirror the removed shim."""
 
-
-def clear_orjson_param_warnings() -> None: ...
-
-
-def _json_dumps_orjson(
-    orjson: Any,
-    obj: Any,
-    params: JsonDumpsParams,
-    **kwargs: Any,
-) -> bytes | str: ...
-
-
-def _json_dumps_std(
-    obj: Any,
-    params: JsonDumpsParams,
-    **kwargs: Any,
-) -> bytes | str: ...
-
-
-def json_dumps(
-    obj: Any,
-    *,
-    sort_keys: bool = ...,
-    default: Callable[[Any], Any] | None = ...,
-    ensure_ascii: bool = ...,
-    separators: tuple[str, str] = ...,
-    cls: type[json.JSONEncoder] | None = ...,
-    to_bytes: bool = ...,
-    **kwargs: Any,
-) -> bytes | str: ...
-
-
-class StructuredFileError(Exception):
-    path: Path
-
-
-TOMLDecodeError: type[BaseException]
-YAMLError: type[BaseException]
-
-
-def read_structured_file(path: Path) -> Any: ...
-
-
-def safe_write(
-    path: str | Path,
-    write: Callable[[Any], Any],
-    *,
-    mode: str = ...,
-    encoding: str | None = ...,
-    atomic: bool = ...,
-    sync: bool | None = ...,
-    **open_kwargs: Any,
-) -> None: ...


### PR DESCRIPTION
## Summary
- replace the legacy `tnfr.cache` and `tnfr.io` stubs with compatibility notices that expose no helpers
- refresh the helper deprecation changelog note to direct projects to `tnfr.utils.cache` and `tnfr.utils.io`

## Testing
- mypy src/tnfr/cache.pyi src/tnfr/io.pyi *(fails: existing typing issues elsewhere in the package)*

------
https://chatgpt.com/codex/tasks/task_e_69046cf1d3648321b9509bdcf2c569a2