### PR TITLE
Restore legacy cache/io shims and document compatibility

### DIFF
--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -150,6 +150,11 @@ instantiate ad-hoc locks when they are not shared.
 
 ## Helper utilities API (`tnfr.utils`)
 
+> **Compatibility note:** ``tnfr.cache`` and ``tnfr.io`` continue to exist as
+> compatibility shims that re-export the helpers in ``tnfr.utils.cache`` and
+> ``tnfr.utils.io``. Update new code to import from ``tnfr.utils`` directly so
+> the structural helpers stay aligned with the canonical namespace.
+
 ### Collections and numeric helpers
 
 - `ensure_collection(it, *, max_materialize=...)` — materialise potentially lazy iterables

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -54,6 +54,11 @@ cached_import.cache_clear()
 prune_failed_imports()
 ```
 
+> **Compatibility note:** The legacy modules :mod:`tnfr.cache` and :mod:`tnfr.io` remain
+> importable as shims that re-export the helpers from :mod:`tnfr.utils.cache` and
+> :mod:`tnfr.utils.io`. Existing code keeps working, but new integrations should migrate to
+> the :mod:`tnfr.utils` entry points directly.
+
 ### Persistent cache layers
 
 `tnfr.utils.cache.build_cache_manager` now hydrates multi-layer caches from a

--- a/src/tnfr/cache.py
+++ b/src/tnfr/cache.py
@@ -1,7 +1,10 @@
-"""Compatibility shim removed; direct users to :mod:`tnfr.utils.cache`."""
+"""Compatibility proxy that re-exports :mod:`tnfr.utils.cache`."""
 
 from __future__ import annotations
 
-raise ImportError(
-    "The 'tnfr.cache' module has been removed. Import cache helpers from 'tnfr.utils.cache'."
-)
+from tnfr.utils.cache import *  # noqa: F401,F403
+from tnfr.utils.cache import __all__ as _cache_all
+
+__all__ = tuple(_cache_all)
+
+del _cache_all

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -11,7 +11,10 @@ from .constants import get_param, normalise_state_token
 from .glyph_runtime import last_glyph
 from .types import TNFRGraph
 from .utils import ensure_collection, get_logger
-from .validation import validate_window
+def _validate_window(window: int) -> int:
+    from .validation import validate_window
+
+    return validate_window(window)
 
 logger = get_logger(__name__)
 
@@ -31,7 +34,7 @@ def _ensure_history(
 ) -> tuple[int, deque[str] | None]:
     """Validate ``window`` and ensure ``nd['glyph_history']`` deque."""
 
-    v_window = validate_window(window)
+    v_window = _validate_window(window)
     if v_window == 0 and not create_zero:
         return v_window, None
     hist = nd.setdefault("glyph_history", deque(maxlen=v_window))

--- a/src/tnfr/io.py
+++ b/src/tnfr/io.py
@@ -1,7 +1,10 @@
-"""Compatibility shim removed; direct users to :mod:`tnfr.utils.io`."""
+"""Compatibility proxy that re-exports :mod:`tnfr.utils.io`."""
 
 from __future__ import annotations
 
-raise ImportError(
-    "The 'tnfr.io' module has been removed. Import IO helpers from 'tnfr.utils.io'."
-)
+from tnfr.utils.io import *  # noqa: F401,F403
+from tnfr.utils.io import __all__ as _io_all
+
+__all__ = tuple(_io_all)
+
+del _io_all

--- a/tests/unit/structural/test_cache_helpers.py
+++ b/tests/unit/structural/test_cache_helpers.py
@@ -1,5 +1,9 @@
 """Unit tests for public cache helpers that track node and edge metadata."""
 
+import importlib
+import sys
+import warnings
+
 from tnfr.utils import (
     edge_version_update,
     ensure_node_index_map,
@@ -48,3 +52,16 @@ def test_node_maps_order(graph_canon):
     offset_map = ensure_node_offset_map(G)
     assert offset_map == {0: 0, 1: 1, 2: 2}
     assert ensure_node_index_map(G) is idx_map
+
+
+def test_legacy_cache_module_proxy(monkeypatch):
+    module_name = "tnfr.cache"
+    sys.modules.pop(module_name, None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        legacy = importlib.import_module(module_name)
+
+    assert not caught
+    assert legacy.ensure_node_offset_map is ensure_node_offset_map
+    assert legacy.ensure_node_index_map is ensure_node_index_map

--- a/tests/unit/structural/test_json_utils.py
+++ b/tests/unit/structural/test_json_utils.py
@@ -1,4 +1,7 @@
+import importlib
 import logging
+import sys
+import warnings
 
 import pytest
 
@@ -39,6 +42,18 @@ def test_lazy_orjson_import(monkeypatch):
     assert calls["n"] == 1
     json_utils.json_dumps({})
     assert calls["n"] == 2
+
+
+def test_legacy_io_module_proxy(monkeypatch):
+    module_name = "tnfr.io"
+    sys.modules.pop(module_name, None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        legacy = importlib.import_module(module_name)
+
+    assert not caught
+    assert legacy.json_dumps is json_utils.json_dumps
 
 
 def test_warns_once_per_combo(monkeypatch, caplog):


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Restores the legacy `tnfr.cache` and `tnfr.io` modules as explicit proxies for `tnfr.utils.cache` and `tnfr.utils.io`, adds regression coverage to ensure the compatibility imports remain warning-free, documents the compatibility shims in the quickstart and telemetry guides, and defers `validate_window` imports to avoid circular import regressions triggered by the revived modules.

**Testing**
- `PYTHONPATH=src pytest tests/unit/structural/test_cache_helpers.py tests/unit/structural/test_json_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_69047f2593008321a7e00de0a16ec20f