### PR TITLE
Clarify backend resolution aliases in benchmarking

### DIFF
--- a/tests/unit/test_evolution_backend_speedup.py
+++ b/tests/unit/test_evolution_backend_speedup.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pytest
+
+from benchmarks import evolution_backend_speedup as benchmark_module
+
+
+class _DummyBackend:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@pytest.mark.parametrize(
+    "requested, expected_names, expected_numpy_calls",
+    [
+        ("np", ["numpy"], 0),
+        ("pytorch", ["numpy", "torch"], 1),
+    ],
+)
+def test_resolve_backends_accepts_aliases_without_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    requested: str,
+    expected_names: list[str],
+    expected_numpy_calls: int,
+) -> None:
+    calls: list[str] = []
+    backend_names: Dict[str, str] = {
+        "numpy": "numpy",
+        "np": "numpy",
+        "torch": "torch",
+        "pytorch": "torch",
+        "jax": "numpy",  # Simulate fallback behaviour for unavailable backend
+    }
+
+    def _fake_get_backend(name: str) -> _DummyBackend:
+        calls.append(name)
+        try:
+            canonical = backend_names[name]
+        except KeyError as exc:  # pragma: no cover - guard for unexpected names
+            raise AssertionError(f"Unexpected backend request: {name}") from exc
+        return _DummyBackend(canonical)
+
+    monkeypatch.setattr(benchmark_module, "get_backend", _fake_get_backend)
+
+    resolved = benchmark_module._resolve_backends([requested, "jax"])
+    out = capsys.readouterr().out
+
+    assert [entry[0] for entry in resolved] == expected_names
+    assert calls.count("numpy") == expected_numpy_calls
+    assert f"[skip] backend '{requested}'" not in out
+    assert "[skip] backend 'jax'" in out


### PR DESCRIPTION
## Summary
- refine benchmark backend resolution to treat aliases as canonical implementations while skipping true NumPy fallbacks
- ensure benchmark aggregates store canonical backend identifiers to prevent duplicate runs
- add regression coverage that verifies alias inputs avoid skip messages and fallback handling remains intact

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_690712a435f883219edbce9bc8ac17e5