### PR TITLE
Centralize alias constant definitions

### DIFF
--- a/src/tnfr/alias.py
+++ b/src/tnfr/alias.py
@@ -25,13 +25,9 @@ from typing import (
     cast,
 )
 
-from .constants import get_aliases
+from .constants.aliases import ALIAS_DNFR, ALIAS_THETA, ALIAS_VF
 from .types import FloatArray, NodeId
 from .utils import convert_value
-
-ALIAS_VF = get_aliases("VF")
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_THETA = get_aliases("THETA")
 
 if TYPE_CHECKING:  # pragma: no cover
     import networkx

--- a/src/tnfr/constants/aliases.py
+++ b/src/tnfr/constants/aliases.py
@@ -1,0 +1,31 @@
+"""Shared alias constants for TNFR attributes."""
+
+from __future__ import annotations
+
+from . import get_aliases
+
+ALIAS_VF = get_aliases("VF")
+ALIAS_THETA = get_aliases("THETA")
+ALIAS_DNFR = get_aliases("DNFR")
+ALIAS_EPI = get_aliases("EPI")
+ALIAS_EPI_KIND = get_aliases("EPI_KIND")
+ALIAS_SI = get_aliases("SI")
+ALIAS_DEPI = get_aliases("DEPI")
+ALIAS_D2EPI = get_aliases("D2EPI")
+ALIAS_DVF = get_aliases("DVF")
+ALIAS_D2VF = get_aliases("D2VF")
+ALIAS_DSI = get_aliases("DSI")
+
+__all__ = [
+    "ALIAS_VF",
+    "ALIAS_THETA",
+    "ALIAS_DNFR",
+    "ALIAS_EPI",
+    "ALIAS_EPI_KIND",
+    "ALIAS_SI",
+    "ALIAS_DEPI",
+    "ALIAS_D2EPI",
+    "ALIAS_DVF",
+    "ALIAS_D2VF",
+    "ALIAS_DSI",
+]

--- a/src/tnfr/dynamics/aliases.py
+++ b/src/tnfr/dynamics/aliases.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from ..constants import get_aliases
-
-ALIAS_VF = get_aliases("VF")
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_SI = get_aliases("SI")
-ALIAS_D2EPI = get_aliases("D2EPI")
-ALIAS_DSI = get_aliases("DSI")
+from ..constants.aliases import (
+    ALIAS_D2EPI,
+    ALIAS_DNFR,
+    ALIAS_DSI,
+    ALIAS_EPI,
+    ALIAS_SI,
+    ALIAS_VF,
+)
 
 __all__ = (
     "ALIAS_VF",

--- a/src/tnfr/dynamics/dnfr.py
+++ b/src/tnfr/dynamics/dnfr.py
@@ -20,7 +20,8 @@ from typing import TYPE_CHECKING, Any, cast
 from time import perf_counter
 
 from ..alias import get_attr, get_theta_attr, set_dnfr
-from ..constants import DEFAULTS, get_aliases, get_param
+from ..constants import DEFAULTS, get_param
+from ..constants.aliases import ALIAS_EPI, ALIAS_VF
 from ..metrics.common import merge_and_normalize_weights
 from ..metrics.trig import neighbor_phase_mean_list
 from ..metrics.trig_cache import compute_theta_trig
@@ -50,9 +51,6 @@ from ..utils import (
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing hook
     import numpy as np
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_VF = get_aliases("VF")
-
 
 _MEAN_VECTOR_EPS = 1e-12
 _SPARSE_DENSITY_THRESHOLD = 0.25

--- a/src/tnfr/dynamics/integrators.py
+++ b/src/tnfr/dynamics/integrators.py
@@ -13,20 +13,18 @@ import networkx as nx
 
 from .._compat import TypeAlias
 from ..alias import collect_attr, get_attr, get_attr_str, set_attr, set_attr_str
-from ..constants import (
-    DEFAULTS,
-    get_aliases,
+from ..constants import DEFAULTS
+from ..constants.aliases import (
+    ALIAS_D2EPI,
+    ALIAS_DEPI,
+    ALIAS_DNFR,
+    ALIAS_EPI,
+    ALIAS_EPI_KIND,
+    ALIAS_VF,
 )
 from ..gamma import _get_gamma_spec, eval_gamma
 from ..types import NodeId, TNFRGraph
 from ..utils import get_numpy
-
-ALIAS_VF = get_aliases("VF")
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_DEPI = get_aliases("DEPI")
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_EPI_KIND = get_aliases("EPI_KIND")
-ALIAS_D2EPI = get_aliases("D2EPI")
 
 __all__ = (
     "AbstractIntegrator",

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -12,9 +12,16 @@ from typing import Any, MutableMapping, cast
 from .._compat import TypeAlias
 from ..alias import collect_attr, collect_theta_attr, get_attr, set_attr
 from ..callback_utils import CallbackEvent, callback_manager
-from ..constants import (
-    get_aliases,
-    get_param,
+from ..constants import get_param
+from ..constants.aliases import (
+    ALIAS_D2VF,
+    ALIAS_DNFR,
+    ALIAS_DSI,
+    ALIAS_DVF,
+    ALIAS_DEPI,
+    ALIAS_EPI,
+    ALIAS_SI,
+    ALIAS_VF,
 )
 from ..glyph_history import append_metric, ensure_history
 from ..utils import clamp01
@@ -47,15 +54,6 @@ from .common import compute_coherence, min_max_range
 from .trig_cache import compute_theta_trig, get_trig_cache
 
 logger = get_logger(__name__)
-
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_VF = get_aliases("VF")
-ALIAS_SI = get_aliases("SI")
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_DEPI = get_aliases("DEPI")
-ALIAS_DSI = get_aliases("DSI")
-ALIAS_DVF = get_aliases("DVF")
-ALIAS_D2VF = get_aliases("D2VF")
 
 GLYPH_LOAD_STABILIZERS_KEY = "glyph_load_stabilizers"
 

--- a/src/tnfr/metrics/common.py
+++ b/src/tnfr/metrics/common.py
@@ -6,15 +6,11 @@ from types import MappingProxyType
 from typing import Any, Iterable, Mapping, Sequence
 
 from ..alias import collect_attr, get_attr, multi_recompute_abs_max
-from ..constants import DEFAULTS, get_aliases
+from ..constants import DEFAULTS
+from ..constants.aliases import ALIAS_D2EPI, ALIAS_DEPI, ALIAS_DNFR, ALIAS_VF
 from ..utils import clamp01, kahan_sum_nd
 from ..types import GraphLike, NodeAttrMap
 from ..utils import edge_version_cache, get_numpy, normalize_weights
-
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_D2EPI = get_aliases("D2EPI")
-ALIAS_DEPI = get_aliases("DEPI")
-ALIAS_VF = get_aliases("VF")
 
 __all__ = (
     "GraphLike",

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -19,10 +19,10 @@ from ..constants import (
     STATE_STABLE,
     STATE_TRANSITION,
     VF_KEY,
-    get_aliases,
     get_param,
     normalise_state_token,
 )
+from ..constants.aliases import ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_VF
 from ..glyph_history import append_metric, ensure_history
 from ..utils import clamp01, similarity_abs
 from ..types import (
@@ -44,11 +44,6 @@ from .common import (
     normalize_dnfr,
 )
 from .trig_cache import compute_theta_trig, get_trig_cache
-
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_VF = get_aliases("VF")
-ALIAS_SI = get_aliases("SI")
-ALIAS_DNFR = get_aliases("DNFR")
 
 CoherenceSeries = Sequence[CoherenceMatrixPayload | None]
 CoherenceHistory = Mapping[str, CoherenceSeries]

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -18,7 +18,8 @@ from typing import (
 
 from ..alias import get_attr
 from ..config.constants import GLYPH_GROUPS, GLYPHS_CANONICAL
-from ..constants import get_aliases, get_param
+from ..constants import get_param
+from ..constants.aliases import ALIAS_EPI
 from ..glyph_history import append_metric
 from ..glyph_runtime import last_glyph
 from ..types import (
@@ -32,8 +33,6 @@ from ..types import (
     MetricsListHistory,
     SigmaTrace,
 )
-
-ALIAS_EPI = get_aliases("EPI")
 
 LATENT_GLYPH: str = "SHA"
 DEFAULT_EPI_SUPPORT_LIMIT = 0.05

--- a/src/tnfr/metrics/sense_index.py
+++ b/src/tnfr/metrics/sense_index.py
@@ -40,7 +40,7 @@ from time import perf_counter
 from typing import Any, Callable, Iterable, Iterator, Mapping, MutableMapping, cast
 
 from ..alias import get_attr, set_attr
-from ..constants import get_aliases
+from ..constants.aliases import ALIAS_DNFR, ALIAS_SI, ALIAS_VF
 from ..utils import angle_diff, angle_diff_array, clamp01
 from ..types import GraphLike, NodeAttrMap
 from ..utils import (
@@ -58,10 +58,6 @@ from .common import (
 )
 from .trig import neighbor_phase_mean_bulk, neighbor_phase_mean_list
 from .trig_cache import get_trig_cache
-
-ALIAS_VF = get_aliases("VF")
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_SI = get_aliases("SI")
 
 PHASE_DISPERSION_KEY = "dSi_dphase_disp"
 _SI_APPROX_BYTES_PER_NODE = 64

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -31,7 +31,15 @@ from .alias import (
     set_vf,
 )
 from .config import context_flags, get_flags
-from .constants import get_aliases
+from .constants.aliases import (
+    ALIAS_D2EPI,
+    ALIAS_DNFR,
+    ALIAS_EPI,
+    ALIAS_EPI_KIND,
+    ALIAS_SI,
+    ALIAS_THETA,
+    ALIAS_VF,
+)
 from .mathematics import (
     BasicStateProjector,
     CoherenceOperator,
@@ -66,14 +74,6 @@ from .utils import (
     increment_edge_version,
     supports_add_edge,
 )
-
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_VF = get_aliases("VF")
-ALIAS_THETA = get_aliases("THETA")
-ALIAS_SI = get_aliases("SI")
-ALIAS_EPI_KIND = get_aliases("EPI_KIND")
-ALIAS_DNFR = get_aliases("DNFR")
-ALIAS_D2EPI = get_aliases("D2EPI")
 
 T = TypeVar("T")
 

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING, Any
 from tnfr import glyph_history
 
 from ..alias import get_attr
-from ..constants import DEFAULTS, get_aliases, get_param
+from ..constants import DEFAULTS, get_param
+from ..constants.aliases import ALIAS_EPI
 from ..utils import angle_diff
 from ..metrics.trig import neighbor_phase_mean
 from ..rng import make_rng
@@ -57,8 +58,6 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 
 GlyphFactors = dict[str, Any]
 GlyphOperation = Callable[["NodeProtocol", GlyphFactors], None]
-
-ALIAS_EPI = get_aliases("EPI")
 
 __all__ = [
     "JitterCache",

--- a/src/tnfr/operators/remesh.py
+++ b/src/tnfr/operators/remesh.py
@@ -17,7 +17,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .._compat import TypeAlias
 from ..alias import get_attr, set_attr
-from ..constants import DEFAULTS, REMESH_DEFAULTS, get_aliases, get_param
+from ..constants import DEFAULTS, REMESH_DEFAULTS, get_param
+from ..constants.aliases import ALIAS_EPI
 from ..rng import make_rng
 from ..types import RemeshMeta
 from ..utils import cached_import, edge_version_update, kahan_sum_nd
@@ -48,9 +49,6 @@ def _ordered_edge(u: Hashable, v: Hashable) -> RemeshEdge:
     """Return a deterministic ordering for an undirected edge."""
 
     return (u, v) if repr(u) <= repr(v) else (v, u)
-
-
-ALIAS_EPI = get_aliases("EPI")
 
 
 COOLDOWN_KEY = "REMESH_COOLDOWN_WINDOW"

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -16,7 +16,8 @@ from .config.constants import (
     ANGLE_MAP,
     GLYPHS_CANONICAL,
 )
-from .constants import get_aliases, get_graph_param
+from .constants import get_graph_param
+from .constants.aliases import ALIAS_EPI, ALIAS_SI
 from .glyph_history import append_metric, count_glyphs, ensure_history
 from .glyph_runtime import last_glyph
 from .utils import clamp01, kahan_sum_nd
@@ -71,9 +72,6 @@ def glyph_unit(g: str) -> complex:
 
     return _resolve_glyph(g, GLYPH_UNITS)
 
-
-ALIAS_SI = get_aliases("SI")
-ALIAS_EPI = get_aliases("EPI")
 
 MODE_FUNCS: dict[str, Callable[[Mapping[str, Any]], float]] = {
     "Si": lambda nd: clamp01(get_attr(nd, ALIAS_SI, 0.5)),

--- a/src/tnfr/validation/graph.py
+++ b/src/tnfr/validation/graph.py
@@ -7,7 +7,8 @@ from collections.abc import Sequence
 from ..alias import get_attr
 from ..glyph_runtime import last_glyph
 from ..config.constants import GLYPHS_CANONICAL_SET
-from ..constants import get_aliases, get_param
+from ..constants import get_param
+from ..constants.aliases import ALIAS_EPI, ALIAS_VF
 from ..utils import within_range
 from ..types import (
     EPIValue,
@@ -17,9 +18,6 @@ from ..types import (
     TNFRGraph,
     ValidatorFunc,
 )
-ALIAS_EPI = get_aliases("EPI")
-ALIAS_VF = get_aliases("VF")
-
 NodeData = NodeAttrMap
 """Read-only node attribute mapping used by validators."""
 

--- a/src/tnfr/validation/rules.py
+++ b/src/tnfr/validation/rules.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Mapping
 
 from ..alias import get_attr
-from ..constants import get_aliases
+from ..constants.aliases import ALIAS_SI
 from ..utils import clamp01
 from ..metrics.common import normalize_dnfr
 from ..types import Glyph
@@ -19,8 +19,6 @@ from .compatibility import CANON_COMPAT, CANON_FALLBACK
 
 if TYPE_CHECKING:  # pragma: no cover - only for typing
     from .grammar import GrammarContext
-
-ALIAS_SI = get_aliases("SI")
 
 __all__ = [
     "coerce_glyph",

--- a/src/tnfr/validation/soft_filters.py
+++ b/src/tnfr/validation/soft_filters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable
 
 from ..alias import get_attr
-from ..constants import get_aliases
+from ..constants.aliases import ALIAS_D2EPI
 from ..glyph_history import recent_glyph
 from ..types import Glyph
 from ..utils import clamp01
@@ -14,8 +14,6 @@ from .rules import glyph_fallback, get_norm, normalized_dnfr
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard
     from collections.abc import Mapping
     from .grammar import GrammarContext
-
-ALIAS_D2EPI = get_aliases("D2EPI")
 
 __all__ = (
     "acceleration_norm",

--- a/tests/unit/structural/test_alias_constants.py
+++ b/tests/unit/structural/test_alias_constants.py
@@ -1,0 +1,41 @@
+"""Ensure canonical alias constants remain synchronized with registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from tnfr.constants import get_aliases
+from tnfr.constants.aliases import (
+    ALIAS_D2EPI,
+    ALIAS_D2VF,
+    ALIAS_DEPI,
+    ALIAS_DNFR,
+    ALIAS_DSI,
+    ALIAS_DVF,
+    ALIAS_EPI,
+    ALIAS_EPI_KIND,
+    ALIAS_SI,
+    ALIAS_THETA,
+    ALIAS_VF,
+)
+
+_ALIAS_MAP = {
+    "D2EPI": ALIAS_D2EPI,
+    "D2VF": ALIAS_D2VF,
+    "DEPI": ALIAS_DEPI,
+    "DNFR": ALIAS_DNFR,
+    "DSI": ALIAS_DSI,
+    "DVF": ALIAS_DVF,
+    "EPI": ALIAS_EPI,
+    "EPI_KIND": ALIAS_EPI_KIND,
+    "SI": ALIAS_SI,
+    "THETA": ALIAS_THETA,
+    "VF": ALIAS_VF,
+}
+
+
+@pytest.mark.parametrize("key, alias", sorted(_ALIAS_MAP.items()))
+def test_alias_constants_match_registry(key: str, alias: tuple[str, ...]) -> None:
+    """Alias constants must match the canonical registry entries."""
+
+    assert alias == get_aliases(key)


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add `tnfr.constants.aliases` as the shared source of canonical `ALIAS_*` tuples and keep `tnfr.dynamics.aliases` re-exporting them
- update dynamics, metrics, validation, node, operator, and sense modules to import their alias constants from the new shared module
- introduce a structural regression test ensuring the exported alias tuples remain synchronized with `get_aliases`

## Testing
- `pytest tests/unit/structural/test_alias_constants.py`


------
https://chatgpt.com/codex/tasks/task_e_6904ad1148588321af8ab8c21bd1815b