### PR TITLE
Refactor spectral validator to use canonical runtime helpers

### DIFF
--- a/tests/unit/mathematics/test_nfr_validator.py
+++ b/tests/unit/mathematics/test_nfr_validator.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import numpy as np
 
 from tnfr.mathematics import CoherenceOperator, FrequencyOperator, HilbertSpace
+from tnfr.mathematics.runtime import (
+    coherence as runtime_coherence,
+    frequency_positive as runtime_frequency_positive,
+    normalized as runtime_normalized,
+    stable_unitary as runtime_stable_unitary,
+)
 from tnfr.validation import ValidationOutcome
 from tnfr.validation.spectral import NFRValidator
 
@@ -90,3 +96,59 @@ def test_validator_frequency_negativity_flagged() -> None:
     assert summary["frequency"]["passed"] is False
     assert "frequency positivity" in validator.report(outcome)
     assert validator.validate_state(state) == (False, summary)
+
+
+def test_validator_summary_matches_runtime_helpers() -> None:
+    validator = _make_simple_validator()
+    state = np.array([1.0 + 0.0j, 1.0j + 0.0j]) / np.sqrt(2.0)
+
+    outcome = validator.validate(state)
+    summary = outcome.summary
+
+    normalised_passed, norm_value = runtime_normalized(
+        state, validator.hilbert_space, atol=validator.atol
+    )
+    assert summary["normalized"] is normalised_passed
+
+    normalised_state = state / norm_value
+
+    coherence_passed, coherence_value = runtime_coherence(
+        normalised_state,
+        validator.coherence_operator,
+        validator.coherence_threshold,
+        normalise=False,
+        atol=validator.atol,
+    )
+    assert summary["coherence"] == {
+        "passed": coherence_passed,
+        "value": coherence_value,
+        "threshold": validator.coherence_threshold,
+    }
+
+    frequency_expected = runtime_frequency_positive(
+        normalised_state,
+        validator.frequency_operator,
+        normalise=False,
+        enforce=True,
+        atol=validator.atol,
+    )
+    frequency_expected = {
+        **frequency_expected,
+        "enforced": frequency_expected["enforce"],
+    }
+    frequency_expected.pop("enforce", None)
+    assert summary["frequency"] == frequency_expected
+
+    unitary_passed, unitary_norm = runtime_stable_unitary(
+        normalised_state,
+        validator.coherence_operator,
+        validator.hilbert_space,
+        normalise=False,
+        atol=validator.atol,
+    )
+    assert summary["unitary_stability"] == {
+        "passed": unitary_passed,
+        "norm_after": unitary_norm,
+    }
+
+    assert np.allclose(outcome.artifacts["normalised_state"], normalised_state)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Delegate spectral validator normalization, coherence, frequency, and unitary checks to the canonical runtime helpers while preserving ValidationOutcome glue.
- Normalize artifacts through the Hilbert space projection and keep enforcement semantics stable for frequency positivity reporting.
- Add regression coverage that compares validator summaries with the runtime helper outputs to ensure behavioral equivalence.

## Testing
- python -m pytest tests/unit/mathematics/test_nfr_validator.py

------
https://chatgpt.com/codex/tasks/task_e_6904b1653e44832196080c8aaee0f3a0