### PR TITLE
Potential fix for code scanning alert no. 220: Wrong number of arguments in a call

### DIFF
--- a/src/tnfr/dynamics/runtime.py
+++ b/src/tnfr/dynamics/runtime.py
@@ -224,8 +224,8 @@ def _call_integrator_factory(factory: Any, G: TNFRGraph) -> Any:
             "Integrator factory must accept at most one positional argument",
         )
 
-    # Check for any required positional arguments, and raise error if present
-    remaining_required_positional = [
+    # Check for any remaining required positional or keyword-only arguments
+    remaining_required = [
         p
         for p in params
         if p.default is inspect._empty
@@ -233,11 +233,12 @@ def _call_integrator_factory(factory: Any, G: TNFRGraph) -> Any:
         in (
             inspect.Parameter.POSITIONAL_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
         )
     ]
-    if remaining_required_positional:
+    if remaining_required:
         raise TypeError(
-            f"Integrator factory requires positional arguments: {', '.join(p.name for p in remaining_required_positional)}"
+            f"Integrator factory requires arguments: {', '.join(p.name for p in remaining_required)}"
         )
     return factory()
 


### PR DESCRIPTION
Potential fix for [https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/220](https://github.com/fermga/TNFR-Python-Engine/security/code-scanning/220)

To fix the problem, we must ensure that `_call_integrator_factory` never calls `factory()` with too few arguments. The current logic already attempts to check that no more than one positional or required positional argument is present, raising a `TypeError` otherwise. But given the reported bug, we should tighten the guards and ensure that if the factory has any required positional or required keyword-only argument, we must not call it without arguments. Thus, before the zero-argument call on line 242, we should check the function signature again to confirm there are no remaining required parameters (positional or keyword-only) and raise a `TypeError` if any are still present.

Edit src/tnfr/dynamics/runtime.py:
- Before calling `factory()` at line 242, inspect all parameters to ensure that all have defaults; if not, raise.
- If all arguments have defaults, proceed to call without arguments.

This only changes the end of `_call_integrator_factory`, so only that function's code block is updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
