### PR TITLE
Potential fix for code scanning alert no. 12: Unnecessary lambda

### DIFF
--- a/tests/unit/dynamics/test_integrators.py
+++ b/tests/unit/dynamics/test_integrators.py
@@ -339,7 +339,7 @@ class _FakeNumpy:
 def _use_fake_numpy(monkeypatch):
     """Force integrator helpers to rely on deterministic fake numpy arrays."""
 
-    monkeypatch.setattr(integrators_mod, "get_numpy", lambda: _FakeNumpy())
+    monkeypatch.setattr(integrators_mod, "get_numpy", _FakeNumpy)
 
 
 @pytest.mark.parametrize("method", ["euler", "rk4"])


### PR DESCRIPTION
Potential fix for [https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/12](https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/12)

To fix the unnecessary lambda, replace the lambda function `lambda: _FakeNumpy()` passed to `monkeypatch.setattr` with the class `_FakeNumpy` itself. This change preserves behavior, as the code being patched expects to replace `get_numpy` with a zero-argument callable that produces a `_FakeNumpy` instance—which the class constructor already is. Precisely, in file `tests/unit/dynamics/test_integrators.py`, line 342, replace `lambda: _FakeNumpy()` with `_FakeNumpy`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
