### PR TITLE
Potential fix for code scanning alert no. 213: Wrong number of arguments in a call

### DIFF
--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -221,8 +221,12 @@ def _call_integrator_factory(factory: Any, G: TNFRGraph) -> Any:
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
         )
     ]
-    if positional:
+    if len(positional) == 1:
         return factory(G)
+    elif len(positional) > 1:
+        raise TypeError(
+            "Integrator factory must accept at most one positional argument",
+        )
 
     # Check for any required positional arguments, and raise error if present
     remaining_required_positional = [


### PR DESCRIPTION
Potential fix for [https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/213](https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/213)

To fix this problem, we should ensure that in all cases, `factory()` is only called with the correct number of arguments. The best fix is to enhance the logic for handling factories that require positional arguments by amending the block at line 225. Specifically, we should only call `factory(G)` if the factory expects exactly one positional argument; otherwise, we should raise an error if more (or fewer) arguments are required, or defer to the prior error handling. This matches what was done for the `positional_required` list, and maintains backward compatibility with existing logic. Thus, the edit should add a length check for `positional`, similar to what is done above, before calling `factory(G)`, and raise a `TypeError` if more than one positional argument exists. The change should be made around line 225 of `src/tnfr/dynamics/runtime.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
