### PR TITLE
Add optional grammar schema validation for GrammarContext

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -123,3 +123,14 @@ Selector helpers and glyph telemetry exporters reuse the shared
 selector-compatible identifiers and :data:`tnfr.types.SigmaTrace` or the
 glyph timing aliases when consuming the metrics payloads, ensuring typed
 extensions stay in sync with the public API.
+
+### Grammar schema validation
+
+`tnfr.operators.grammar.GrammarContext` now validates the soft and canonical
+grammar dictionaries against the bundled JSON schema (`tnfr.schemas/grammar.json`)
+whenever the optional `jsonschema` dependency is available. Validation runs in
+``auto`` mode by default—if the dependency or resource cannot be loaded the
+engine keeps operating without raising. Set the environment variable
+``TNFR_GRAMMAR_VALIDATE=1`` to require validation (raising when the schema or
+dependency is missing) or ``TNFR_GRAMMAR_VALIDATE=0`` to skip schema checks when
+working with experimental configurations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ Repository = "https://github.com/fermga/TNFR-Python-Engine"
 GPT = "https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-resonant-fractal-nature-theory"
 
 [tool.setuptools.package-data]
-tnfr = ["py.typed"]
+tnfr = ["py.typed", "schemas/*.json"]
 
 [tool.setuptools_scm]
 tag_regex = '^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'

--- a/src/tnfr/schemas/__init__.py
+++ b/src/tnfr/schemas/__init__.py
@@ -1,0 +1,8 @@
+"""JSON schema resources bundled with the TNFR engine."""
+
+from __future__ import annotations
+
+__all__ = ["package"]
+
+# Namespace packages need at least one attribute for static analysers.
+package = __name__

--- a/src/tnfr/schemas/grammar.json
+++ b/src/tnfr/schemas/grammar.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://tnfr.io/schemas/grammar.json",
+  "title": "TNFR Grammar Configuration",
+  "type": "object",
+  "definitions": {
+    "glyphCode": {
+      "description": "Canonical glyph identifier in uppercase notation.",
+      "type": "string",
+      "pattern": "^[A-Z][A-Z_]*$"
+    },
+    "probability": {
+      "description": "Threshold constrained to the [0, 1] interval.",
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "cfg_soft": {
+      "type": "object",
+      "description": "Soft grammar preferences applied before canonical automaton rules.",
+      "properties": {
+        "window": {
+          "description": "History window inspected to avoid short-term glyph repetitions.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "avoid_repeats": {
+          "description": "Glyph codes that should be substituted when repeated inside the window.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/glyphCode" },
+          "uniqueItems": true
+        },
+        "fallbacks": {
+          "description": "Mapping of glyph codes to their explicit substitution when repetition is detected.",
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/glyphCode" }
+        },
+        "force_dnfr": {
+          "description": "Minimum |ΔNFR| normalised score that bypasses soft filtering.",
+          "$ref": "#/definitions/probability"
+        },
+        "force_accel": {
+          "description": "Minimum acceleration normalised score that bypasses soft filtering.",
+          "$ref": "#/definitions/probability"
+        }
+      },
+      "additionalProperties": true
+    },
+    "cfg_canon": {
+      "type": "object",
+      "description": "Canonical grammar thresholds enforced by the automaton.",
+      "properties": {
+        "enabled": {
+          "description": "Toggle canonical grammar enforcement during metric runs.",
+          "type": "boolean"
+        },
+        "zhir_requires_oz_window": {
+          "description": "Window requiring a DISSONANCE glyph before a MUTATION.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "zhir_dnfr_min": {
+          "description": "Minimum normalised |ΔNFR| required to allow MUTATION without recent DISSONANCE.",
+          "type": "number",
+          "minimum": 0.0
+        },
+        "thol_min_len": {
+          "description": "Minimum number of THOL glyphs before canonical closure is allowed.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "thol_max_len": {
+          "description": "Maximum number of THOL glyphs tolerated before forcing closure.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "thol_close_dnfr": {
+          "description": "Upper bound on normalised |ΔNFR| that triggers THOL closure.",
+          "$ref": "#/definitions/probability"
+        },
+        "si_high": {
+          "description": "Sense index threshold differentiating contraction vs silence closures.",
+          "$ref": "#/definitions/probability"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "properties": {
+    "cfg_soft": { "$ref": "#/definitions/cfg_soft" },
+    "cfg_canon": { "$ref": "#/definitions/cfg_canon" }
+  },
+  "additionalProperties": false
+}

--- a/tests/unit/operators/test_grammar_schema_validation.py
+++ b/tests/unit/operators/test_grammar_schema_validation.py
@@ -1,0 +1,115 @@
+"""Validation tests for the grammar configuration schema."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+
+import networkx as nx
+import pytest
+
+from tnfr.constants import DEFAULTS
+from tnfr.operators.grammar import (
+    GrammarConfigurationError,
+    GrammarContext,
+    enforce_canonical_grammar,
+)
+from tnfr.types import Glyph
+
+jsonschema = pytest.importorskip("jsonschema")
+
+
+@pytest.fixture(scope="module")
+def grammar_schema():
+    data = resources.files("tnfr.schemas").joinpath("grammar.json").read_text("utf-8")
+    return json.loads(data)
+
+
+@pytest.fixture(scope="module")
+def soft_validator(grammar_schema):
+    schema = dict(grammar_schema["definitions"]["cfg_soft"])
+    schema.setdefault("definitions", grammar_schema["definitions"])
+    return jsonschema.Draft7Validator(schema)
+
+
+@pytest.fixture(scope="module")
+def canon_validator(grammar_schema):
+    schema = dict(grammar_schema["definitions"]["cfg_canon"])
+    schema.setdefault("definitions", grammar_schema["definitions"])
+    return jsonschema.Draft7Validator(schema)
+
+
+def _graph_with_configs(cfg_soft, cfg_canon):
+    G = nx.DiGraph()
+    G.add_node(0, glyph_history=[])
+    G.graph["GRAMMAR"] = cfg_soft
+    G.graph["GRAMMAR_CANON"] = cfg_canon
+    return G
+
+
+def test_schema_accepts_minimal_configs(soft_validator, canon_validator):
+    soft_validator.validate({})
+    canon_validator.validate({})
+
+
+def test_schema_accepts_default_configs(soft_validator, canon_validator):
+    soft_validator.validate(DEFAULTS.get("GRAMMAR", {}))
+    canon_validator.validate(DEFAULTS.get("GRAMMAR_CANON", {}))
+
+
+def test_context_valid_configuration_passes_and_integrates(monkeypatch):
+    monkeypatch.setenv("TNFR_GRAMMAR_VALIDATE", "1")
+    cfg_soft = {
+        "window": 4,
+        "avoid_repeats": ["ZHIR", "OZ"],
+        "fallbacks": {"ZHIR": "NAV"},
+        "force_dnfr": 0.75,
+        "force_accel": 0.80,
+    }
+    cfg_canon = {
+        "zhir_requires_oz_window": 5,
+        "zhir_dnfr_min": 0.07,
+        "thol_min_len": 2,
+        "thol_max_len": 6,
+        "thol_close_dnfr": 0.20,
+        "si_high": 0.7,
+    }
+    ctx = GrammarContext.from_graph(_graph_with_configs(cfg_soft, cfg_canon))
+    assert ctx.cfg_soft["window"] == 4
+    # ensure the automaton pipeline still accepts the validated context
+    result = enforce_canonical_grammar(ctx.G, 0, Glyph.AL, ctx=ctx)
+    assert result == Glyph.AL
+
+
+def test_context_invalid_soft_window_raises(monkeypatch):
+    monkeypatch.setenv("TNFR_GRAMMAR_VALIDATE", "1")
+    cfg_soft = {"window": -1}
+    cfg_canon = DEFAULTS.get("GRAMMAR_CANON", {})
+    with pytest.raises(GrammarConfigurationError) as excinfo:
+        GrammarContext.from_graph(_graph_with_configs(cfg_soft, cfg_canon))
+    message = str(excinfo.value)
+    assert "cfg_soft" in message
+    assert "window" in message
+
+
+def test_validation_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("TNFR_GRAMMAR_VALIDATE", "0")
+    cfg_soft = {"window": -3}
+    cfg_canon = {"thol_min_len": 4, "thol_max_len": 3}
+    ctx = GrammarContext.from_graph(_graph_with_configs(cfg_soft, cfg_canon))
+    assert ctx.cfg_soft["window"] == -3
+    # disable flag should permit enforcing grammar without raising
+    result = enforce_canonical_grammar(ctx.G, 0, Glyph.AL, ctx=ctx)
+    assert result == Glyph.AL
+
+
+def test_enforce_raises_when_validation_fails(monkeypatch):
+    monkeypatch.setenv("TNFR_GRAMMAR_VALIDATE", "1")
+    cfg_soft = DEFAULTS.get("GRAMMAR", {})
+    cfg_canon = {"thol_min_len": 5, "thol_max_len": 1}
+    with pytest.raises(GrammarConfigurationError):
+        enforce_canonical_grammar(
+            _graph_with_configs(cfg_soft, cfg_canon),
+            0,
+            Glyph.AL,
+        )


### PR DESCRIPTION
## Summary
- package a JSON schema for grammar configuration and expose it as package data
- validate soft and canonical grammar configuration in `GrammarContext` with optional environment controls
- document the validation toggle and add unit tests covering valid/invalid configurations

## Testing
- pytest -o addopts= tests/unit/operators/test_grammar_schema_validation.py

------
https://chatgpt.com/codex/tasks/task_e_6904f901ecdc83218e4a81dec8073086