### PR TITLE
Refactor logging usage to go through tnfr.utils.get_logger

### DIFF
--- a/src/tnfr/mathematics/runtime.py
+++ b/src/tnfr/mathematics/runtime.py
@@ -6,6 +6,7 @@ from typing import Sequence
 import numpy as np
 
 from ..config import get_flags
+from ..utils import get_logger
 from .operators import CoherenceOperator, FrequencyOperator
 from .spaces import HilbertSpace
 
@@ -17,6 +18,9 @@ __all__ = [
     "coherence_expectation",
     "frequency_expectation",
 ]
+
+
+LOGGER = get_logger(__name__)
 
 
 def _as_vector(state: Sequence[complex] | np.ndarray, *, dimension: int) -> np.ndarray:
@@ -32,9 +36,7 @@ def _as_vector(state: Sequence[complex] | np.ndarray, *, dimension: int) -> np.n
 def _maybe_log(metric: str, payload: dict[str, object]) -> None:
     if not get_flags().log_performance:
         return
-    import logging
-
-    logging.getLogger(__name__).debug("%s: %s", metric, payload)
+    LOGGER.debug("%s: %s", metric, payload)
 
 
 def normalized(

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 import math
 from collections.abc import Hashable
 from dataclasses import dataclass
@@ -63,6 +62,7 @@ from .types import (
 from .utils import (
     cached_node_list,
     ensure_node_offset_map,
+    get_logger,
     increment_edge_version,
     supports_add_edge,
 )
@@ -80,7 +80,7 @@ T = TypeVar("T")
 __all__ = ("NodeNX", "NodeProtocol", "add_edge")
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/tnfr/utils/cache.py
+++ b/src/tnfr/utils/cache.py
@@ -80,9 +80,6 @@ __all__ = (
 if TYPE_CHECKING:  # pragma: no cover - typing aide
     from ..dynamics.dnfr import DnfrCache
 
-_logger = logging.getLogger(__name__)
-
-
 @dataclass(frozen=True)
 class CacheCapacityConfig:
     """Configuration snapshot for cache capacity policies."""
@@ -748,9 +745,7 @@ class CacheManager:
                 try:
                     emit(name, stats)
                 except Exception:  # pragma: no cover - defensive logging
-                    logging.getLogger(__name__).exception(
-                        "Cache metrics publisher failed for %s", name
-                    )
+                    _logger.exception("Cache metrics publisher failed for %s", name)
 
     def log_metrics(self, logger: logging.Logger, *, level: int = logging.INFO) -> None:
         """Emit cache metrics using ``logger`` for telemetry hooks."""
@@ -766,6 +761,11 @@ class CacheManager:
                 stats.timings,
                 stats.total_time,
             )
+
+
+from .init import get_logger
+
+_logger = get_logger(__name__)
 
 
 def _normalise_callbacks(


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Routed node, cache, and runtime logging through `tnfr.utils.get_logger` to centralize configuration.
- Verified no remaining direct `logging.getLogger` usage outside modules that intentionally configure the root logger.


------
https://chatgpt.com/codex/tasks/task_e_690490555abc83219432420968aeab5d