### PR TITLE
Add backend parity tests and evolution benchmark

### DIFF
--- a/benchmarks/evolution_backend_speedup.py
+++ b/benchmarks/evolution_backend_speedup.py
@@ -1,0 +1,299 @@
+"""Benchmark backend trajectories for unitary and contractive dynamics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Callable, Iterable
+
+import numpy as np
+
+from tnfr.mathematics import HilbertSpace
+from tnfr.mathematics.backend import get_backend
+from tnfr.mathematics.dynamics import ContractiveDynamicsEngine, MathematicalDynamicsEngine
+
+DEFAULT_SIZES = (2, 4, 8, 16)
+DEFAULT_STEPS = 32
+DEFAULT_REPEATS = 3
+DEFAULT_DT = 0.05
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sizes",
+        nargs="*",
+        type=int,
+        default=list(DEFAULT_SIZES),
+        help="Hilbert space dimensions to benchmark (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=DEFAULT_STEPS,
+        help="Number of evolution steps per run (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=DEFAULT_REPEATS,
+        help="How many times to repeat each measurement (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dt",
+        type=float,
+        default=DEFAULT_DT,
+        help="Time increment between steps (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="RNG seed used to generate synthetic generators (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--backends",
+        nargs="*",
+        default=None,
+        help="Subset of backends to benchmark (default: auto-detect all available)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to persist JSON results for reproducibility",
+    )
+    return parser.parse_args()
+
+
+def _resolve_backends(names: Iterable[str] | None) -> list[tuple[str, object]]:
+    requested = list(names) if names else ["numpy", "jax", "torch"]
+    resolved: list[tuple[str, object]] = []
+    seen: set[str] = set()
+    for name in requested:
+        backend = get_backend(name)
+        if backend.name != name:
+            print(f"[skip] backend '{name}' unavailable (resolved to {backend.name!r}).")
+            continue
+        if backend.name in seen:
+            continue
+        resolved.append((name, backend))
+        seen.add(backend.name)
+    if not any(entry[0] == "numpy" for entry in resolved):
+        numpy_backend = get_backend("numpy")
+        resolved.insert(0, ("numpy", numpy_backend))
+    return resolved
+
+
+def _random_state(rng: np.random.Generator, dim: int) -> np.ndarray:
+    vector = rng.standard_normal(dim) + 1j * rng.standard_normal(dim)
+    norm = np.linalg.norm(vector)
+    if norm == 0:
+        return np.zeros(dim, dtype=np.complex128)
+    return (vector / norm).astype(np.complex128)
+
+
+def _hermitian_generator(rng: np.random.Generator, dim: int) -> np.ndarray:
+    raw = rng.standard_normal((dim, dim)) + 1j * rng.standard_normal((dim, dim))
+    hermitian = 0.5 * (raw + raw.conj().T)
+    return hermitian.astype(np.complex128)
+
+
+def _contractive_generator(rng: np.random.Generator, dim: int) -> np.ndarray:
+    raw = rng.standard_normal((dim, dim)) + 1j * rng.standard_normal((dim, dim))
+    anti_hermitian = raw - raw.conj().T
+    generator = -0.3 * np.eye(dim, dtype=np.complex128) + 0.05 * anti_hermitian
+    return generator.astype(np.complex128)
+
+
+def _density_from_state(state: np.ndarray) -> np.ndarray:
+    return np.outer(state, state.conjugate())
+
+
+def _time_callable(func: Callable[[], None], repeats: int) -> list[float]:
+    measurements: list[float] = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        func()
+        measurements.append(time.perf_counter() - start)
+    return measurements
+
+
+def _prepare_problems(rng: np.random.Generator, dims: Iterable[int]) -> dict[int, dict[str, np.ndarray]]:
+    problems: dict[int, dict[str, np.ndarray]] = {}
+    for dim in dims:
+        state = _random_state(rng, dim)
+        density = _density_from_state(state)
+        problems[dim] = {
+            "state": state,
+            "density": density,
+            "unitary_generator": _hermitian_generator(rng, dim),
+            "contractive_generator": _contractive_generator(rng, dim * dim),
+        }
+    return problems
+
+
+def _benchmark_unitary(
+    backend: object,
+    generator: np.ndarray,
+    state: np.ndarray,
+    dim: int,
+    *,
+    steps: int,
+    dt: float,
+    repeats: int,
+) -> list[float]:
+    hilbert = HilbertSpace(dimension=dim)
+    engine = MathematicalDynamicsEngine(generator, hilbert, backend=backend, use_scipy=False)
+    state_backend = backend.as_array(state)
+
+    def _run() -> None:
+        engine.evolve(state_backend, steps=steps, dt=dt)
+
+    return _time_callable(_run, repeats)
+
+
+def _benchmark_contractive(
+    backend: object,
+    generator: np.ndarray,
+    density: np.ndarray,
+    dim: int,
+    *,
+    steps: int,
+    dt: float,
+    repeats: int,
+) -> list[float]:
+    hilbert = HilbertSpace(dimension=dim)
+    engine = ContractiveDynamicsEngine(generator, hilbert, backend=backend, use_scipy=False)
+    density_backend = backend.as_array(density)
+
+    def _run() -> None:
+        engine.evolve(density_backend, steps=steps, dt=dt)
+
+    return _time_callable(_run, repeats)
+
+
+def _format_seconds(value: float) -> str:
+    return f"{value * 1000:.3f} ms"
+
+
+def _print_table(title: str, dims: Iterable[int], backends: list[str], table: dict[str, dict[int, float]], *, suffix: str = "s") -> None:
+    header = "| dim | " + " | ".join(backends) + " |"
+    separator = "| --- | " + " | ".join("---" for _ in backends) + " |"
+    print(f"\n{title}")
+    print(header)
+    print(separator)
+    for dim in dims:
+        cells = [f"{dim}"]
+        for backend in backends:
+            value = table.get(backend, {}).get(dim)
+            if value is None or not np.isfinite(value):
+                cells.append("—")
+            else:
+                cells.append(f"{value:.3f} {suffix}" if suffix == "x" else _format_seconds(value))
+        print("| " + " | ".join(cells) + " |")
+
+
+def main() -> None:
+    args = _parse_args()
+    rng = np.random.default_rng(args.seed)
+    dims = tuple(sorted(args.sizes))
+    backends = _resolve_backends(args.backends)
+    if not backends:
+        raise SystemExit("No numerical backend available for benchmarking.")
+
+    problems = _prepare_problems(rng, dims)
+    results: dict[str, dict[str, dict[int, dict[str, list[float] | float]]]] = {
+        "unitary": {},
+        "contractive": {},
+    }
+
+    mean_unitary: dict[str, dict[int, float]] = {}
+    mean_contractive: dict[str, dict[int, float]] = {}
+
+    for name, backend in backends:
+        results["unitary"][name] = {}
+        results["contractive"][name] = {}
+        mean_unitary[name] = {}
+        mean_contractive[name] = {}
+        for dim, payload in problems.items():
+            unitary_timings = _benchmark_unitary(
+                backend,
+                payload["unitary_generator"],
+                payload["state"],
+                dim,
+                steps=args.steps,
+                dt=args.dt,
+                repeats=args.repeats,
+            )
+            contractive_timings = _benchmark_contractive(
+                backend,
+                payload["contractive_generator"],
+                payload["density"],
+                dim,
+                steps=args.steps,
+                dt=args.dt,
+                repeats=args.repeats,
+            )
+            unitary_mean = float(np.mean(unitary_timings))
+            contractive_mean = float(np.mean(contractive_timings))
+            results["unitary"][name][dim] = {
+                "timings": unitary_timings,
+                "mean_seconds": unitary_mean,
+            }
+            results["contractive"][name][dim] = {
+                "timings": contractive_timings,
+                "mean_seconds": contractive_mean,
+            }
+            mean_unitary[name][dim] = unitary_mean
+            mean_contractive[name][dim] = contractive_mean
+
+    baseline_unitary = mean_unitary.get("numpy", {})
+    baseline_contractive = mean_contractive.get("numpy", {})
+    speedup_unitary: dict[str, dict[int, float]] = {}
+    speedup_contractive: dict[str, dict[int, float]] = {}
+    for name, backend_means in mean_unitary.items():
+        speedup_unitary[name] = {}
+        for dim, timing in backend_means.items():
+            base = baseline_unitary.get(dim)
+            speedup_unitary[name][dim] = (
+                float(base / timing) if base is not None and timing > 0 else float("nan")
+            )
+    for name, backend_means in mean_contractive.items():
+        speedup_contractive[name] = {}
+        for dim, timing in backend_means.items():
+            base = baseline_contractive.get(dim)
+            speedup_contractive[name][dim] = (
+                float(base / timing) if base is not None and timing > 0 else float("nan")
+            )
+
+    metadata = {
+        "seed": args.seed,
+        "steps": args.steps,
+        "repeats": args.repeats,
+        "dt": args.dt,
+        "sizes": dims,
+    }
+
+    if args.output:
+        payload = {
+            "metadata": metadata,
+            "results": results,
+            "speedups": {
+                "unitary": speedup_unitary,
+                "contractive": speedup_contractive,
+            },
+        }
+        args.output.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        print(f"\nSaved results to {args.output}")
+
+    backend_labels = [name for name, _ in backends]
+    _print_table("Unitary evolution (mean time per run)", dims, backend_labels, mean_unitary)
+    _print_table("Contractive evolution (mean time per run)", dims, backend_labels, mean_contractive)
+    _print_table("Unitary speed-up vs NumPy", dims, backend_labels, speedup_unitary, suffix="x")
+    _print_table("Contractive speed-up vs NumPy", dims, backend_labels, speedup_contractive, suffix="x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,16 @@
 
 This document describes the purpose of tests in the suite that monitor internal debugging, diagnostic features, and performance regressions. Default `pytest` options (such as marker selection and benchmark skipping) are configured in the `[tool.pytest.ini_options]` section of `pyproject.toml`, so invocations without extra flags automatically inherit that configuration.
 
+## Backend selection
+
+Pass `--math-backend=<name>` to `pytest` (or set `TNFR_TEST_MATH_BACKEND`) to exercise the suite under a specific numerical adapter. The flag sets `TNFR_MATH_BACKEND` before modules import and clears cached backend instances, ensuring that optional dependencies such as JAX or PyTorch are only used when explicitly requested.
+
+```bash
+PYTHONPATH=src pytest tests/mathematics --math-backend=torch
+```
+
+When the requested backend is unavailable, `pytest` will skip the backend-specific tests while the remainder of the suite continues to run under NumPy.
+
 ## Debugging and diagnostic tests
 
 - **test_logging_module.py** – verifies that the root logger is configured once and sets a default level.

--- a/tests/mathematics/test_autodiff.py
+++ b/tests/mathematics/test_autodiff.py
@@ -1,0 +1,94 @@
+"""Automatic differentiation checks for optional backends."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tnfr.mathematics.backend import get_backend
+
+
+def _require_backend(name: str) -> object:
+    backend = get_backend(name)
+    if backend.name != name:
+        pytest.skip(f"Backend '{name}' is unavailable; installed: {backend.name!r}.")
+    return backend
+
+
+def test_jax_norm_gradient_matches_analytic() -> None:
+    backend = _require_backend("jax")
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    vector = jnp.array([0.4, -1.2, 0.8], dtype=jnp.float64)
+
+    def norm_squared(val: object) -> object:
+        arr = backend.as_array(val, dtype=jnp.float64)
+        norm = backend.norm(arr)
+        return jnp.real(norm ** 2)
+
+    grad = jax.grad(norm_squared)(vector)
+    expected = 2.0 * vector
+    np.testing.assert_allclose(np.asarray(grad), np.asarray(expected), rtol=1e-6, atol=1e-6)
+
+
+def test_jax_expectation_gradient_matches_closed_form() -> None:
+    backend = _require_backend("jax")
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    matrix_np = np.array([[1.5, 0.2], [0.2, -0.3]], dtype=np.float64)
+    matrix = backend.as_array(matrix_np, dtype=jnp.float64)
+    vector_np = np.array([0.7, -0.45], dtype=np.float64)
+    vector = jnp.array(vector_np)
+
+    def expectation(val: object) -> object:
+        arr = backend.as_array(val, dtype=jnp.float64)
+        hv = backend.matmul(matrix, arr)
+        numerator = jnp.vdot(arr, hv)
+        denom = jnp.vdot(arr, arr)
+        return jnp.real(numerator / denom)
+
+    grad = jax.grad(expectation)(vector)
+
+    denom_np = float(np.dot(vector_np, vector_np))
+    energy_np = float(vector_np @ (matrix_np @ vector_np) / denom_np)
+    expected = 2.0 * (matrix_np @ vector_np - energy_np * vector_np) / denom_np
+    np.testing.assert_allclose(np.asarray(grad), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_torch_norm_gradient_matches_analytic() -> None:
+    backend = _require_backend("torch")
+    torch = pytest.importorskip("torch")
+
+    vector = torch.tensor([0.5, -0.9, 0.25], dtype=torch.double, requires_grad=True)
+
+    arr = backend.as_array(vector)
+    norm = backend.norm(arr)
+    value = (norm ** 2).real
+    grad, = torch.autograd.grad(value, vector)
+
+    expected = 2.0 * vector.detach().cpu().numpy()
+    np.testing.assert_allclose(grad.detach().cpu().numpy(), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_torch_expectation_gradient_matches_closed_form() -> None:
+    backend = _require_backend("torch")
+    torch = pytest.importorskip("torch")
+
+    matrix_np = np.array([[1.2, -0.15], [-0.15, 0.6]], dtype=np.float64)
+    matrix = backend.as_array(torch.tensor(matrix_np, dtype=torch.double))
+    vector = torch.tensor([0.9, -0.4], dtype=torch.double, requires_grad=True)
+
+    arr = backend.as_array(vector)
+    hv = backend.matmul(matrix, arr)
+    numerator = torch.dot(arr, hv)
+    denom = torch.dot(arr, arr)
+    value = (numerator / denom).real
+    grad, = torch.autograd.grad(value, vector)
+
+    vector_np = vector.detach().cpu().numpy()
+    denom_np = float(np.dot(vector_np, vector_np))
+    energy_np = float(vector_np @ (matrix_np @ vector_np) / denom_np)
+    expected = 2.0 * (matrix_np @ vector_np - energy_np * vector_np) / denom_np
+    np.testing.assert_allclose(grad.detach().cpu().numpy(), expected, rtol=1e-6, atol=1e-6)

--- a/tests/mathematics/test_backends.py
+++ b/tests/mathematics/test_backends.py
@@ -1,0 +1,134 @@
+"""Cross-backend numerical consistency checks."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tnfr.mathematics import CoherenceOperator, HilbertSpace
+from tnfr.mathematics.backend import ensure_numpy, get_backend
+from tnfr.mathematics.dynamics import ContractiveDynamicsEngine, MathematicalDynamicsEngine
+
+_BACKEND_NAMES = ("numpy", "jax", "torch")
+
+
+def _require_backend(name: str) -> object:
+    backend = get_backend(name)
+    if backend.name != name:
+        pytest.skip(f"Backend '{name}' is unavailable; installed: {backend.name!r}.")
+    return backend
+
+
+def _to_numpy(value: object, *, backend: object) -> np.ndarray:
+    return np.asarray(ensure_numpy(value, backend=backend))
+
+
+@pytest.mark.parametrize("backend_name", _BACKEND_NAMES)
+def test_coherence_operator_matches_numpy(backend_name: str, structural_tolerances: dict[str, float]) -> None:
+    """Coherence operators must agree across available numerical backends."""
+
+    backend = _require_backend(backend_name)
+    reference_backend = get_backend("numpy")
+
+    matrix = np.array([[0.9, 0.2 - 0.05j], [0.2 + 0.05j, 0.4]], dtype=np.complex128)
+    state = np.array([0.6 + 0.1j, 0.3 - 0.2j], dtype=np.complex128)
+
+    reference = CoherenceOperator(matrix, backend=reference_backend)
+    operator = CoherenceOperator(matrix, backend=backend)
+
+    np.testing.assert_allclose(
+        operator.matrix,
+        reference.matrix,
+        rtol=structural_tolerances["rtol"],
+        atol=structural_tolerances["atol"],
+    )
+    np.testing.assert_allclose(
+        operator.eigenvalues,
+        reference.eigenvalues,
+        rtol=structural_tolerances["rtol"],
+        atol=structural_tolerances["atol"],
+    )
+    assert pytest.approx(reference.c_min, rel=structural_tolerances["rtol"], abs=structural_tolerances["atol"]) == operator.c_min
+
+    expectation_backend = operator.expectation(state)
+    expectation_reference = reference.expectation(state)
+    assert expectation_backend == pytest.approx(
+        expectation_reference,
+        rel=structural_tolerances["rtol"],
+        abs=structural_tolerances["atol"],
+    )
+
+
+@pytest.mark.parametrize("backend_name", _BACKEND_NAMES)
+def test_mathematical_dynamics_matches_numpy(backend_name: str, structural_tolerances: dict[str, float]) -> None:
+    """Unitary trajectories should be backend agnostic within tolerance."""
+
+    backend = _require_backend(backend_name)
+    reference_backend = get_backend("numpy")
+
+    hilbert = HilbertSpace(dimension=2)
+    generator = np.array([[1.0, 0.25 - 0.15j], [0.25 + 0.15j, -0.5]], dtype=np.complex128)
+    state = np.array([0.8 + 0.1j, 0.3 - 0.2j], dtype=np.complex128)
+
+    reference_engine = MathematicalDynamicsEngine(
+        generator,
+        hilbert,
+        backend=reference_backend,
+        use_scipy=False,
+    )
+    engine = MathematicalDynamicsEngine(
+        generator,
+        hilbert,
+        backend=backend,
+        use_scipy=False,
+    )
+
+    trajectory_reference = reference_engine.evolve(state, steps=3, dt=0.05)
+    trajectory_backend = engine.evolve(state, steps=3, dt=0.05)
+
+    np.testing.assert_allclose(
+        _to_numpy(trajectory_backend, backend=backend),
+        trajectory_reference,
+        rtol=structural_tolerances["rtol"],
+        atol=structural_tolerances["atol"],
+    )
+
+
+@pytest.mark.parametrize("backend_name", _BACKEND_NAMES)
+def test_contractive_dynamics_matches_numpy(backend_name: str, structural_tolerances: dict[str, float]) -> None:
+    """Contractive trajectories should remain invariant across backends."""
+
+    backend = _require_backend(backend_name)
+    reference_backend = get_backend("numpy")
+
+    hilbert = HilbertSpace(dimension=2)
+    lindblad_generator = -0.2 * np.eye(4, dtype=np.complex128)
+    density = np.array([[0.7, 0.1 + 0.05j], [0.1 - 0.05j, 0.3]], dtype=np.complex128)
+
+    reference_engine = ContractiveDynamicsEngine(
+        lindblad_generator,
+        hilbert,
+        backend=reference_backend,
+        use_scipy=False,
+    )
+    engine = ContractiveDynamicsEngine(
+        lindblad_generator,
+        hilbert,
+        backend=backend,
+        use_scipy=False,
+    )
+
+    evolved_reference = reference_engine.step(density, dt=0.1)
+    evolved_backend = engine.step(density, dt=0.1)
+
+    np.testing.assert_allclose(
+        _to_numpy(evolved_backend, backend=backend),
+        evolved_reference,
+        rtol=structural_tolerances["rtol"],
+        atol=structural_tolerances["atol"],
+    )
+    assert engine.last_contractivity_gap == pytest.approx(
+        reference_engine.last_contractivity_gap,
+        rel=structural_tolerances["rtol"],
+        abs=structural_tolerances["atol"],
+    )


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

## Summary
- add backend consistency tests and autodiff checks covering numpy/jax/torch adapters
- expose pytest CLI/env hooks to select math backend and document usage
- create evolution_backend_speedup benchmark with JSON output and README tables for speed-up ratios

## Testing
- PYTHONPATH=src pytest tests/mathematics/test_backends.py tests/mathematics/test_autodiff.py -q

------
https://chatgpt.com/codex/tasks/task_e_690639fc7bf48321b1831aa2d0f1ecac