### PR TITLE
Add symbol mapping and canonical validator documentation

### DIFF
--- a/docs/source/api/api_mapping.rst
+++ b/docs/source/api/api_mapping.rst
@@ -1,0 +1,68 @@
+.. _api-symbol-map:
+
+TNFR symbol → API mapping
+=========================
+
+The canonical TNFR symbols reference specific public classes and factories that
+expose the mathematical objects used throughout the engine. Use this map when
+you need to correlate the algebraic notation with importable Python APIs.
+
+NFR — node factories and structural loops
+-----------------------------------------
+
+``NFR`` denotes a resonant node: its public API is exposed through the
+structural helpers that seed a graph node and run validated operator
+trajectories.
+
+.. autofunction:: tnfr.structural.create_nfr
+
+.. autofunction:: tnfr.structural.run_sequence
+
+.. autoclass:: tnfr.node.NodeNX
+   :show-inheritance:
+
+Ĉ — coherence operator
+----------------------
+
+``Ĉ`` captures how coherence redistributes across the EPI spectrum. The
+mathematical operators module provides the canonical implementation and
+factories for coherence operators.
+
+.. autoclass:: tnfr.mathematics.operators.CoherenceOperator
+   :show-inheritance:
+
+.. autofunction:: tnfr.mathematics.operators_factory.make_coherence_operator
+
+Ĵ — frequency operator
+----------------------
+
+``Ĵ`` is the structural frequency operator paired with ``Ĉ``. It ensures
+νf remains non-negative and aligned with the Hilbert basis.
+
+.. autoclass:: tnfr.mathematics.operators.FrequencyOperator
+   :show-inheritance:
+
+.. autofunction:: tnfr.mathematics.operators_factory.make_frequency_operator
+
+ΔNFR — canonical reorganisation hook
+------------------------------------
+
+``ΔNFR`` measures the internal demand for reorganisation. The structural layer
+installs a canonical hook that mixes EPI and νf before every operator step.
+
+.. autofunction:: tnfr.dynamics.dnfr.dnfr_epi_vf_mixed
+
+EPI — primary information structure
+-----------------------------------
+
+``EPI`` stores the coherent form that operators reorganise. The mathematics
+package exposes Banach elements validated against the canonical domain.
+
+.. autoclass:: tnfr.mathematics.epi.BEPIElement
+   :show-inheritance:
+
+.. autoclass:: tnfr.mathematics.spaces.BanachSpaceEPI
+   :show-inheritance:
+.. seealso::
+
+   {doc}`api/canonical_validators` for runtime validation helpers.

--- a/docs/source/api/canonical_validators.rst
+++ b/docs/source/api/canonical_validators.rst
@@ -1,0 +1,70 @@
+.. _api-canonical-validators:
+
+Canonical validators and dynamics checks
+=======================================
+
+Use these validators to keep simulations within the canonical TNFR
+constraints. Each entry links to the public API and includes a minimal doctest
+that runs in CI.
+
+stable_unitary — unitary stability check
+----------------------------------------
+
+.. autofunction:: tnfr.mathematics.runtime.stable_unitary
+
+Example
+~~~~~~~
+
+.. doctest::
+   >>> import numpy as np
+   >>> from tnfr.mathematics.operators import CoherenceOperator
+   >>> from tnfr.mathematics.runtime import stable_unitary
+   >>> from tnfr.mathematics.spaces import HilbertSpace
+   >>> hilbert = HilbertSpace(2)
+   >>> operator = CoherenceOperator([0.0, 0.5])
+   >>> state = np.array([1.0, 0.0], dtype=np.complex128)
+   >>> passed, norm_after = stable_unitary(state, operator, hilbert)
+   >>> passed
+   True
+   >>> round(norm_after, 6)
+   1.0
+
+frequency_positive — structural frequency guard
+-----------------------------------------------
+
+.. autofunction:: tnfr.mathematics.runtime.frequency_positive
+
+Example
+~~~~~~~
+
+.. doctest::
+   >>> import numpy as np
+   >>> from tnfr.mathematics.operators import FrequencyOperator
+   >>> from tnfr.mathematics.runtime import frequency_positive
+   >>> operator = FrequencyOperator(np.diag([0.2, 0.4]))
+   >>> summary = frequency_positive(np.array([1.0, 0.0], dtype=np.complex128), operator)
+   >>> summary["passed"], round(summary["value"], 3)
+   (True, 0.2)
+
+ContractiveDynamicsEngine — dissipative evolution monitor
+---------------------------------------------------------
+
+.. autoclass:: tnfr.mathematics.dynamics.ContractiveDynamicsEngine
+   :show-inheritance:
+
+Example
+~~~~~~~
+
+.. doctest::
+   >>> import numpy as np
+   >>> from tnfr.mathematics.dynamics import ContractiveDynamicsEngine
+   >>> from tnfr.mathematics.spaces import HilbertSpace
+   >>> hilbert = HilbertSpace(2)
+   >>> lindblad = -0.05 * np.eye(4, dtype=np.complex128)
+   >>> engine = ContractiveDynamicsEngine(lindblad, hilbert)
+   >>> rho0 = np.array([[1.0, 0.0], [0.0, 0.0]], dtype=np.complex128)
+   >>> rho1 = engine.step(rho0, dt=0.25)
+   >>> float(np.trace(rho1).real)
+   1.0
+   >>> engine.last_contractivity_gap >= -1e-9
+   True

--- a/docs/source/api/overview.md
+++ b/docs/source/api/overview.md
@@ -134,3 +134,6 @@ engine keeps operating without raising. Set the environment variable
 ``TNFR_GRAMMAR_VALIDATE=1`` to require validation (raising when the schema or
 dependency is missing) or ``TNFR_GRAMMAR_VALIDATE=0`` to skip schema checks when
 working with experimental configurations.
+
+
+For symbol-level references and canonical validators, see {doc}`api/api_mapping` and {doc}`api/canonical_validators`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,9 @@ This site curates the canonical TNFR knowledge base, API contracts, and structur
    :caption: API
 
    Overview <api/overview>
+   Symbol map <api/api_mapping>
    Structural operators <api/operators>
+   Canonical validators <api/canonical_validators>
    Telemetry & utilities <api/telemetry>
 
 .. toctree::


### PR DESCRIPTION
## Summary
- add a TNFR symbol-to-API mapping page that ties canonical glyphs to the exposed modules
- document the canonical validator helpers with runnable doctest snippets
- surface both references from the API toctree and overview page to ease navigation

## Testing
- not run (sphinx-build unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_6906092358248321b39d731ff5feec4c