### PR TITLE
feat: add configurable mathematics backend adapters

### DIFF
--- a/docs/source/getting-started/math-backends.md
+++ b/docs/source/getting-started/math-backends.md
@@ -1,0 +1,59 @@
+# Mathematics backends
+
+TNFR separates structural semantics from numerical implementations via the
+`tnfr.mathematics.backend` module.  This lets you couple nodes, evaluate
+coherence, and propagate ΔNFR in environments that favour different numerical
+libraries.
+
+## Selecting a backend
+
+```python
+from tnfr.mathematics import get_backend
+
+backend = get_backend("jax")  # explicit name overrides other signals
+xp = backend.as_array
+```
+
+Resolution order:
+
+1. Explicit name passed to `get_backend`.
+2. `TNFR_MATH_BACKEND` environment variable.
+3. `tnfr.config.get_flags().math_backend`.
+4. NumPy (default).
+
+The default keeps NumPy active so canonical coherence operators continue to
+work when optional dependencies are absent.
+
+## Available adapters
+
+| Backend | Extra dependency | Autodiff | Notes |
+| ------- | ---------------- | -------- | ----- |
+| NumPy   | `pip install tnfr[numpy]` | No | Canonical reference implementation. Uses SciPy for `expm` when available, otherwise falls back to an eigen decomposition strategy. |
+| JAX     | `pip install tnfr[jax]`   | Yes | Requires `jax` and `jax.scipy`. Some imperative NumPy routines (e.g. in observers) remain NumPy-only. |
+| PyTorch | `pip install tnfr[torch]` | Yes | Uses `torch.linalg`. Exporting tensors to NumPy moves them to CPU and breaks gradients. |
+
+> Autodifferentiation support is scoped to backend operations.  TNFR structural
+> pipelines that execute pure NumPy functions or rely on mutable state will not
+> become differentiable automatically.
+
+## Configuration helpers
+
+Use `tnfr.config.context_flags` to adjust the backend temporarily without
+mutating global state:
+
+```python
+from tnfr.config import context_flags
+from tnfr.mathematics import get_backend
+
+with context_flags(math_backend="torch"):
+    torch_backend = get_backend()
+```
+
+Set `TNFR_MATH_BACKEND` in your environment to persist a preference across
+processes:
+
+```bash
+export TNFR_MATH_BACKEND=jax
+```
+
+Remember to install the matching extra before enabling a backend.

--- a/docs/source/getting-started/quickstart.md
+++ b/docs/source/getting-started/quickstart.md
@@ -18,6 +18,8 @@ pip install tnfr
 Optional extras:
 
 - NumPy: `pip install tnfr[numpy]`
+- JAX: `pip install tnfr[jax]`
+- PyTorch: `pip install tnfr[torch]`
 - YAML: `pip install tnfr[yaml]`
 - orjson (faster JSON serialization): `pip install tnfr[orjson]`
 - All extras: `pip install tnfr[numpy,yaml,orjson]`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ This site curates the canonical TNFR knowledge base, API contracts, and structur
    :caption: Getting started
 
    Quickstart <getting-started/quickstart>
+   Mathematics backends <getting-started/math-backends>
    Quick Start (Mathematics) <foundations>
    Migrating from Remesh Window <getting-started/migrating-remesh-window>
    How to reproduce TNFR results <how_to_reproduce_results>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 
 [project.optional-dependencies]
 numpy = ["numpy>=1.24"]
+jax = ["jax>=0.4"]
+torch = ["torch>=2.1"]
 yaml = ["pyyaml>=6.0"]
 orjson = ["orjson>=3"]
 viz = ["matplotlib>=3.7"]

--- a/src/tnfr/config/feature_flags.py
+++ b/src/tnfr/config/feature_flags.py
@@ -17,6 +17,7 @@ class MathFeatureFlags:
     enable_math_validation: bool = False
     enable_math_dynamics: bool = False
     log_performance: bool = False
+    math_backend: str = "numpy"
 
 
 _TRUE_VALUES = {"1", "true", "on", "yes", "y", "t"}
@@ -41,6 +42,8 @@ def _parse_env_flag(name: str, default: bool) -> bool:
 def _load_base_flags() -> MathFeatureFlags:
     global _BASE_FLAGS
     if _BASE_FLAGS is None:
+        backend = os.getenv("TNFR_MATH_BACKEND")
+        backend_choice = backend.strip() if backend else "numpy"
         _BASE_FLAGS = MathFeatureFlags(
             enable_math_validation=_parse_env_flag(
                 "TNFR_ENABLE_MATH_VALIDATION", False
@@ -49,6 +52,7 @@ def _load_base_flags() -> MathFeatureFlags:
                 "TNFR_ENABLE_MATH_DYNAMICS", False
             ),
             log_performance=_parse_env_flag("TNFR_LOG_PERF", False),
+            math_backend=backend_choice or "numpy",
         )
     return _BASE_FLAGS
 

--- a/src/tnfr/mathematics/__init__.py
+++ b/src/tnfr/mathematics/__init__.py
@@ -1,5 +1,19 @@
-"""Mathematics primitives aligned with TNFR coherence modeling."""
+"""Mathematics primitives aligned with TNFR coherence modeling.
 
+Backend selection
+-----------------
+Use :func:`get_backend` to retrieve a numerical backend compatible with TNFR's
+structural operators.  The selection order is ``name`` → ``TNFR_MATH_BACKEND``
+→ :func:`tnfr.config.get_flags`.  NumPy remains the canonical default so
+existing code continues to operate even when optional dependencies are absent.
+"""
+
+from .backend import (
+    MathematicsBackend,
+    available_backends,
+    get_backend,
+    register_backend,
+)
 from .dynamics import ContractiveDynamicsEngine, MathematicalDynamicsEngine
 from .epi import BEPIElement, CoherenceEvaluation, evaluate_coherence_transform
 from .generators import build_delta_nfr, build_lindblad_delta_nfr
@@ -27,6 +41,7 @@ from .transforms import (
 from ..validation import NFRValidator
 
 __all__ = [
+    "MathematicsBackend",
     "HilbertSpace",
     "BanachSpaceEPI",
     "BEPIElement",
@@ -56,4 +71,7 @@ __all__ = [
     "dcoh",
     "coherence_expectation",
     "frequency_expectation",
+    "available_backends",
+    "get_backend",
+    "register_backend",
 ]

--- a/src/tnfr/mathematics/backend.py
+++ b/src/tnfr/mathematics/backend.py
@@ -1,0 +1,363 @@
+"""Backend abstraction for TNFR mathematical kernels.
+
+This module introduces a unified interface that maps core linear algebra
+operations to concrete numerical libraries.  Keeping this layer small and
+canonical guarantees we can switch implementations without diluting the
+structural semantics required by TNFR (coherence, phase, νf, ΔNFR, etc.).
+
+The canonical entry point is :func:`get_backend`, which honours three lookup
+mechanisms in order of precedence:
+
+1. Explicit ``name`` argument.
+2. ``TNFR_MATH_BACKEND`` environment variable.
+3. ``tnfr.config.get_flags().math_backend``.
+
+If none of these provide a value we default to the NumPy backend.  Optional
+backends are registered lazily so downstream environments without JAX or
+PyTorch remain functional.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any, Callable, ClassVar, Iterable, Mapping, MutableMapping, Protocol
+
+from ..utils import cached_import, get_logger
+
+logger = get_logger(__name__)
+
+
+class BackendUnavailableError(RuntimeError):
+    """Raised when a registered backend cannot be constructed."""
+
+
+class MathematicsBackend(Protocol):
+    """Structural numerical backend interface."""
+
+    name: str
+    supports_autodiff: bool
+
+    def as_array(self, value: Any, *, dtype: Any | None = None) -> Any:
+        """Convert ``value`` into a backend-native dense array."""
+
+    def eig(self, matrix: Any) -> tuple[Any, Any]:
+        """Return eigenvalues and eigenvectors for a general matrix."""
+
+    def eigh(self, matrix: Any) -> tuple[Any, Any]:
+        """Return eigenpairs for a Hermitian/symmetric matrix."""
+
+    def matrix_exp(self, matrix: Any) -> Any:
+        """Compute the matrix exponential of ``matrix``."""
+
+    def norm(self, value: Any, *, ord: Any | None = None, axis: Any | None = None) -> Any:
+        """Return the matrix or vector norm according to ``ord``."""
+
+    def einsum(self, pattern: str, *operands: Any, **kwargs: Any) -> Any:
+        """Evaluate an Einstein summation expression."""
+
+    def matmul(self, a: Any, b: Any) -> Any:
+        """Matrix multiplication that respects backend broadcasting rules."""
+
+    def conjugate_transpose(self, matrix: Any) -> Any:
+        """Hermitian conjugate of ``matrix`` († operator)."""
+
+    def stack(self, arrays: Iterable[Any], *, axis: int = 0) -> Any:
+        """Stack arrays along a new ``axis``."""
+
+    def to_numpy(self, value: Any) -> Any:
+        """Convert ``value`` to a ``numpy.ndarray`` when possible."""
+
+
+BackendFactory = Callable[[], MathematicsBackend]
+
+
+@dataclass(slots=True)
+class _NumpyBackend:
+    """NumPy backed implementation."""
+
+    _np: Any
+    _scipy_linalg: Any | None
+
+    name: ClassVar[str] = "numpy"
+    supports_autodiff: ClassVar[bool] = False
+
+    def as_array(self, value: Any, *, dtype: Any | None = None) -> Any:
+        return self._np.asarray(value, dtype=dtype)
+
+    def eig(self, matrix: Any) -> tuple[Any, Any]:
+        return self._np.linalg.eig(matrix)
+
+    def eigh(self, matrix: Any) -> tuple[Any, Any]:
+        return self._np.linalg.eigh(matrix)
+
+    def matrix_exp(self, matrix: Any) -> Any:
+        if self._scipy_linalg is not None:
+            return self._scipy_linalg.expm(matrix)
+        eigvals, eigvecs = self._np.linalg.eig(matrix)
+        inv = self._np.linalg.inv(eigvecs)
+        exp_vals = self._np.exp(eigvals)
+        return eigvecs @ self._np.diag(exp_vals) @ inv
+
+    def norm(self, value: Any, *, ord: Any | None = None, axis: Any | None = None) -> Any:
+        return self._np.linalg.norm(value, ord=ord, axis=axis)
+
+    def einsum(self, pattern: str, *operands: Any, **kwargs: Any) -> Any:
+        return self._np.einsum(pattern, *operands, **kwargs)
+
+    def matmul(self, a: Any, b: Any) -> Any:
+        return self._np.matmul(a, b)
+
+    def conjugate_transpose(self, matrix: Any) -> Any:
+        return self._np.conjugate(matrix).T
+
+    def stack(self, arrays: Iterable[Any], *, axis: int = 0) -> Any:
+        return self._np.stack(tuple(arrays), axis=axis)
+
+    def to_numpy(self, value: Any) -> Any:
+        return self._np.asarray(value)
+
+
+@dataclass(slots=True)
+class _JaxBackend:
+    """JAX backed implementation."""
+
+    _jnp: Any
+    _jax_linalg: Any
+    _jax: Any
+
+    name: ClassVar[str] = "jax"
+    supports_autodiff: ClassVar[bool] = True
+
+    def as_array(self, value: Any, *, dtype: Any | None = None) -> Any:
+        return self._jnp.asarray(value, dtype=dtype)
+
+    def eig(self, matrix: Any) -> tuple[Any, Any]:
+        return self._jnp.linalg.eig(matrix)
+
+    def eigh(self, matrix: Any) -> tuple[Any, Any]:
+        return self._jnp.linalg.eigh(matrix)
+
+    def matrix_exp(self, matrix: Any) -> Any:
+        return self._jax_linalg.expm(matrix)
+
+    def norm(self, value: Any, *, ord: Any | None = None, axis: Any | None = None) -> Any:
+        return self._jnp.linalg.norm(value, ord=ord, axis=axis)
+
+    def einsum(self, pattern: str, *operands: Any, **kwargs: Any) -> Any:
+        return self._jnp.einsum(pattern, *operands, **kwargs)
+
+    def matmul(self, a: Any, b: Any) -> Any:
+        return self._jnp.matmul(a, b)
+
+    def conjugate_transpose(self, matrix: Any) -> Any:
+        return self._jnp.conjugate(matrix).T
+
+    def stack(self, arrays: Iterable[Any], *, axis: int = 0) -> Any:
+        return self._jnp.stack(tuple(arrays), axis=axis)
+
+    def to_numpy(self, value: Any) -> Any:
+        np_mod = cached_import("numpy")
+        if np_mod is None:
+            raise BackendUnavailableError("NumPy is required to export JAX arrays")
+        return np_mod.asarray(self._jax.device_get(value))
+
+
+@dataclass(slots=True)
+class _TorchBackend:
+    """PyTorch backed implementation."""
+
+    _torch: Any
+    _torch_linalg: Any
+
+    name: ClassVar[str] = "torch"
+    supports_autodiff: ClassVar[bool] = True
+
+    def as_array(self, value: Any, *, dtype: Any | None = None) -> Any:
+        tensor = self._torch.as_tensor(value)
+        if dtype is not None:
+            tensor = tensor.to(dtype=dtype)
+        return tensor
+
+    def eig(self, matrix: Any) -> tuple[Any, Any]:
+        eigenvalues, eigenvectors = self._torch.linalg.eig(matrix)
+        return eigenvalues, eigenvectors
+
+    def eigh(self, matrix: Any) -> tuple[Any, Any]:
+        eigenvalues, eigenvectors = self._torch.linalg.eigh(matrix)
+        return eigenvalues, eigenvectors
+
+    def matrix_exp(self, matrix: Any) -> Any:
+        return self._torch_linalg.matrix_exp(matrix)
+
+    def norm(self, value: Any, *, ord: Any | None = None, axis: Any | None = None) -> Any:
+        if axis is None:
+            return self._torch.linalg.norm(value, ord=ord)
+        return self._torch.linalg.norm(value, ord=ord, dim=axis)
+
+    def einsum(self, pattern: str, *operands: Any, **kwargs: Any) -> Any:
+        return self._torch.einsum(pattern, *operands, **kwargs)
+
+    def matmul(self, a: Any, b: Any) -> Any:
+        return self._torch.matmul(a, b)
+
+    def conjugate_transpose(self, matrix: Any) -> Any:
+        return matrix.mH if hasattr(matrix, "mH") else matrix.conj().transpose(-2, -1)
+
+    def stack(self, arrays: Iterable[Any], *, axis: int = 0) -> Any:
+        return self._torch.stack(tuple(arrays), dim=axis)
+
+    def to_numpy(self, value: Any) -> Any:
+        np_mod = cached_import("numpy")
+        if np_mod is None:
+            raise BackendUnavailableError("NumPy is required to export Torch tensors")
+        if hasattr(value, "detach"):
+            return value.detach().cpu().numpy()
+        return np_mod.asarray(value)
+
+
+def _normalise_name(name: str) -> str:
+    return name.strip().lower()
+
+
+_BACKEND_FACTORIES: MutableMapping[str, BackendFactory] = {}
+_BACKEND_ALIASES: MutableMapping[str, str] = {}
+_BACKEND_CACHE: MutableMapping[str, MathematicsBackend] = {}
+
+
+def register_backend(
+    name: str,
+    factory: BackendFactory,
+    *,
+    aliases: Iterable[str] | None = None,
+    override: bool = False,
+) -> None:
+    """Register a backend factory under ``name``.
+
+    Parameters
+    ----------
+    name:
+        Canonical backend identifier.
+    factory:
+        Callable that returns a :class:`MathematicsBackend` instance.
+    aliases:
+        Optional alternative identifiers that will resolve to ``name``.
+    override:
+        When ``True`` replaces existing registrations.
+    """
+
+    key = _normalise_name(name)
+    if not override and key in _BACKEND_FACTORIES:
+        raise ValueError(f"Backend '{name}' already registered")
+    _BACKEND_FACTORIES[key] = factory
+    if aliases:
+        for alias in aliases:
+            alias_key = _normalise_name(alias)
+            if not override and alias_key in _BACKEND_ALIASES:
+                raise ValueError(f"Backend alias '{alias}' already registered")
+            _BACKEND_ALIASES[alias_key] = key
+
+
+def _resolve_backend_name(name: str | None) -> str:
+    if name:
+        return _normalise_name(name)
+
+    env_choice = os.getenv("TNFR_MATH_BACKEND")
+    if env_choice:
+        return _normalise_name(env_choice)
+
+    backend_from_flags: str | None = None
+    try:
+        from ..config import get_flags  # Local import avoids circular dependency
+
+        backend_from_flags = getattr(get_flags(), "math_backend", None)
+    except Exception:  # pragma: no cover - defensive; config must not break selection
+        backend_from_flags = None
+
+    if backend_from_flags:
+        return _normalise_name(backend_from_flags)
+
+    return "numpy"
+
+
+def _resolve_factory(name: str) -> BackendFactory:
+    canonical = _BACKEND_ALIASES.get(name, name)
+    try:
+        return _BACKEND_FACTORIES[canonical]
+    except KeyError as exc:  # pragma: no cover - defensive path
+        raise LookupError(f"Unknown mathematics backend: {name}") from exc
+
+
+def get_backend(name: str | None = None) -> MathematicsBackend:
+    """Return a backend instance using the configured resolution order."""
+
+    resolved_name = _resolve_backend_name(name)
+    canonical = _BACKEND_ALIASES.get(resolved_name, resolved_name)
+    if canonical in _BACKEND_CACHE:
+        return _BACKEND_CACHE[canonical]
+
+    factory = _resolve_factory(canonical)
+    try:
+        backend = factory()
+    except BackendUnavailableError as exc:
+        logger.warning("Backend '%s' unavailable: %s", canonical, exc)
+        if canonical != "numpy":
+            logger.warning("Falling back to NumPy backend")
+            return get_backend("numpy")
+        raise
+
+    _BACKEND_CACHE[canonical] = backend
+    return backend
+
+
+def available_backends() -> Mapping[str, BackendFactory]:
+    """Return the registered backend factories."""
+
+    return dict(_BACKEND_FACTORIES)
+
+
+def _make_numpy_backend() -> MathematicsBackend:
+    np_module = cached_import("numpy")
+    if np_module is None:
+        raise BackendUnavailableError("NumPy is not installed")
+    scipy_linalg = cached_import("scipy.linalg")
+    if scipy_linalg is None:
+        logger.debug("SciPy not available; falling back to eigen decomposition for expm")
+    return _NumpyBackend(np_module, scipy_linalg)
+
+
+def _make_jax_backend() -> MathematicsBackend:
+    jnp_module = cached_import("jax.numpy")
+    if jnp_module is None:
+        raise BackendUnavailableError("jax.numpy is not available")
+    jax_scipy = cached_import("jax.scipy.linalg")
+    if jax_scipy is None:
+        raise BackendUnavailableError("jax.scipy.linalg is required for matrix_exp")
+    jax_module = cached_import("jax")
+    if jax_module is None:
+        raise BackendUnavailableError("jax core module is required")
+    return _JaxBackend(jnp_module, jax_scipy, jax_module)
+
+
+def _make_torch_backend() -> MathematicsBackend:
+    torch_module = cached_import("torch")
+    if torch_module is None:
+        raise BackendUnavailableError("PyTorch is not installed")
+    torch_linalg = cached_import("torch.linalg")
+    if torch_linalg is None:
+        raise BackendUnavailableError("torch.linalg is required for linear algebra operations")
+    return _TorchBackend(torch_module, torch_linalg)
+
+
+register_backend("numpy", _make_numpy_backend, aliases=("np",))
+register_backend("jax", _make_jax_backend)
+register_backend("torch", _make_torch_backend, aliases=("pytorch",))
+
+
+__all__ = [
+    "MathematicsBackend",
+    "BackendUnavailableError",
+    "register_backend",
+    "get_backend",
+    "available_backends",
+]

--- a/tests/unit/mathematics/test_backend.py
+++ b/tests/unit/mathematics/test_backend.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+
+from tnfr.mathematics import backend as backend_module
+
+
+@pytest.fixture(autouse=True)
+def reset_backend_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset backend caches and configuration between tests."""
+
+    backend_module._BACKEND_CACHE.clear()
+    monkeypatch.delenv("TNFR_MATH_BACKEND", raising=False)
+
+    feature_flags = importlib.import_module("tnfr.config.feature_flags")
+    feature_flags._BASE_FLAGS = None
+    feature_flags._FLAGS_STACK.clear()
+    yield
+    backend_module._BACKEND_CACHE.clear()
+    monkeypatch.delenv("TNFR_MATH_BACKEND", raising=False)
+    feature_flags._BASE_FLAGS = None
+    feature_flags._FLAGS_STACK.clear()
+
+
+@contextmanager
+def _mock_torch(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Provide minimal torch stubs so the backend can be instantiated."""
+
+    class DummyTensor:
+        def __init__(self, value: np.ndarray | list[float] | float):
+            self._value = np.asarray(value)
+
+        def detach(self) -> "DummyTensor":
+            return self
+
+        def cpu(self) -> "DummyTensor":
+            return self
+
+        def numpy(self) -> np.ndarray:
+            return self._value
+
+        def conj(self) -> "DummyTensor":
+            return DummyTensor(np.conjugate(self._value))
+
+        def transpose(self, *axes: int) -> "DummyTensor":
+            return DummyTensor(np.transpose(self._value, axes=axes or None))
+
+        @property
+        def mH(self) -> "DummyTensor":
+            return DummyTensor(np.conjugate(self._value.T))
+
+        def __matmul__(self, other: object) -> "DummyTensor":
+            return DummyTensor(self._value @ _to_array(other))
+
+        def __array__(self) -> np.ndarray:  # pragma: no cover - numpy interop only
+            return self._value
+
+    def _to_array(value: object) -> np.ndarray:
+        if isinstance(value, DummyTensor):
+            return value._value
+        return np.asarray(value)
+
+    class DummyLinalg:
+        def eig(self, matrix: object) -> tuple[DummyTensor, DummyTensor]:
+            vals, vecs = np.linalg.eig(_to_array(matrix))
+            return DummyTensor(vals), DummyTensor(vecs)
+
+        def eigh(self, matrix: object) -> tuple[DummyTensor, DummyTensor]:
+            vals, vecs = np.linalg.eigh(_to_array(matrix))
+            return DummyTensor(vals), DummyTensor(vecs)
+
+        def matrix_exp(self, matrix: object) -> DummyTensor:
+            vals, vecs = np.linalg.eig(_to_array(matrix))
+            inv = np.linalg.inv(vecs)
+            return DummyTensor(vecs @ np.diag(np.exp(vals)) @ inv)
+
+        def norm(self, value: object, ord: object = None, dim: object = None) -> DummyTensor:
+            arr = _to_array(value)
+            if dim is None:
+                return DummyTensor(np.linalg.norm(arr, ord=ord))
+            return DummyTensor(np.linalg.norm(arr, ord=ord, axis=dim))
+
+    class DummyTorch:
+        def as_tensor(self, value: object) -> DummyTensor:
+            return DummyTensor(np.asarray(value))
+
+        def einsum(self, pattern: str, *operands: object, **kwargs: object) -> DummyTensor:
+            return DummyTensor(np.einsum(pattern, *(_to_array(o) for o in operands), **kwargs))
+
+        def matmul(self, a: object, b: object) -> DummyTensor:
+            return DummyTensor(_to_array(a) @ _to_array(b))
+
+        def stack(self, arrays: object, dim: int = 0) -> DummyTensor:
+            stacked = np.stack([_to_array(x) for x in arrays], axis=dim)
+            return DummyTensor(stacked)
+
+    dummy_torch = DummyTorch()
+    dummy_linalg = DummyLinalg()
+
+    original_cached_import = backend_module.cached_import
+
+    def fake_cached_import(name: str, attr: str | None = None, **kwargs: object) -> object:
+        if name == "torch" and attr is None:
+            return dummy_torch
+        if name == "torch.linalg" and attr is None:
+            return dummy_linalg
+        if name == "numpy" and attr is None:
+            return np
+        return original_cached_import(name, attr=attr, **kwargs)
+
+    monkeypatch.setattr(backend_module, "cached_import", fake_cached_import)
+    try:
+        yield
+    finally:
+        monkeypatch.setattr(backend_module, "cached_import", original_cached_import)
+
+
+def test_default_backend_is_numpy() -> None:
+    backend = backend_module.get_backend()
+    assert backend.name == "numpy"
+
+
+def test_alias_resolution_returns_numpy() -> None:
+    backend = backend_module.get_backend("np")
+    assert backend.name == "numpy"
+
+
+def test_environment_prefers_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TNFR_MATH_BACKEND", "torch")
+    with _mock_torch(monkeypatch):
+        backend = backend_module.get_backend()
+    assert backend.name == "torch"
+
+
+def test_context_flags_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    with _mock_torch(monkeypatch):
+        from tnfr.config import context_flags
+
+        with context_flags(math_backend="torch"):
+            backend = backend_module.get_backend()
+            assert backend.name == "torch"
+
+    backend_module._BACKEND_CACHE.clear()
+    assert backend_module.get_backend().name == "numpy"
+
+
+def test_register_backend_rejects_duplicates() -> None:
+    with pytest.raises(ValueError):
+        backend_module.register_backend("numpy", lambda: backend_module.get_backend("numpy"))


### PR DESCRIPTION
### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- add a configurable mathematics backend abstraction with NumPy, JAX, and Torch adapters plus a registry API
- expose the selector from tnfr.mathematics, extend feature flags/env configuration, and document installation extras
- cover backend selection with unit tests and a getting-started guide for choosing and installing optional backends

## Testing
- pytest tests/unit/mathematics/test_backend.py

------
https://chatgpt.com/codex/tasks/task_e_690632c46798832189e6491f0c8e83d6