### PR TITLE
Refine chunk sizing heuristics across dynamics and metrics

### DIFF
--- a/src/tnfr/dynamics/adaptation.py
+++ b/src/tnfr/dynamics/adaptation.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from ..alias import collect_attr, set_vf
 from ..constants import get_graph_param
-from ..utils import clamp
+from ..utils import clamp, resolve_chunk_size
 from ..metrics.common import ensure_neighbors_map
 from ..types import CoherenceMetric, DeltaNFR, NodeId, TNFRGraph
 from ..utils import get_numpy
@@ -243,7 +243,12 @@ def adapt_vf_by_coherence(G: TNFRGraph, n_jobs: int | None = None) -> None:
         )
         work_items.append((node, idx, neigh_indices))
 
-    chunk_size = max(1, math.ceil(len(work_items) / jobs))
+    approx_chunk = math.ceil(len(work_items) / jobs) if jobs else None
+    chunk_size = resolve_chunk_size(
+        approx_chunk,
+        len(work_items),
+        minimum=1,
+    )
     chunks = [
         work_items[i : i + chunk_size] for i in range(0, len(work_items), chunk_size)
     ]

--- a/src/tnfr/dynamics/coordination.py
+++ b/src/tnfr/dynamics/coordination.py
@@ -17,7 +17,7 @@ from ..constants import (
     normalise_state_token,
 )
 from ..glyph_history import append_metric
-from ..utils import angle_diff
+from ..utils import angle_diff, resolve_chunk_size
 from ..metrics.common import ensure_neighbors_map
 from ..metrics.trig import neighbor_phase_mean_list
 from ..metrics.trig_cache import get_trig_cache
@@ -354,7 +354,12 @@ def coordinate_global_local_phase(
             set_theta(G, node, float(th + kG * dG + kL * dL))
         return
 
-    chunk_size = max(1, math.ceil(len(nodes) / jobs))
+    approx_chunk = math.ceil(len(nodes) / jobs) if jobs else None
+    chunk_size = resolve_chunk_size(
+        approx_chunk,
+        len(nodes),
+        minimum=1,
+    )
     chunks = [nodes[idx : idx + chunk_size] for idx in range(0, len(nodes), chunk_size)]
     args: list[ChunkArgs] = [
         (

--- a/src/tnfr/glyph_history.py
+++ b/src/tnfr/glyph_history.py
@@ -288,6 +288,8 @@ def count_glyphs(
     """
 
     if window is not None:
+        from tnfr.validation.window import validate_window
+
         window = validate_window(window)
         if window == 0:
             return Counter()

--- a/src/tnfr/metrics/glyph_timing.py
+++ b/src/tnfr/metrics/glyph_timing.py
@@ -22,6 +22,7 @@ from ..constants import get_param
 from ..constants.aliases import ALIAS_EPI
 from ..glyph_history import append_metric
 from ..glyph_runtime import last_glyph
+from ..utils import resolve_chunk_size
 from ..types import (
     GlyphCounts,
     GlyphMetricsHistory,
@@ -218,7 +219,12 @@ def _update_tg(
             }
         )
     elif n_jobs is not None and n_jobs > 1 and len(glyph_sequence) > 1:
-        chunk_size = max(1, math.ceil(len(glyph_sequence) / n_jobs))
+        approx_chunk = math.ceil(len(glyph_sequence) / n_jobs) if n_jobs else None
+        chunk_size = resolve_chunk_size(
+            approx_chunk,
+            len(glyph_sequence),
+            minimum=1,
+        )
         futures = []
         with ProcessPoolExecutor(max_workers=n_jobs) as executor:
             for start in range(0, len(glyph_sequence), chunk_size):
@@ -298,7 +304,12 @@ def _update_epi_support(
             abs(_coerce_float(get_attr(nd, ALIAS_EPI, 0.0)))
             for _, nd in G.nodes(data=True)
         ]
-        chunk_size = max(1, math.ceil(len(values) / n_jobs))
+        approx_chunk = math.ceil(len(values) / n_jobs) if n_jobs else None
+        chunk_size = resolve_chunk_size(
+            approx_chunk,
+            len(values),
+            minimum=1,
+        )
         totals: list[tuple[float, int]] = []
         with ProcessPoolExecutor(max_workers=n_jobs) as executor:
             futures = []

--- a/src/tnfr/operators/grammar.py
+++ b/src/tnfr/operators/grammar.py
@@ -6,6 +6,7 @@ import json
 import os
 from collections.abc import Iterable, MutableMapping
 from copy import deepcopy
+from dataclasses import dataclass
 from importlib import resources
 from json import JSONDecodeError
 from types import MappingProxyType


### PR DESCRIPTION
## Summary
- replace manual chunk size calculations with resolve_chunk_size throughout dynamics and metrics modules to centralise heuristics
- ensure supporting utilities import dataclass and validate glyph history windows without circular imports
- extend stress and unit tests to assert resolve_chunk_size usage and updated chunk expectations

## Testing
- pytest tests/unit/metrics/test_metrics.py
- pytest tests/unit/metrics/test_collect_selector_metrics.py
- pytest tests/unit/metrics/test_diagnosis_parallel.py
- pytest tests/unit/dynamics/test_vf_coherence.py
- pytest tests/unit/dynamics/test_integrators_parallel.py
- pytest tests/stress/test_phase_coordination.py -m slow -k coordinate_phase_parallel_matches_sequential -s


------
https://chatgpt.com/codex/tasks/task_e_69062b36e1908321bd78f9bdf2cf0910