### PR TITLE
Ensure grammar glyph application coerces canonical inputs

### DIFF
--- a/src/tnfr/operators/grammar.py
+++ b/src/tnfr/operators/grammar.py
@@ -728,5 +728,13 @@ def apply_glyph_with_grammar(
             err.attach_context(node=node_id, stage="apply_glyph", history=history)
             _record_grammar_violation(G, node_id, err, stage="apply_glyph")
             raise
-        _apply_glyph(G, node_id, g_eff, window=window)
-        on_applied_glyph(G, node_id, g_eff)
+        telemetry_token = g_eff
+        glyph_obj = g_eff if isinstance(g_eff, Glyph) else function_name_to_glyph(g_eff)
+        if glyph_obj is None:
+            coerced = _rules.coerce_glyph(g_eff)
+            glyph_obj = coerced if isinstance(coerced, Glyph) else None
+        if glyph_obj is None:
+            raise ValueError(f"unknown glyph: {g_eff}")
+
+        _apply_glyph(G, node_id, glyph_obj, window=window)
+        on_applied_glyph(G, node_id, telemetry_token)

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -311,6 +311,24 @@ def test_apply_glyph_with_grammar_invokes_apply(monkeypatch: pytest.MonkeyPatch)
     assert captured["args"][3] == 7
 
 
+def test_apply_glyph_with_grammar_accepts_glyph_instances() -> None:
+    G = _make_graph()
+
+    apply_glyph_with_grammar(G, [0], Glyph.AL)
+
+    history = tuple(G.nodes[0]["glyph_history"])
+    assert history[-1] == Glyph.AL.value
+
+
+def test_apply_glyph_with_grammar_translates_canonical_strings() -> None:
+    G = _make_graph()
+
+    apply_glyph_with_grammar(G, [0], EMISSION)
+
+    history = tuple(G.nodes[0]["glyph_history"])
+    assert history[-1] == Glyph.AL.value
+
+
 def test_repeat_window_error_uses_structural_names() -> None:
     G = _make_graph()
     nd = G.nodes[0]


### PR DESCRIPTION
## Summary
- ensure `apply_glyph_with_grammar` always resolves glyph values to a `Glyph` instance before invoking low-level application logic while still emitting canonical telemetry tokens
- add regression coverage verifying glyph history updates succeed when applying both glyph objects and canonical operator strings

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6905efb41a0083218e2c3272abf649e2