### PR TITLE
Use shared json_dumps helper for benchmarking and security scripts

### DIFF
--- a/benchmarks/compute_si_profile.py
+++ b/benchmarks/compute_si_profile.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import cProfile
-import json
 import math
 import pstats
 from contextlib import contextmanager
@@ -28,6 +27,7 @@ import networkx as nx
 from tnfr.alias import set_attr
 from tnfr.constants import get_aliases
 from tnfr.metrics.sense_index import compute_Si
+from tnfr.utils import json_dumps
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_VF = get_aliases("VF")
@@ -123,7 +123,7 @@ def _dump_stats(profile: cProfile.Profile, path: Path, *, fmt: str, sort: str) -
         )
 
     rows.sort(key=lambda entry: entry[sort_key], reverse=True)
-    path.write_text(json.dumps(rows, indent=2, ensure_ascii=False))
+    path.write_text(json_dumps(rows, indent=2, ensure_ascii=False))
 
 
 def profile_compute_si(

--- a/benchmarks/default_compute_delta_nfr.py
+++ b/benchmarks/default_compute_delta_nfr.py
@@ -13,6 +13,7 @@ import networkx as nx
 
 from tnfr.constants import get_aliases
 from tnfr.dynamics import default_compute_delta_nfr
+from tnfr.utils import json_dumps
 
 BenchmarkMode = Literal["auto", "force-dense", "python"]
 
@@ -96,9 +97,7 @@ def _profile(
 
     payload.sort(key=lambda entry: entry["totaltime"], reverse=True)
 
-    import json
-
-    output.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    output.write_text(json_dumps(payload, indent=2, ensure_ascii=False))
     print(f"Stored ΔNFR profile at {output}")
 
 

--- a/benchmarks/full_pipeline_profile.py
+++ b/benchmarks/full_pipeline_profile.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import argparse
 import cProfile
-import json
 import math
 import pstats
 from collections.abc import Iterable
@@ -61,6 +60,7 @@ from tnfr.metrics.sense_index import (
 import tnfr.utils as tnfr_utils
 from tnfr.cli.utils import _coerce_optional_int, _parse_cli_variants
 from tnfr.utils.chunks import resolve_chunk_size
+from tnfr.utils import json_dumps
 
 ALIAS_THETA = get_aliases("THETA")
 ALIAS_EPI = get_aliases("EPI")
@@ -333,7 +333,7 @@ def _dump_profile_outputs(
         "rows": rows,
     }
     base_path.with_suffix(".json").write_text(
-        json.dumps(report, indent=2, ensure_ascii=False)
+        json_dumps(report, indent=2, ensure_ascii=False)
     )
 
 

--- a/scripts/generate_security_dashboard.py
+++ b/scripts/generate_security_dashboard.py
@@ -21,6 +21,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+from tnfr.utils import json_dumps
+
 SEVERITY_ORDER = ["critical", "high", "medium", "low", "info"]
 CANONICAL_TOOL_NAMES = {
     "codeql": "CodeQL",
@@ -442,7 +444,7 @@ def main(argv: list[str] | None = None) -> int:
             "dependabot": dependabot,
         }
         args.json_output.write_text(
-            json.dumps(json_payload, indent=2, ensure_ascii=False),
+            json_dumps(json_payload, indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
     return 0

--- a/scripts/post_security_summary.py
+++ b/scripts/post_security_summary.py
@@ -11,6 +11,8 @@ import sys
 import urllib.error
 import urllib.request
 
+from tnfr.utils import json_dumps
+
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -91,7 +93,7 @@ def build_message(payload: dict, markdown_path: pathlib.Path | None) -> str:
 
 
 def post_message(webhook: str, message: str) -> None:
-    data = json.dumps({"text": message}).encode("utf-8")
+    data = json_dumps({"text": message}, to_bytes=True)
     request = urllib.request.Request(
         webhook,
         data=data,


### PR DESCRIPTION
## Summary
- swap benchmark JSON writers to tnfr.utils.json_dumps for consistent encoding
- update security dashboard scripts to build payloads with json_dumps and drop redundant imports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69048b2a48688321be45936f36668c97