### PR TITLE
Ensure GrammarContext clones default configurations

### DIFF
--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -17,7 +17,7 @@ from tnfr.config.operator_names import (
     TRANSITION,
     operator_display_name,
 )
-from tnfr.constants import inject_defaults
+from tnfr.constants import DEFAULTS, inject_defaults
 from tnfr.operators.grammar import (
     GrammarContext,
     MutationPreconditionError,
@@ -133,6 +133,21 @@ def _make_graph() -> nx.Graph:
     nd = G.nodes[0]
     nd.setdefault("glyph_history", deque())
     return G
+
+
+def test_grammar_context_isolates_default_configurations() -> None:
+    g1 = nx.Graph()
+    g2 = nx.Graph()
+
+    ctx_one = GrammarContext.from_graph(g1)
+    ctx_two = GrammarContext.from_graph(g2)
+
+    ctx_one.cfg_soft["fallbacks"]["ZHIR"] = "CUSTOM"
+
+    default_value = DEFAULTS["GRAMMAR"]["fallbacks"]["ZHIR"]
+
+    assert ctx_two.cfg_soft["fallbacks"]["ZHIR"] == default_value
+    assert DEFAULTS["GRAMMAR"]["fallbacks"]["ZHIR"] == default_value
 
 
 def test_enforce_canonical_grammar_skips_unknown_tokens() -> None:


### PR DESCRIPTION
## Summary
- clone grammar defaults when building a GrammarContext so graphs without overrides get isolated mutable copies
- document the behaviour of GrammarContext.from_graph when relying on defaults and add a regression test covering cfg_soft isolation

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6905e8ee7d3c8321a338f733c2eb0b6a