### PR TITLE
Guard grammar canon configs against invalid payload types

### DIFF
--- a/src/tnfr/operators/grammar.py
+++ b/src/tnfr/operators/grammar.py
@@ -275,11 +275,27 @@ def _validate_grammar_configs(ctx: GrammarContext) -> None:
     if soft_validator is not None:
         for err in soft_validator.iter_errors(ctx.cfg_soft):  # type: ignore[union-attr]
             issues.append(("cfg_soft", _format_validation_error(err)))
+
+    canon_cfg: Mapping[str, Any] | None
+    if isinstance(ctx.cfg_canon, Mapping):
+        canon_cfg = ctx.cfg_canon
+    else:
+        canon_cfg = None
+        issues.append(
+            (
+                "cfg_canon",
+                "GRAMMAR_CANON must be a mapping"
+                f" (received {type(ctx.cfg_canon).__name__})",
+            )
+        )
+
     if canon_validator is not None:
         for err in canon_validator.iter_errors(ctx.cfg_canon):  # type: ignore[union-attr]
             issues.append(("cfg_canon", _format_validation_error(err)))
-    min_len = ctx.cfg_canon.get("thol_min_len")
-    max_len = ctx.cfg_canon.get("thol_max_len")
+
+    cfg_for_lengths: Mapping[str, Any] = canon_cfg or {}
+    min_len = cfg_for_lengths.get("thol_min_len")
+    max_len = cfg_for_lengths.get("thol_max_len")
     if isinstance(min_len, int) and isinstance(max_len, int) and max_len < min_len:
         issues.append(
             (

--- a/tests/unit/operators/test_grammar_schema_validation.py
+++ b/tests/unit/operators/test_grammar_schema_validation.py
@@ -92,6 +92,17 @@ def test_context_invalid_soft_window_raises(monkeypatch):
     assert "window" in message
 
 
+def test_context_invalid_canon_type_raises(monkeypatch):
+    monkeypatch.setenv("TNFR_GRAMMAR_VALIDATE", "1")
+    cfg_soft = DEFAULTS.get("GRAMMAR", {})
+    cfg_canon = "not-a-mapping"
+    with pytest.raises(GrammarConfigurationError) as excinfo:
+        GrammarContext.from_graph(_graph_with_configs(cfg_soft, cfg_canon))
+    message = str(excinfo.value)
+    assert "cfg_canon" in message
+    assert "mapping" in message
+
+
 def test_validation_can_be_disabled(monkeypatch):
     monkeypatch.setenv("TNFR_GRAMMAR_VALIDATE", "0")
     cfg_soft = {"window": -3}


### PR DESCRIPTION
## Summary
- Guard canonical grammar configuration validation against non-mapping payloads and keep length checks safe.
- Add regression coverage ensuring GrammarConfigurationError is raised when GRAMMAR_CANON is not a mapping.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_690502ec38148321a782d2749fed1d72