### PR TITLE
Potential fix for code scanning alert no. 20: Wrong number of arguments in a call

### DIFF
--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -224,6 +224,21 @@ def _call_integrator_factory(factory: Any, G: TNFRGraph) -> Any:
     if positional:
         return factory(G)
 
+    # Check for any required positional arguments, and raise error if present
+    remaining_required_positional = [
+        p
+        for p in params
+        if p.default is inspect._empty
+        and p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    if remaining_required_positional:
+        raise TypeError(
+            f"Integrator factory requires positional arguments: {', '.join(p.name for p in remaining_required_positional)}"
+        )
     return factory()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/20](https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/20)

To fix the problem, we need to ensure that `_call_integrator_factory` never calls a factory with fewer arguments than required. The current logic already raises an exception if more than one required positional argument exists. However, in the fallback at line 227, it's possible to end up with a factory requiring required positional arguments (e.g., two), and still call it with zero arguments. To fix this, we should add an explicit check right before calling `factory()` in line 227, verifying that no required positional arguments remain in the signature. If any are present, we raise a `TypeError` indicating that the factory's required positional arguments cannot be satisfied in this branch.

This change should be made in `src/tnfr/dynamics/runtime.py` within the `_call_integrator_factory` method, just before line 227.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
