### PR TITLE
Improve operator grammar diagnostics for unknown tokens

### DIFF
--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -97,6 +97,14 @@ def test_validate_sequence_requires_known_tokens() -> None:
     assert "unknown" in result.message
 
 
+def test_validate_sequence_reports_first_unknown_token_index() -> None:
+    probe = [EMISSION, "UNKNOWN", RECEPTION, COHERENCE, RESONANCE, SILENCE]
+    result = validate_sequence(probe)
+    assert not result.passed
+    assert result.summary["error"]["index"] == 1
+    assert result.summary["error"]["token"] == "UNKNOWN"
+
+
 def test_validate_sequence_requires_thol_closure() -> None:
     result = validate_sequence(
         [EMISSION, RECEPTION, COHERENCE, SELF_ORGANIZATION, RESONANCE, TRANSITION]


### PR DESCRIPTION
- Track the first unknown operator encountered during sequence validation so the syntax error points at the offending token.
- Add a regression test covering the updated error metadata.

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6905dd70f4a88321b0b312047f7cabf2