### PR TITLE
Align dcoh dissimilarity with orthogonality expectations

### DIFF
--- a/src/tnfr/mathematics/metrics.py
+++ b/src/tnfr/mathematics/metrics.py
@@ -75,9 +75,9 @@ def dcoh(
         vector1_norm = vector1
         vector2_norm = vector2
 
-    cross = np.vdot(vector1_norm, operator.matrix @ vector2_norm)
+    cross = np.vdot(vector1_norm, vector2_norm)
     if not np.isfinite(cross):
-        raise ValueError("Operator-weighted overlap produced a non-finite value.")
+        raise ValueError("State overlap produced a non-finite value.")
 
     expect1 = float(operator.expectation(vector1, normalise=normalise, atol=atol))
     expect2 = float(operator.expectation(vector2, normalise=normalise, atol=atol))

--- a/tests/mathematics/test_metrics.py
+++ b/tests/mathematics/test_metrics.py
@@ -60,6 +60,18 @@ def test_dcoh_is_symmetric(
     assert forward == pytest.approx(backward, rel=1e-12, abs=1e-12)
 
 
+def test_dcoh_orthogonal_states_are_maximally_dissimilar(
+    hermitian_operator: CoherenceOperator, orthonormal_basis: tuple[np.ndarray, np.ndarray]
+) -> None:
+    """Orthogonal basis vectors must yield maximal coherence dissimilarity."""
+
+    psi1, psi2 = orthonormal_basis
+
+    result = dcoh(psi1, psi2, hermitian_operator)
+
+    assert result == pytest.approx(1.0, abs=1e-12)
+
+
 def test_dcoh_satisfies_triangle_inequality(
     hermitian_operator: CoherenceOperator, orthonormal_basis: tuple[np.ndarray, np.ndarray]
 ) -> None:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6904c9452f188321842011328cec00a7