### PR TITLE
Ensure canonical string operators traverse grammar checks

### DIFF
--- a/src/tnfr/operators/grammar.py
+++ b/src/tnfr/operators/grammar.py
@@ -621,6 +621,13 @@ def enforce_canonical_grammar(
     cand = _rules.coerce_glyph(cand)
     input_was_str = isinstance(raw_cand, str)
 
+    if not isinstance(cand, Glyph):
+        translated = function_name_to_glyph(raw_cand if input_was_str else cand)
+        if translated is None and cand is not raw_cand:
+            translated = function_name_to_glyph(cand)
+        if translated is not None:
+            cand = translated
+
     from ..validation.compatibility import CANON_COMPAT
 
     if not isinstance(cand, Glyph) or cand not in CANON_COMPAT:
@@ -642,10 +649,7 @@ def enforce_canonical_grammar(
 def on_applied_glyph(G: TNFRGraph, n: NodeId, applied: Glyph | str) -> None:
     nd = G.nodes[n]
     st = _gram_state(nd)
-    try:
-        glyph = applied if isinstance(applied, Glyph) else Glyph(str(applied))
-    except ValueError:
-        glyph = None
+    glyph = function_name_to_glyph(applied)
 
     if glyph is Glyph.THOL:
         st["thol_open"] = True


### PR DESCRIPTION
- Translate canonical operator strings to glyphs before the canonical compatibility guard so string inputs are validated by the full grammar pipeline and resolve to the correct glyph for application.
- Recognise canonical operator strings inside `on_applied_glyph` so THOL bookkeeping toggles when strings are supplied.
- Add regression tests that exercise canonical strings through `enforce_canonical_grammar` and `apply_glyph_with_grammar`, covering THOL violations and toggles.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6905d979d3548321a95137724bc2b5f3