### PR TITLE
Refine flatten streaming with reusable preview helper

### DIFF
--- a/src/tnfr/utils/data.pyi
+++ b/src/tnfr/utils/data.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Literal, TypeVar, overload
 
 T = TypeVar("T")
 
@@ -38,12 +38,23 @@ def flatten_structure(
     expand: Callable[[Any], Iterable[Any] | None] | None = ...,
 ) -> Iterator[Any]: ...
 def normalize_materialize_limit(max_materialize: int | None) -> int | None: ...
+@overload
 def ensure_collection(
     it: Iterable[T],
     *,
-    max_materialize: int | None = ...,
-    error_msg: str | None = ...,
+    max_materialize: int | None = ..., 
+    error_msg: str | None = ..., 
+    return_view: Literal[False] = ..., 
 ) -> Collection[T]: ...
+
+@overload
+def ensure_collection(
+    it: Iterable[T],
+    *,
+    max_materialize: int | None = ..., 
+    error_msg: str | None = ..., 
+    return_view: Literal[True],
+) -> tuple[Collection[T], Iterable[T]]: ...
 def normalize_weights(
     dict_like: Mapping[str, Any],
     keys: Iterable[str] | Sequence[str],

--- a/tests/integration/test_program.py
+++ b/tests/integration/test_program.py
@@ -511,6 +511,26 @@ def test_compile_sequence_zero_materialize_stops_iteration():
     assert events == []
 
 
+def test_parse_program_tokens_handles_empty_iterable():
+    def token_stream():
+        if False:
+            yield None
+
+    tokens = flatten_module.parse_program_tokens(token_stream(), max_materialize=3)
+    assert tokens == []
+
+
+def test_parse_program_tokens_enforces_limit_for_iterables():
+    def token_stream():
+        yield "AL"
+        yield "RA"
+        yield "OZ"
+        yield "EN"
+
+    with pytest.raises(ValueError, match=r"Iterable produced 4 items, exceeds limit 3"):
+        flatten_module.parse_program_tokens(token_stream(), max_materialize=3)
+
+
 def test_thol_repeat_lt_one_raises():
     with pytest.raises(ValueError, match="repeat must be ≥1"):
         compile_sequence([THOL(body=[], repeat=0)])


### PR DESCRIPTION
## Summary
- extend `ensure_collection` to provide optional streaming views and update the public stub
- refactor `tnfr.flatten._iter_source` to reuse the shared helper for limit handling
- add coverage for iterator views and parse-program edge cases in the test suite

## Testing
- pytest tests/unit/structural/test_ensure_collection.py
- pytest tests/integration/test_program.py::test_parse_program_tokens_handles_empty_iterable tests/integration/test_program.py::test_parse_program_tokens_enforces_limit_for_iterables

### What it reorganizes
- [x] Increases C(t) or reduces ΔNFR where appropriate
- [x] Preserves operator closure and operational fractality

### Evidence
- [ ] Phase/νf logs
- [ ] C(t), Si curves
- [ ] Controlled bifurcation cases

### Compatibility
- [x] Stable or mapped API
- [x] Reproducible seed


------
https://chatgpt.com/codex/tasks/task_e_6907ae03699c83218b1b372663d26b13