### PR TITLE
Align validation imports with facade exports

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -42,7 +42,7 @@ from ..utils import (
 )
 from .arguments import _args_to_dict
 from .utils import _parse_cli_variants
-from ..validation.runtime import validate_canon
+from ..validation import validate_canon
 
 logger = get_logger(__name__)
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -65,8 +65,12 @@ from ..metrics.sense_index import compute_Si
 from ..operators import apply_glyph
 from ..types import GlyphCode
 from ..utils import get_numpy
-from ..validation import enforce_canonical_grammar, on_applied_glyph
-from ..validation.runtime import apply_canonical_clamps, validate_canon
+from ..validation import (
+    apply_canonical_clamps,
+    enforce_canonical_grammar,
+    on_applied_glyph,
+    validate_canon,
+)
 from . import coordination, dnfr, integrators
 from .adaptation import adapt_vf_by_coherence
 from .aliases import (

--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -17,7 +17,7 @@ from ..metrics.sense_index import compute_Si
 from ..operators import apply_remesh_if_globally_stable
 from ..telemetry import publish_graph_cache_metrics
 from ..types import HistoryState, NodeId, TNFRGraph
-from ..validation.runtime import apply_canonical_clamps, validate_canon
+from ..validation import apply_canonical_clamps, validate_canon
 from . import adaptation, coordination, integrators, selectors
 from .aliases import ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_VF
 from .dnfr import default_compute_delta_nfr


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- update the dynamics facade to import validation helpers directly from `tnfr.validation` while keeping the existing exports intact
- switch runtime orchestration to use the same validation facade entry points
- align CLI execution to the new validation import path so the CLI continues to use the canonical validator


------
https://chatgpt.com/codex/tasks/task_e_690482f5549083218bc260ecf448451f