### PR TITLE
Enforce structural grammar violations via explicit exceptions

### DIFF
--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -22,6 +22,11 @@ from ..utils import get_nodenx
 from . import definitions as _definitions
 from .grammar import (
     GrammarContext,
+    StructuralGrammarError,
+    RepeatWindowError,
+    MutationPreconditionError,
+    TholClosureError,
+    TransitionCompatibilityError,
     SequenceSyntaxError,
     SequenceValidationResult,
     _gram_state,
@@ -77,6 +82,11 @@ __all__ = [
     "reset_jitter_manager",
     "random_jitter",
     "GrammarContext",
+    "StructuralGrammarError",
+    "RepeatWindowError",
+    "MutationPreconditionError",
+    "TholClosureError",
+    "TransitionCompatibilityError",
     "SequenceValidationResult",
     "SequenceSyntaxError",
     "_gram_state",

--- a/src/tnfr/operators/__init__.pyi
+++ b/src/tnfr/operators/__init__.pyi
@@ -19,6 +19,11 @@ JitterCache: Any
 JitterCacheManager: Any
 OPERATORS: Any
 GrammarContext: Any
+StructuralGrammarError: Any
+RepeatWindowError: Any
+MutationPreconditionError: Any
+TholClosureError: Any
+TransitionCompatibilityError: Any
 SequenceValidationResult: Any
 SequenceSyntaxError: Any
 _gram_state: Any

--- a/src/tnfr/validation/grammar.py
+++ b/src/tnfr/validation/grammar.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from ..operators.grammar import (
     GrammarContext,
+    StructuralGrammarError,
+    RepeatWindowError,
+    MutationPreconditionError,
+    TholClosureError,
+    TransitionCompatibilityError,
     SequenceSyntaxError,
     SequenceValidationResult,
     _gram_state,
@@ -16,6 +21,11 @@ from ..operators.grammar import (
 
 __all__ = [
     "GrammarContext",
+    "StructuralGrammarError",
+    "RepeatWindowError",
+    "MutationPreconditionError",
+    "TholClosureError",
+    "TransitionCompatibilityError",
     "SequenceSyntaxError",
     "SequenceValidationResult",
     "_gram_state",

--- a/src/tnfr/validation/grammar.pyi
+++ b/src/tnfr/validation/grammar.pyi
@@ -1,5 +1,10 @@
 from ..operators.grammar import (
     GrammarContext,
+    StructuralGrammarError,
+    RepeatWindowError,
+    MutationPreconditionError,
+    TholClosureError,
+    TransitionCompatibilityError,
     SequenceSyntaxError,
     SequenceValidationResult,
     _gram_state,
@@ -12,6 +17,11 @@ from ..operators.grammar import (
 
 __all__ = (
     "GrammarContext",
+    "StructuralGrammarError",
+    "RepeatWindowError",
+    "MutationPreconditionError",
+    "TholClosureError",
+    "TransitionCompatibilityError",
     "SequenceSyntaxError",
     "SequenceValidationResult",
     "_gram_state",

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -17,6 +17,7 @@ from tnfr.config.operator_names import (
 from tnfr.constants import inject_defaults
 from tnfr.operators.grammar import (
     GrammarContext,
+    TholClosureError,
     SequenceSyntaxError,
     SequenceValidationResult,
     apply_glyph_with_grammar,
@@ -138,8 +139,10 @@ def test_enforce_canonical_grammar_respects_thol_state() -> None:
     ctx.cfg_canon.update({"thol_min_len": 0, "thol_max_len": 1, "thol_close_dnfr": 1.0})
     st = nd["_GRAM"]
     st["thol_len"] = 2
-    coerced = enforce_canonical_grammar(G, 0, Glyph.EN, ctx)
-    assert coerced in {Glyph.SHA, Glyph.NUL}
+    with pytest.raises(TholClosureError) as excinfo:
+        enforce_canonical_grammar(G, 0, Glyph.EN, ctx)
+    err = excinfo.value
+    assert err.order[-1] == RECEPTION
 
 
 def test_apply_glyph_with_grammar_invokes_apply(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
- Introduced structural grammar exceptions that capture window, threshold and ordering metadata while feeding telemetry.
- Updated canonical enforcement to raise on mutation preconditions, THOL closures and repeat windows, enriching selector/apply paths with node context.
- Expanded unit coverage to assert the new error flows and telemetry payloads.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6904f6cfae18832185942265a19a8dde