### PR TITLE
Expose get_lock via tnfr.utils

### DIFF
--- a/docs/source/api/overview.md
+++ b/docs/source/api/overview.md
@@ -61,7 +61,7 @@ flowchart LR
 - `tnfr.trace.register_trace` attaches before/after callbacks through the shared callback
   manager, capturing Γ specs, selector state, ΔNFR weights, Kuramoto metrics, and operator
   counts in the graph history so every simulation leaves an auditable trail.
-- Named locks from `tnfr.locking.get_lock` synchronise shared caches such as the RNG seed
+- Named locks from `tnfr.utils.get_lock` (re-exporting `tnfr.locking.get_lock`) synchronise shared caches such as the RNG seed
   tables, ensuring deterministic jitter across processes without duplicating lock
   definitions.
 - Helper facades re-export cache utilities so higher layers depend on a stable API while

--- a/docs/source/api/telemetry.md
+++ b/docs/source/api/telemetry.md
@@ -144,7 +144,8 @@ As with traces, an explicit override of `METRICS` parameters (for example `save_
 ## Locking policy
 
 The engine centralises reusable process-wide locks in `tnfr.locking`. Obtain named locks with
-`tnfr.locking.get_lock()` and reuse them for caches, RNG seeds, and other shared resources.
+`tnfr.utils.get_lock()` (re-exporting :func:`tnfr.locking.get_lock`) and reuse them for caches,
+RNG seeds, and other shared resources.
 Avoid scattering bare `threading.Lock` instances across modules; only short-lived objects may
 instantiate ad-hoc locks when they are not shared.
 

--- a/src/tnfr/utils/__init__.py
+++ b/src/tnfr/utils/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Final
 
 from . import init as _init
+from ..locking import get_lock
 
 WarnOnce = _init.WarnOnce
 cached_import = _init.cached_import
@@ -109,6 +110,7 @@ __all__ = (
     "warm_cached_import",
     "LazyImportProxy",
     "get_logger",
+    "get_lock",
     "get_nodenx",
     "get_numpy",
     "prune_failed_imports",

--- a/src/tnfr/utils/__init__.pyi
+++ b/src/tnfr/utils/__init__.pyi
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Final
 
+from threading import Lock
+
 from .cache import (
     CacheCapacityConfig,
     CacheLayer,
@@ -100,6 +102,7 @@ __all__ = (
     "warm_cached_import",
     "LazyImportProxy",
     "get_logger",
+    "get_lock",
     "get_nodenx",
     "get_numpy",
     "prune_failed_imports",
@@ -174,6 +177,8 @@ __all__ = (
     "_DEFAULT_CACHE_SIZE",
     "EMIT_MAP",
 )
+
+def get_lock(name: str, /) -> Lock: ...
 
 _DYNAMIC_EXPORTS: Final[frozenset[str]]
 


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- Re-export `tnfr.locking.get_lock` from the `tnfr.utils` namespace and update the type stub so helpers can import it consistently.
- Document the new `tnfr.utils.get_lock` entry point in the telemetry and overview guides to keep the locking policy references aligned.


------
https://chatgpt.com/codex/tasks/task_e_69061ba3dee48321b4a99a17963cd67e