### PR TITLE
Align self-organization grammar errors with structural labels

### DIFF
--- a/src/tnfr/operators/grammar.py
+++ b/src/tnfr/operators/grammar.py
@@ -433,7 +433,7 @@ class _SequenceAutomaton:
             raise SequenceSyntaxError(
                 index=len(names) - 1,
                 token=names[-1],
-                message="THOL block without closure",
+                message=f"{operator_display_name(SELF_ORGANIZATION)} block without closure",
             )
 
     @property

--- a/src/tnfr/validation/rules.py
+++ b/src/tnfr/validation/rules.py
@@ -17,7 +17,9 @@ from ..config.operator_names import (
     CONTRACTION,
     DISSONANCE,
     MUTATION,
+    SELF_ORGANIZATION,
     SILENCE,
+    operator_display_name,
 )
 from ..utils import clamp01
 from ..metrics.common import normalize_dnfr
@@ -184,7 +186,9 @@ def _check_thol_closure(
                 raise _grammar.TholClosureError(
                     rule="thol-closure",
                     candidate=cand_label,
-                    message="THOL block requires canonical closure",
+                    message=(
+                        f"{operator_display_name(SELF_ORGANIZATION)} block requires canonical closure"
+                    ),
                     window=st["thol_len"],
                     threshold=close_dn,
                     order=order,

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -13,6 +13,7 @@ from tnfr.config.operator_names import (
     SELF_ORGANIZATION,
     SILENCE,
     TRANSITION,
+    operator_display_name,
 )
 from tnfr.constants import inject_defaults
 from tnfr.operators.grammar import (
@@ -98,7 +99,7 @@ def test_validate_sequence_requires_thol_closure() -> None:
         [EMISSION, RECEPTION, COHERENCE, SELF_ORGANIZATION, RESONANCE, TRANSITION]
     )
     assert not result.passed
-    assert "THOL" in result.message
+    assert operator_display_name(SELF_ORGANIZATION) in result.message
 
 
 def test_parse_sequence_returns_result() -> None:

--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -12,6 +12,7 @@ from tnfr.config.operator_names import (
     SELF_ORGANIZATION,
     SILENCE,
     TRANSITION,
+    operator_display_name,
 )
 from tnfr.constants import (
     D2EPI_PRIMARY,
@@ -140,7 +141,7 @@ def test_thol_requires_closure() -> None:
     ]
     outcome = validate_sequence(names)
     assert not outcome.passed
-    assert "THOL" in outcome.summary["message"]
+    assert operator_display_name(SELF_ORGANIZATION) in outcome.summary["message"]
 
 
 def test_validate_sequence_rejects_unknown_tokens() -> None:


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

Notes:
- Format open self-organization block syntax errors with `operator_display_name` to avoid raw glyph codes.
- Update `TholClosureError` messaging and grammar tests to expect the structural label.
- `pytest tests/unit/operators/test_grammar_module.py` (skipped: missing numpy dependency).


------
https://chatgpt.com/codex/tasks/task_e_6904ff48e2dc8321af4a52b2e304260e