### PR TITLE
Add BEPIElement algebra and delegate Banach operations

### DIFF
--- a/docs/foundations.md
+++ b/docs/foundations.md
@@ -16,7 +16,16 @@ level operators.
 
 1. **Select a space** – use :class:`tnfr.mathematics.HilbertSpace` for discrete
    spectral experiments or :class:`tnfr.mathematics.BanachSpaceEPI` when mixing
-   the continuous EPI tail.
+   the continuous EPI tail.  The Banach constructor now ships with
+   :class:`tnfr.mathematics.BEPIElement`, a dataclass that keeps the trio
+   ``(f_continuous, a_discrete, x_grid)`` coherent and exposes the EPI algebra
+   ``⊕``/:meth:`~tnfr.mathematics.BEPIElement.direct_sum`, ``⊗``/
+   :meth:`~tnfr.mathematics.BEPIElement.tensor`, ``*``/
+   :meth:`~tnfr.mathematics.BEPIElement.adjoint` and ``∘``/
+   :meth:`~tnfr.mathematics.BEPIElement.compose`.  Factor helpers on
+   :class:`~tnfr.mathematics.BanachSpaceEPI` generate zero elements, canonical
+   basis vectors and Hilbert tensors so that ΔNFR operators always receive
+   validated inputs.
 2. **Construct ΔNFR** – call :func:`tnfr.mathematics.build_delta_nfr` with a
    topology (``"laplacian"`` or ``"adjacency"``) and νf scaling.  The helper
    guarantees a Hermitian generator so downstream coherence checks remain

--- a/src/tnfr/mathematics/__init__.py
+++ b/src/tnfr/mathematics/__init__.py
@@ -1,6 +1,7 @@
 """Mathematics primitives aligned with TNFR coherence modeling."""
 
 from .dynamics import MathematicalDynamicsEngine
+from .epi import BEPIElement
 from .generators import build_delta_nfr
 from .operators import CoherenceOperator, FrequencyOperator
 from .operators_factory import make_coherence_operator, make_frequency_operator
@@ -25,6 +26,7 @@ from ..validation import NFRValidator
 __all__ = [
     "HilbertSpace",
     "BanachSpaceEPI",
+    "BEPIElement",
     "CoherenceOperator",
     "FrequencyOperator",
     "MathematicalDynamicsEngine",

--- a/src/tnfr/mathematics/epi.py
+++ b/src/tnfr/mathematics/epi.py
@@ -1,0 +1,124 @@
+"""EPI elements and algebraic helpers for the TNFR Banach space."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+import numpy as np
+
+
+class _EPIValidators:
+    """Shared validation helpers for EPI Banach constructions."""
+
+    _complex_dtype = np.complex128
+
+    @staticmethod
+    def _as_array(values: Sequence[complex] | np.ndarray, *, dtype: np.dtype) -> np.ndarray:
+        array = np.asarray(values, dtype=dtype)
+        if array.ndim != 1:
+            raise ValueError("Inputs must be one-dimensional arrays.")
+        if not np.all(np.isfinite(array)):
+            raise ValueError("Inputs must not contain NaNs or infinities.")
+        return array
+
+    @classmethod
+    def _validate_grid(cls, grid: Sequence[float] | np.ndarray, expected_size: int) -> np.ndarray:
+        array = np.asarray(grid, dtype=float)
+        if array.ndim != 1:
+            raise ValueError("x_grid must be one-dimensional.")
+        if array.size != expected_size:
+            raise ValueError("x_grid length must match continuous component.")
+        if array.size < 2:
+            raise ValueError("x_grid must contain at least two points.")
+        if not np.all(np.isfinite(array)):
+            raise ValueError("x_grid must not contain NaNs or infinities.")
+
+        spacings = np.diff(array)
+        if np.any(spacings <= 0):
+            raise ValueError("x_grid must be strictly increasing.")
+        if not np.allclose(spacings, spacings[0], rtol=1e-9, atol=1e-12):
+            raise ValueError("x_grid must be uniform for finite-difference stability.")
+        return array
+
+    @classmethod
+    def validate_domain(
+        cls,
+        f_continuous: Sequence[complex] | np.ndarray,
+        a_discrete: Sequence[complex] | np.ndarray,
+        x_grid: Sequence[float] | np.ndarray | None = None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
+        """Validate dimensionality and sampling grid compatibility."""
+
+        f_array = cls._as_array(f_continuous, dtype=cls._complex_dtype)
+        a_array = cls._as_array(a_discrete, dtype=cls._complex_dtype)
+
+        if x_grid is None:
+            return f_array, a_array, None
+
+        grid_array = cls._validate_grid(x_grid, f_array.size)
+        return f_array, a_array, grid_array
+
+
+@dataclass(frozen=True)
+class BEPIElement(_EPIValidators):
+    """Concrete :math:`C^0([0,1]) \oplus \ell^2` element with TNFR operations."""
+
+    f_continuous: Sequence[complex] | np.ndarray
+    a_discrete: Sequence[complex] | np.ndarray
+    x_grid: Sequence[float] | np.ndarray
+
+    def __post_init__(self) -> None:
+        f_array, a_array, grid = self.validate_domain(self.f_continuous, self.a_discrete, self.x_grid)
+        if grid is None:
+            raise ValueError("x_grid is mandatory for BEPIElement instances.")
+        object.__setattr__(self, "f_continuous", f_array)
+        object.__setattr__(self, "a_discrete", a_array)
+        object.__setattr__(self, "x_grid", grid)
+
+    def _assert_compatible(self, other: BEPIElement) -> None:
+        if self.f_continuous.shape != other.f_continuous.shape:
+            raise ValueError("Continuous components must share shape for direct sums.")
+        if self.a_discrete.shape != other.a_discrete.shape:
+            raise ValueError("Discrete tails must share shape for direct sums.")
+        if not np.allclose(self.x_grid, other.x_grid, rtol=1e-12, atol=1e-12):
+            raise ValueError("x_grid must match to combine EPI elements.")
+
+    def direct_sum(self, other: BEPIElement) -> BEPIElement:
+        """Return the algebraic direct sum ``self ⊕ other``."""
+
+        self._assert_compatible(other)
+        return BEPIElement(self.f_continuous + other.f_continuous, self.a_discrete + other.a_discrete, self.x_grid)
+
+    def tensor(self, vector: Sequence[complex] | np.ndarray) -> np.ndarray:
+        """Return the tensor product between the discrete tail and a Hilbert vector."""
+
+        hilbert_vector = self._as_array(vector, dtype=self._complex_dtype)
+        return np.outer(self.a_discrete, hilbert_vector)
+
+    def adjoint(self) -> BEPIElement:
+        """Return the conjugate element representing the ``*`` operation."""
+
+        return BEPIElement(np.conjugate(self.f_continuous), np.conjugate(self.a_discrete), self.x_grid)
+
+    @staticmethod
+    def _apply_transform(transform: Callable[[np.ndarray], np.ndarray], values: np.ndarray) -> np.ndarray:
+        result = np.asarray(transform(values), dtype=np.complex128)
+        if result.shape != values.shape:
+            raise ValueError("Transforms must preserve the element shape.")
+        if not np.all(np.isfinite(result)):
+            raise ValueError("Transforms must return finite values.")
+        return result
+
+    def compose(
+        self,
+        transform: Callable[[np.ndarray], np.ndarray],
+        *,
+        spectral_transform: Callable[[np.ndarray], np.ndarray] | None = None,
+    ) -> BEPIElement:
+        """Compose the element with linear transforms on both components."""
+
+        new_f = self._apply_transform(transform, self.f_continuous)
+        spectral_fn = spectral_transform or transform
+        new_a = self._apply_transform(spectral_fn, self.a_discrete)
+        return BEPIElement(new_f, new_a, self.x_grid)
+

--- a/tests/mathematics/test_epi.py
+++ b/tests/mathematics/test_epi.py
@@ -1,0 +1,143 @@
+"""Tests for EPI elements and Banach space delegation."""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from tnfr.mathematics import BEPIElement, BanachSpaceEPI, HilbertSpace
+
+
+@pytest.fixture()
+def sample_grid() -> np.ndarray:
+    return np.linspace(0.0, 1.0, 4)
+
+
+@pytest.fixture()
+def sample_elements(sample_grid: np.ndarray) -> tuple[BEPIElement, BEPIElement]:
+    first = BEPIElement(
+        np.array([0.0 + 0.0j, 0.2 + 0.5j, -0.1 + 0.1j, 0.3 + 0.0j]),
+        np.array([1.0 + 0.0j, 0.5 + 0.0j], dtype=np.complex128),
+        sample_grid,
+    )
+    second = BEPIElement(
+        np.array([0.1 + 0.0j, -0.1 + 0.1j, 0.2 - 0.2j, 0.0 + 0.0j]),
+        np.array([-0.5 + 0.0j, 0.0 + 0.5j], dtype=np.complex128),
+        sample_grid,
+    )
+    return first, second
+
+
+def test_direct_sum_preserves_norm_structure(sample_elements: tuple[BEPIElement, BEPIElement]) -> None:
+    space = BanachSpaceEPI()
+    element_a, element_b = sample_elements
+
+    combined = space.direct_sum(element_a, element_b)
+
+    np.testing.assert_allclose(
+        combined.f_continuous,
+        element_a.f_continuous + element_b.f_continuous,
+    )
+    np.testing.assert_allclose(
+        combined.a_discrete,
+        element_a.a_discrete + element_b.a_discrete,
+    )
+
+    expected_norm = space.coherence_norm(
+        element_a.f_continuous + element_b.f_continuous,
+        element_a.a_discrete + element_b.a_discrete,
+        x_grid=combined.x_grid,
+    )
+    combined_norm = space.coherence_norm(
+        combined.f_continuous,
+        combined.a_discrete,
+        x_grid=combined.x_grid,
+    )
+    assert combined_norm == pytest.approx(expected_norm)
+
+
+def test_adjoint_inverts_phase(sample_elements: tuple[BEPIElement, BEPIElement]) -> None:
+    space = BanachSpaceEPI()
+    element_a, _ = sample_elements
+
+    adjoint = space.adjoint(element_a)
+
+    np.testing.assert_allclose(adjoint.f_continuous, np.conjugate(element_a.f_continuous))
+    np.testing.assert_allclose(adjoint.a_discrete, np.conjugate(element_a.a_discrete))
+
+    original_norm = space.coherence_norm(
+        element_a.f_continuous,
+        element_a.a_discrete,
+        x_grid=element_a.x_grid,
+    )
+    adjoint_norm = space.coherence_norm(
+        adjoint.f_continuous,
+        adjoint.a_discrete,
+        x_grid=adjoint.x_grid,
+    )
+    assert original_norm == pytest.approx(adjoint_norm)
+
+
+def test_tensor_with_hilbert_matches_outer_product(sample_elements: tuple[BEPIElement, BEPIElement]) -> None:
+    element_a, _ = sample_elements
+    hilbert = HilbertSpace(dimension=2)
+    vector = np.array([1.0 + 0.0j, 1.0j], dtype=hilbert.dtype)
+
+    tensor = element_a.tensor(vector)
+    via_space = BanachSpaceEPI().tensor_with_hilbert(element_a, hilbert, vector)
+
+    expected = np.outer(element_a.a_discrete, vector)
+    np.testing.assert_allclose(tensor, expected)
+    np.testing.assert_allclose(via_space, expected)
+
+
+def test_compose_applies_componentwise(sample_elements: tuple[BEPIElement, BEPIElement]) -> None:
+    space = BanachSpaceEPI()
+    element_a, _ = sample_elements
+
+    scaled = space.compose(
+        element_a,
+        lambda values: 2.0 * values,
+        spectral_transform=lambda values: values + 1.0,
+    )
+
+    np.testing.assert_allclose(scaled.f_continuous, 2.0 * element_a.f_continuous)
+    np.testing.assert_allclose(scaled.a_discrete, element_a.a_discrete + 1.0)
+
+    scaled_norm = space.coherence_norm(
+        scaled.f_continuous,
+        scaled.a_discrete,
+        x_grid=scaled.x_grid,
+    )
+    manual_norm = space.coherence_norm(
+        2.0 * element_a.f_continuous,
+        element_a.a_discrete + 1.0,
+        x_grid=element_a.x_grid,
+    )
+    assert scaled_norm == pytest.approx(manual_norm)
+
+
+def test_zero_and_basis_factories(sample_grid: np.ndarray) -> None:
+    space = BanachSpaceEPI()
+
+    zero = space.zero_element(continuous_size=4, discrete_size=3, x_grid=sample_grid)
+    assert isinstance(zero, BEPIElement)
+    assert np.allclose(zero.f_continuous, 0.0)
+    assert np.allclose(zero.a_discrete, 0.0)
+
+    basis = space.canonical_basis(
+        continuous_size=4,
+        discrete_size=3,
+        continuous_index=2,
+        discrete_index=1,
+        x_grid=sample_grid,
+    )
+    assert basis.f_continuous[2] == pytest.approx(1.0)
+    assert np.count_nonzero(basis.f_continuous) == 1
+    assert basis.a_discrete[1] == pytest.approx(1.0)
+    assert np.count_nonzero(basis.a_discrete) == 1
+
+    combined = space.direct_sum(zero, basis)
+    np.testing.assert_allclose(combined.f_continuous, basis.f_continuous)
+    np.testing.assert_allclose(combined.a_discrete, basis.a_discrete)


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [x] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add a BEPIElement dataclass that centralises the EPI direct sum, tensor, adjoint and composition operations while reusing the Banach validators
- delegate BanachSpaceEPI factories and tensor helpers to the new element, including neutral and canonical basis constructors
- document the BEPIElement workflow in the mathematics guide and add unit tests covering the algebra and induced coherence norms

## Testing
- `pytest tests/mathematics/test_spaces.py tests/mathematics/test_epi.py`


------
https://chatgpt.com/codex/tasks/task_e_6904bc16004483219a3f9689fe486415