### PR TITLE
Consolidate validation facade exports

### DIFF
--- a/docs/source/api/overview.md
+++ b/docs/source/api/overview.md
@@ -126,7 +126,7 @@ extensions stay in sync with the public API.
 
 ### Grammar schema validation
 
-`tnfr.operators.grammar.GrammarContext` now validates the soft and canonical
+`tnfr.validation.GrammarContext` now validates the soft and canonical
 grammar dictionaries against the bundled JSON schema (`tnfr.schemas/grammar.json`)
 whenever the optional `jsonschema` dependency is available. Validation runs in
 ``auto`` mode by default—if the dependency or resource cannot be loaded the

--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -112,6 +112,16 @@ We manage versions with `python-semantic-release`, deriving release tags directl
 
 <!-- version history -->
 
+### Upcoming (validation API unification)
+
+- Centralised all grammar and runtime validators under :mod:`tnfr.validation`.
+  Legacy attributes in :mod:`tnfr.dynamics`, :mod:`tnfr.operators`, and
+  :mod:`tnfr.mathematics` now emit :class:`DeprecationWarning` while delegating
+  to the unified facade so downstream integrations migrate progressively.
+- Updated tests, CLI helpers, and documentation to import grammar primitives
+  from :mod:`tnfr.validation`, keeping the public surface consistent with the
+  consolidated module.
+
 .. _rollback-script:
 
 ## Rollback automation script
@@ -356,7 +366,7 @@ python scripts/rollback_release.py --version 16.0.0 \
 - Retired the long-standing compatibility modules :mod:`tnfr.constants_glyphs`,
   :mod:`tnfr.presets`, and :mod:`tnfr.grammar`. The deprecated shims have been
   removed; import :mod:`tnfr.config.constants`, :mod:`tnfr.config.presets`, and
-  :mod:`tnfr.operators.grammar` instead.
+  the unified :mod:`tnfr.validation` facade instead.
 
 ### 7.0.0 (Spanish identifiers removed)
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -60,12 +60,15 @@ Examples
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
+import warnings
+from typing import Any
 
 from ..metrics.sense_index import compute_Si
-from ..operators import apply_glyph, enforce_canonical_grammar, on_applied_glyph
+from ..operators import apply_glyph
 from ..types import GlyphCode
 from ..utils import get_numpy
-from ..validation import apply_canonical_clamps, validate_canon
+from ..validation import apply_canonical_clamps as _apply_canonical_clamps
+from ..validation import validate_canon as _validate_canon
 from . import coordination, dnfr, integrators
 from .adaptation import adapt_vf_by_coherence
 from .aliases import (
@@ -166,7 +169,6 @@ __all__ = (
     "_init_dnfr_cache",
     "_refresh_dnfr_vectors",
     "adapt_vf_by_coherence",
-    "apply_canonical_clamps",
     "coordinate_global_local_phase",
     "compute_Si",
     "default_compute_delta_nfr",
@@ -174,9 +176,7 @@ __all__ = (
     "dnfr_epi_vf_mixed",
     "dnfr_laplacian",
     "dnfr_phase_only",
-    "enforce_canonical_grammar",
     "get_numpy",
-    "on_applied_glyph",
     "apply_glyph",
     "parametric_glyph_selector",
     "AbstractIntegrator",
@@ -186,5 +186,56 @@ __all__ = (
     "set_delta_nfr_hook",
     "step",
     "update_epi_via_nodal_equation",
-    "validate_canon",
 )
+
+
+def apply_canonical_clamps(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for :func:`tnfr.validation.apply_canonical_clamps`."""
+
+    warnings.warn(
+        "`tnfr.dynamics.apply_canonical_clamps` is deprecated; import it from "
+        "`tnfr.validation` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _apply_canonical_clamps(*args, **kwargs)
+
+
+def validate_canon(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for :func:`tnfr.validation.validate_canon`."""
+
+    warnings.warn(
+        "`tnfr.dynamics.validate_canon` is deprecated; import it from "
+        "`tnfr.validation` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _validate_canon(*args, **kwargs)
+
+
+def enforce_canonical_grammar(*args: Any, **kwargs: Any) -> Any:
+    """Deprecated grammar access redirecting to :mod:`tnfr.validation`."""
+
+    warnings.warn(
+        "`tnfr.dynamics.enforce_canonical_grammar` is deprecated; import "
+        "grammar helpers from `tnfr.validation`.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from ..validation import enforce_canonical_grammar as _enforce
+
+    return _enforce(*args, **kwargs)
+
+
+def on_applied_glyph(*args: Any, **kwargs: Any) -> Any:
+    """Deprecated hook redirecting to :mod:`tnfr.validation`."""
+
+    warnings.warn(
+        "`tnfr.dynamics.on_applied_glyph` is deprecated; import grammar "
+        "hooks from `tnfr.validation` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from ..validation import on_applied_glyph as _on_applied
+
+    return _on_applied(*args, **kwargs)

--- a/src/tnfr/dynamics/__init__.pyi
+++ b/src/tnfr/dynamics/__init__.pyi
@@ -1,7 +1,13 @@
 from typing import Any, Literal, Sequence
 
 from tnfr.types import GlyphCode, TNFRGraph
-from tnfr.validation import ValidationOutcome
+from tnfr.validation import (
+    ValidationOutcome,
+    apply_canonical_clamps as _apply_canonical_clamps,
+    validate_canon as _validate_canon,
+    enforce_canonical_grammar as _enforce_canonical_grammar,
+    on_applied_glyph as _on_applied_glyph,
+)
 
 __all__: tuple[str, ...]
 
@@ -43,16 +49,16 @@ _compute_neighbor_means: Any
 _init_dnfr_cache: Any
 _refresh_dnfr_vectors: Any
 adapt_vf_by_coherence: Any
-apply_canonical_clamps: Any
+apply_canonical_clamps = _apply_canonical_clamps
 coordinate_global_local_phase: Any
 default_compute_delta_nfr: Any
 default_glyph_selector: Any
 dnfr_epi_vf_mixed: Any
 dnfr_laplacian: Any
 dnfr_phase_only: Any
-enforce_canonical_grammar: Any
+enforce_canonical_grammar = _enforce_canonical_grammar
 get_numpy: Any
-on_applied_glyph: Any
+on_applied_glyph = _on_applied_glyph
 apply_glyph: Any
 parametric_glyph_selector: Any
 
@@ -79,4 +85,4 @@ def update_epi_via_nodal_equation(
     n_jobs: int | None = ...,
 ) -> None: ...
 
-def validate_canon(G: TNFRGraph) -> ValidationOutcome[TNFRGraph]: ...
+validate_canon = _validate_canon

--- a/src/tnfr/mathematics/__init__.py
+++ b/src/tnfr/mathematics/__init__.py
@@ -8,6 +8,8 @@ structural operators.  The selection order is ``name`` → ``TNFR_MATH_BACKEND``
 existing code continues to operate even when optional dependencies are absent.
 """
 
+import warnings
+
 from .backend import (
     MathematicsBackend,
     available_backends,
@@ -40,7 +42,6 @@ from .transforms import (
     ensure_coherence_monotonicity,
     validate_norm_preservation,
 )
-from ..validation import NFRValidator
 
 __all__ = [
     "MathematicsBackend",
@@ -60,7 +61,6 @@ __all__ = [
     "build_lindblad_delta_nfr",
     "make_coherence_operator",
     "make_frequency_operator",
-    "NFRValidator",
     "IsometryFactory",
     "build_isometry_factory",
     "validate_norm_preservation",
@@ -79,3 +79,17 @@ __all__ = [
     "get_backend",
     "register_backend",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "NFRValidator":
+        warnings.warn(
+            "`tnfr.mathematics.NFRValidator` is deprecated; import it from "
+            "`tnfr.validation` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from ..validation import NFRValidator as _NFRValidator
+
+        return _NFRValidator
+    raise AttributeError(name)

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Iterator
 from itertools import islice
 from statistics import StatisticsError, fmean
 from typing import TYPE_CHECKING, Any
+import warnings
 
 from tnfr import glyph_history
 
@@ -20,22 +21,6 @@ from ..rng import make_rng
 from ..types import EPIValue, Glyph, NodeId, TNFRGraph
 from ..utils import get_nodenx
 from . import definitions as _definitions
-from .grammar import (
-    GrammarContext,
-    StructuralGrammarError,
-    RepeatWindowError,
-    MutationPreconditionError,
-    TholClosureError,
-    TransitionCompatibilityError,
-    SequenceSyntaxError,
-    SequenceValidationResult,
-    _gram_state,
-    apply_glyph_with_grammar,
-    enforce_canonical_grammar,
-    on_applied_glyph,
-    parse_sequence,
-    validate_sequence,
-)
 from .jitter import (
     JitterCache,
     JitterCacheManager,
@@ -81,20 +66,6 @@ __all__ = [
     "get_jitter_manager",
     "reset_jitter_manager",
     "random_jitter",
-    "GrammarContext",
-    "StructuralGrammarError",
-    "RepeatWindowError",
-    "MutationPreconditionError",
-    "TholClosureError",
-    "TransitionCompatibilityError",
-    "SequenceValidationResult",
-    "SequenceSyntaxError",
-    "_gram_state",
-    "apply_glyph_with_grammar",
-    "parse_sequence",
-    "validate_sequence",
-    "enforce_canonical_grammar",
-    "on_applied_glyph",
     "get_neighbor_epi",
     "get_glyph_factors",
     "GLYPH_OPERATIONS",
@@ -109,6 +80,40 @@ __all__ = [
 ]
 
 __all__.extend(_DEFINITION_EXPORTS.keys())
+
+_GRAMMAR_REDIRECTS = {
+    "GrammarContext",
+    "StructuralGrammarError",
+    "RepeatWindowError",
+    "MutationPreconditionError",
+    "TholClosureError",
+    "TransitionCompatibilityError",
+    "SequenceValidationResult",
+    "SequenceSyntaxError",
+    "_gram_state",
+    "apply_glyph_with_grammar",
+    "parse_sequence",
+    "validate_sequence",
+    "enforce_canonical_grammar",
+    "on_applied_glyph",
+    "record_grammar_violation",
+    "glyph_function_name",
+    "function_name_to_glyph",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _GRAMMAR_REDIRECTS:
+        warnings.warn(
+            "`tnfr.operators.%s` is deprecated; import grammar helpers from "
+            "`tnfr.validation`." % name,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from .. import validation as _validation
+
+        return getattr(_validation, name)
+    raise AttributeError(name)
 
 
 def get_glyph_factors(node: NodeProtocol) -> GlyphFactors:

--- a/src/tnfr/operators/__init__.pyi
+++ b/src/tnfr/operators/__init__.pyi
@@ -1,5 +1,21 @@
 from typing import Any
 
+from tnfr.validation import (
+    GrammarContext as _GrammarContext,
+    StructuralGrammarError as _StructuralGrammarError,
+    RepeatWindowError as _RepeatWindowError,
+    MutationPreconditionError as _MutationPreconditionError,
+    TholClosureError as _TholClosureError,
+    TransitionCompatibilityError as _TransitionCompatibilityError,
+    SequenceValidationResult as _SequenceValidationResult,
+    SequenceSyntaxError as _SequenceSyntaxError,
+    apply_glyph_with_grammar as _apply_glyph_with_grammar,
+    enforce_canonical_grammar as _enforce_canonical_grammar,
+    on_applied_glyph as _on_applied_glyph,
+    parse_sequence as _parse_sequence,
+    validate_sequence as _validate_sequence,
+)
+
 Operator: Any
 Emission: Any
 Reception: Any
@@ -18,28 +34,28 @@ GLYPH_OPERATIONS: Any
 JitterCache: Any
 JitterCacheManager: Any
 OPERATORS: Any
-GrammarContext: Any
-StructuralGrammarError: Any
-RepeatWindowError: Any
-MutationPreconditionError: Any
-TholClosureError: Any
-TransitionCompatibilityError: Any
-SequenceValidationResult: Any
-SequenceSyntaxError: Any
+GrammarContext = _GrammarContext
+StructuralGrammarError = _StructuralGrammarError
+RepeatWindowError = _RepeatWindowError
+MutationPreconditionError = _MutationPreconditionError
+TholClosureError = _TholClosureError
+TransitionCompatibilityError = _TransitionCompatibilityError
+SequenceValidationResult = _SequenceValidationResult
+SequenceSyntaxError = _SequenceSyntaxError
 _gram_state: Any
 apply_glyph: Any
 apply_glyph_obj: Any
-apply_glyph_with_grammar: Any
+apply_glyph_with_grammar = _apply_glyph_with_grammar
 apply_network_remesh: Any
 apply_remesh_if_globally_stable: Any
 apply_topological_remesh: Any
 discover_operators: Any
-enforce_canonical_grammar: Any
+enforce_canonical_grammar = _enforce_canonical_grammar
 get_glyph_factors: Any
 get_jitter_manager: Any
 get_neighbor_epi: Any
-on_applied_glyph: Any
-parse_sequence: Any
+on_applied_glyph = _on_applied_glyph
+parse_sequence = _parse_sequence
 random_jitter: Any
 reset_jitter_manager: Any
-validate_sequence: Any
+validate_sequence = _validate_sequence

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -39,11 +39,10 @@ from .mathematics import (
     FrequencyOperator,
     HilbertSpace,
     MathematicalDynamicsEngine,
-    NFRValidator,
     make_coherence_operator,
     make_frequency_operator,
 )
-from .validation import validate_sequence
+from tnfr.validation import NFRValidator, validate_sequence
 from .operators.definitions import (
     Coherence,
     Contraction,

--- a/src/tnfr/validation/rules.py
+++ b/src/tnfr/validation/rules.py
@@ -1,7 +1,7 @@
 """Validation helpers grouped by rule type.
 
 These utilities implement the canonical checks required by
-:mod:`tnfr.operators.grammar`.  They are organised here to make it
+:mod:`tnfr.validation`.  They are organised here to make it
 explicit which pieces enforce repetition control, transition
 compatibility or stabilisation thresholds.
 """

--- a/src/tnfr/validation/soft_filters.py
+++ b/src/tnfr/validation/soft_filters.py
@@ -27,7 +27,7 @@ def acceleration_norm(ctx: "GrammarContext", nd: "Mapping[str, Any]") -> float:
     """Return the node acceleration normalised to ``[0, 1]``.
 
     The computation uses the canonical ``accel_max`` bound stored in
-    :class:`~tnfr.operators.grammar.GrammarContext`.  Values beyond the bound are
+    :class:`~tnfr.validation.GrammarContext`.  Values beyond the bound are
     clamped to preserve structural comparability with ΔNFR-based heuristics.
     """
 

--- a/tests/integration/test_validation_compatibility.py
+++ b/tests/integration/test_validation_compatibility.py
@@ -3,7 +3,7 @@
 from tnfr.config.operator_names import CONTRACTION, MUTATION, RESONANCE, SILENCE
 from tnfr.types import Glyph
 from tnfr.validation.compatibility import CANON_COMPAT, CANON_FALLBACK
-from tnfr.operators.grammar import glyph_function_name
+from tnfr.validation import glyph_function_name
 
 
 def test_thol_maintains_closure_paths():

--- a/tests/integration/test_validation_rules.py
+++ b/tests/integration/test_validation_rules.py
@@ -7,10 +7,9 @@ import networkx as nx
 from tnfr.constants import inject_defaults
 from tnfr.types import Glyph
 from tnfr.config.operator_names import DISSONANCE, MUTATION
-from tnfr.validation import rules as rules_mod
+from tnfr.validation import GrammarContext, glyph_function_name, rules as rules_mod
 from tnfr.validation.soft_filters import maybe_force
 from tnfr.validation.compatibility import CANON_COMPAT, CANON_FALLBACK
-from tnfr.operators.grammar import GrammarContext, glyph_function_name
 
 
 def _graph_with_node():

--- a/tests/unit/dynamics/test_grammar.py
+++ b/tests/unit/dynamics/test_grammar.py
@@ -17,7 +17,7 @@ from tnfr.config.operator_names import (
 )
 from tnfr.dynamics import _choose_glyph
 from tnfr.types import Glyph
-from tnfr.operators.grammar import (
+from tnfr.validation import (
     apply_glyph_with_grammar,
     enforce_canonical_grammar,
     on_applied_glyph,

--- a/tests/unit/dynamics/test_operators.py
+++ b/tests/unit/dynamics/test_operators.py
@@ -18,7 +18,7 @@ from tnfr.operators import (
     reset_jitter_manager,
     _um_candidate_iter,
 )
-from tnfr.operators.grammar import SequenceValidationResult
+from tnfr.validation import SequenceValidationResult
 from tnfr.structural import Dissonance, create_nfr, run_sequence
 from tnfr.types import Glyph
 from tnfr.utils import angle_diff

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -18,20 +18,20 @@ from tnfr.config.operator_names import (
     operator_display_name,
 )
 from tnfr.constants import DEFAULTS, inject_defaults
-from tnfr.operators.grammar import (
+from tnfr.validation import (
     GrammarContext,
     MutationPreconditionError,
     RepeatWindowError,
     TholClosureError,
     SequenceSyntaxError,
     SequenceValidationResult,
+    ValidationOutcome,
     apply_glyph_with_grammar,
     enforce_canonical_grammar,
     on_applied_glyph,
     parse_sequence,
     validate_sequence,
 )
-from tnfr.validation import ValidationOutcome
 from tnfr.types import Glyph
 
 

--- a/tests/unit/operators/test_grammar_schema_validation.py
+++ b/tests/unit/operators/test_grammar_schema_validation.py
@@ -9,7 +9,7 @@ import networkx as nx
 import pytest
 
 from tnfr.constants import DEFAULTS
-from tnfr.operators.grammar import (
+from tnfr.validation import (
     GrammarConfigurationError,
     GrammarContext,
     enforce_canonical_grammar,

--- a/tests/unit/structural/test_structural.py
+++ b/tests/unit/structural/test_structural.py
@@ -23,8 +23,8 @@ from tnfr.constants import (
     VF_PRIMARY,
     inject_defaults,
 )
-from tnfr.mathematics import BasicStateProjector, NFRValidator
-from tnfr.operators.grammar import SequenceValidationResult
+from tnfr.mathematics import BasicStateProjector
+from tnfr.validation import NFRValidator, SequenceValidationResult
 from tnfr.structural import (
     Coherence,
     Contraction,

--- a/tests/unit/validation/test_rules_normalization.py
+++ b/tests/unit/validation/test_rules_normalization.py
@@ -9,10 +9,9 @@ import pytest
 from tnfr.constants import get_aliases
 from tnfr.config.operator_names import COHERENCE, EXPANSION
 from tnfr.types import Glyph
-from tnfr.validation import rules
+from tnfr.validation import GrammarContext, glyph_function_name, rules
 from tnfr.validation.soft_filters import acceleration_norm
 from tnfr.validation.compatibility import CANON_FALLBACK
-from tnfr.operators.grammar import GrammarContext, glyph_function_name
 
 
 @pytest.fixture

--- a/tests/unit/validation/test_rules_repeats.py
+++ b/tests/unit/validation/test_rules_repeats.py
@@ -7,7 +7,7 @@ from collections import deque
 from tnfr.config.operator_names import RESONANCE, SILENCE
 from tnfr.types import Glyph
 from tnfr.validation.soft_filters import check_repeats
-from tnfr.operators.grammar import GrammarContext, glyph_function_name
+from tnfr.validation import GrammarContext, glyph_function_name
 
 
 def _ctx_with_node(graph_canon, cfg_soft):

--- a/tests/unit/validation/test_rules_thol.py
+++ b/tests/unit/validation/test_rules_thol.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from tnfr.types import Glyph
 from tnfr.config.operator_names import CONTRACTION, RESONANCE, SILENCE
-from tnfr.operators.grammar import GrammarContext, glyph_function_name
-from tnfr.validation import rules
+from tnfr.validation import GrammarContext, glyph_function_name, rules
 
 
 def _ctx_with_node(


### PR DESCRIPTION
## Summary
- centralize grammar and runtime validator exports through `tnfr.validation` with deprecation wrappers for legacy modules
- update dynamics, structural, and operator consumers plus tests to import from the unified validation facade
- refresh documentation to announce the consolidated interface and note the compatibility shim behaviour

## Testing
- pytest tests/unit/validation -q


------
https://chatgpt.com/codex/tasks/task_e_6907697b34c083218351f2ab27499237