### PR TITLE
Align coherence metric numerator with operator weighting

### DIFF
--- a/src/tnfr/mathematics/metrics.py
+++ b/src/tnfr/mathematics/metrics.py
@@ -75,7 +75,9 @@ def dcoh(
         vector1_norm = vector1
         vector2_norm = vector2
 
-    overlap = np.vdot(vector1_norm, vector2_norm)
+    cross = np.vdot(vector1_norm, operator.matrix @ vector2_norm)
+    if not np.isfinite(cross):
+        raise ValueError("Operator-weighted overlap produced a non-finite value.")
 
     expect1 = float(operator.expectation(vector1, normalise=normalise, atol=atol))
     expect2 = float(operator.expectation(vector2, normalise=normalise, atol=atol))
@@ -98,7 +100,7 @@ def dcoh(
             " evaluate dissimilarity."
         )
 
-    ratio = (np.abs(overlap) ** 2) / denominator
+    ratio = (np.abs(cross) ** 2) / denominator
     eps = max(np.finfo(float).eps * 10.0, atol)
     if ratio < -eps:
         raise ValueError("Overlap produced a negative coherence ratio.")

--- a/tests/mathematics/test_metrics.py
+++ b/tests/mathematics/test_metrics.py
@@ -34,6 +34,18 @@ def test_dcoh_identity_returns_zero(
     assert result == pytest.approx(0.0, abs=1e-12)
 
 
+def test_dcoh_identity_superposition(
+    hermitian_operator: CoherenceOperator, orthonormal_basis: tuple[np.ndarray, np.ndarray]
+) -> None:
+    """Non-eigenstates remain coherent with themselves under any operator."""
+
+    psi1, psi2 = orthonormal_basis
+    superposition = (psi1 + psi2) / np.sqrt(2.0)
+
+    result = dcoh(superposition, superposition, hermitian_operator)
+    assert result == pytest.approx(0.0, abs=1e-12)
+
+
 def test_dcoh_is_symmetric(
     hermitian_operator: CoherenceOperator, orthonormal_basis: tuple[np.ndarray, np.ndarray]
 ) -> None:


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6904c6e1b88c83218faaeaf91955b871