### PR TITLE
fix: align glyph history validator import

### DIFF
--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -11,7 +11,7 @@ from .constants import get_param, normalise_state_token
 from .glyph_runtime import last_glyph
 from .types import TNFRGraph
 from .utils import ensure_collection, get_logger
-from .validation.window import validate_window
+from tnfr.validation import validate_window
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Align glyph history window validation import with the `tnfr.validation` public interface.
- `python -m mypy src/tnfr/glyph_history.py` (fails due to pre-existing stub issues outside the touched module).


------
https://chatgpt.com/codex/tasks/task_e_69048fb2dd4483219890654a5d3b7828