### PR TITLE
Preserve canonical operator names when enforcing grammar

### DIFF
--- a/src/tnfr/operators/grammar.py
+++ b/src/tnfr/operators/grammar.py
@@ -612,6 +612,13 @@ def enforce_canonical_grammar(
     cand: Glyph | str,
     ctx: Optional[GrammarContext] = None,
 ) -> Glyph | str:
+    """Validate ``cand`` against canonical grammar rules and preserve structural identifiers.
+
+    When callers provide textual operator identifiers (for example ``"emission"``), the
+    returned value mirrors the canonical structural token instead of the raw glyph code.
+    This keeps downstream traces aligned with TNFR operator semantics while still
+    permitting glyph inputs for internal workflows.
+    """
     if ctx is None:
         ctx = GrammarContext.from_graph(G)
 
@@ -641,6 +648,11 @@ def enforce_canonical_grammar(
 
     coerced_final = _rules.coerce_glyph(cand)
     if input_was_str:
+        resolved = glyph_function_name(coerced_final)
+        if resolved is None:
+            resolved = glyph_function_name(cand)
+        if resolved is not None:
+            return resolved
         if isinstance(coerced_final, Glyph):
             return coerced_final.value
         return str(cand)

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -142,6 +142,15 @@ def test_enforce_canonical_grammar_skips_unknown_tokens() -> None:
     assert result == "UNKNOWN"
 
 
+def test_enforce_canonical_grammar_returns_structural_name_for_text_input() -> None:
+    G = _make_graph()
+    ctx = GrammarContext.from_graph(G)
+
+    result = enforce_canonical_grammar(G, 0, EMISSION, ctx)
+
+    assert result == EMISSION
+
+
 def test_enforce_canonical_grammar_respects_thol_state() -> None:
     G = _make_graph()
     ctx = GrammarContext.from_graph(G)


### PR DESCRIPTION
## Summary
- keep `enforce_canonical_grammar` returning canonical structural identifiers for string inputs
- document the structural preservation behaviour within the grammar helper
- add a regression test confirming canonical names survive canonical validation

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6905e81e70c88321951f12454d6e8a7b