### PR TITLE
Centralize soft grammar filters for selectors

### DIFF
--- a/src/tnfr/validation/__init__.py
+++ b/src/tnfr/validation/__init__.py
@@ -46,6 +46,12 @@ from .grammar import (
 from .graph import GRAPH_VALIDATORS, run_validators, validate_window
 from .runtime import GraphCanonicalValidator, apply_canonical_clamps, validate_canon
 from .rules import coerce_glyph, get_norm, glyph_fallback, normalized_dnfr
+from .soft_filters import (
+    acceleration_norm,
+    check_repeats,
+    maybe_force,
+    soft_grammar_filters,
+)
 from .syntax import validate_sequence
 
 __all__ = (
@@ -63,6 +69,10 @@ __all__ = (
     "glyph_fallback",
     "normalized_dnfr",
     "get_norm",
+    "acceleration_norm",
+    "check_repeats",
+    "maybe_force",
+    "soft_grammar_filters",
     "CANON_COMPAT",
     "CANON_FALLBACK",
     "GraphCanonicalValidator",

--- a/src/tnfr/validation/__init__.pyi
+++ b/src/tnfr/validation/__init__.pyi
@@ -11,6 +11,7 @@ from .grammar import (
 )
 from .graph import GRAPH_VALIDATORS, run_validators, validate_window
 from .rules import coerce_glyph, get_norm, glyph_fallback, normalized_dnfr
+from .soft_filters import (acceleration_norm, check_repeats, maybe_force, soft_grammar_filters)
 from .runtime import GraphCanonicalValidator, apply_canonical_clamps, validate_canon
 from .spectral import NFRValidator
 from .syntax import validate_sequence
@@ -46,6 +47,10 @@ __all__ = (
     "glyph_fallback",
     "normalized_dnfr",
     "get_norm",
+    "acceleration_norm",
+    "check_repeats",
+    "maybe_force",
+    "soft_grammar_filters",
     "CANON_COMPAT",
     "CANON_FALLBACK",
     "GraphCanonicalValidator",

--- a/src/tnfr/validation/grammar.py
+++ b/src/tnfr/validation/grammar.py
@@ -10,6 +10,7 @@ from ..constants import DEFAULTS, get_param
 from ..operators import apply_glyph
 from ..types import Glyph, NodeId, TNFRGraph
 from . import rules as _rules
+from .soft_filters import soft_grammar_filters
 from .compatibility import CANON_COMPAT
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -87,15 +88,7 @@ def enforce_canonical_grammar(
     if not isinstance(cand, Glyph) or cand not in CANON_COMPAT:
         return raw_cand if input_was_str else cand
 
-    original = cand
-    cand = _rules._check_repeats(ctx, n, cand)
-
-    cand = _rules._maybe_force(
-        ctx, n, cand, original, _rules.normalized_dnfr, "force_dnfr"
-    )
-    cand = _rules._maybe_force(
-        ctx, n, cand, original, _rules._accel_norm, "force_accel"
-    )
+    cand = soft_grammar_filters(ctx, n, cand)
     cand = _rules._check_oz_to_zhir(ctx, n, cand)
     cand = _rules._check_thol_closure(ctx, n, cand, st)
     cand = _rules._check_compatibility(ctx, n, cand)

--- a/src/tnfr/validation/rules.pyi
+++ b/src/tnfr/validation/rules.pyi
@@ -1,6 +1,8 @@
 from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
 
+from typing import Any, Mapping, TypeVar
+
 from ..types import Glyph, NodeId
 from .grammar import GrammarContext
 
@@ -11,9 +13,6 @@ __all__ = (
     "normalized_dnfr",
     "_norm_attr",
     "_si",
-    "_accel_norm",
-    "_check_repeats",
-    "_maybe_force",
     "_check_oz_to_zhir",
     "_check_thol_closure",
     "_check_compatibility",
@@ -39,23 +38,7 @@ def _norm_attr(
 def _si(nd: Mapping[str, Any]) -> float: ...
 
 
-def _accel_norm(ctx: GrammarContext, nd: Mapping[str, Any]) -> float: ...
-
-
 def normalized_dnfr(ctx: GrammarContext, nd: Mapping[str, Any]) -> float: ...
-
-
-def _check_repeats(ctx: GrammarContext, n: NodeId, cand: Glyph | str) -> Glyph | str: ...
-
-
-def _maybe_force(
-    ctx: GrammarContext,
-    n: NodeId,
-    cand: Glyph | str,
-    original: Glyph | str,
-    accessor: Callable[[GrammarContext, Mapping[str, Any]], float],
-    key: str,
-) -> Glyph | str: ...
 
 
 def _check_oz_to_zhir(ctx: GrammarContext, n: NodeId, cand: Glyph | str) -> Glyph | str: ...

--- a/src/tnfr/validation/soft_filters.py
+++ b/src/tnfr/validation/soft_filters.py
@@ -1,0 +1,140 @@
+"""Soft grammar filters harmonising canonical selector heuristics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from ..alias import get_attr
+from ..constants import get_aliases
+from ..glyph_history import recent_glyph
+from ..types import Glyph
+from ..utils import clamp01
+from .rules import glyph_fallback, get_norm, normalized_dnfr
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from collections.abc import Mapping
+    from .grammar import GrammarContext
+
+ALIAS_D2EPI = get_aliases("D2EPI")
+
+__all__ = (
+    "acceleration_norm",
+    "check_repeats",
+    "maybe_force",
+    "soft_grammar_filters",
+)
+
+
+def acceleration_norm(ctx: "GrammarContext", nd: "Mapping[str, Any]") -> float:
+    """Return the node acceleration normalised to ``[0, 1]``.
+
+    The computation uses the canonical ``accel_max`` bound stored in
+    :class:`~tnfr.validation.grammar.GrammarContext`.  Values beyond the bound are
+    clamped to preserve structural comparability with ΔNFR-based heuristics.
+    """
+
+    max_val = get_norm(ctx, "accel_max")
+    return clamp01(abs(get_attr(nd, ALIAS_D2EPI, 0.0)) / max_val)
+def check_repeats(
+    ctx: "GrammarContext", n: Any, cand: Glyph | str
+) -> Glyph | str:
+    """Swap ``cand`` when it breaches the configured repetition window.
+
+    The rule honours the soft grammar configuration stored in ``ctx.cfg_soft``:
+
+    * ``window`` specifies the history length inspected using
+      :func:`tnfr.glyph_history.recent_glyph`.
+    * ``avoid_repeats`` enumerates glyph codes to dodge within that window.
+    * ``fallbacks`` optionally map avoided glyph codes to explicit
+      replacements, defaulting to canonical fallbacks when unspecified.
+    """
+
+    nd = ctx.G.nodes[n]
+    cfg = ctx.cfg_soft
+    gwin = int(cfg.get("window", 0))
+    avoid = set(cfg.get("avoid_repeats", []))
+    fallbacks = cfg.get("fallbacks", {})
+    cand_key = cand.value if isinstance(cand, Glyph) else str(cand)
+    if gwin > 0 and cand_key in avoid and recent_glyph(nd, cand_key, gwin):
+        return glyph_fallback(cand_key, fallbacks)
+    return cand
+
+
+def maybe_force(
+    ctx: "GrammarContext",
+    n: Any,
+    cand: Glyph | str,
+    original: Glyph | str,
+    accessor: Callable[["GrammarContext", "Mapping[str, Any]"], float],
+    key: str,
+) -> Glyph | str:
+    """Return ``original`` when ``accessor`` crosses the soft threshold ``key``.
+
+    ``accessor`` receives the grammar context and node attributes.  Whenever the
+    resulting score is greater than or equal to the configured threshold the
+    original candidate is restored, ensuring soft filters never override
+    high-confidence canonical choices.
+    """
+
+    if cand == original:
+        return cand
+    force_th = float(ctx.cfg_soft.get(key, 0.60))
+    if accessor(ctx, ctx.G.nodes[n]) >= force_th:
+        return original
+    return cand
+
+
+def _match_template(result: Glyph | str, template: Glyph | str) -> Glyph | str:
+    """Coerce ``result`` to mirror ``template``'s representation when possible."""
+
+    if isinstance(template, str) and isinstance(result, Glyph):
+        return result.value
+    if isinstance(template, Glyph) and isinstance(result, str):
+        try:
+            return Glyph(result)
+        except (TypeError, ValueError):
+            return result
+    return result
+
+
+def soft_grammar_filters(
+    ctx: "GrammarContext",
+    n: Any,
+    cand: Glyph | str,
+    *,
+    original: Glyph | str | None = None,
+    template: Glyph | str | None = None,
+) -> Glyph | str:
+    """Apply the canonical soft grammar pipeline for ``cand``.
+
+    The pipeline performs three ordered checks:
+
+    1. :func:`check_repeats` swaps recent repetitions for the configured
+       fallback glyphs.
+    2. :func:`maybe_force` with :func:`tnfr.validation.rules.normalized_dnfr`
+       restores the original glyph when ΔNFR already exceeds ``force_dnfr``.
+    3. :func:`maybe_force` with :func:`acceleration_norm` performs the same
+       safeguard using the ``force_accel`` threshold.
+
+    Parameters
+    ----------
+    ctx:
+        Active grammar context providing node access and configuration.
+    n:
+        Node identifier inside ``ctx.G``.
+    cand:
+        Candidate glyph (``Glyph`` or code string) to validate softly.
+    original:
+        Optional glyph used as the reference for :func:`maybe_force`.  When
+        omitted, ``cand`` before filtering is used as the anchor value.
+    template:
+        Optional value whose type will be preserved in the returned result.  By
+        default the original ``cand`` representation is used.
+    """
+
+    anchor = cand if original is None else original
+    filtered = check_repeats(ctx, n, cand)
+    filtered = maybe_force(ctx, n, filtered, anchor, normalized_dnfr, "force_dnfr")
+    filtered = maybe_force(ctx, n, filtered, anchor, acceleration_norm, "force_accel")
+    base_template = cand if template is None else template
+    return _match_template(filtered, base_template)

--- a/src/tnfr/validation/soft_filters.pyi
+++ b/src/tnfr/validation/soft_filters.pyi
@@ -1,0 +1,37 @@
+from typing import Any, Callable, Mapping
+
+from ..types import Glyph
+from .grammar import GrammarContext
+
+__all__ = (
+    "acceleration_norm",
+    "check_repeats",
+    "maybe_force",
+    "soft_grammar_filters",
+)
+
+
+def acceleration_norm(ctx: GrammarContext, nd: Mapping[str, Any]) -> float: ...
+
+
+def check_repeats(ctx: GrammarContext, n: Any, cand: Glyph | str) -> Glyph | str: ...
+
+
+def maybe_force(
+    ctx: GrammarContext,
+    n: Any,
+    cand: Glyph | str,
+    original: Glyph | str,
+    accessor: Callable[[GrammarContext, Mapping[str, Any]], float],
+    key: str,
+) -> Glyph | str: ...
+
+
+def soft_grammar_filters(
+    ctx: GrammarContext,
+    n: Any,
+    cand: Glyph | str,
+    *,
+    original: Glyph | str | None = ...,
+    template: Glyph | str | None = ...,
+) -> Glyph | str: ...

--- a/tests/integration/test_validation_rules.py
+++ b/tests/integration/test_validation_rules.py
@@ -7,6 +7,7 @@ import networkx as nx
 from tnfr.constants import inject_defaults
 from tnfr.types import Glyph
 from tnfr.validation import rules as rules_mod
+from tnfr.validation.soft_filters import maybe_force
 from tnfr.validation.compatibility import CANON_COMPAT, CANON_FALLBACK
 from tnfr.validation.grammar import GrammarContext
 
@@ -27,7 +28,7 @@ def test_maybe_force_recovers_original_when_dnfr_high():
     nd["ΔNFR"] = 0.6
     ctx = GrammarContext.from_graph(G)
 
-    forced = rules_mod._maybe_force(
+    forced = maybe_force(
         ctx,
         0,
         Glyph.NAV,

--- a/tests/unit/validation/test_rules_normalization.py
+++ b/tests/unit/validation/test_rules_normalization.py
@@ -9,6 +9,7 @@ import pytest
 from tnfr.constants import get_aliases
 from tnfr.types import Glyph
 from tnfr.validation import rules
+from tnfr.validation.soft_filters import acceleration_norm
 from tnfr.validation.compatibility import CANON_FALLBACK
 from tnfr.validation.grammar import GrammarContext
 
@@ -42,7 +43,7 @@ def test_norm_helpers_handle_defaults_and_bounds(seeded_context):
     assert rules.get_norm(ctx_missing, "accel_max") == 1.0
     direct = rules._norm_attr(ctx_missing, nd, get_aliases("D2EPI"), "accel_max")
     assert direct == pytest.approx(0.25)
-    assert rules._accel_norm(ctx_missing, nd) == pytest.approx(0.25)
+    assert acceleration_norm(ctx_missing, nd) == pytest.approx(0.25)
 
     # Saturated SI values clamp to bounds.
     assert rules._si(nd) == 1.0
@@ -52,7 +53,7 @@ def test_norm_helpers_handle_defaults_and_bounds(seeded_context):
     # Tight maxima clamp the ratio to 1.0.
     G.graph["_sel_norms"] = {"accel_max": 0.1, "dnfr_max": 0.5}
     ctx_small = GrammarContext.from_graph(G)
-    assert rules._accel_norm(ctx_small, nd) == 1.0
+    assert acceleration_norm(ctx_small, nd) == 1.0
     nd[dnfr_key] = 1.0
     assert rules.normalized_dnfr(ctx_small, nd) == 1.0
 

--- a/tests/unit/validation/test_rules_repeats.py
+++ b/tests/unit/validation/test_rules_repeats.py
@@ -1,11 +1,11 @@
-"""Tests for repetition avoidance in :mod:`tnfr.validation.rules`."""
+"""Tests for repetition avoidance in :mod:`tnfr.validation.soft_filters`."""
 
 from __future__ import annotations
 
 from collections import deque
 
 from tnfr.types import Glyph
-from tnfr.validation import rules
+from tnfr.validation.soft_filters import check_repeats
 from tnfr.validation.grammar import GrammarContext
 
 
@@ -29,7 +29,7 @@ def test_check_repeats_swaps_to_configured_fallback(graph_canon):
     nd = ctx.G.nodes[node_id]
     nd["glyph_history"] = deque([Glyph.IL.value, Glyph.RA.value], maxlen=3)
 
-    swapped = rules._check_repeats(ctx, node_id, Glyph.RA)
+    swapped = check_repeats(ctx, node_id, Glyph.RA)
 
     assert swapped == Glyph.SHA
 
@@ -44,7 +44,7 @@ def test_check_repeats_leaves_non_recent_candidate(graph_canon):
     nd = ctx.G.nodes[node_id]
     nd["glyph_history"] = deque([Glyph.OZ.value, Glyph.IL.value], maxlen=4)
 
-    cand = rules._check_repeats(ctx, node_id, Glyph.RA)
+    cand = check_repeats(ctx, node_id, Glyph.RA)
 
     assert cand == Glyph.RA
 
@@ -59,6 +59,6 @@ def test_check_repeats_with_zero_window_passthrough(graph_canon):
     nd = ctx.G.nodes[node_id]
     nd["glyph_history"] = deque([Glyph.RA.value], maxlen=1)
 
-    cand = rules._check_repeats(ctx, node_id, Glyph.RA)
+    cand = check_repeats(ctx, node_id, Glyph.RA)
 
     assert cand == Glyph.RA


### PR DESCRIPTION
## Summary
- introduce `tnfr.validation.soft_filters` with public helpers for repetition and force heuristics
- switch grammar enforcement and dynamics selectors to rely on the consolidated soft filter API
- update validation and selector tests to exercise the new entry points

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6904768ebafc8321bdecbf5f42d49b6a