### PR TITLE
Ensure Lindblad generators validate explicit dimension hints

### DIFF
--- a/src/tnfr/mathematics/generators.py
+++ b/src/tnfr/mathematics/generators.py
@@ -138,7 +138,9 @@ def build_lindblad_delta_nfr(
         Hamiltonian.  When ``None`` the generator reduces to the coherent part.
     dim:
         Explicit Hilbert-space dimension.  Only required if neither
-        ``hamiltonian`` nor ``collapse_operators`` are provided.
+        ``hamiltonian`` nor ``collapse_operators`` are provided.  When supplied,
+        it must match the dimension inferred from the Hamiltonian and collapse
+        operators.
     nu_f, scale:
         Structural frequency scaling applied uniformly to the final generator.
     ensure_trace_preserving:
@@ -167,6 +169,12 @@ def build_lindblad_delta_nfr(
         raise ValueError("ΔNFR generators require a positive dimension.")
 
     dimension = inferred_dim
+
+    if dim is not None and dim != dimension:
+        raise ValueError(
+            "Provided dim is inconsistent with the supplied operators: "
+            f"expected {dimension}, received {dim}."
+        )
 
     if hamiltonian is None:
         hermitian = np.zeros((dimension, dimension), dtype=np.complex128)

--- a/tests/mathematics/test_dissipative_dynamics.py
+++ b/tests/mathematics/test_dissipative_dynamics.py
@@ -59,6 +59,33 @@ def test_lindblad_generator_preserves_trace(hilbert_qubit: HilbertSpace) -> None
     assert np.max(eigenvalues.real) <= 1e-9
 
 
+def test_lindblad_generator_rejects_dim_mismatch_with_hamiltonian(
+    hilbert_qubit: HilbertSpace,
+) -> None:
+    dim = hilbert_qubit.dimension
+    hamiltonian = np.zeros((dim, dim), dtype=np.complex128)
+
+    with pytest.raises(ValueError, match="Provided dim is inconsistent"):
+        build_lindblad_delta_nfr(
+            hamiltonian=hamiltonian,
+            collapse_operators=[np.zeros_like(hamiltonian)],
+            dim=dim + 1,
+        )
+
+
+def test_lindblad_generator_rejects_dim_mismatch_with_collapse_operator(
+    hilbert_qubit: HilbertSpace,
+) -> None:
+    dim = hilbert_qubit.dimension
+    lowering = np.array([[0.0, 1.0], [0.0, 0.0]], dtype=np.complex128)
+
+    with pytest.raises(ValueError, match="Provided dim is inconsistent"):
+        build_lindblad_delta_nfr(
+            collapse_operators=[lowering],
+            dim=dim + 1,
+        )
+
+
 def test_contractive_engine_preserves_trace_and_contractivity(hilbert_qubit: HilbertSpace) -> None:
     gamma = 0.4
     lowering = np.array([[0.0, 1.0], [0.0, 0.0]], dtype=np.complex128)


### PR DESCRIPTION
## Summary
- validate that explicit `dim` arguments agree with the inferred Hilbert-space dimension when constructing Lindblad ΔNFR generators
- document the expectation and add regression tests covering mismatched Hamiltonian and collapse operator inputs

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6904e16d905483218874c8ae39881404