### PR TITLE
docs: clarify remesh migration guidance

### DIFF
--- a/docs/source/getting-started/migrating-remesh-window.md
+++ b/docs/source/getting-started/migrating-remesh-window.md
@@ -9,9 +9,10 @@ configuration cannot slip through pipelines.
 Legacy graphs that still expose non-canonical cooldown metadata **had to be
 migrated before 2025-03-31**. That date marked the end of the archival
 compatibility window communicated in TNFR 14.x. Starting with ``tnfr`` 15.0.0 the
-runtime no longer ships :func:`tnfr.utils.migrations.migrate_legacy_remesh_cooldown`
-or the phase attribute shim, so persisted payloads must already use the canonical
-keys.
+runtime no longer ships the built-in remesh cooldown or phase attribute migration
+helpers, so persisted payloads must already use the canonical keys when you
+upgrade. Historical archives that missed the window need to be rewritten with an
+external script before they are loaded into a modern runtime.
 
 ## Who is affected?
 
@@ -43,13 +44,41 @@ keys.
        apply_remesh_if_globally_stable(G, **normalize_remesh_kwargs(user_kwargs))
 
 3. Audit persisted graphs or configs that reference non-English names **before
-   upgrading to ``tnfr`` 15.0.0**. Without the helper, the update must happen in
-   the stored artifact (for example by running a one-off script on the graph
-   metadata) prior to importing the new release.
+   upgrading to ``tnfr`` 15.0.0**. Without the bundled helper, the update must
+   happen in the stored artifact (for example by running a one-off script on the
+   graph metadata) prior to importing the new release.
 
 4. Verify that serialized graphs expose only ``"theta"``, ``"phase"`` and
    ``"REMESH_COOLDOWN_WINDOW"``. Any other synonym indicates the artifact still
    targets an unsupported contract.
+
+### Rewriting archives after the helper removal
+
+When the bundled migration helpers shipped in ``tnfr`` 14.x they performed an
+in-place rewrite of legacy keys. With their removal you need to run an external
+upgrade step before the graph interacts with the runtime. A lightweight script
+that walks the stored payload and promotes the canonical keys is sufficient::
+
+    import json
+
+    def rewrite_remesh_metadata(payload: dict) -> dict:
+        upgraded = dict(payload)
+        if "θ" in upgraded and "theta" not in upgraded:
+            upgraded["theta"] = upgraded.pop("θ")
+        legacy_window = upgraded.pop("ventana_enfriamiento", None)
+        if legacy_window is not None and "REMESH_COOLDOWN_WINDOW" not in upgraded:
+            upgraded["REMESH_COOLDOWN_WINDOW"] = legacy_window
+        return upgraded
+
+    with open("graph.json") as fh:
+        data = json.load(fh)
+    data["graph"] = rewrite_remesh_metadata(data["graph"])
+    with open("graph.json", "w") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+
+Integrations can adapt the sample to their storage format (for example, NetworkX
+pickles or database rows). The important part is that the normalization happens
+*before* the graph loads into ``tnfr`` 15.0.0 or later.
 
 ## Verification checklist
 
@@ -60,8 +89,8 @@ keys.
 - Downstream logs or telemetry that templated the legacy name should be
   updated to keep observability messages aligned with the supported API.
 - Graph validation pipelines must fail fast if a payload still contains the
-  deprecated legacy keys after the deadline, because the helpers are no longer
-  available to rewrite them.
+  deprecated legacy keys after the deadline, because the automatic rewrites are
+  no longer part of the runtime.
 
 Following these steps ensures remesh orchestration remains stable while the
 engine enforces the English-only parameter surface.

--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -167,9 +167,9 @@ python scripts/rollback_release.py --version 16.0.0 \
   :mod:`tnfr.config.constants`, :mod:`tnfr.config.operator_names`, and
   :mod:`tnfr.operators.registry`. Accessing retired identifiers now surfaces the
   standard :class:`AttributeError` without custom wording.
-- Documented the retirement timeline for
-  :mod:`tnfr.utils.migrations`, which remains available for archival upgrades
-  until ``tnfr`` 15.0.0 completes the migration window.
+- Documented the retirement timeline for the archival migration helpers,
+  clarifying that they would remain available only until ``tnfr`` 15.0.0
+  completed the migration window.
 - Updated guides and release notes to describe the final English-only contract
   and the requirement to normalise archives with the compatibility helpers.
 
@@ -283,12 +283,10 @@ python scripts/rollback_release.py --version 16.0.0 \
 
 ### 15.0.0 (legacy migration helpers removed)
 
-- Finalised the English-only payload contract by removing
-  :func:`tnfr.utils.migrations.migrate_legacy_phase_attributes` and
-  :func:`tnfr.utils.migrations.migrate_legacy_remesh_cooldown`. Projects must now
-  persist ``"theta"``, ``"phase"`` and ``"REMESH_COOLDOWN_WINDOW"`` directly
-  because the helpers no longer rewrite non-English aliases or the standalone
-  theta symbol.
+- Finalised the English-only payload contract by removing the bundled phase and
+  remesh cooldown migration helpers. Projects must now persist ``"theta"``,
+  ``"phase"`` and ``"REMESH_COOLDOWN_WINDOW"`` directly because the runtime no
+  longer rewrites non-English aliases or the standalone theta symbol on import.
 - The archival migration window announced in TNFR 14.x expired on 2025-03-31.
   Upgrade pipelines should refuse to import graphs that still contain retired
   keys instead of attempting a best-effort rewrite.


### PR DESCRIPTION
## Summary
- clarify the remesh stability window guide to note the retirement of the bundled migration helpers and point to external rewrites
- add an explicit archive rewriting example to help downstream users upgrade payloads after the helper removal
- update the release notes to describe the helper retirement timeline without referencing the deleted module

## Testing
- sphinx-build -b html docs/source docs/_build/html

------
https://chatgpt.com/codex/tasks/task_e_690763b1a3048321a5965398e4b15c2b