### PR TITLE
Centralize telemetry TypedDict definitions

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any, MutableMapping, TypedDict, cast
+from typing import Any, MutableMapping, cast
 
 from .._compat import TypeAlias
 from ..alias import collect_attr, collect_theta_attr, get_attr, set_attr
@@ -33,6 +33,7 @@ from ..types import (
     GlyphLoadDistribution,
     HistoryState,
     NodeId,
+    ParallelWijPayload,
     SigmaVector,
     TNFRGraph,
 )
@@ -108,21 +109,6 @@ StabilityChunkResult = tuple[
 MetricValue: TypeAlias = CoherenceMetric
 MetricProvider = Callable[[], MetricValue]
 MetricRecord: TypeAlias = tuple[MetricValue | MetricProvider, str]
-
-
-class ParallelWijPayload(TypedDict):
-    """Container for broadcasting Wij components across worker pools."""
-
-    epi_vals: Sequence[float]
-    vf_vals: Sequence[float]
-    si_vals: Sequence[float]
-    cos_vals: Sequence[float]
-    sin_vals: Sequence[float]
-    weights: tuple[float, float, float, float]
-    epi_range: float
-    vf_range: float
-
-
 def _compute_wij_phase_epi_vf_si_vectorized(
     epi: FloatArray,
     vf: FloatArray,

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -13,14 +13,14 @@ from itertools import combinations
 from operator import ge, le
 from statistics import StatisticsError, fmean
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from .._compat import TypeAlias
 from ..alias import get_attr, set_attr
 from ..constants import DEFAULTS, REMESH_DEFAULTS, get_aliases, get_param
-from ..utils import kahan_sum_nd
 from ..rng import make_rng
-from ..utils import cached_import, edge_version_update
+from ..types import RemeshMeta
+from ..utils import cached_import, edge_version_update, kahan_sum_nd
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ..callback_utils import CallbackEvent, CallbackManager
@@ -30,24 +30,6 @@ NetworkxModule: TypeAlias = ModuleType
 CommunityModule: TypeAlias = ModuleType
 RemeshEdge: TypeAlias = tuple[Hashable, Hashable]
 NetworkxModules: TypeAlias = tuple[NetworkxModule, CommunityModule]
-
-
-class RemeshMeta(TypedDict, total=False):
-    alpha: float
-    alpha_source: str
-    tau_global: int
-    tau_local: int
-    step: int | None
-    topo_hash: str | None
-    epi_mean_before: float
-    epi_mean_after: float
-    epi_checksum_before: str
-    epi_checksum_after: str
-    stable_frac_last: float
-    phase_sync_last: float
-    glyph_disr_last: float
-
-
 RemeshConfigValue: TypeAlias = bool | float | int
 
 

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterable, Mapping
 from types import MappingProxyType
-from typing import Any, Callable, NamedTuple, Protocol, TypedDict, cast
+from typing import Any, Callable, NamedTuple, Protocol, cast
 
 from .constants import TRACE
 from .glyph_history import append_metric, count_glyphs, ensure_history
@@ -26,6 +26,8 @@ from .types import (
     TraceFieldFn,
     TraceFieldMap,
     TraceFieldRegistry,
+    TraceMetadata,
+    TraceSnapshot,
 )
 from .utils import cached_import, get_graph_mapping, is_non_string_sequence
 
@@ -43,29 +45,6 @@ class CallbackSpec(NamedTuple):
 
     name: str | None
     func: Callable[..., Any]
-
-
-class TraceMetadata(TypedDict, total=False):
-    """Metadata captured by trace field functions."""
-
-    gamma: Mapping[str, Any]
-    grammar: Mapping[str, Any]
-    selector: str | None
-    dnfr_weights: Mapping[str, Any]
-    si_weights: Mapping[str, Any]
-    si_sensitivity: Mapping[str, Any]
-    callbacks: Mapping[str, list[str] | None]
-    thol_open_nodes: int
-    kuramoto: Mapping[str, float]
-    sigma: Mapping[str, float]
-    glyphs: Mapping[str, int]
-
-
-class TraceSnapshot(TraceMetadata, total=False):
-    """Trace snapshot stored in the history."""
-
-    t: float
-    phase: str
 
 
 class TraceFieldSpec(NamedTuple):

--- a/src/tnfr/trace.pyi
+++ b/src/tnfr/trace.pyi
@@ -1,7 +1,14 @@
 from collections.abc import Iterable, Mapping
-from typing import Any, Callable, NamedTuple, TypedDict
+from typing import Any, Callable, NamedTuple
 
-from .types import TNFRGraph, TraceFieldFn, TraceFieldMap, TraceFieldRegistry
+from .types import (
+    TNFRGraph,
+    TraceFieldFn,
+    TraceFieldMap,
+    TraceFieldRegistry,
+    TraceMetadata,
+    TraceSnapshot,
+)
 
 __all__: tuple[str, ...]
 
@@ -10,23 +17,6 @@ def __getattr__(name: str) -> Any: ...
 class CallbackSpec(NamedTuple):
     name: str | None
     func: Callable[..., Any]
-
-class TraceMetadata(TypedDict, total=False):
-    gamma: Mapping[str, Any]
-    grammar: Mapping[str, Any]
-    selector: str | None
-    dnfr_weights: Mapping[str, Any]
-    si_weights: Mapping[str, Any]
-    si_sensitivity: Mapping[str, Any]
-    callbacks: Mapping[str, list[str] | None]
-    thol_open_nodes: int
-    kuramoto: Mapping[str, float]
-    sigma: Mapping[str, float]
-    glyphs: Mapping[str, int]
-
-class TraceSnapshot(TraceMetadata, total=False):
-    t: float
-    phase: str
 
 kuramoto_R_psi: Callable[[TNFRGraph], tuple[float, float]]
 TRACE_FIELDS: TraceFieldRegistry

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -63,6 +63,9 @@ __all__ = (
     "TraceFieldFn",
     "TraceFieldMap",
     "TraceFieldRegistry",
+    "TraceMetadata",
+    "TraceSnapshot",
+    "RemeshMeta",
     "HistoryState",
     "DiagnosisNodeData",
     "DiagnosisSharedState",
@@ -91,6 +94,7 @@ __all__ = (
     "GlyphMetricsHistoryValue",
     "GlyphMetricsHistory",
     "MetricsListHistory",
+    "ParallelWijPayload",
 )
 
 
@@ -99,8 +103,6 @@ if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
 
     from .glyph_history import HistoryDict as _HistoryDict
     from .tokens import Token as _Token
-    from .trace import TraceMetadata
-
     TNFRGraph: TypeAlias = nx.Graph
 else:  # pragma: no cover - runtime fallback without networkx
     TNFRGraph: TypeAlias = Any
@@ -382,6 +384,30 @@ TraceFieldMap: TypeAlias = Mapping[str, "TraceFieldFn"]
 TraceFieldRegistry: TypeAlias = dict[str, dict[str, "TraceFieldFn"]]
 #: Registry grouping trace field producers by capture phase.
 
+
+class TraceMetadata(TypedDict, total=False):
+    """Metadata captured by trace field producers across phases."""
+
+    gamma: Mapping[str, Any]
+    grammar: Mapping[str, Any]
+    selector: str | None
+    dnfr_weights: Mapping[str, Any]
+    si_weights: Mapping[str, Any]
+    si_sensitivity: Mapping[str, Any]
+    callbacks: Mapping[str, list[str] | None]
+    thol_open_nodes: int
+    kuramoto: Mapping[str, float]
+    sigma: Mapping[str, float]
+    glyphs: Mapping[str, int]
+
+
+class TraceSnapshot(TraceMetadata, total=False):
+    """Trace metadata snapshot recorded in TNFR history."""
+
+    t: float
+    phase: str
+
+
 HistoryState: TypeAlias = _HistoryDict | dict[str, Any]
 #: History container used to accumulate glyph metrics and logs for the graph.
 
@@ -463,3 +489,34 @@ GlyphMetricsHistory: TypeAlias = MutableMapping[str, GlyphMetricsHistoryValue]
 
 MetricsListHistory: TypeAlias = MutableMapping[str, list[Any]]
 """Mapping associating glyph metric identifiers with time series."""
+
+
+class RemeshMeta(TypedDict, total=False):
+    """Event metadata persisted after applying REMESH coherence operators."""
+
+    alpha: float
+    alpha_source: str
+    tau_global: int
+    tau_local: int
+    step: int | None
+    topo_hash: str | None
+    epi_mean_before: float
+    epi_mean_after: float
+    epi_checksum_before: str
+    epi_checksum_after: str
+    stable_frac_last: float
+    phase_sync_last: float
+    glyph_disr_last: float
+
+
+class ParallelWijPayload(TypedDict):
+    """Container for broadcasting Wij coherence components to worker pools."""
+
+    epi_vals: Sequence[float]
+    vf_vals: Sequence[float]
+    si_vals: Sequence[float]
+    cos_vals: Sequence[float]
+    sin_vals: Sequence[float]
+    weights: tuple[float, float, float, float]
+    epi_range: float
+    vf_range: float

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -26,8 +26,6 @@ except Exception:
 
 from .glyph_history import HistoryDict as _HistoryDict
 from .tokens import Token
-from .trace import TraceMetadata
-
 __all__: tuple[str, ...] = (
     "TNFRGraph",
     "Graph",
@@ -62,6 +60,8 @@ __all__: tuple[str, ...] = (
     "TraceFieldFn",
     "TraceFieldMap",
     "TraceFieldRegistry",
+    "TraceMetadata",
+    "TraceSnapshot",
     "HistoryState",
     "DiagnosisNodeData",
     "DiagnosisSharedState",
@@ -90,6 +90,8 @@ __all__: tuple[str, ...] = (
     "GlyphMetricsHistoryValue",
     "GlyphMetricsHistory",
     "MetricsListHistory",
+    "ParallelWijPayload",
+    "RemeshMeta",
 )
 
 def __getattr__(name: str) -> Any: ...
@@ -221,9 +223,26 @@ SelectorPreselectionPayload: TypeAlias = tuple[
     SelectorPreselectionMetrics,
     SelectorPreselectionChoices,
 ]
-TraceFieldFn: TypeAlias = Callable[[TNFRGraph], TraceMetadata]
-TraceFieldMap: TypeAlias = Mapping[str, TraceFieldFn]
-TraceFieldRegistry: TypeAlias = dict[str, dict[str, TraceFieldFn]]
+TraceFieldFn: TypeAlias = Callable[[TNFRGraph], "TraceMetadata"]
+TraceFieldMap: TypeAlias = Mapping[str, "TraceFieldFn"]
+TraceFieldRegistry: TypeAlias = dict[str, dict[str, "TraceFieldFn"]]
+
+class TraceMetadata(TypedDict, total=False):
+    gamma: Mapping[str, Any]
+    grammar: Mapping[str, Any]
+    selector: str | None
+    dnfr_weights: Mapping[str, Any]
+    si_weights: Mapping[str, Any]
+    si_sensitivity: Mapping[str, Any]
+    callbacks: Mapping[str, list[str] | None]
+    thol_open_nodes: int
+    kuramoto: Mapping[str, float]
+    sigma: Mapping[str, float]
+    glyphs: Mapping[str, int]
+
+class TraceSnapshot(TraceMetadata, total=False):
+    t: float
+    phase: str
 HistoryState: TypeAlias = _HistoryDict | dict[str, Any]
 TraceCallback: TypeAlias = Callable[[TNFRGraph, dict[str, Any]], None]
 
@@ -270,3 +289,28 @@ GlyphCounts: TypeAlias = Mapping[str, int]
 GlyphMetricsHistoryValue: TypeAlias = MutableMapping[Any, Any] | MutableSequence[Any]
 GlyphMetricsHistory: TypeAlias = MutableMapping[str, GlyphMetricsHistoryValue]
 MetricsListHistory: TypeAlias = MutableMapping[str, list[Any]]
+
+class RemeshMeta(TypedDict, total=False):
+    alpha: float
+    alpha_source: str
+    tau_global: int
+    tau_local: int
+    step: int | None
+    topo_hash: str | None
+    epi_mean_before: float
+    epi_mean_after: float
+    epi_checksum_before: str
+    epi_checksum_after: str
+    stable_frac_last: float
+    phase_sync_last: float
+    glyph_disr_last: float
+
+class ParallelWijPayload(TypedDict):
+    epi_vals: Sequence[float]
+    vf_vals: Sequence[float]
+    si_vals: Sequence[float]
+    cos_vals: Sequence[float]
+    sin_vals: Sequence[float]
+    weights: tuple[float, float, float, float]
+    epi_range: float
+    vf_range: float


### PR DESCRIPTION
## Summary
- centralised the remesh metadata, trace metadata/snapshot, and parallel Wij payload TypedDicts inside `tnfr.types`
- updated remesh, trace, and coherence metric modules plus stubs to import the shared definitions
- refreshed exported symbols so downstream imports keep resolving the shared telemetry types

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_690486de2bb08321bb8fa5379896ae68