### PR TITLE
chore: remove deprecated dynamics validation shims

### DIFF
--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -121,6 +121,11 @@ We manage versions with `python-semantic-release`, deriving release tags directl
 - Updated tests, CLI helpers, and documentation to import grammar primitives
   from :mod:`tnfr.validation`, keeping the public surface consistent with the
   consolidated module.
+- Removed the :mod:`tnfr.dynamics` runtime shims for
+  :func:`~tnfr.validation.apply_canonical_clamps`,
+  :func:`~tnfr.validation.validate_canon`, and related grammar hooks to complete
+  the migration. Downstream code should import these helpers directly from
+  :mod:`tnfr.validation`.
 
 .. _rollback-script:
 

--- a/src/tnfr/dynamics/__init__.py
+++ b/src/tnfr/dynamics/__init__.py
@@ -60,15 +60,11 @@ Examples
 from __future__ import annotations
 
 from concurrent.futures import ProcessPoolExecutor
-import warnings
-from typing import Any
 
 from ..metrics.sense_index import compute_Si
 from ..operators import apply_glyph
 from ..types import GlyphCode
 from ..utils import get_numpy
-from ..validation import apply_canonical_clamps as _apply_canonical_clamps
-from ..validation import validate_canon as _validate_canon
 from . import coordination, dnfr, integrators
 from .adaptation import adapt_vf_by_coherence
 from .aliases import (
@@ -187,55 +183,3 @@ __all__ = (
     "step",
     "update_epi_via_nodal_equation",
 )
-
-
-def apply_canonical_clamps(*args: Any, **kwargs: Any) -> Any:
-    """Compatibility wrapper for :func:`tnfr.validation.apply_canonical_clamps`."""
-
-    warnings.warn(
-        "`tnfr.dynamics.apply_canonical_clamps` is deprecated; import it from "
-        "`tnfr.validation` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _apply_canonical_clamps(*args, **kwargs)
-
-
-def validate_canon(*args: Any, **kwargs: Any) -> Any:
-    """Compatibility wrapper for :func:`tnfr.validation.validate_canon`."""
-
-    warnings.warn(
-        "`tnfr.dynamics.validate_canon` is deprecated; import it from "
-        "`tnfr.validation` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _validate_canon(*args, **kwargs)
-
-
-def enforce_canonical_grammar(*args: Any, **kwargs: Any) -> Any:
-    """Deprecated grammar access redirecting to :mod:`tnfr.validation`."""
-
-    warnings.warn(
-        "`tnfr.dynamics.enforce_canonical_grammar` is deprecated; import "
-        "grammar helpers from `tnfr.validation`.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    from ..validation import enforce_canonical_grammar as _enforce
-
-    return _enforce(*args, **kwargs)
-
-
-def on_applied_glyph(*args: Any, **kwargs: Any) -> Any:
-    """Deprecated hook redirecting to :mod:`tnfr.validation`."""
-
-    warnings.warn(
-        "`tnfr.dynamics.on_applied_glyph` is deprecated; import grammar "
-        "hooks from `tnfr.validation` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    from ..validation import on_applied_glyph as _on_applied
-
-    return _on_applied(*args, **kwargs)

--- a/src/tnfr/dynamics/__init__.pyi
+++ b/src/tnfr/dynamics/__init__.pyi
@@ -1,14 +1,6 @@
 from typing import Any, Literal, Sequence
 
 from tnfr.types import GlyphCode, TNFRGraph
-from tnfr.validation import (
-    ValidationOutcome,
-    apply_canonical_clamps as _apply_canonical_clamps,
-    validate_canon as _validate_canon,
-    enforce_canonical_grammar as _enforce_canonical_grammar,
-    on_applied_glyph as _on_applied_glyph,
-)
-
 __all__: tuple[str, ...]
 
 dnfr: Any
@@ -49,16 +41,13 @@ _compute_neighbor_means: Any
 _init_dnfr_cache: Any
 _refresh_dnfr_vectors: Any
 adapt_vf_by_coherence: Any
-apply_canonical_clamps = _apply_canonical_clamps
 coordinate_global_local_phase: Any
 default_compute_delta_nfr: Any
 default_glyph_selector: Any
 dnfr_epi_vf_mixed: Any
 dnfr_laplacian: Any
 dnfr_phase_only: Any
-enforce_canonical_grammar = _enforce_canonical_grammar
 get_numpy: Any
-on_applied_glyph = _on_applied_glyph
 apply_glyph: Any
 parametric_glyph_selector: Any
 
@@ -85,4 +74,3 @@ def update_epi_via_nodal_equation(
     n_jobs: int | None = ...,
 ) -> None: ...
 
-validate_canon = _validate_canon

--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -9,7 +9,6 @@ from collections import deque
 from collections.abc import Iterable, Mapping, MutableMapping
 from numbers import Real
 from typing import Any, cast
-import warnings
 
 from ..alias import get_attr
 from ..callback_utils import CallbackEvent, callback_manager
@@ -20,8 +19,7 @@ from ..operators import apply_remesh_if_globally_stable
 from ..telemetry import publish_graph_cache_metrics
 from ..types import HistoryState, NodeId, TNFRGraph
 from ..utils import normalize_optional_int
-from ..validation import apply_canonical_clamps as _apply_canonical_clamps
-from ..validation import validate_canon as _validate_canon
+from ..validation import apply_canonical_clamps, validate_canon
 from . import adaptation, coordination, integrators, selectors
 from .aliases import ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_THETA, ALIAS_VF
 
@@ -64,40 +62,6 @@ __all__ = (
     "step",
     "run",
 )
-
-
-def apply_canonical_clamps(*args: Any, **kwargs: Any) -> Any:
-    """Redirect to :func:`tnfr.validation.apply_canonical_clamps`.
-
-    This wrapper preserves the legacy import path while emitting a
-    :class:`DeprecationWarning` guiding callers towards
-    :mod:`tnfr.validation`.
-    """
-
-    warnings.warn(
-        "`tnfr.dynamics.runtime.apply_canonical_clamps` is deprecated; "
-        "import `apply_canonical_clamps` from `tnfr.validation` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _apply_canonical_clamps(*args, **kwargs)
-
-
-def validate_canon(*args: Any, **kwargs: Any) -> Any:
-    """Redirect to :func:`tnfr.validation.validate_canon`.
-
-    The runtime continues to offer the attribute for compatibility but it
-    now simply delegates to :mod:`tnfr.validation` after warning callers
-    about the new canonical import path.
-    """
-
-    warnings.warn(
-        "`tnfr.dynamics.runtime.validate_canon` is deprecated; import "
-        "`validate_canon` from `tnfr.validation` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _validate_canon(*args, **kwargs)
 
 
 def _normalize_job_overrides(
@@ -422,7 +386,7 @@ def _update_nodes(
         n_jobs=n_jobs,
     )
     for n, nd in G.nodes(data=True):
-        _apply_canonical_clamps(cast(MutableMapping[str, Any], nd), G, cast(NodeId, n))
+        apply_canonical_clamps(cast(MutableMapping[str, Any], nd), G, cast(NodeId, n))
     phase_jobs = _resolve_jobs_override(
         overrides,
         "PHASE",
@@ -915,5 +879,3 @@ def run(
                 v >= frac for v in numeric_series[-w:]
             ):
                 break
-    "apply_canonical_clamps",
-    "validate_canon",

--- a/tests/unit/dynamics/test_dynamics_run.py
+++ b/tests/unit/dynamics/test_dynamics_run.py
@@ -14,6 +14,7 @@ import tnfr.dynamics.coordination as coordination
 import tnfr.dynamics.integrators as integrators
 import tnfr.dynamics.runtime as runtime
 import tnfr.dynamics.selectors as selectors
+import tnfr.validation as validation
 from tnfr.alias import get_attr
 from tnfr.constants import DEFAULTS
 from tnfr.glyph_history import ensure_history
@@ -297,7 +298,7 @@ def test_step_respects_n_jobs_overrides(monkeypatch, graph_canon):
     monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
     monkeypatch.setattr(selectors, "_apply_glyphs", lambda G, selector, hist: None)
     monkeypatch.setattr(
-        dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None
+        validation, "apply_canonical_clamps", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(runtime, "apply_canonical_clamps", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)
@@ -371,7 +372,7 @@ def test_step_defaults_to_graph_jobs(monkeypatch, graph_canon):
     monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", fake_adapt_vf_by_coherence)
     monkeypatch.setattr(selectors, "_apply_glyphs", lambda G, selector, hist: None)
     monkeypatch.setattr(
-        dynamics, "apply_canonical_clamps", lambda *args, **kwargs: None
+        validation, "apply_canonical_clamps", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(runtime, "apply_canonical_clamps", lambda *args, **kwargs: None)
     monkeypatch.setattr(dynamics, "_update_node_sample", lambda *args, **kwargs: None)

--- a/tests/unit/metrics/test_phase_coordination_jobs.py
+++ b/tests/unit/metrics/test_phase_coordination_jobs.py
@@ -10,6 +10,7 @@ import tnfr.dynamics.coordination as coordination
 import tnfr.dynamics.integrators as integrators
 import tnfr.dynamics.runtime as runtime
 import tnfr.dynamics.selectors as selectors
+import tnfr.validation as validation
 from tnfr.alias import get_attr, set_attr
 from tnfr.constants import get_aliases
 
@@ -58,7 +59,7 @@ def test_update_nodes_forwards_phase_jobs(monkeypatch, graph_canon):
     monkeypatch.setattr(selectors, "_apply_selector", lambda *a, **k: None)
     G.graph["integrator"] = _NoOpIntegrator()
     monkeypatch.setattr(adaptation, "adapt_vf_by_coherence", lambda *a, **k: None)
-    monkeypatch.setattr(dynamics, "apply_canonical_clamps", lambda *a, **k: None)
+    monkeypatch.setattr(validation, "apply_canonical_clamps", lambda *a, **k: None)
     monkeypatch.setattr(runtime, "apply_canonical_clamps", lambda *a, **k: None)
 
     dynamics._update_nodes(


### PR DESCRIPTION
### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [ ] Reproducible seed

## Summary
- remove the deprecated validation wrappers from `tnfr.dynamics` and point runtime orchestration straight at the canonical `tnfr.validation` helpers
- delete the stub exports for the removed compatibility layer and update targeted tests to patch the validation facade directly
- document the completed migration in the release notes so downstream users follow the `tnfr.validation` import path

## Testing
- `pytest tests/unit/dynamics/test_dynamics_run.py tests/unit/metrics/test_phase_coordination_jobs.py` *(fails: optional numpy dependency missing in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_6907a87bfdb48321b5cfe7520383067c