### PR TITLE
Align grammar sequence validation with unified outcome

### DIFF
--- a/src/tnfr/validation/syntax.py
+++ b/src/tnfr/validation/syntax.py
@@ -1,39 +1,8 @@
-"""Compatibility wrapper around :mod:`tnfr.operators.grammar` validators."""
+"""Compatibility re-export for canonical sequence validation."""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
-from . import ValidationOutcome
-from ..operators.grammar import SequenceValidationResult, validate_sequence as _validate
+from ..operators.grammar import validate_sequence
 
 __all__ = ("validate_sequence",)
 
-
-def _to_validation_outcome(result: SequenceValidationResult) -> ValidationOutcome[tuple[str, ...]]:
-    summary = dict(result.summary)
-    artifacts = {
-        "canonical_tokens": result.canonical_tokens,
-        "metadata": result.metadata,
-    }
-    return ValidationOutcome(
-        subject=result.tokens,
-        passed=result.passed,
-        summary=summary,
-        artifacts=artifacts,
-    )
-
-
-def validate_sequence(
-    names: Iterable[str] | object = None, **kwargs: object
-) -> ValidationOutcome[tuple[str, ...]]:
-    """Validate minimal TNFR syntax rules returning a legacy :class:`ValidationOutcome`."""
-
-    if names is None and "names" not in kwargs:
-        raise TypeError("validate_sequence() missing required argument: 'names'")
-
-    if names is None and "names" in kwargs:
-        names = kwargs.pop("names")
-
-    result = _validate(names, **kwargs)
-    return _to_validation_outcome(result)

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -31,6 +31,7 @@ from tnfr.operators.grammar import (
     parse_sequence,
     validate_sequence,
 )
+from tnfr.validation import ValidationOutcome
 from tnfr.types import Glyph
 
 
@@ -40,6 +41,7 @@ def _canonical_sequence() -> list[str]:
 
 def test_validate_sequence_success() -> None:
     result = validate_sequence(_canonical_sequence())
+    assert isinstance(result, ValidationOutcome)
     assert isinstance(result, SequenceValidationResult)
     assert result.passed
     assert result.message == "ok"

--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -44,6 +44,7 @@ from tnfr.structural import (
     create_nfr,
     validate_sequence,
 )
+from tnfr.validation import ValidationOutcome
 
 
 def _outcome_stub(names: list[str] | tuple[str, ...]) -> SequenceValidationResult:
@@ -93,6 +94,7 @@ def test_sequence_validation_and_run() -> None:
     ops = [Emission(), Reception(), Coherence(), Resonance(), Silence()]
     names = [op.name for op in ops]
     outcome = validate_sequence(names)
+    assert isinstance(outcome, ValidationOutcome)
     assert isinstance(outcome, SequenceValidationResult)
     assert outcome.passed, outcome.summary["message"]
     assert outcome.summary["tokens"] == tuple(names)


### PR DESCRIPTION
## Summary
- extend `SequenceValidationResult` from the canonical `ValidationOutcome` so grammar validation yields the unified contract while keeping legacy attributes available
- collapse `tnfr.validation.syntax.validate_sequence` into a lightweight re-export of the grammar helper
- adjust operator and structural tests to assert the shared `ValidationOutcome` interface

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_69061ca59db883218b84b0acea923de7