### PR TITLE
Replace TNFR viz example outputs with code-only notebook

### DIFF
--- a/examples/tnfr_visualization.ipynb
+++ b/examples/tnfr_visualization.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "08845311",
+   "metadata": {},
+   "source": [
+    "# TNFR Visualization Examples\n",
+    "\n",
+    "This notebook demonstrates deterministic TNFR telemetry visualizations\n",
+    "powered by the helpers in `tnfr.viz.matplotlib`. Execute the cells to\n",
+    "produce coherence, phase synchrony, and spectral figures driven by\n",
+    "reproducible synthetic data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "155411f6",
+   "metadata": {},
+   "source": [
+    "## Reproducibility contract\n",
+    "\n",
+    "The synthetic signals are generated from a fixed NumPy random seed and\n",
+    "all relevant library versions are logged. The resulting figures can be\n",
+    "regenerated on any system with the same dependency set by re-running the\n",
+    "notebook from top to bottom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b11e8c52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import json\n",
+    "from importlib import metadata\n",
+    "from importlib.metadata import PackageNotFoundError\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "SEED = 202405\n",
+    "rng = np.random.default_rng(SEED)\n",
+    "\n",
+    "try:\n",
+    "    tnfr_version = metadata.version(\"tnfr\")\n",
+    "except PackageNotFoundError:  # Fallback to the local package version\n",
+    "    from tnfr import __version__ as tnfr_version\n",
+    "\n",
+    "metadata_report = {\n",
+    "    \"seed\": SEED,\n",
+    "    \"numpy\": np.__version__,\n",
+    "    \"tnfr\": tnfr_version,\n",
+    "}\n",
+    "\n",
+    "print(json.dumps(metadata_report, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75de6a87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tnfr.viz import plot_coherence_matrix, plot_phase_sync, plot_spectrum_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af5ab9f5",
+   "metadata": {},
+   "source": [
+    "## Coherence matrix\n",
+    "\n",
+    "This example crafts a symmetric coherence matrix that highlights a\n",
+    "coupled quartet of nodes. Running the cell renders the matrix using the\n",
+    "canonical `plot_coherence_matrix` helper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2752590",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channels = [\"α\", \"β\", \"γ\", \"δ\"]\n",
+    "base = rng.uniform(0.45, 0.9, size=(len(channels), len(channels)))\n",
+    "coherence = (base + base.T) / 2\n",
+    "np.fill_diagonal(coherence, 1.0)\n",
+    "\n",
+    "fig, ax = plot_coherence_matrix(coherence, channels=channels)\n",
+    "fig.tight_layout()\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "def8c623",
+   "metadata": {},
+   "source": [
+    "## Phase synchrony trajectories\n",
+    "\n",
+    "The next cell emits deterministic phase trajectories for three nodes\n",
+    "under a shared structural frequency. The `plot_phase_sync` helper tracks\n",
+    "how synchrony evolves across structural cycles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdfe6f64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structural_frequency = 3.5  # Hz_str\n",
+    "samples = 240\n",
+    "time_axis = np.linspace(0.0, 12.0, samples)\n",
+    "\n",
+    "phase_offsets = rng.uniform(-0.4, 0.4, size=3)\n",
+    "phase_noise = rng.normal(scale=0.03, size=(3, samples))\n",
+    "base_phase = np.sin(time_axis / (np.pi / 1.8))\n",
+    "phase_paths = base_phase + phase_offsets[:, None] + phase_noise\n",
+    "\n",
+    "fig, ax = plot_phase_sync(\n",
+    "    phase_paths,\n",
+    "    time_axis,\n",
+    "    structural_frequency=structural_frequency,\n",
+    "    node_labels=[\"node α\", \"node β\", \"node γ\"],\n",
+    ")\n",
+    "fig.tight_layout()\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db9c98ae",
+   "metadata": {},
+   "source": [
+    "## Structural spectrum\n",
+    "\n",
+    "Finally, the spectrum helper tracks how coherence redistributes across\n",
+    "structural frequencies. The generated deterministic curve simulates a\n",
+    "stable resonance band with light secondary harmonics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20261ca1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frequencies = np.linspace(0.5, 8.0, 256)\n",
+    "peak = np.exp(-0.5 * ((frequencies - 3.2) / 0.6) ** 2)\n",
+    "secondary = 0.35 * np.exp(-0.5 * ((frequencies - 5.6) / 0.8) ** 2)\n",
+    "noise_floor = 0.08 + 0.03 * np.cos(frequencies * 1.7)\n",
+    "spectrum = peak + secondary + noise_floor\n",
+    "\n",
+    "fig, ax = plot_spectrum_path(\n",
+    "    frequencies,\n",
+    "    spectrum,\n",
+    "    label=\"ΔNFR resonance distribution\",\n",
+    ")\n",
+    "fig.tight_layout()\n",
+    "fig"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

Rebuilt `examples/tnfr_visualization.ipynb` so it documents the deterministic
random seed and library versions while leaving all outputs empty. Removed the
previously tracked PNG artifacts so the repository remains code-only for easier
PR handling.

------
https://chatgpt.com/codex/tasks/task_e_6905fcd3b9cc832197c9a65ed6a17bbc