### PR TITLE
Prefer backend propagators for autodiff dynamics

### DIFF
--- a/tests/mathematics/test_autodiff.py
+++ b/tests/mathematics/test_autodiff.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 from tnfr.mathematics.backend import get_backend
+from tnfr.mathematics.dynamics import ContractiveDynamicsEngine, MathematicalDynamicsEngine
+from tnfr.mathematics.spaces import HilbertSpace
 
 
 def _require_backend(name: str) -> object:
@@ -92,3 +94,60 @@ def test_torch_expectation_gradient_matches_closed_form() -> None:
     energy_np = float(vector_np @ (matrix_np @ vector_np) / denom_np)
     expected = 2.0 * (matrix_np @ vector_np - energy_np * vector_np) / denom_np
     np.testing.assert_allclose(grad.detach().cpu().numpy(), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_torch_dynamics_step_supports_autodiff() -> None:
+    backend = _require_backend("torch")
+    torch = pytest.importorskip("torch")
+
+    hilbert = HilbertSpace(dimension=2)
+    generator = torch.tensor(
+        [[0.3 + 0.0j, 0.2 - 0.1j], [0.2 + 0.1j, -0.4 + 0.0j]],
+        dtype=torch.complex128,
+    )
+    engine = MathematicalDynamicsEngine(generator, hilbert, backend=backend)
+
+    state = torch.tensor([0.8 + 0.0j, 0.1 + 0.3j], dtype=torch.complex128, requires_grad=True)
+    result = engine.step(state, dt=0.25, normalize=False)
+    value = result.abs().pow(2).sum()
+
+    grad, = torch.autograd.grad(value, state)
+    grad_np = grad.detach().cpu().numpy()
+    assert grad_np.shape == (2,)
+    assert np.all(np.isfinite(grad_np))
+
+
+def test_jax_contractive_step_supports_autodiff() -> None:
+    backend = _require_backend("jax")
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    hilbert = HilbertSpace(dimension=2)
+    generator_np = np.diag([-0.4, -0.2, -0.3, -0.1]).astype(np.complex128)
+    generator = backend.as_array(generator_np, dtype=jnp.complex128)
+    engine = ContractiveDynamicsEngine(
+        generator,
+        hilbert,
+        ensure_contractive=False,
+        backend=backend,
+    )
+
+    density = jnp.array(
+        [[0.7 + 0.0j, 0.1 - 0.05j], [0.1 + 0.05j, 0.3 + 0.0j]],
+        dtype=jnp.complex128,
+    )
+
+    def frobenius_energy(density_matrix: object) -> object:
+        evolved = engine.step(
+            density_matrix,
+            dt=0.15,
+            normalize_trace=False,
+            enforce_contractivity=False,
+            symmetrize=False,
+        )
+        return jnp.real(jnp.sum(jnp.abs(evolved) ** 2))
+
+    grad = jax.grad(frobenius_energy)(density)
+    grad_np = np.asarray(grad)
+    assert grad_np.shape == density.shape
+    assert np.all(np.isfinite(grad_np))


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

- Default both dynamics engines to backend-native matrix exponentials whenever available, reserving SciPy for explicit opt-in or missing implementations.
- Added autodiff regression coverage for the PyTorch and JAX backends to verify gradients propagate through `step`.


------
https://chatgpt.com/codex/tasks/task_e_690641b36f8c832192b05d9b96434b79