### PR TITLE
Align math engine νf logging with alias map

### DIFF
--- a/src/tnfr/cli/execution.py
+++ b/src/tnfr/cli/execution.py
@@ -18,7 +18,8 @@ from ..config.presets import (
     PREFERRED_PRESET_NAMES,
     get_preset,
 )
-from ..constants import METRIC_DEFAULTS, get_param
+from ..alias import get_attr
+from ..constants import METRIC_DEFAULTS, VF_PRIMARY, get_aliases, get_param
 from ..dynamics import default_glyph_selector, parametric_glyph_selector, run
 from ..execution import CANONICAL_PRESET_NAME, play
 from ..flatten import parse_program_tokens
@@ -57,6 +58,11 @@ from .utils import _parse_cli_variants
 from ..validation import validate_canon
 
 logger = get_logger(__name__)
+
+_VF_ALIASES = get_aliases("VF")
+VF_ALIAS_KEYS: tuple[str, ...] = (VF_PRIMARY,) + tuple(
+    alias for alias in _VF_ALIASES if alias != VF_PRIMARY
+)
 
 
 # CLI summaries should remain concise by default while allowing callers to
@@ -511,7 +517,13 @@ def _log_math_engine_summary(G: "nx.Graph") -> None:
     for node_id in nodes:
         data = G.nodes[node_id]
         epi = float(data.get("EPI", 0.0))
-        nu_f = float(data.get("vf", 0.0))
+        nu_f = float(
+            get_attr(
+                data,
+                VF_ALIAS_KEYS,
+                default=float(data.get(VF_PRIMARY, 0.0)),
+            )
+        )
         theta = float(data.get("theta", 0.0))
         state = state_projector(epi=epi, nu_f=nu_f, theta=theta, dim=hilbert_space.dimension)
         norm_values.append(float(hilbert_space.norm(state)))


### PR DESCRIPTION
## Summary
- load structural frequency from the canonical νf alias set when building math-engine summaries
- reuse the projected νf values inside the CLI regression to assert positivity logs match validator output

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [x] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6904d8283f4483219cad2087199a7c67