### PR TITLE
Import Node directly in tokens module

### DIFF
--- a/src/tnfr/tokens.py
+++ b/src/tnfr/tokens.py
@@ -6,10 +6,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Iterable, Optional, Sequence, Union
 
-from .types import Glyph, NodeId
-
-Node = NodeId
-#: Alias maintained for backwards compatibility with historical token helpers.
+from .types import Glyph, Node
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- import the canonical `Node` alias from `tnfr.types` in the token primitives to remove the redundant `NodeId` re-export

## Testing
- pytest tests/unit/structural/test_normalize_weights.py tests/unit/structural/test_parse_program_errors.py tests/unit/structural/test_flatten_structure.py *(fails: skipped because numpy is unavailable in the environment)*

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_69071c8008a48321aaa3fc206222ee38