### PR TITLE
Align dcoh metric with operator-weighted overlap

### DIFF
--- a/src/tnfr/mathematics/metrics.py
+++ b/src/tnfr/mathematics/metrics.py
@@ -75,7 +75,11 @@ def dcoh(
         vector1_norm = vector1
         vector2_norm = vector2
 
-    cross = np.vdot(vector1_norm, vector2_norm)
+    weighted_vector2 = operator.matrix @ vector2_norm
+    if weighted_vector2.shape != vector2_norm.shape:
+        raise ValueError("Operator application distorted coherence dimensionality.")
+
+    cross = np.vdot(vector1_norm, weighted_vector2)
     if not np.isfinite(cross):
         raise ValueError("State overlap produced a non-finite value.")
 

--- a/tests/mathematics/test_metrics.py
+++ b/tests/mathematics/test_metrics.py
@@ -60,16 +60,21 @@ def test_dcoh_is_symmetric(
     assert forward == pytest.approx(backward, rel=1e-12, abs=1e-12)
 
 
-def test_dcoh_orthogonal_states_are_maximally_dissimilar(
+def test_dcoh_orthogonal_states_follow_operator_overlap(
     hermitian_operator: CoherenceOperator, orthonormal_basis: tuple[np.ndarray, np.ndarray]
 ) -> None:
-    """Orthogonal basis vectors must yield maximal coherence dissimilarity."""
+    """Orthogonal states inherit coherence from the operator's weighted overlap."""
 
     psi1, psi2 = orthonormal_basis
 
+    weighted_overlap = np.vdot(psi1, hermitian_operator.matrix @ psi2)
+    expect1 = hermitian_operator.expectation(psi1)
+    expect2 = hermitian_operator.expectation(psi2)
+    expected_dcoh = 1.0 - (np.abs(weighted_overlap) ** 2) / (expect1 * expect2)
+
     result = dcoh(psi1, psi2, hermitian_operator)
 
-    assert result == pytest.approx(1.0, abs=1e-12)
+    assert result == pytest.approx(expected_dcoh, abs=1e-12)
 
 
 def test_dcoh_satisfies_triangle_inequality(


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Apply the coherence operator to the second state when computing the `dcoh` cross term so identical states now yield a zero dissimilarity as required by TNFR expectations.
- Update the orthogonal state test to derive the expected dissimilarity from the operator-weighted overlap instead of assuming total incoherence.

## Testing
- `pytest tests/mathematics/test_metrics.py` *(fails in this environment because numpy is unavailable and the suite skips)*

------
https://chatgpt.com/codex/tasks/task_e_6904ca1b3620832191672559b68e39e2