### PR TITLE
Remove tnfr.operators grammar shim and refresh validation guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This guide expands the README summary by detailing how the TNFR Python Engine or
 
 | Layer | Key modules | Primary responsibilities | TNFR invariants guarded |
 | --- | --- | --- | --- |
-| Structural grammar | `tnfr.structural`, `tnfr.validation`, `tnfr.operators.grammar`, `tnfr.flatten` | Instantiate nodes, validate operator sequences, expand THOL blocks, and ensure all operations traverse the canonical grammar before execution.【F:src/tnfr/structural.py†L39-L109】【F:src/tnfr/validation/__init__.py†L1-L98】【F:src/tnfr/operators/grammar.py†L1-L318】【F:src/tnfr/flatten.py†L1-L120】 | Invariants 1, 4, 5, 7 — operators drive EPI evolution, maintain closure, enforce phase checks, and preserve fractality. |
+| Structural grammar | `tnfr.structural`, `tnfr.validation`, `tnfr.flatten` | Instantiate nodes, validate operator sequences, expand THOL blocks, and ensure all operations traverse the canonical grammar before execution.【F:src/tnfr/structural.py†L39-L109】【F:src/tnfr/validation/__init__.py†L1-L104】【F:src/tnfr/operators/grammar.py†L1-L318】【F:src/tnfr/flatten.py†L1-L120】 | Invariants 1, 4, 5, 7 — operators drive EPI evolution, maintain closure, enforce phase checks, and preserve fractality. |
 | Operator registry | `tnfr.operators.definitions`, `tnfr.operators.registry` | Declare canonical operators, bind glyphs to ASCII names, and auto-discover implementations so the structural layer never executes unknown tokens.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L50】 | Invariants 3, 4, 10 — ΔNFR semantics remain canonical, closure is preserved, and the glyph alphabet stays domain-neutral. |
 | Dynamics and adaptation | `tnfr.dynamics.__init__`, `tnfr.dynamics.dnfr`, `tnfr.dynamics.integrators` | Mix ΔNFR, adapt νf/phase, integrate the nodal equation, and route job overrides or clamps so runtime evolution honours reproducibility and unit constraints.【F:src/tnfr/dynamics/__init__.py†L59-L169】【F:src/tnfr/dynamics/dnfr.py†L1958-L2020】【F:src/tnfr/dynamics/integrators.py†L420-L483】 | Invariants 1, 2, 3, 5, 8 — nodal equation controls EPI, νf stays in Hz_str, ΔNFR keeps canonical meaning, coupling checks phase synchrony, and stochastic hooks remain traceable. |
 | Telemetry and traces | `tnfr.metrics.common`, `tnfr.metrics.sense_index`, `tnfr.trace`, `tnfr.metrics.trig`, `tnfr.metrics.trig_cache` | Compute C(t), ΔNFR summaries, Si, and phase telemetry; capture before/after snapshots; expose caches for reproducible analytics.【F:src/tnfr/metrics/common.py†L32-L111】【F:src/tnfr/metrics/common.py†L96-L149】【F:src/tnfr/metrics/sense_index.py†L1-L200】【F:src/tnfr/trace.py†L169-L319】【F:src/tnfr/metrics/trig_cache.py†L1-L120】 | Invariants 8, 9 — telemetry remains reproducible, coherence metrics stay visible, and trace history documents operator effects. |
@@ -44,7 +44,7 @@ flowchart LR
 ```
 
 1. **Discovery** imports the operator package so decorators populate the registry before any structural execution.【F:src/tnfr/operators/registry.py†L33-L50】
-2. **Validation** confirms the canonical RECEPTION→COHERENCE segment, checks THOL closure, and rejects unknown tokens before touching graph state.【F:src/tnfr/validation/__init__.py†L1-L98】【F:src/tnfr/operators/grammar.py†L600-L720】
+2. **Validation** confirms the canonical RECEPTION→COHERENCE segment, checks THOL closure, and rejects unknown tokens before touching graph state.【F:src/tnfr/validation/__init__.py†L1-L104】【F:src/tnfr/operators/grammar.py†L600-L720】
 3. **Execution** invokes each operator, then defers ΔNFR/EPI recomputation to the configured hook, keeping the structural layer free of ad-hoc state mutation.【F:src/tnfr/structural.py†L87-L105】
 4. **Dynamics** recompute ΔNFR, integrate the nodal equation, and coordinate phase coupling. Hooks accept per-run overrides while clamping νf/EPI against canonical bounds.【F:src/tnfr/dynamics/dnfr.py†L1958-L2006】【F:src/tnfr/dynamics/integrators.py†L420-L483】【F:src/tnfr/dynamics/__init__.py†L172-L199】
 5. **Telemetry** extracts coherence, Si, and trace snapshots with caches that ensure reproducible neighbour maps and glyph histories.【F:src/tnfr/metrics/common.py†L32-L111】【F:src/tnfr/metrics/sense_index.py†L1-L200】【F:src/tnfr/trace.py†L169-L319】
@@ -69,7 +69,7 @@ Operator classes apply the `@register_operator` decorator, which verifies unique
 When introducing new operators:
 
 - Provide ASCII `name` and canonical `Glyph` binding on the class definition.【F:src/tnfr/operators/definitions.py†L45-L180】
-- Update grammar/syntax tables if the operator alters the canonical sequence, ensuring THOL blocks and closure sets remain valid.【F:src/tnfr/validation/__init__.py†L1-L98】【F:src/tnfr/operators/grammar.py†L600-L720】
+- Update grammar/syntax tables if the operator alters the canonical sequence, ensuring THOL blocks and closure sets remain valid.【F:src/tnfr/validation/__init__.py†L1-L104】【F:src/tnfr/operators/grammar.py†L600-L720】
 - Supply trace fields or telemetry hooks if the operator produces novel metrics, keeping the coherence log consistent.【F:src/tnfr/trace.py†L169-L319】
 
 ### Operator vocabulary (English only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,8 +263,8 @@ artifacts (e.g., `node_modules/` or `dist/`) are not committed.
   and validation continue to work without manual wiring.【F:src/tnfr/operators/registry.py†L12-L49】
 - **Keep operator closure intact** by updating grammar/syntax rules alongside
   new operator sequences. Start with `tnfr.validation.validate_sequence`
-  and `tnfr.operators.grammar.enforce_canonical_grammar`, then add any THOL
-  handling you need in `tnfr.flatten`.【F:src/tnfr/validation/__init__.py†L1-L98】【F:src/tnfr/operators/grammar.py†L600-L720】【F:src/tnfr/flatten.py†L1-L120】
+  and `tnfr.validation.enforce_canonical_grammar`, then add any THOL
+  handling you need in `tnfr.flatten`.【F:src/tnfr/validation/__init__.py†L1-L104】【F:src/tnfr/operators/grammar.py†L600-L720】【F:src/tnfr/flatten.py†L1-L120】
 - **Share caches, locks, and telemetry** through the provided helpers instead
   of ad-hoc globals. Reuse `tnfr.utils` exports, `tnfr.utils.cache.CacheManager`,
   and `tnfr.locking.get_lock` when extending RNG, ΔNFR, or metric pipelines so
@@ -282,10 +282,10 @@ core layers, where they live, and why edits must preserve the invariant and
 telemetry contracts already documented.
 
 - **Structural grammar** — `tnfr.structural`,
-  `tnfr.validation`, `tnfr.operators.grammar`, `tnfr.flatten`.
+  `tnfr.validation`, `tnfr.flatten`.
   These modules instantiate nodes, validate operator sequences, and expand
   THOL blocks so every execution path honours the canonical grammar before
-  mutating EPI.【F:src/tnfr/structural.py†L39-L109】【F:src/tnfr/validation/__init__.py†L1-L98】【F:src/tnfr/operators/grammar.py†L600-L720】【F:src/tnfr/flatten.py†L1-L120】
+  mutating EPI.【F:src/tnfr/structural.py†L39-L109】【F:src/tnfr/validation/__init__.py†L1-L104】【F:src/tnfr/operators/grammar.py†L600-L720】【F:src/tnfr/flatten.py†L1-L120】
 - **Operator registry** — `tnfr.operators.definitions`,
   `tnfr.operators.registry`. They bind glyphs to implementations and enforce
   closure so the structural layer never executes unknown tokens.【F:src/tnfr/operators/definitions.py†L45-L180】【F:src/tnfr/operators/registry.py†L13-L50】

--- a/src/tnfr/operators/__init__.py
+++ b/src/tnfr/operators/__init__.py
@@ -8,7 +8,6 @@ from collections.abc import Callable, Iterator
 from itertools import islice
 from statistics import StatisticsError, fmean
 from typing import TYPE_CHECKING, Any
-import warnings
 
 from tnfr import glyph_history
 
@@ -80,40 +79,6 @@ __all__ = [
 ]
 
 __all__.extend(_DEFINITION_EXPORTS.keys())
-
-_GRAMMAR_REDIRECTS = {
-    "GrammarContext",
-    "StructuralGrammarError",
-    "RepeatWindowError",
-    "MutationPreconditionError",
-    "TholClosureError",
-    "TransitionCompatibilityError",
-    "SequenceValidationResult",
-    "SequenceSyntaxError",
-    "_gram_state",
-    "apply_glyph_with_grammar",
-    "parse_sequence",
-    "validate_sequence",
-    "enforce_canonical_grammar",
-    "on_applied_glyph",
-    "record_grammar_violation",
-    "glyph_function_name",
-    "function_name_to_glyph",
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _GRAMMAR_REDIRECTS:
-        warnings.warn(
-            "`tnfr.operators.%s` is deprecated; import grammar helpers from "
-            "`tnfr.validation`." % name,
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        from .. import validation as _validation
-
-        return getattr(_validation, name)
-    raise AttributeError(name)
 
 
 def get_glyph_factors(node: NodeProtocol) -> GlyphFactors:

--- a/src/tnfr/operators/__init__.pyi
+++ b/src/tnfr/operators/__init__.pyi
@@ -1,21 +1,5 @@
 from typing import Any
 
-from tnfr.validation import (
-    GrammarContext as _GrammarContext,
-    StructuralGrammarError as _StructuralGrammarError,
-    RepeatWindowError as _RepeatWindowError,
-    MutationPreconditionError as _MutationPreconditionError,
-    TholClosureError as _TholClosureError,
-    TransitionCompatibilityError as _TransitionCompatibilityError,
-    SequenceValidationResult as _SequenceValidationResult,
-    SequenceSyntaxError as _SequenceSyntaxError,
-    apply_glyph_with_grammar as _apply_glyph_with_grammar,
-    enforce_canonical_grammar as _enforce_canonical_grammar,
-    on_applied_glyph as _on_applied_glyph,
-    parse_sequence as _parse_sequence,
-    validate_sequence as _validate_sequence,
-)
-
 Operator: Any
 Emission: Any
 Reception: Any
@@ -34,28 +18,14 @@ GLYPH_OPERATIONS: Any
 JitterCache: Any
 JitterCacheManager: Any
 OPERATORS: Any
-GrammarContext = _GrammarContext
-StructuralGrammarError = _StructuralGrammarError
-RepeatWindowError = _RepeatWindowError
-MutationPreconditionError = _MutationPreconditionError
-TholClosureError = _TholClosureError
-TransitionCompatibilityError = _TransitionCompatibilityError
-SequenceValidationResult = _SequenceValidationResult
-SequenceSyntaxError = _SequenceSyntaxError
-_gram_state: Any
 apply_glyph: Any
 apply_glyph_obj: Any
-apply_glyph_with_grammar = _apply_glyph_with_grammar
 apply_network_remesh: Any
 apply_remesh_if_globally_stable: Any
 apply_topological_remesh: Any
 discover_operators: Any
-enforce_canonical_grammar = _enforce_canonical_grammar
 get_glyph_factors: Any
 get_jitter_manager: Any
 get_neighbor_epi: Any
-on_applied_glyph = _on_applied_glyph
-parse_sequence = _parse_sequence
 random_jitter: Any
 reset_jitter_manager: Any
-validate_sequence = _validate_sequence

--- a/src/tnfr/operators/definitions.py
+++ b/src/tnfr/operators/definitions.py
@@ -78,7 +78,7 @@ class Operator:
         Notes
         -----
         The invocation delegates to
-        :func:`tnfr.operators.grammar.apply_glyph_with_grammar`, which enforces
+        :func:`tnfr.validation.apply_glyph_with_grammar`, which enforces
         the TNFR grammar before activating the glyph. The grammar may expand,
         contract or stabilise the neighbourhood so that the operator preserves
         canonical closure and coherence.

--- a/src/tnfr/validation/__init__.py
+++ b/src/tnfr/validation/__init__.py
@@ -1,8 +1,8 @@
 """Unified validation interface consolidating grammar, graph and spectral checks.
 
-This package re-exports the canonical grammar helpers implemented in
-``tnfr.operators.grammar`` and the runtime validators so downstream code can rely
-on a single import path for structural validation primitives.
+This package re-exports the canonical grammar helpers and runtime validators so
+downstream code can rely on ``tnfr.validation`` as the single import path for
+structural validation primitives.
 """
 
 from __future__ import annotations
@@ -91,7 +91,7 @@ def enforce_canonical_grammar(
     cand: Any,
     ctx: Any | None = None,
 ) -> Any:
-    """Proxy to :func:`tnfr.operators.grammar.enforce_canonical_grammar` preserving Glyph outputs."""
+    """Proxy to the canonical grammar enforcement helper preserving Glyph outputs."""
 
     result = _ENFORCE_CANONICAL_GRAMMAR(G, n, cand, ctx)
     if isinstance(cand, Glyph) and not isinstance(result, Glyph):

--- a/tests/unit/operators/test_grammar_module.py
+++ b/tests/unit/operators/test_grammar_module.py
@@ -300,7 +300,7 @@ def test_apply_glyph_with_grammar_invokes_apply(monkeypatch: pytest.MonkeyPatch)
         captured["args"] = (graph, node_id, glyph, window)
 
     monkeypatch.setattr(
-        "tnfr.operators.grammar.enforce_canonical_grammar",
+        "tnfr.validation.enforce_canonical_grammar",
         lambda graph, node, cand, ctx=None: cand,
     )
     monkeypatch.setattr("tnfr.operators.apply_glyph", fake_apply, raising=False)


### PR DESCRIPTION
## Summary
- remove the tnfr.operators grammar redirect shim so the package only exposes operator utilities
- update validation docs, type hints, and operator notes to point grammar helpers at tnfr.validation
- refresh contributor and architecture guides to reference the consolidated validation namespace and adjust tests accordingly

### What it reorganizes
- [ ] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed

------
https://chatgpt.com/codex/tasks/task_e_6907aa2678c88321829fee4b312701a5