### PR TITLE
Align EPI attribute handling with BEPI serialization

### DIFF
--- a/src/tnfr/mathematics/epi.py
+++ b/src/tnfr/mathematics/epi.py
@@ -122,3 +122,17 @@ class BEPIElement(_EPIValidators):
         new_a = self._apply_transform(spectral_fn, self.a_discrete)
         return BEPIElement(new_f, new_a, self.x_grid)
 
+    def _max_magnitude(self) -> float:
+        mags = []
+        if self.f_continuous.size:
+            mags.append(float(np.max(np.abs(self.f_continuous))))
+        if self.a_discrete.size:
+            mags.append(float(np.max(np.abs(self.a_discrete))))
+        return float(max(mags)) if mags else 0.0
+
+    def __float__(self) -> float:
+        return self._max_magnitude()
+
+    def __abs__(self) -> float:
+        return self._max_magnitude()
+

--- a/src/tnfr/types.pyi
+++ b/src/tnfr/types.pyi
@@ -1,4 +1,10 @@
-from collections.abc import Hashable, Mapping, MutableMapping, MutableSequence, Sequence
+from collections.abc import (
+    Hashable,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Sequence,
+)
 from enum import Enum
 from typing import Any, Callable, ContextManager, Iterable, Protocol, TypedDict, cast
 
@@ -34,6 +40,10 @@ __all__: tuple[str, ...] = (
     "Node",
     "GammaSpec",
     "EPIValue",
+    "BEPIProtocol",
+    "ensure_bepi",
+    "serialize_bepi",
+    "ZERO_BEPI_STORAGE",
     "DeltaNFR",
     "SecondDerivativeEPI",
     "Phase",
@@ -104,7 +114,12 @@ Node: TypeAlias = NodeId
 NodeInitAttrMap: TypeAlias = MutableMapping[str, float]
 NodeAttrMap: TypeAlias = Mapping[str, Any]
 GammaSpec: TypeAlias = Mapping[str, Any]
-EPIValue: TypeAlias = float
+class BEPIProtocol(Protocol): ...
+
+EPIValue: TypeAlias = BEPIProtocol
+ZERO_BEPI_STORAGE: dict[str, tuple[complex, ...] | tuple[float, ...]]
+def ensure_bepi(value: Any) -> "BEPIElement": ...
+def serialize_bepi(value: Any) -> dict[str, tuple[complex, ...] | tuple[float, ...]]: ...
 DeltaNFR: TypeAlias = float
 SecondDerivativeEPI: TypeAlias = float
 Phase: TypeAlias = float

--- a/src/tnfr/validation/graph.py
+++ b/src/tnfr/validation/graph.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Sequence
+
+import numpy as np
+
 from ..alias import get_attr
 from ..glyph_runtime import last_glyph
 from ..config.constants import GLYPHS_CANONICAL_SET
@@ -17,6 +20,7 @@ from ..types import (
     StructuralFrequency,
     TNFRGraph,
     ValidatorFunc,
+    ensure_bepi,
 )
 NodeData = NodeAttrMap
 """Read-only node attribute mapping used by validators."""
@@ -27,20 +31,35 @@ AliasSequence = Sequence[str]
 __all__ = ("run_validators", "GRAPH_VALIDATORS")
 
 
+def _materialize_node_mapping(data: NodeData) -> dict[str, object]:
+    if isinstance(data, dict):
+        return data
+    return dict(data)
+
+
 def _require_attr(
     data: NodeData, alias: AliasSequence, node: NodeId, name: str
 ) -> float:
-    """Return attribute value or raise if missing."""
+    """Return scalar attribute value or raise if missing."""
 
-    mapping: dict[str, object]
-    if isinstance(data, dict):
-        mapping = data
-    else:
-        mapping = dict(data)
+    mapping = _materialize_node_mapping(data)
     val = get_attr(mapping, alias, None)
     if val is None:
         raise ValueError(f"Missing {name} attribute in node {node}")
     return float(val)
+
+
+def _require_epi(data: NodeData, node: NodeId) -> EPIValue:
+    """Return a validated BEPI element stored in ``data``."""
+
+    mapping = _materialize_node_mapping(data)
+    value = get_attr(mapping, ALIAS_EPI, None, conv=lambda obj: obj)
+    if value is None:
+        raise ValueError(f"Missing EPI attribute in node {node}")
+    try:
+        return ensure_bepi(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid EPI payload in node {node}: {exc}") from exc
 
 
 def _validate_sigma(graph: TNFRGraph) -> None:
@@ -55,17 +74,28 @@ GRAPH_VALIDATORS: tuple[ValidatorFunc, ...] = (_validate_sigma,)
 """Ordered collection of graph-level validators."""
 
 
-def _check_epi_vf(
+def _max_abs(values: np.ndarray) -> float:
+    if values.size == 0:
+        return 0.0
+    return float(np.max(np.abs(values)))
+
+
+def _check_epi(
     epi: EPIValue,
-    vf: StructuralFrequency,
     epi_min: float,
     epi_max: float,
-    vf_min: float,
-    vf_max: float,
     node: NodeId,
 ) -> None:
-    _check_range(epi, epi_min, epi_max, "EPI", node)
-    _check_range(vf, vf_min, vf_max, "VF", node)
+    continuous_max = _max_abs(epi.f_continuous)
+    discrete_max = _max_abs(epi.a_discrete)
+    _check_range(continuous_max, epi_min, epi_max, "EPI continuous", node)
+    _check_range(discrete_max, epi_min, epi_max, "EPI discrete", node)
+
+    spacings = np.diff(epi.x_grid)
+    if np.any(spacings <= 0.0):
+        raise ValueError(f"EPI grid must be strictly increasing for node {node}")
+    if not np.allclose(spacings, spacings[0], rtol=1e-9, atol=1e-12):
+        raise ValueError(f"EPI grid must be uniform for node {node}")
 
 
 def _out_of_range_msg(name: str, node: NodeId, val: float) -> str:
@@ -98,9 +128,10 @@ def run_validators(graph: TNFRGraph) -> None:
     vf_max = float(get_param(graph, "VF_MAX"))
 
     for node, data in graph.nodes(data=True):
-        epi = EPIValue(_require_attr(data, ALIAS_EPI, node, "EPI"))
+        epi = _require_epi(data, node)
         vf = StructuralFrequency(_require_attr(data, ALIAS_VF, node, "VF"))
-        _check_epi_vf(epi, vf, epi_min, epi_max, vf_min, vf_max, node)
+        _check_epi(epi, epi_min, epi_max, node)
+        _check_range(vf, vf_min, vf_max, "VF", node)
         _check_glyph(last_glyph(data), node)
 
     for validator in GRAPH_VALIDATORS:

--- a/tests/unit/structural/test_bepi_node_and_validators.py
+++ b/tests/unit/structural/test_bepi_node_and_validators.py
@@ -1,0 +1,102 @@
+"""Integration tests for BEPI storage across nodes and validators."""
+
+from __future__ import annotations
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from tnfr.alias import set_attr
+from tnfr.constants.aliases import ALIAS_EPI, ALIAS_VF
+from tnfr.mathematics import BEPIElement
+from tnfr.node import NodeNX
+from tnfr.validation.graph import run_validators
+from tnfr.validation.runtime import GraphCanonicalValidator
+
+
+def _make_bepi() -> BEPIElement:
+    return BEPIElement(
+        (1.0 + 0.0j, 0.2 + 0.3j, -0.5 + 0.1j),
+        (0.1 + 0.2j, -0.3 + 0.4j, 0.5 + 0.0j),
+        (0.0, 0.5, 1.0),
+    )
+
+
+def _configure_bounds(graph: nx.Graph, *, epi_max: float = 1.0) -> None:
+    graph.graph.update({
+        "EPI_MIN": 0.0,
+        "EPI_MAX": epi_max,
+        "VF_MIN": 0.0,
+        "VF_MAX": 3.0,
+    })
+
+
+def test_nodenx_epi_roundtrip_serializes_bepi() -> None:
+    graph = nx.Graph()
+    graph.add_node("n0")
+    node = NodeNX(graph, "n0")
+
+    element = _make_bepi()
+    node.EPI = element
+
+    stored = graph.nodes["n0"][ALIAS_EPI[0]]
+    assert set(stored) == {"continuous", "discrete", "grid"}
+    np.testing.assert_allclose(np.array(stored["continuous"]), element.f_continuous)
+    np.testing.assert_allclose(np.array(stored["discrete"]), element.a_discrete)
+    np.testing.assert_allclose(np.array(stored["grid"], dtype=float), element.x_grid)
+
+    roundtrip = node.EPI
+    np.testing.assert_allclose(roundtrip.f_continuous, element.f_continuous)
+    np.testing.assert_allclose(roundtrip.a_discrete, element.a_discrete)
+    np.testing.assert_allclose(roundtrip.x_grid, element.x_grid)
+
+
+def test_graph_validators_accept_bepi_payload() -> None:
+    graph = nx.Graph()
+    _configure_bounds(graph, epi_max=2.0)
+    graph.add_node(0)
+    node = NodeNX(graph, 0)
+    node.EPI = _make_bepi()
+    node.vf = 1.5
+
+    run_validators(graph)
+
+
+def test_graph_validators_reject_malformed_bepi() -> None:
+    graph = nx.Graph()
+    _configure_bounds(graph, epi_max=2.0)
+    graph.add_node(0)
+    set_attr(graph.nodes[0], ALIAS_VF, 1.0)
+    malformed = {
+        "continuous": (1.0 + 0.0j, 0.5 + 0.1j),
+        "discrete": (0.1 + 0.2j, 0.2 + 0.3j),
+        "grid": (0.0, 0.25, 0.5),
+    }
+    graph.nodes[0][ALIAS_EPI[0]] = malformed
+
+    with pytest.raises(ValueError):
+        run_validators(graph)
+
+
+def test_runtime_validator_clamps_bepi_components() -> None:
+    graph = nx.Graph()
+    _configure_bounds(graph, epi_max=0.4)
+    graph.add_node(0)
+    node = NodeNX(graph, 0)
+
+    exaggerated = BEPIElement(
+        (1.2 + 0.0j, -0.9 + 0.4j, 0.3 + 0.9j),
+        (0.9 + 0.6j, -1.2 + 0.0j, 0.5 + 0.2j),
+        (0.0, 0.5, 1.0),
+    )
+    node.EPI = exaggerated
+    node.vf = 2.5
+
+    validator = GraphCanonicalValidator()
+    outcome = validator.validate(graph)
+
+    assert outcome.passed
+    clamped = node.EPI
+    assert np.max(np.abs(clamped.f_continuous)) <= 0.4 + 1e-12
+    assert np.max(np.abs(clamped.a_discrete)) <= 0.4 + 1e-12
+


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Promote `EPIValue` to a BEPI-aware protocol with helpers to normalise and serialise elements.
- Adapt `NodeNX` accessors plus graph and runtime validators to clamp and validate BEPI payloads.
- Extend `BEPIElement` numeric behaviour and add structural tests covering BEPI round-trips and validation paths.
- `pytest tests/unit/structural/test_bepi_node_and_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_6904bdc9da3c8321ac78984a7416d1f2