### PR TITLE
Refactor grammar compatibility around structural operator names

### DIFF
--- a/src/tnfr/validation/compatibility.py
+++ b/src/tnfr/validation/compatibility.py
@@ -1,59 +1,95 @@
-"""Canonical TNFR compatibility tables.
-
-This module centralises the canonical transitions that keep TNFR
-coherence consistent across refactors.  It is intentionally lightweight
-so :mod:`tnfr.operators.grammar` can depend on it without introducing
-cycles.
-"""
+"""Canonical TNFR compatibility tables expressed via structural operators."""
 
 from __future__ import annotations
 
+from ..config.operator_names import (
+    COHERENCE,
+    CONTRACTION,
+    COUPLING,
+    DISSONANCE,
+    EMISSION,
+    EXPANSION,
+    MUTATION,
+    RECEPTION,
+    RESONANCE,
+    SELF_ORGANIZATION,
+    SILENCE,
+    TRANSITION,
+)
+from ..operators import grammar as _grammar
 from ..types import Glyph
 
 __all__ = ["CANON_COMPAT", "CANON_FALLBACK"]
 
-# Canonical compatibilities (allowed next glyphs)
-CANON_COMPAT: dict[Glyph, set[Glyph]] = {
+# Canonical compatibilities (allowed next operators) expressed via structural names
+_STRUCTURAL_COMPAT: dict[str, set[str]] = {
     # Opening / initiation
-    Glyph.AL: {Glyph.EN, Glyph.RA, Glyph.NAV, Glyph.VAL, Glyph.UM},
-    Glyph.EN: {Glyph.IL, Glyph.UM, Glyph.RA, Glyph.NAV},
+    EMISSION: {RECEPTION, RESONANCE, TRANSITION, EXPANSION, COUPLING},
+    RECEPTION: {COHERENCE, COUPLING, RESONANCE, TRANSITION},
     # Stabilisation / diffusion / coupling
-    Glyph.IL: {Glyph.RA, Glyph.VAL, Glyph.UM, Glyph.SHA},
-    Glyph.UM: {Glyph.RA, Glyph.IL, Glyph.VAL, Glyph.NAV},
-    Glyph.RA: {Glyph.IL, Glyph.VAL, Glyph.UM, Glyph.NAV},
-    Glyph.VAL: {Glyph.UM, Glyph.RA, Glyph.IL, Glyph.NAV},
+    COHERENCE: {RESONANCE, EXPANSION, COUPLING, SILENCE},
+    COUPLING: {RESONANCE, COHERENCE, EXPANSION, TRANSITION},
+    RESONANCE: {COHERENCE, EXPANSION, COUPLING, TRANSITION},
+    EXPANSION: {COUPLING, RESONANCE, COHERENCE, TRANSITION},
     # Dissonance → transition → mutation
-    Glyph.OZ: {Glyph.ZHIR, Glyph.NAV},
-    Glyph.ZHIR: {Glyph.IL, Glyph.NAV},
-    Glyph.NAV: {Glyph.OZ, Glyph.ZHIR, Glyph.RA, Glyph.IL, Glyph.UM},
+    DISSONANCE: {MUTATION, TRANSITION},
+    MUTATION: {COHERENCE, TRANSITION},
+    TRANSITION: {DISSONANCE, MUTATION, RESONANCE, COHERENCE, COUPLING},
     # Closures / latent states
-    Glyph.SHA: {Glyph.AL, Glyph.EN},
-    Glyph.NUL: {Glyph.AL, Glyph.IL},
+    SILENCE: {EMISSION, RECEPTION},
+    CONTRACTION: {EMISSION, COHERENCE},
     # Self-organising blocks
-    Glyph.THOL: {
-        Glyph.OZ,
-        Glyph.ZHIR,
-        Glyph.NAV,
-        Glyph.RA,
-        Glyph.IL,
-        Glyph.UM,
-        Glyph.SHA,
-        Glyph.NUL,
+    SELF_ORGANIZATION: {
+        DISSONANCE,
+        MUTATION,
+        TRANSITION,
+        RESONANCE,
+        COHERENCE,
+        COUPLING,
+        SILENCE,
+        CONTRACTION,
     },
 }
 
-# Canonical fallbacks when a transition is not allowed
-CANON_FALLBACK: dict[Glyph, Glyph] = {
-    Glyph.AL: Glyph.EN,
-    Glyph.EN: Glyph.IL,
-    Glyph.IL: Glyph.RA,
-    Glyph.NAV: Glyph.RA,
-    Glyph.NUL: Glyph.AL,
-    Glyph.OZ: Glyph.ZHIR,
-    Glyph.RA: Glyph.IL,
-    Glyph.SHA: Glyph.AL,
-    Glyph.THOL: Glyph.NAV,
-    Glyph.UM: Glyph.RA,
-    Glyph.VAL: Glyph.RA,
-    Glyph.ZHIR: Glyph.IL,
+
+def _name_to_glyph(name: str) -> Glyph:
+    glyph = _grammar.function_name_to_glyph(name)
+    if glyph is None:
+        raise KeyError(f"No glyph mapped to structural operator '{name}'")
+    return glyph
+
+
+def _translate_structural() -> tuple[dict[Glyph, set[Glyph]], dict[Glyph, Glyph]]:
+    compat: dict[Glyph, set[Glyph]] = {}
+    for src, targets in _STRUCTURAL_COMPAT.items():
+        src_glyph = _name_to_glyph(src)
+        compat[src_glyph] = {_name_to_glyph(target) for target in targets}
+    fallback: dict[Glyph, Glyph] = {}
+    for src, target in _STRUCTURAL_FALLBACK.items():
+        fallback[_name_to_glyph(src)] = _name_to_glyph(target)
+    return compat, fallback
+
+
+# Canonical fallbacks when a transition is not allowed (structural names)
+_STRUCTURAL_FALLBACK: dict[str, str] = {
+    EMISSION: RECEPTION,
+    RECEPTION: COHERENCE,
+    COHERENCE: RESONANCE,
+    TRANSITION: RESONANCE,
+    CONTRACTION: EMISSION,
+    DISSONANCE: MUTATION,
+    RESONANCE: COHERENCE,
+    SILENCE: EMISSION,
+    SELF_ORGANIZATION: TRANSITION,
+    COUPLING: RESONANCE,
+    EXPANSION: RESONANCE,
+    MUTATION: COHERENCE,
 }
+
+
+CANON_COMPAT, CANON_FALLBACK = _translate_structural()
+
+# Re-export structural tables for internal consumers that operate on functional
+# identifiers without exposing them as part of the public API.
+_STRUCTURAL_COMPAT_TABLE = _STRUCTURAL_COMPAT
+_STRUCTURAL_FALLBACK_TABLE = _STRUCTURAL_FALLBACK

--- a/tests/integration/test_validation_compatibility.py
+++ b/tests/integration/test_validation_compatibility.py
@@ -1,19 +1,21 @@
 """Tests for :mod:`tnfr.validation.compatibility`."""
 
+from tnfr.config.operator_names import CONTRACTION, MUTATION, RESONANCE, SILENCE
 from tnfr.types import Glyph
 from tnfr.validation.compatibility import CANON_COMPAT, CANON_FALLBACK
+from tnfr.operators.grammar import glyph_function_name
 
 
 def test_thol_maintains_closure_paths():
     """THOL blocks must always offer closure glyphs to preserve phase."""
 
-    thol_transitions = CANON_COMPAT[Glyph.THOL]
-    assert Glyph.SHA in thol_transitions
-    assert Glyph.NUL in thol_transitions
+    thol_transitions = {glyph_function_name(g) for g in CANON_COMPAT[Glyph.THOL]}
+    assert SILENCE in thol_transitions
+    assert CONTRACTION in thol_transitions
 
 
 def test_fallbacks_reinforce_mutation_flow():
     """Fallbacks keep ΔNFR-driven mutation aligned with canon."""
 
-    assert CANON_FALLBACK[Glyph.OZ] == Glyph.ZHIR
-    assert CANON_FALLBACK[Glyph.NAV] == Glyph.RA
+    assert glyph_function_name(CANON_FALLBACK[Glyph.OZ]) == MUTATION
+    assert glyph_function_name(CANON_FALLBACK[Glyph.NAV]) == RESONANCE

--- a/tests/integration/test_validation_rules.py
+++ b/tests/integration/test_validation_rules.py
@@ -6,10 +6,11 @@ import networkx as nx
 
 from tnfr.constants import inject_defaults
 from tnfr.types import Glyph
+from tnfr.config.operator_names import DISSONANCE, MUTATION
 from tnfr.validation import rules as rules_mod
 from tnfr.validation.soft_filters import maybe_force
 from tnfr.validation.compatibility import CANON_COMPAT, CANON_FALLBACK
-from tnfr.operators.grammar import GrammarContext
+from tnfr.operators.grammar import GrammarContext, glyph_function_name
 
 
 def _graph_with_node():
@@ -37,7 +38,7 @@ def test_maybe_force_recovers_original_when_dnfr_high():
         "force_dnfr",
     )
 
-    assert forced == Glyph.ZHIR
+    assert glyph_function_name(forced) == MUTATION
 
 
 def test_check_compatibility_returns_fallback_glyph():
@@ -48,8 +49,9 @@ def test_check_compatibility_returns_fallback_glyph():
 
     result = rules_mod._check_compatibility(ctx, 0, Glyph.ZHIR)
 
-    assert Glyph.ZHIR not in CANON_COMPAT[Glyph.AL]
-    assert result == CANON_FALLBACK[Glyph.AL]
+    successors = {glyph_function_name(g) for g in CANON_COMPAT[Glyph.AL]}
+    assert MUTATION not in successors
+    assert glyph_function_name(result) == glyph_function_name(CANON_FALLBACK[Glyph.AL])
 
 
 def test_check_oz_to_zhir_requires_recent_oz():
@@ -62,4 +64,4 @@ def test_check_oz_to_zhir_requires_recent_oz():
 
     result = rules_mod._check_oz_to_zhir(ctx, 0, Glyph.ZHIR)
 
-    assert result == Glyph.OZ
+    assert glyph_function_name(result) == DISSONANCE

--- a/tests/unit/validation/test_rules_normalization.py
+++ b/tests/unit/validation/test_rules_normalization.py
@@ -7,11 +7,12 @@ from collections import deque
 import pytest
 
 from tnfr.constants import get_aliases
+from tnfr.config.operator_names import COHERENCE, EXPANSION
 from tnfr.types import Glyph
 from tnfr.validation import rules
 from tnfr.validation.soft_filters import acceleration_norm
 from tnfr.validation.compatibility import CANON_FALLBACK
-from tnfr.operators.grammar import GrammarContext
+from tnfr.operators.grammar import GrammarContext, glyph_function_name
 
 
 @pytest.fixture
@@ -75,7 +76,9 @@ def test_coerce_glyph_and_invalid_values():
 def test_glyph_fallback_prefers_custom_and_canon():
     fallbacks = {"OZ": "VAL", "RA": Glyph.IL, "??": "??"}
 
-    assert rules.glyph_fallback("OZ", fallbacks) == Glyph.VAL
-    assert rules.glyph_fallback("RA", fallbacks) == Glyph.IL
-    assert rules.glyph_fallback("SHA", fallbacks) == CANON_FALLBACK[Glyph.SHA]
+    assert glyph_function_name(rules.glyph_fallback("OZ", fallbacks)) == EXPANSION
+    assert glyph_function_name(rules.glyph_fallback("RA", fallbacks)) == COHERENCE
+    assert glyph_function_name(rules.glyph_fallback("SHA", fallbacks)) == glyph_function_name(
+        CANON_FALLBACK[Glyph.SHA]
+    )
     assert rules.glyph_fallback("??", fallbacks) == "??"

--- a/tests/unit/validation/test_rules_repeats.py
+++ b/tests/unit/validation/test_rules_repeats.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections import deque
 
+from tnfr.config.operator_names import RESONANCE, SILENCE
 from tnfr.types import Glyph
 from tnfr.validation.soft_filters import check_repeats
-from tnfr.operators.grammar import GrammarContext
+from tnfr.operators.grammar import GrammarContext, glyph_function_name
 
 
 def _ctx_with_node(graph_canon, cfg_soft):
@@ -31,7 +32,7 @@ def test_check_repeats_swaps_to_configured_fallback(graph_canon):
 
     swapped = check_repeats(ctx, node_id, Glyph.RA)
 
-    assert swapped == Glyph.SHA
+    assert glyph_function_name(swapped) == SILENCE
 
 
 def test_check_repeats_leaves_non_recent_candidate(graph_canon):
@@ -46,7 +47,7 @@ def test_check_repeats_leaves_non_recent_candidate(graph_canon):
 
     cand = check_repeats(ctx, node_id, Glyph.RA)
 
-    assert cand == Glyph.RA
+    assert glyph_function_name(cand) == RESONANCE
 
 
 def test_check_repeats_with_zero_window_passthrough(graph_canon):
@@ -61,4 +62,4 @@ def test_check_repeats_with_zero_window_passthrough(graph_canon):
 
     cand = check_repeats(ctx, node_id, Glyph.RA)
 
-    assert cand == Glyph.RA
+    assert glyph_function_name(cand) == RESONANCE

--- a/tests/unit/validation/test_rules_thol.py
+++ b/tests/unit/validation/test_rules_thol.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from tnfr.types import Glyph
-from tnfr.operators.grammar import GrammarContext
+from tnfr.config.operator_names import CONTRACTION, RESONANCE, SILENCE
+from tnfr.operators.grammar import GrammarContext, glyph_function_name
 from tnfr.validation import rules
 
 
@@ -51,7 +52,7 @@ def test_thol_closure_waits_until_min_length(graph_canon):
 
     cand = rules._check_thol_closure(ctx, node_id, Glyph.RA, state)
 
-    assert cand == Glyph.RA
+    assert glyph_function_name(cand) == RESONANCE
     assert state["thol_len"] == 1
 
 
@@ -71,7 +72,7 @@ def test_thol_closure_triggers_at_max_length_with_high_si(graph_canon):
 
     glyph = rules._check_thol_closure(ctx, node_id, Glyph.RA, state)
 
-    assert glyph == Glyph.NUL
+    assert glyph_function_name(glyph) == CONTRACTION
     assert state["thol_len"] == 5
 
 
@@ -91,7 +92,7 @@ def test_thol_closure_low_dnfr_uses_sha_when_si_below_threshold(graph_canon):
 
     glyph = rules._check_thol_closure(ctx, node_id, Glyph.RA, state)
 
-    assert glyph == Glyph.SHA
+    assert glyph_function_name(glyph) == SILENCE
     assert state["thol_len"] == 3
 
 
@@ -111,5 +112,5 @@ def test_thol_closure_low_dnfr_with_high_si_prefers_nul(graph_canon):
 
     glyph = rules._check_thol_closure(ctx, node_id, Glyph.RA, state)
 
-    assert glyph == Glyph.NUL
+    assert glyph_function_name(glyph) == CONTRACTION
     assert state["thol_len"] == 3


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [x] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Establish a canonical mapping between glyph codes and structural operator names, exposing helpers to translate in both directions and enriching inline documentation for each operator.
- Rewrite canonical compatibility and fallback tables using structural identifiers, with lazy translation bridges inside validation rules to preserve existing glyph-based APIs.
- Update grammar and validation tests to assert on structural operator names, ensuring external behaviours remain focused on TNFR semantics rather than internal glyph codes.

## Testing
- `pytest tests/unit/dynamics/test_grammar.py tests/integration/test_validation_rules.py tests/unit/validation/test_rules_normalization.py tests/integration/test_validation_compatibility.py tests/unit/validation/test_rules_thol.py tests/unit/validation/test_rules_repeats.py` *(fails: missing numpy dependency required by test suite bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_6904f4a7a97c8321b1fbb2d3b0206e71