### PR TITLE
Add create_math_nfr structural factory

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -75,6 +75,21 @@ EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
         ),
         "third_party": ("networkx",),
     },
+    "create_math_nfr": {
+        "submodules": (
+            "tnfr.structural",
+            "tnfr.constants",
+            "tnfr.dynamics",
+            "tnfr.operators.definitions",
+            "tnfr.operators.registry",
+            "tnfr.validation",
+            "tnfr.mathematics",
+        ),
+        "third_party": (
+            "networkx",
+            "numpy",
+        ),
+    },
     "run_sequence": {
         "submodules": (
             "tnfr.structural",
@@ -236,7 +251,9 @@ _assign_exports("dynamics", ("step", "run"))
 _HAS_PREPARE_NETWORK = _assign_exports("ontosim", ("prepare_network",))
 
 
-_HAS_RUN_SEQUENCE = _assign_exports("structural", ("create_nfr", "run_sequence"))
+_HAS_STRUCTURAL_EXPORTS = _assign_exports(
+    "structural", ("create_nfr", "run_sequence", "create_math_nfr")
+)
 
 
 def _emit_missing_dependency_warning() -> None:
@@ -264,8 +281,8 @@ __all__ = [
     "create_nfr",
 ]
 
-if _HAS_RUN_SEQUENCE:
-    __all__.append("run_sequence")
+if _HAS_STRUCTURAL_EXPORTS:
+    __all__.extend(["run_sequence", "create_math_nfr"])
 
 
 _validate_export_dependencies()

--- a/src/tnfr/structural.pyi
+++ b/src/tnfr/structural.pyi
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Hashable, Iterable, Sequence
 
 from .operators.definitions import (
     Coherence,
@@ -20,6 +20,14 @@ from .validation import ValidationOutcome
 
 if TYPE_CHECKING:
     import networkx as nx
+    from .mathematics import (
+        BasicStateProjector,
+        CoherenceOperator,
+        FrequencyOperator,
+        HilbertSpace,
+        MathematicalDynamicsEngine,
+        NFRValidator,
+    )
 
 __all__: tuple[str, ...]
 
@@ -32,6 +40,27 @@ def create_nfr(
     theta: float = ...,
     graph: "nx.Graph" | None = ...,
     dnfr_hook: Callable[..., None] = ...,
+) -> tuple["nx.Graph", str]: ...
+def create_math_nfr(
+    name: str,
+    *,
+    epi: float = ...,
+    vf: float = ...,
+    theta: float = ...,
+    graph: "nx.Graph" | None = ...,
+    dnfr_hook: Callable[..., None] = ...,
+    dimension: int | None = ...,
+    hilbert_space: "HilbertSpace" | None = ...,
+    coherence_operator: "CoherenceOperator" | None = ...,
+    coherence_spectrum: Sequence[float] | None = ...,
+    coherence_c_min: float | None = ...,
+    coherence_threshold: float | None = ...,
+    frequency_operator: "FrequencyOperator" | None = ...,
+    frequency_diagonal: Sequence[float] | None = ...,
+    generator_diagonal: Sequence[float] | None = ...,
+    state_projector: "BasicStateProjector" | None = ...,
+    dynamics_engine: "MathematicalDynamicsEngine" | None = ...,
+    validator: "NFRValidator" | None = ...,
 ) -> tuple["nx.Graph", str]: ...
 
 OPERATORS: dict[str, Operator]

--- a/tests/unit/dynamics/test_export_dependencies.py
+++ b/tests/unit/dynamics/test_export_dependencies.py
@@ -38,7 +38,7 @@ def test_dynamics_helpers_dependencies():
 def test_structural_helpers_dependencies():
     from tnfr import EXPORT_DEPENDENCIES
 
-    expected_submodules = {
+    base_submodules = {
         "tnfr.structural",
         "tnfr.constants",
         "tnfr.dynamics",
@@ -50,8 +50,12 @@ def test_structural_helpers_dependencies():
 
     for helper in ("create_nfr", "run_sequence"):
         deps = EXPORT_DEPENDENCIES[helper]
-        assert set(deps["submodules"]) == expected_submodules
+        assert set(deps["submodules"]) == base_submodules
         assert deps["third_party"] == expected_third_party
+
+    math_deps = EXPORT_DEPENDENCIES["create_math_nfr"]
+    assert set(math_deps["submodules"]) == base_submodules | {"tnfr.mathematics"}
+    assert math_deps["third_party"] == ("networkx", "numpy")
 
 
 def test_manifest_validator_catches_mismatches(monkeypatch):


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Phase/νf logs
- [x] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Implemented a `create_math_nfr` factory that layers Hilbert-space configuration, coherence/frequency operators, and validation metrics onto structural nodes. Exported the helper via `tnfr.__all__` and dependency manifest, refreshed structural doctests, and added unit coverage to confirm math metrics align with the validation workflow.

------
https://chatgpt.com/codex/tasks/task_e_6904d3d0a7dc8321839ffd0d447a2597