### PR TITLE
Add Hz_str conversion utilities and defaults

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -101,6 +101,27 @@ EXPORT_DEPENDENCIES: dict[str, dict[str, tuple[str, ...]]] = {
         ),
         "third_party": ("networkx",),
     },
+    "get_hz_bridge": {
+        "submodules": (
+            "tnfr.units",
+            "tnfr.constants",
+        ),
+        "third_party": (),
+    },
+    "hz_str_to_hz": {
+        "submodules": (
+            "tnfr.units",
+            "tnfr.constants",
+        ),
+        "third_party": (),
+    },
+    "hz_to_hz_str": {
+        "submodules": (
+            "tnfr.units",
+            "tnfr.constants",
+        ),
+        "third_party": (),
+    },
 }
 
 
@@ -256,6 +277,9 @@ _HAS_STRUCTURAL_EXPORTS = _assign_exports(
 )
 
 
+_assign_exports("units", ("get_hz_bridge", "hz_str_to_hz", "hz_to_hz_str"))
+
+
 def _emit_missing_dependency_warning() -> None:
     if not _MISSING_EXPORTS:
         return
@@ -279,6 +303,9 @@ __all__ = [
     "run",
     "prepare_network",
     "create_nfr",
+    "get_hz_bridge",
+    "hz_str_to_hz",
+    "hz_to_hz_str",
 ]
 
 if _HAS_STRUCTURAL_EXPORTS:

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -71,6 +71,7 @@ class CoreDefaults:
     GLYPH_SELECTOR_MARGIN: float = 0.05
     VF_ADAPT_TAU: int = 5
     VF_ADAPT_MU: float = 0.1
+    HZ_STR_BRIDGE: float = 1.0
     GLYPH_FACTORS: dict[str, float] = field(
         default_factory=lambda: {
             "AL_boost": 0.05,

--- a/src/tnfr/units.py
+++ b/src/tnfr/units.py
@@ -1,0 +1,69 @@
+"""Structural unit conversion helpers.
+
+The TNFR engine tracks structural dynamics using the ``Hz_str`` unit.  A
+single configurable scale factor ``k`` bridges this canonical structural
+frequency with the conventional ``Hz`` base unit.  The factor is resolved
+according to the following invariants:
+
+* ``k`` is always read from the graph configuration via :func:`get_param` so
+  per-graph overrides take precedence over the package defaults.
+* The fallback value comes from :data:`tnfr.constants.DEFAULTS`, ensuring the
+  canonical 1 Hz_str↔Hz relationship is preserved when callers do not provide
+  explicit overrides.
+* ``k`` must remain strictly positive.  Invalid overrides raise
+  :class:`ValueError` to prevent incoherent conversions.
+
+All helpers defined here operate purely on ``GraphLike`` instances and only
+depend on :mod:`tnfr.constants` for configuration access, keeping the
+conversion logic transparent and side-effect free.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .constants import get_param
+from .types import GraphLike
+
+__all__ = ("get_hz_bridge", "hz_str_to_hz", "hz_to_hz_str")
+
+HZ_STR_BRIDGE_KEY: Final[str] = "HZ_STR_BRIDGE"
+
+
+def _coerce_bridge_factor(raw: object) -> float:
+    """Return ``raw`` coerced to a strictly positive floating point factor."""
+
+    try:
+        factor = float(raw)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise TypeError(
+            "HZ_STR_BRIDGE must be a real number convertible to float"
+        ) from exc
+
+    if factor <= 0.0:
+        raise ValueError("HZ_STR_BRIDGE must be strictly positive")
+
+    return factor
+
+
+def get_hz_bridge(G: GraphLike) -> float:
+    """Return the ``Hz_str``→``Hz`` bridge factor for ``G``.
+
+    The helper always consults ``G.graph`` via :func:`get_param` so per-graph
+    overrides remain authoritative.
+    """
+
+    return _coerce_bridge_factor(get_param(G, HZ_STR_BRIDGE_KEY))
+
+
+def hz_str_to_hz(value: float, G: GraphLike) -> float:
+    """Convert ``value`` expressed in ``Hz_str`` into ``Hz`` using ``G``."""
+
+    return float(value) * get_hz_bridge(G)
+
+
+def hz_to_hz_str(value: float, G: GraphLike) -> float:
+    """Convert ``value`` expressed in ``Hz`` into ``Hz_str`` using ``G``."""
+
+    return float(value) / get_hz_bridge(G)
+

--- a/src/tnfr/units.pyi
+++ b/src/tnfr/units.pyi
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Final
+
+from .types import GraphLike
+
+__all__ = ("get_hz_bridge", "hz_str_to_hz", "hz_to_hz_str")
+
+HZ_STR_BRIDGE_KEY: Final[str]
+
+def get_hz_bridge(G: GraphLike) -> float: ...
+
+def hz_str_to_hz(value: float, G: GraphLike) -> float: ...
+
+def hz_to_hz_str(value: float, G: GraphLike) -> float: ...
+


### PR DESCRIPTION
## Summary
- add a canonical Hz_str↔Hz bridge factor to the core defaults
- introduce structural frequency conversion helpers with typing stubs
- expose the conversion helpers through the public tnfr exports manifest

## Testing
- python -m compileall src/tnfr/units.py

------
https://chatgpt.com/codex/tasks/task_e_6904e41676408321849dd574b6fb4124