### PR TITLE
Add Matplotlib visualization support for TNFR telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 numpy = ["numpy>=1.24"]
 yaml = ["pyyaml>=6.0"]
 orjson = ["orjson>=3"]
+viz = ["matplotlib>=3.7"]
 test = [
   "pytest>=7",
   "pytest-benchmark>=4",
@@ -45,6 +46,7 @@ test = [
   "flake8>=5",
   "flake8-pyproject>=1.2",
   "vulture>=2",
+  "matplotlib>=3.7",
 ]
 typecheck = [
   "mypy>=1.8",

--- a/src/tnfr/viz/__init__.py
+++ b/src/tnfr/viz/__init__.py
@@ -1,0 +1,9 @@
+"""Visualization helpers for TNFR telemetry."""
+
+from .matplotlib import plot_coherence_matrix, plot_phase_sync, plot_spectrum_path
+
+__all__ = [
+    "plot_coherence_matrix",
+    "plot_phase_sync",
+    "plot_spectrum_path",
+]

--- a/src/tnfr/viz/matplotlib.py
+++ b/src/tnfr/viz/matplotlib.py
@@ -1,0 +1,246 @@
+"""Matplotlib plots for TNFR telemetry channels."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+PathLike = str | Path
+
+
+def _normalise_path(save_path: PathLike | None) -> Path | None:
+    if save_path is None:
+        return None
+    return Path(save_path).expanduser().resolve()
+
+
+def _prepare_metadata(base: Mapping[str, str] | None = None, **entries: float | str) -> MutableMapping[str, str]:
+    metadata: MutableMapping[str, str] = {"engine": "TNFR"}
+    if base is not None:
+        metadata.update(base)
+    for key, value in entries.items():
+        metadata[key] = str(value)
+    return metadata
+
+
+def plot_coherence_matrix(
+    coherence_matrix: np.ndarray,
+    *,
+    channels: Sequence[str] | None = None,
+    save_path: PathLike | None = None,
+    dpi: int = 300,
+    cmap: str = "viridis",
+) -> tuple[Figure, Axes]:
+    """Plot the coherence matrix :math:`C(t)` describing nodal coupling.
+
+    Parameters
+    ----------
+    coherence_matrix:
+        Square matrix reporting pairwise TNFR coherence (0-1). Each entry
+        encodes how two nodes sustain a mutual resonance while the total coherence
+        :math:`C(t)` evolves.
+    channels:
+        Optional channel names aligned with the matrix axes.
+    save_path:
+        Optional filesystem location. When provided the figure is exported with
+        explicit metadata so structural logs can capture how :math:`C(t)` was
+        rendered.
+    dpi:
+        Resolution of the exported artifact in dots per inch.
+    cmap:
+        Matplotlib colormap name used for the coherence heatmap.
+
+    Returns
+    -------
+    (Figure, Axes)
+        The Matplotlib figure and heatmap axis.
+    """
+
+    matrix = np.asarray(coherence_matrix, dtype=float)
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("coherence_matrix must be a square 2D array")
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    image = ax.imshow(matrix, cmap=cmap, vmin=0.0, vmax=1.0)
+    ax.set_title("TNFR Coherence Matrix C(t)")
+    ax.set_xlabel("Emission nodes (νf order)")
+    ax.set_ylabel("Reception nodes (νf order)")
+    cbar = fig.colorbar(image, ax=ax, shrink=0.85)
+    cbar.set_label("Structural coherence C(t)")
+
+    size = matrix.shape[0]
+    ticks = np.arange(size)
+    ax.set_xticks(ticks)
+    ax.set_yticks(ticks)
+    if channels is not None and len(channels) == size:
+        ax.set_xticklabels(channels, rotation=45, ha="right")
+        ax.set_yticklabels(channels)
+
+    mean_coherence = float(matrix.mean())
+    metadata = _prepare_metadata(
+        {"tnfr_plot": "coherence_matrix"},
+        c_t_mean=mean_coherence,
+        phase_reference="synchrony-check",
+    )
+
+    resolved_path = _normalise_path(save_path)
+    if resolved_path is not None:
+        fig.savefig(
+            resolved_path,
+            dpi=dpi,
+            bbox_inches="tight",
+            metadata=metadata,
+        )
+
+    return fig, ax
+
+
+def plot_phase_sync(
+    phase_paths: np.ndarray,
+    time_axis: np.ndarray,
+    *,
+    structural_frequency: float,
+    node_labels: Sequence[str] | None = None,
+    save_path: PathLike | None = None,
+    dpi: int = 300,
+) -> tuple[Figure, Axes]:
+    """Plot phase synchrony φ(t) trajectories for TNFR nodes.
+
+    Parameters
+    ----------
+    phase_paths:
+        Array with shape ``(nodes, samples)`` describing the phase of each node
+        in radians. Synchronised paths map how the coupling operator preserves
+        phase locking.
+    time_axis:
+        Monotonic timestamps aligned with the samples describing the evolution of
+        :math:`C(t)`.
+    structural_frequency:
+        Global structural frequency :math:`ν_f` (Hz_str) used as the reference
+        rate for the displayed phases.
+    node_labels:
+        Optional labels describing the emitting nodes. When omitted generic
+        indices are used.
+    save_path:
+        Optional filesystem location to export the figure with TNFR metadata.
+    dpi:
+        Resolution used for exported figures.
+
+    Returns
+    -------
+    (Figure, Axes)
+        The Matplotlib figure and axis holding the phase trajectories.
+    """
+
+    phases = np.asarray(phase_paths, dtype=float)
+    times = np.asarray(time_axis, dtype=float)
+    if phases.ndim != 2:
+        raise ValueError("phase_paths must be a 2D array")
+    if times.ndim != 1:
+        raise ValueError("time_axis must be a 1D array")
+    if phases.shape[1] != times.shape[0]:
+        raise ValueError("phase_paths samples must align with time_axis")
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    labels: Iterable[str]
+    if node_labels is not None and len(node_labels) == phases.shape[0]:
+        labels = node_labels
+    else:
+        labels = (f"node {idx}" for idx in range(phases.shape[0]))
+
+    for path, label in zip(phases, labels):
+        ax.plot(times, path, label=label)
+
+    ax.set_title("TNFR Phase Synchrony φ(t)")
+    ax.set_xlabel("Time (structural cycles)")
+    ax.set_ylabel("Phase (rad)")
+    ax.legend(loc="best")
+
+    metadata = _prepare_metadata(
+        {"tnfr_plot": "phase_sync"},
+        nu_f_hz_str=structural_frequency,
+        phase_span=float(np.ptp(phases)),
+    )
+
+    resolved_path = _normalise_path(save_path)
+    if resolved_path is not None:
+        fig.savefig(
+            resolved_path,
+            dpi=dpi,
+            bbox_inches="tight",
+            metadata=metadata,
+        )
+
+    return fig, ax
+
+
+def plot_spectrum_path(
+    frequencies: np.ndarray,
+    spectrum: np.ndarray,
+    *,
+    label: str = "C(t) spectral density",
+    save_path: PathLike | None = None,
+    dpi: int = 300,
+) -> tuple[Figure, Axes]:
+    """Plot the spectral path of coherence intensity over structural frequency.
+
+    Parameters
+    ----------
+    frequencies:
+        Frequency samples (Hz_str) that describe the spectrum of ΔNFR driven
+        reorganisations.
+    spectrum:
+        Intensity values tracking how coherence redistributes along the
+        structural frequency axis.
+    label:
+        Legend label identifying the traced path of :math:`C(t)`.
+    save_path:
+        Optional filesystem location to persist the figure with TNFR metadata.
+    dpi:
+        Resolution used for exported figures.
+
+    Returns
+    -------
+    (Figure, Axes)
+        The Matplotlib figure and axis holding the spectrum path.
+    """
+
+    freq = np.asarray(frequencies, dtype=float)
+    spec = np.asarray(spectrum, dtype=float)
+    if freq.ndim != 1:
+        raise ValueError("frequencies must be a 1D array")
+    if spec.ndim != 1:
+        raise ValueError("spectrum must be a 1D array")
+    if freq.shape[0] != spec.shape[0]:
+        raise ValueError("frequencies and spectrum must share the same length")
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    ax.plot(freq, spec, marker="o", label=label)
+    ax.fill_between(freq, spec, alpha=0.2)
+    ax.set_title("TNFR Structural Spectrum")
+    ax.set_xlabel("Structural frequency ν_f (Hz_str)")
+    ax.set_ylabel("Coherence intensity C(t)")
+    ax.legend(loc="best")
+
+    metadata = _prepare_metadata(
+        {"tnfr_plot": "spectrum_path"},
+        nu_f_min=float(freq.min()),
+        nu_f_max=float(freq.max()),
+    )
+
+    resolved_path = _normalise_path(save_path)
+    if resolved_path is not None:
+        fig.savefig(
+            resolved_path,
+            dpi=dpi,
+            bbox_inches="tight",
+            metadata=metadata,
+        )
+
+    return fig, ax
+

--- a/tests/unit/viz/test_matplotlib.py
+++ b/tests/unit/viz/test_matplotlib.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from matplotlib.figure import Figure
+
+from tnfr.viz import matplotlib as tnfr_matplotlib
+
+
+def _patch_savefig(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_savefig(self, path, *args, **kwargs):  # type: ignore[override]
+        calls["self"] = self
+        calls["path"] = Path(path)
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setattr(Figure, "savefig", fake_savefig, raising=True)
+    return calls
+
+
+def test_plot_coherence_matrix_exports_metadata(tmp_path, monkeypatch):
+    save_spy = _patch_savefig(monkeypatch)
+    matrix = np.array([[1.0, 0.5], [0.5, 1.0]])
+
+    fig, ax = tnfr_matplotlib.plot_coherence_matrix(
+        matrix,
+        channels=["EPI-A", "EPI-B"],
+        save_path=tmp_path / "coherence.png",
+        dpi=200,
+    )
+
+    assert isinstance(fig, Figure)
+    assert fig.axes[0] is ax
+    assert save_spy["path"] == (tmp_path / "coherence.png").resolve()
+    kwargs = save_spy["kwargs"]
+    assert kwargs["dpi"] == 200
+    assert kwargs["bbox_inches"] == "tight"
+    assert kwargs["metadata"]["tnfr_plot"] == "coherence_matrix"
+    assert kwargs["metadata"]["engine"] == "TNFR"
+    fig.clf()
+
+
+def test_plot_phase_sync_exports_metadata(tmp_path, monkeypatch):
+    save_spy = _patch_savefig(monkeypatch)
+    phase_paths = np.array([[0.0, 0.5, 1.0], [0.1, 0.6, 1.1]])
+    time_axis = np.array([0.0, 1.0, 2.0])
+
+    fig, ax = tnfr_matplotlib.plot_phase_sync(
+        phase_paths,
+        time_axis,
+        structural_frequency=2.5,
+        node_labels=["Emitter", "Receiver"],
+        save_path=tmp_path / "phase.png",
+        dpi=150,
+    )
+
+    assert isinstance(fig, Figure)
+    assert fig.axes[0] is ax
+    kwargs = save_spy["kwargs"]
+    assert kwargs["dpi"] == 150
+    assert kwargs["bbox_inches"] == "tight"
+    assert kwargs["metadata"]["tnfr_plot"] == "phase_sync"
+    assert float(kwargs["metadata"]["nu_f_hz_str"]) == 2.5
+    fig.clf()
+
+
+def test_plot_spectrum_path_exports_metadata(tmp_path, monkeypatch):
+    save_spy = _patch_savefig(monkeypatch)
+    frequencies = np.array([0.5, 1.0, 1.5])
+    spectrum = np.array([0.2, 0.5, 0.3])
+
+    fig, ax = tnfr_matplotlib.plot_spectrum_path(
+        frequencies,
+        spectrum,
+        label="C(t) path",
+        save_path=tmp_path / "spectrum.png",
+        dpi=180,
+    )
+
+    assert isinstance(fig, Figure)
+    assert fig.axes[0] is ax
+    kwargs = save_spy["kwargs"]
+    assert kwargs["dpi"] == 180
+    assert kwargs["bbox_inches"] == "tight"
+    assert kwargs["metadata"]["tnfr_plot"] == "spectrum_path"
+    assert float(kwargs["metadata"]["nu_f_max"]) == 1.5
+    fig.clf()


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [x] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

---

- add a dedicated `tnfr.viz` package with Matplotlib helpers for coherence matrices, phase synchrony, and spectrum paths that speak TNFR terminology and export explicit metadata
- surface the new helpers in the package namespace and declare Matplotlib as an optional visualization extra while ensuring test environments install it
- cover the plotting utilities with smoke tests that patch `savefig` to verify DPI, tight bounding boxes, and TNFR metadata are written during exports

------
https://chatgpt.com/codex/tasks/task_e_6905f972f5148321a1d0f27a05b4f240