### PR TITLE
Expose math-engine controls in the CLI and log spectral validation

### DIFF
--- a/src/tnfr/cli/arguments.py
+++ b/src/tnfr/cli/arguments.py
@@ -123,6 +123,7 @@ def add_canon_toggle(parser: argparse.ArgumentParser) -> None:
 
 def _add_run_parser(sub: argparse._SubParsersAction) -> None:
     """Configure the ``run`` subcommand."""
+
     from .execution import DEFAULT_SUMMARY_SERIES_LIMIT, cmd_run
 
     p_run = sub.add_parser(
@@ -166,6 +167,64 @@ def _add_run_parser(sub: argparse._SubParsersAction) -> None:
             " disable trimming)"
         ),
     )
+
+    math_group = p_run.add_argument_group("Mathematical dynamics")
+    math_group.add_argument(
+        "--math-engine",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Enable the spectral mathematical dynamics engine to project nodes"
+            " onto Hilbert space vectors and validate norm, coherence and"
+            " structural frequency invariants"
+        ),
+    )
+    math_group.add_argument(
+        "--math-dimension",
+        type=int,
+        help="Hilbert space dimension to use when the math engine is enabled",
+    )
+    math_group.add_argument(
+        "--math-coherence-spectrum",
+        type=float,
+        nargs="+",
+        metavar="λ",
+        help=(
+            "Eigenvalues for the coherence operator (defaults to a flat"
+            " spectrum when omitted)"
+        ),
+    )
+    math_group.add_argument(
+        "--math-coherence-c-min",
+        type=float,
+        help="Explicit coherence floor C_min for the operator",
+    )
+    math_group.add_argument(
+        "--math-coherence-threshold",
+        type=float,
+        help="Coherence expectation threshold enforced during validation",
+    )
+    math_group.add_argument(
+        "--math-frequency-diagonal",
+        type=float,
+        nargs="+",
+        metavar="ν",
+        help=(
+            "Diagonal entries for the structural frequency operator"
+            " (defaults to the identity spectrum)"
+        ),
+    )
+    math_group.add_argument(
+        "--math-generator-diagonal",
+        type=float,
+        nargs="+",
+        metavar="ω",
+        help=(
+            "Diagonal ΔNFR generator used by the mathematical dynamics"
+            " engine (defaults to the null generator)"
+        ),
+    )
+
     p_run.set_defaults(func=cmd_run)
 
 

--- a/tests/cli/test_math_engine_run.py
+++ b/tests/cli/test_math_engine_run.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import copy
+
+import networkx as nx  # type: ignore[import-untyped]
+import pytest
+
+from tnfr.cli import main
+
+
+def test_math_engine_cli_preserves_classic_metrics(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Ensure math-engine runs report extra summaries without altering runtime state."""
+
+    recorded_runs: list[dict[str, object]] = []
+
+    def fake_build_basic_graph(args):  # noqa: ANN001 - test helper signature
+        graph = nx.Graph()
+        graph.add_node(0, EPI=0.9, vf=0.8, theta=0.1)
+        graph.add_node(1, EPI=0.6, vf=0.7, theta=-0.2)
+        graph.graph["COHERENCE"] = {"enabled": False}
+        graph.graph["DIAGNOSIS"] = {"enabled": False}
+        graph.graph["history"] = {"W_stats": [], "nodal_diag": []}
+        return graph
+
+    def fake_prepare_network(graph):  # noqa: ANN001 - integration helper
+        return graph
+
+    def fake_register_callbacks(graph):  # noqa: ANN001 - integration helper
+        graph.graph.setdefault("hooks", {})["registered"] = True
+
+    def fake_ensure_history(graph):  # noqa: ANN001 - integration helper
+        return graph.graph.setdefault("history", {"W_stats": [], "nodal_diag": []})
+
+    def fake_run(graph, *, steps, dt=None, use_Si=True, apply_glyphs=True, n_jobs=None):
+        for _, data in graph.nodes(data=True):
+            data["EPI"] = float(data["EPI"]) * 0.95
+            data["vf"] = float(data["vf"]) + 0.02
+            data["theta"] = float(data["theta"]) + 0.01
+        history = graph.graph.setdefault("history", {"W_stats": [], "nodal_diag": []})
+        history.setdefault("C_steps", []).append({"step": steps, "dt": dt})
+        return None
+
+    execution_mod = pytest.importorskip("tnfr.cli.execution")
+    original_run_program = execution_mod.run_program
+
+    def spy_run_program(graph, program, args):  # noqa: ANN001 - integration helper
+        result_graph = original_run_program(graph, program, args)
+        recorded_runs.append(
+            {
+                "nodes": {n: dict(data) for n, data in result_graph.nodes(data=True)},
+                "history": copy.deepcopy(result_graph.graph.get("history", {})),
+            }
+        )
+        return result_graph
+
+    monkeypatch.setattr("tnfr.cli.execution.build_basic_graph", fake_build_basic_graph)
+    monkeypatch.setattr("tnfr.cli.execution.prepare_network", fake_prepare_network)
+    monkeypatch.setattr(
+        "tnfr.cli.execution.register_callbacks_and_observer", fake_register_callbacks
+    )
+    monkeypatch.setattr("tnfr.cli.execution.ensure_history", fake_ensure_history)
+    monkeypatch.setattr("tnfr.cli.execution.run", fake_run)
+    monkeypatch.setattr("tnfr.dynamics.runtime.run", fake_run)
+    monkeypatch.setattr("tnfr.cli.execution.play", lambda *_, **__: None)
+    monkeypatch.setattr(execution_mod, "run_program", spy_run_program)
+
+    rc_classic = main(["run", "--nodes", "2", "--steps", "1"])
+    assert rc_classic == 0
+    assert recorded_runs
+    classic_snapshot = recorded_runs[-1]
+    classic_output = capfd.readouterr().out
+    assert "[MATH]" not in classic_output
+
+    rc_math = main(
+        [
+            "run",
+            "--nodes",
+            "2",
+            "--steps",
+            "1",
+            "--math-engine",
+            "--math-coherence-spectrum",
+            "0.2",
+            "0.25",
+            "--math-coherence-threshold",
+            "0.18",
+            "--math-frequency-diagonal",
+            "0.4",
+            "0.5",
+            "--math-generator-diagonal",
+            "0.0",
+            "0.05",
+        ]
+    )
+    assert rc_math == 0
+    assert len(recorded_runs) >= 2
+    math_snapshot = recorded_runs[-1]
+
+    math_output = capfd.readouterr().out
+    math_logs = [line for line in math_output.splitlines() if line.startswith("[MATH]")]
+    assert math_logs, "math engine summaries should be logged"
+    assert any("Hilbert norm" in message for message in math_logs)
+    assert any("C_min" in message for message in math_logs)
+    assert any("νf positivity" in message for message in math_logs)
+
+    assert classic_snapshot["nodes"] == math_snapshot["nodes"]
+    assert classic_snapshot["history"] == math_snapshot["history"]

--- a/tests/integration/test_cli_run_execution.py
+++ b/tests/integration/test_cli_run_execution.py
@@ -139,6 +139,12 @@ def test_cli_run_handles_degenerate_stop_early(
         return result_graph
 
     monkeypatch.setattr(execution_mod, "run_program", spy_run_program)
+    def fake_register_callbacks(graph: nx.Graph) -> None:
+        hist = graph.graph.setdefault("history", {})
+        hist.setdefault("program_trace", [])
+        hist.setdefault("trace_meta", [])
+
+    monkeypatch.setattr("tnfr.cli.execution.register_callbacks_and_observer", fake_register_callbacks)
     monkeypatch.setattr("tnfr.cli.execution._log_run_summaries", lambda *_, **__: None)
 
     caplog.set_level("INFO")


### PR DESCRIPTION
## Summary
- add a dedicated "Mathematical dynamics" argument group to `tnfr run`, exposing `--math-engine` and operator configuration toggles
- build Hilbert-space operators and the mathematical dynamics engine from CLI flags, wiring validation summaries into the standard run logging
- add CLI regression coverage for math-engine runs and adjust existing stubs to accommodate the new hooks

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6904cd4b1ab88321b34786a3f40e5098